### PR TITLE
Fix rust-lightning log & create all data dirs for on chain wallet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1285,12 +1285,14 @@ dependencies = [
  "lightning-net-tokio",
  "lightning-persister",
  "lightning-rapid-gossip-sync",
+ "log",
  "rand 0.6.5",
  "reqwest",
  "serde",
  "sha2",
  "tokio",
  "tracing",
+ "tracing-log",
  "tracing-subscriber",
 ]
 

--- a/crates/ln-dlc-node/Cargo.toml
+++ b/crates/ln-dlc-node/Cargo.toml
@@ -24,10 +24,12 @@ lightning-invoice = { version = "0.21" }
 lightning-net-tokio = { version = "0.0.113" }
 lightning-persister = { version = "0.0.113" }
 lightning-rapid-gossip-sync = { version = "0.0.113" }
+log = "0.4.17"
 rand = "^0.6.0"
 reqwest = { version = "0.11", default-features = false, features = ["json"] }
 serde = "1.0.147"
 sha2 = "0.10"
 tokio = { version = "1", default-features = false, features = ["io-util", "macros", "rt", "rt-multi-thread", "sync", "net", "time"] }
 tracing = "0.1.37"
+tracing-log = "0.1.3"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/crates/ln-dlc-node/src/logger.rs
+++ b/crates/ln-dlc-node/src/logger.rs
@@ -1,30 +1,32 @@
+use lightning::util::logger::Level;
 use lightning::util::logger::Logger;
-use lightning::util::logger::Record;
+use lightning::util::logger::Record as LnRecord;
+use tracing_log::log;
+use tracing_log::log::Metadata;
 
 #[derive(Copy, Clone)]
 pub(crate) struct TracingLogger;
 
 impl Logger for TracingLogger {
-    fn log(&self, record: &Record) {
-        match record.level {
-            lightning::util::logger::Level::Gossip => {
-                println!("GOSSIP: {}", record.args.to_string());
-            }
-            lightning::util::logger::Level::Trace => {
-                println!("TRACE: {}", record.args.to_string());
-            }
-            lightning::util::logger::Level::Debug => {
-                println!("DEBUG: {}", record.args.to_string());
-            }
-            lightning::util::logger::Level::Info => {
-                println!("INFO: {}", record.args.to_string());
-            }
-            lightning::util::logger::Level::Warn => {
-                println!("WARN: {}", record.args.to_string());
-            }
-            lightning::util::logger::Level::Error => {
-                println!("ERROR: {}", record.args.to_string());
-            }
-        }
+    fn log(&self, record: &LnRecord) {
+        let level = match record.level {
+            Level::Gossip | Level::Trace => log::Level::Trace,
+            Level::Debug => log::Level::Debug,
+            Level::Info => log::Level::Info,
+            Level::Warn => log::Level::Warn,
+            Level::Error => log::Level::Error,
+        };
+
+        tracing_log::format_trace(
+            &log::Record::builder()
+                .level(level)
+                .args(record.args)
+                .target(record.module_path)
+                .module_path_static(Some(record.module_path))
+                .file_static(Some(record.file))
+                .line(Some(record.line))
+                .build(),
+        )
+        .expect("to be able to format a log record as a trace")
     }
 }

--- a/crates/ln-dlc-node/src/on_chain_wallet.rs
+++ b/crates/ln-dlc-node/src/on_chain_wallet.rs
@@ -20,9 +20,9 @@ impl OnChainWallet {
 
         let data_dir = data_dir.join(&network.to_string());
         if !data_dir.exists() {
-            // TODO: Had to create the `on_chain` directory manually for this to work in the tests
-            std::fs::create_dir(&data_dir)
-                .context(format!("Could not create data dir for {network}"))?;
+            std::fs::create_dir_all(&data_dir).context(format!(
+                "Could not create data dir ({data_dir:?}) for {network}"
+            ))?;
         }
 
         let ext_priv_key = seed.derive_extended_priv_key(network)?;


### PR DESCRIPTION
Two commits here
- Create all data dirs for on chain walet: this will create all required parent directories (similar to `mkdir -p`)
- Log rust-lightning records to tracing: this logs records from rust-lightning crates to tracing through the tracing_log crate 

This is a small PR because I can't push to upstream currently. Fixes #103.