### PR TITLE
Refactor: contract symbol instead of trading pair

### DIFF
--- a/mobile/lib/features/trade/contract_symbol_icon.dart
+++ b/mobile/lib/features/trade/contract_symbol_icon.dart
@@ -1,26 +1,33 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/svg.dart';
+import 'package:get_10101/features/trade/domain/contract_symbol.dart';
 
 class ContractSymbolIcon extends StatelessWidget {
   const ContractSymbolIcon(
       {this.height = 30.0,
       this.width = 30.0,
       this.paddingUsd = const EdgeInsets.only(left: 20.0),
-      super.key});
+      super.key,
+      this.contractSymbol = ContractSymbol.btcusd});
 
   final double width;
   final double height;
   final EdgeInsets paddingUsd;
+  final ContractSymbol contractSymbol;
 
   @override
   Widget build(BuildContext context) {
-    return Stack(children: [
-      Container(
-        padding: paddingUsd,
-        child:
-            SizedBox(height: height, width: width, child: SvgPicture.asset("assets/USD_logo.svg")),
-      ),
-      SizedBox(height: height, width: width, child: SvgPicture.asset("assets/Bitcoin_logo.svg")),
-    ]);
+    switch (contractSymbol) {
+      default:
+        return Stack(children: [
+          Container(
+            padding: paddingUsd,
+            child: SizedBox(
+                height: height, width: width, child: SvgPicture.asset("assets/USD_logo.svg")),
+          ),
+          SizedBox(
+              height: height, width: width, child: SvgPicture.asset("assets/Bitcoin_logo.svg")),
+        ]);
+    }
   }
 }

--- a/mobile/lib/features/trade/contract_symbol_icon.dart
+++ b/mobile/lib/features/trade/contract_symbol_icon.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/svg.dart';
 
-class BtcUsdTradingPairImage extends StatelessWidget {
-  const BtcUsdTradingPairImage(
+class ContractSymbolIcon extends StatelessWidget {
+  const ContractSymbolIcon(
       {this.height = 30.0,
       this.width = 30.0,
       this.paddingUsd = const EdgeInsets.only(left: 20.0),

--- a/mobile/lib/features/trade/domain/contract_symbol.dart
+++ b/mobile/lib/features/trade/domain/contract_symbol.dart
@@ -1,0 +1,5 @@
+enum ContractSymbol { btcusd }
+
+extension ContractSymbolExtension on ContractSymbol {
+  String get label => "${name.substring(0, 3).toUpperCase()}/${name.substring(3).toUpperCase()}";
+}

--- a/mobile/lib/features/trade/trade_bottom_sheet_confirmation.dart
+++ b/mobile/lib/features/trade/trade_bottom_sheet_confirmation.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:get_10101/common/amount_text.dart';
 import 'package:get_10101/common/domain/model.dart';
 import 'package:get_10101/common/value_data_row.dart';
-import 'package:get_10101/features/trade/btc_usd_trading_pair_image.dart';
+import 'package:get_10101/features/trade/contract_symbol_icon.dart';
 import 'package:get_10101/features/trade/domain/direction.dart';
 import 'package:get_10101/features/trade/domain/trade_values.dart';
 import 'package:get_10101/features/trade/submit_order_change_notifier.dart';
@@ -63,7 +63,7 @@ class TradeBottomSheetConfirmation extends StatelessWidget {
         padding: const EdgeInsets.all(20),
         child: Column(
           children: [
-            const BtcUsdTradingPairImage(),
+            const ContractSymbolIcon(),
             Text("Market ${direction.nameU}",
                 style: TextStyle(fontWeight: FontWeight.bold, fontSize: 17, color: color)),
             Center(

--- a/mobile/lib/features/trade/trade_screen.dart
+++ b/mobile/lib/features/trade/trade_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:get_10101/common/submission_status_dialog.dart';
 import 'package:get_10101/common/value_data_row.dart';
 import 'package:get_10101/features/trade/contract_symbol_icon.dart';
+import 'package:get_10101/features/trade/domain/contract_symbol.dart';
 import 'package:get_10101/features/trade/domain/direction.dart';
 import 'package:get_10101/features/trade/submit_order_change_notifier.dart';
 import 'package:get_10101/features/trade/trade_bottom_sheet.dart';
@@ -97,7 +98,7 @@ class TradeScreen extends StatelessWidget {
           child: Column(
             children: [
               Row(
-                children: const [ContractSymbolIcon(), Text("BTC/USD")],
+                children: [const ContractSymbolIcon(), Text(ContractSymbol.btcusd.label)],
               ),
               Column(
                 crossAxisAlignment: CrossAxisAlignment.stretch,

--- a/mobile/lib/features/trade/trade_screen.dart
+++ b/mobile/lib/features/trade/trade_screen.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:get_10101/common/submission_status_dialog.dart';
 import 'package:get_10101/common/value_data_row.dart';
-import 'package:get_10101/features/trade/btc_usd_trading_pair_image.dart';
+import 'package:get_10101/features/trade/contract_symbol_icon.dart';
 import 'package:get_10101/features/trade/domain/direction.dart';
 import 'package:get_10101/features/trade/submit_order_change_notifier.dart';
 import 'package:get_10101/features/trade/trade_bottom_sheet.dart';
@@ -97,7 +97,7 @@ class TradeScreen extends StatelessWidget {
           child: Column(
             children: [
               Row(
-                children: const [BtcUsdTradingPairImage(), Text("BTC/USD")],
+                children: const [ContractSymbolIcon(), Text("BTC/USD")],
               ),
               Column(
                 crossAxisAlignment: CrossAxisAlignment.stretch,

--- a/mobile/test/contract_symbol_test.dart
+++ b/mobile/test/contract_symbol_test.dart
@@ -1,0 +1,9 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get_10101/features/trade/domain/contract_symbol.dart';
+
+void main() {
+  test('Contract symbol label correct', () {
+    const contractSymbol = ContractSymbol.btcusd;
+    expect(contractSymbol.label, "BTC/USD");
+  });
+}


### PR DESCRIPTION
Introduce `ContractSymbol` in the UI and harmonize the name.

---

Not sure we want to open that can of worms again: Terminology.
At first I thought about opening a discussion, but I am not sure it's worth it. In the end we just have to agree what we use - I think there is no golden path here.

I opted for using `contract symbol` because that's what we agreed upon in the past.
Personally, I find `trading pair` more intuitive - because it does not limit us to "contracts" - but I'm happy roll with `contract symbol` for now.
