### PR TITLE
fix: align all product identifier strings to `finance.get10101.app`

### DIFF
--- a/mobile/android/app/build.gradle
+++ b/mobile/android/app/build.gradle
@@ -42,7 +42,7 @@ android {
     }
 
     defaultConfig {
-        applicationId "finance.get10101"
+        applicationId "finance.get10101.app"
         minSdkVersion 21
         targetSdkVersion 30
         versionCode flutterVersionCode.toInteger()

--- a/mobile/android/app/src/debug/AndroidManifest.xml
+++ b/mobile/android/app/src/debug/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="finance.get10101">
+    package="finance.get10101.app">
     <!-- The INTERNET permission is required for development. Specifically,
          the Flutter tool needs it to communicate with the running application
          to allow setting breakpoints, to provide hot reload, etc.

--- a/mobile/android/app/src/main/AndroidManifest.xml
+++ b/mobile/android/app/src/main/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="finance.get10101">
+    package="finance.get10101.app">
    <application
         android:label="10101"
         android:name="${applicationName}"

--- a/mobile/android/app/src/main/kotlin/com/example/flutter_rust_bridge_template/MainActivity.kt
+++ b/mobile/android/app/src/main/kotlin/com/example/flutter_rust_bridge_template/MainActivity.kt
@@ -1,4 +1,4 @@
-package finance.get10101
+package finance.get10101.app
 
 import io.flutter.embedding.android.FlutterActivity
 

--- a/mobile/android/app/src/profile/AndroidManifest.xml
+++ b/mobile/android/app/src/profile/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="finance.get10101">
+    package="finance.get10101.app">
     <!-- The INTERNET permission is required for development. Specifically,
          the Flutter tool needs it to communicate with the running application
          to allow setting breakpoints, to provide hot reload, etc.

--- a/mobile/ios/Runner.xcodeproj/project.pbxproj
+++ b/mobile/ios/Runner.xcodeproj/project.pbxproj
@@ -435,7 +435,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = finance.10101.app;
+				PRODUCT_BUNDLE_IDENTIFIER = finance.get10101.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
@@ -563,7 +563,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = finance.10101.app;
+				PRODUCT_BUNDLE_IDENTIFIER = finance.get10101.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -585,7 +585,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = finance.10101.app;
+				PRODUCT_BUNDLE_IDENTIFIER = finance.get10101.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;

--- a/mobile/linux/CMakeLists.txt
+++ b/mobile/linux/CMakeLists.txt
@@ -7,7 +7,7 @@ project(runner LANGUAGES CXX)
 set(BINARY_NAME "10101")
 # The unique GTK application identifier for this application. See:
 # https://wiki.gnome.org/HowDoI/ChooseApplicationID
-set(APPLICATION_ID "finance.10101")
+set(APPLICATION_ID "finance.get10101.app")
 
 # Explicitly opt in to modern CMake behaviors to avoid warnings with recent
 # versions of CMake.

--- a/mobile/macos/Runner/Configs/AppInfo.xcconfig
+++ b/mobile/macos/Runner/Configs/AppInfo.xcconfig
@@ -8,7 +8,7 @@
 PRODUCT_NAME = 10101
 
 // The application's bundle identifier
-PRODUCT_BUNDLE_IDENTIFIER = finance.10101.app
+PRODUCT_BUNDLE_IDENTIFIER = finance.get10101.app
 
 // The copyright displayed in application information
 PRODUCT_COPYRIGHT = Copyright © 2022 com.example. All rights reserved.


### PR DESCRIPTION
Took my brain overnight that it might be better to align these - I only changed some of them yesterday :)
Tested deploy to my Android phone and iOS simulator after a `flutter clean`