### PR TITLE
fix: building docker image for coordinator

### DIFF
--- a/.github/workflows/publish_docker.yml
+++ b/.github/workflows/publish_docker.yml
@@ -42,7 +42,7 @@ jobs:
           username: ${{ github.repository }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - run: cargo build --release
+      - run: cargo build --release --bin coordinator --target-dir ./target
 
       - uses: docker/metadata-action@v4
         id: meta


### PR DESCRIPTION
building the image was broken because of the introduction of a cargo workspace