### PR TITLE
Support web ffi

### DIFF
--- a/justfile
+++ b/justfile
@@ -32,7 +32,8 @@ gen:
         --rust-output native/src/bridge_generated/bridge_generated.rs \
         --dart-output lib/bridge_generated/bridge_generated.dart \
         --dart-decl-output lib/bridge_generated/bridge_definitions.dart \
-        --dart-format-line-length {{line_length}}
+        --dart-format-line-length {{line_length}} \
+        --wasm
 
 native:
     cd mobile/native && cargo build


### PR DESCRIPTION
In order to properly support the `ffi_web.dart` file that is part of the project we have to generate the bridge code accordingly.

This resolves dart analyser errors in the project.

---

alternatively we can also remove the `ffi_web.dart` file if we don't want to support web target.