### PR TITLE
Use a global test subscriber and switch to traces for most printlns

### DIFF
--- a/crates/ln-dlc-node/src/lib.rs
+++ b/crates/ln-dlc-node/src/lib.rs
@@ -1,3 +1,4 @@
+use crate::logger::TracingLogger;
 use dlc_manager::custom_signer::CustomKeysManager;
 use dlc_manager::custom_signer::CustomSigner;
 use dlc_messages::message_handler::MessageHandler as DlcMessageHandler;
@@ -20,7 +21,6 @@ use ln_dlc_wallet::LnDlcWallet;
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::sync::Mutex;
-use crate::logger::TracingLogger;
 
 mod disk;
 mod ln;

--- a/crates/ln-dlc-node/src/ln/event_handler.rs
+++ b/crates/ln-dlc-node/src/ln/event_handler.rs
@@ -18,8 +18,6 @@ use lightning::util::events::PaymentPurpose;
 use rand::thread_rng;
 use rand::Rng;
 use std::collections::hash_map::Entry;
-use std::io;
-use std::io::Write;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::runtime;
@@ -118,13 +116,12 @@ impl lightning::util::events::EventHandler for EventHandler {
                 amount_msat,
                 receiver_node_id: _,
             } => {
-                println!(
-                    "\nEVENT: claimed payment from payment hash {} of {} millisatoshis",
-                    hex::encode(&payment_hash.0),
-                    amount_msat,
+                tracing::info!(
+                    %amount_msat,
+                    payment_hash = %hex::encode(&payment_hash.0),
+                    "Claimed payment",
                 );
-                print!("> ");
-                io::stdout().flush().unwrap();
+
                 let (payment_preimage, payment_secret) = match purpose {
                     PaymentPurpose::InvoicePayment {
                         payment_preimage,
@@ -162,19 +159,15 @@ impl lightning::util::events::EventHandler for EventHandler {
                     if *hash == payment_hash {
                         payment.preimage = Some(payment_preimage);
                         payment.status = HTLCStatus::Succeeded;
-                        println!(
-                        "\nEVENT: successfully sent payment of {:?} millisatoshis{} from payment hash {:?} with preimage {:?}",
-                        payment.amt_msat,
-                        if let Some(fee) = fee_paid_msat {
-                            format!(" (fee {} msat)", fee)
-                        } else {
-                            "".to_string()
-                        },
-                        hex::encode(&payment_hash.0),
-                        hex::encode(&payment_preimage.0)
-                    );
-                        print!("> ");
-                        io::stdout().flush().unwrap();
+
+                        let preimage_hash = hex::encode(&payment_preimage.0);
+                        tracing::info!(
+                            amount_msat = ?payment.amt_msat.0,
+                            fee_paid_msat = ?fee_paid_msat,
+                            payment_hash = %hex::encode(&payment_hash.0),
+                            %preimage_hash,
+                            "\nSuccessfully sent payment",
+                        );
                     }
                 }
             }
@@ -185,8 +178,6 @@ impl lightning::util::events::EventHandler for EventHandler {
             Event::PaymentPathFailed { .. } => {}
             Event::PaymentFailed { payment_hash, .. } => {
                 print!("\nEVENT: Failed to send payment to payment hash {:?}: exhausted payment retry attempts", hex::encode(&payment_hash.0));
-                print!("> ");
-                io::stdout().flush().unwrap();
 
                 let mut payments = self.outbound_payments.lock().unwrap();
                 if payments.contains_key(&payment_hash) {
@@ -244,18 +235,16 @@ impl lightning::util::events::EventHandler for EventHandler {
                     "from HTLC fulfill message"
                 };
                 if let Some(fee_earned) = fee_earned_msat {
-                    println!(
-                        "\nEVENT: Forwarded payment{}{}, earning {} msat {}",
+                    tracing::info!(
+                        "Forwarded payment{}{}, earning {} msat {}",
                         from_prev_str, to_next_str, fee_earned, from_onchain_str
                     );
                 } else {
-                    println!(
-                        "\nEVENT: Forwarded payment{}{}, claiming onchain {}",
+                    tracing::info!(
+                        "Forwarded payment{}{}, claiming onchain {}",
                         from_prev_str, to_next_str, from_onchain_str
                     );
                 }
-                print!("> ");
-                io::stdout().flush().unwrap();
             }
             Event::PendingHTLCsForwardable { time_forwardable } => {
                 let forwarding_channel_manager = self.channel_manager.clone();
@@ -289,13 +278,12 @@ impl lightning::util::events::EventHandler for EventHandler {
                 reason,
                 user_channel_id: _,
             } => {
-                println!(
-                    "\nEVENT: Channel {} closed due to: {:?}",
-                    hex::encode(channel_id),
-                    reason
+                let channel = hex::encode(channel_id);
+                tracing::info!(
+                    %channel,
+                    ?reason,
+                    "\nChannel closed",
                 );
-                print!("> ");
-                io::stdout().flush().unwrap();
             }
             Event::DiscardFunding { .. } => {
                 // A "real" node should probably "lock" the UTXOs spent in funding transactions
@@ -314,9 +302,9 @@ impl lightning::util::events::EventHandler for EventHandler {
                 via_channel_id: _,
                 via_user_channel_id: _,
             } => {
-                println!("\nEVENT: received payment from payment hash {} of {} millisatoshis", util::hex_str(&payment_hash.0), amount_msat.to_string());
-                print!("> ");
-                io::stdout().flush().unwrap();
+                let payment_hash = util::hex_str(&payment_hash.0);
+                tracing::info!(%payment_hash, %amount_msat, "Received payment");
+
                 let payment_preimage = match purpose {
                     PaymentPurpose::InvoicePayment { payment_preimage, .. } => payment_preimage,
                     PaymentPurpose::SpontaneousPayment(preimage) => Some(preimage),

--- a/crates/ln-dlc-node/src/logger.rs
+++ b/crates/ln-dlc-node/src/logger.rs
@@ -1,8 +1,6 @@
 use lightning::util::logger::Level;
 use lightning::util::logger::Logger;
 use lightning::util::logger::Record as LnRecord;
-use tracing_log::log;
-use tracing_log::log::Metadata;
 
 #[derive(Copy, Clone)]
 pub(crate) struct TracingLogger;

--- a/crates/ln-dlc-node/src/node.rs
+++ b/crates/ln-dlc-node/src/node.rs
@@ -23,10 +23,11 @@ use dlc_manager::custom_signer::CustomKeysManager;
 use dlc_messages::message_handler::MessageHandler as DlcMessageHandler;
 use futures::Future;
 use lightning::chain;
+use lightning::chain::chainmonitor;
 use lightning::chain::keysinterface::KeysInterface;
 use lightning::chain::keysinterface::KeysManager;
+use lightning::chain::Access;
 use lightning::chain::BestBlock;
-use lightning::chain::{chainmonitor, Access};
 use lightning::ln::channelmanager::ChainParameters;
 use lightning::ln::msgs::NetAddress;
 use lightning::ln::peer_handler::IgnoringMessageHandler;
@@ -55,6 +56,7 @@ use std::sync::Arc;
 use std::sync::Mutex;
 use std::time::Duration;
 use std::time::SystemTime;
+use tracing::instrument::WithSubscriber;
 
 /// An LN-DLC node.
 pub struct Node {
@@ -466,16 +468,16 @@ impl Node {
                 tracing::info!("EVENT: initiated sending {amt_msat} msats to {payee_pubkey}",);
                 HTLCStatus::Pending
             }
-            Err(PaymentError::Invoice(e)) => {
-                tracing::error!("Invalid invoice: {e}");
-                anyhow::bail!(e);
+            Err(PaymentError::Invoice(err)) => {
+                tracing::error!(%err, "Invalid invoice");
+                anyhow::bail!(err);
             }
-            Err(PaymentError::Routing(e)) => {
-                tracing::error!("Failed to find route: {e:?}");
-                anyhow::bail!("{:?}", e);
+            Err(PaymentError::Routing(err)) => {
+                tracing::error!(?err, "Failed to find route");
+                anyhow::bail!("{:?}", err);
             }
-            Err(PaymentError::Sending(e)) => {
-                tracing::error!("Failed to send payment: {e:?}");
+            Err(PaymentError::Sending(err)) => {
+                tracing::error!(?err, "Failed to send payment");
                 HTLCStatus::Failed
             }
         };

--- a/crates/ln-dlc-node/src/tests.rs
+++ b/crates/ln-dlc-node/src/tests.rs
@@ -5,6 +5,7 @@ use dlc_manager::Oracle;
 use dlc_manager::Wallet;
 use serde::Serialize;
 use std::str::FromStr;
+use std::sync::Once;
 use std::time::Duration;
 
 mod add_dlc;
@@ -17,6 +18,19 @@ mod single_hop_payment;
 const CHOPSTICKS_FAUCET_ORIGIN: &str = "http://localhost:3000";
 
 const ELECTRS_ORIGIN: &str = "tcp://localhost:50000";
+
+fn init_tracing() {
+    static TRACING_TEST_SUBSCRIBER: Once = Once::new();
+
+    TRACING_TEST_SUBSCRIBER.call_once(|| {
+        tracing_subscriber::fmt()
+            .with_env_filter(
+                "debug,hyper=warn,reqwest=warn,rustls=warn,bdk=info,ldk=debug,sled=info",
+            )
+            .with_test_writer()
+            .init()
+    })
+}
 
 struct MockOracle;
 

--- a/crates/ln-dlc-node/src/tests/multi_hop_payment.rs
+++ b/crates/ln-dlc-node/src/tests/multi_hop_payment.rs
@@ -1,6 +1,7 @@
 use crate::node::Node;
 use crate::seed::Bip39Seed;
 use crate::tests::fund_and_mine;
+use crate::tests::init_tracing;
 use crate::tests::ELECTRS_ORIGIN;
 use bip39::Mnemonic;
 use bitcoin::Network;
@@ -8,14 +9,10 @@ use dlc_manager::Wallet;
 use rand::thread_rng;
 use rand::RngCore;
 use std::time::Duration;
-use tracing_subscriber::util::SubscriberInitExt;
 
 #[tokio::test]
 async fn multi_hop_payment() {
-    let _guard = tracing_subscriber::fmt()
-        .with_env_filter("debug,hyper=warn,reqwest=warn,rustls=warn,bdk=info,ldk=debug,sled=info")
-        .with_test_writer()
-        .set_default();
+    init_tracing();
 
     // 1. Set up two LN-DLC nodes.
     let alice = {

--- a/crates/ln-dlc-node/src/tests/single_hop_payment.rs
+++ b/crates/ln-dlc-node/src/tests/single_hop_payment.rs
@@ -1,20 +1,17 @@
 use crate::node::Node;
 use crate::seed::Bip39Seed;
 use crate::tests::fund_and_mine;
+use crate::tests::init_tracing;
 use crate::tests::ELECTRS_ORIGIN;
 use bitcoin::Network;
 use dlc_manager::Wallet;
 use rand::thread_rng;
 use rand::RngCore;
 use std::time::Duration;
-use tracing_subscriber::util::SubscriberInitExt;
 
 #[tokio::test]
 async fn given_sibling_channel_when_payment_then_can_be_claimed() {
-    let _guard = tracing_subscriber::fmt()
-        .with_env_filter("debug,hyper=warn,reqwest=warn,rustls=warn,bdk=info,ldk=debug,sled=info")
-        .with_test_writer()
-        .set_default();
+    init_tracing();
 
     // 1. Set up two LN-DLC nodes.
     let alice = {


### PR DESCRIPTION
Global test subscriber was needed to capture traces from threads spawned by the rust-lightning libraries (e.g lightning-background-processor spawns its own threads, which we cannot install the local subscriber in).

I did leave some printlns  hat start with `EVENT` as they seemed to take control of stdout itself and do other things, which I did not understand and want to meddle with yet.