### PR TITLE
refactor: direction and position

### DIFF
--- a/mobile/ios/Runner/bridge_generated.h
+++ b/mobile/ios/Runner/bridge_generated.h
@@ -27,7 +27,7 @@ WireSyncReturn wire_calculate_margin(double price, double quantity, double lever
 
 WireSyncReturn wire_calculate_quantity(double price, uint64_t margin, double leverage);
 
-WireSyncReturn wire_calculate_liquidation_price(double price, double leverage, int32_t position);
+WireSyncReturn wire_calculate_liquidation_price(double price, double leverage, int32_t direction);
 
 void free_WireSyncReturn(WireSyncReturn ptr);
 

--- a/mobile/lib/features/trade/domain/direction.dart
+++ b/mobile/lib/features/trade/domain/direction.dart
@@ -1,14 +1,14 @@
-import '../../../bridge_generated/bridge_definitions.dart';
+import '../../../bridge_generated/bridge_definitions.dart' as rust;
 
-enum Direction { buy, sell }
+enum Direction { long, short }
 
 extension DirectionExt on Direction {
-  Position intoPosition() {
+  rust.Direction toApi() {
     switch (this) {
-      case Direction.buy:
-        return Position.Long;
-      case Direction.sell:
-        return Position.Short;
+      case Direction.long:
+        return rust.Direction.Long;
+      case Direction.short:
+        return rust.Direction.Short;
     }
   }
 

--- a/mobile/lib/features/trade/domain/trade_values.dart
+++ b/mobile/lib/features/trade/domain/trade_values.dart
@@ -1,6 +1,6 @@
 import 'package:get_10101/features/trade/domain/direction.dart';
 import 'package:get_10101/features/trade/domain/leverage.dart';
-import 'package:get_10101/ffi.dart';
+import 'package:get_10101/ffi.dart' as rust;
 import 'package:get_10101/common/domain/model.dart';
 
 class TradeValues {
@@ -30,10 +30,10 @@ class TradeValues {
       required double price,
       required double fundingRate,
       required Direction direction}) {
-    Amount margin =
-        Amount(api.calculateMargin(price: price, quantity: quantity, leverage: leverage.leverage));
-    double liquidationPrice = api.calculateLiquidationPrice(
-        price: price, leverage: leverage.leverage, position: direction.intoPosition());
+    Amount margin = Amount(
+        rust.api.calculateMargin(price: price, quantity: quantity, leverage: leverage.leverage));
+    double liquidationPrice = rust.api.calculateLiquidationPrice(
+        price: price, leverage: leverage.leverage, direction: direction.toApi());
 
     // TODO: Calculate fee based on price, quantity and funding rate
     Amount fee = Amount(30);
@@ -72,20 +72,20 @@ class TradeValues {
   }
 
   _recalculateMargin() {
-    Amount margin =
-        Amount(api.calculateMargin(price: price, quantity: quantity, leverage: leverage.leverage));
+    Amount margin = Amount(
+        rust.api.calculateMargin(price: price, quantity: quantity, leverage: leverage.leverage));
     this.margin = margin;
   }
 
   _recalculateQuantity() {
     double quantity =
-        api.calculateQuantity(price: price, margin: margin.sats, leverage: leverage.leverage);
+        rust.api.calculateQuantity(price: price, margin: margin.sats, leverage: leverage.leverage);
     this.quantity = quantity;
   }
 
   _recalculateLiquidationPrice() {
-    double liquidationPrice = api.calculateLiquidationPrice(
-        price: price, leverage: leverage.leverage, position: direction.intoPosition());
+    double liquidationPrice = rust.api.calculateLiquidationPrice(
+        price: price, leverage: leverage.leverage, direction: direction.toApi());
     this.liquidationPrice = liquidationPrice;
   }
 }

--- a/mobile/lib/features/trade/trade_bottom_sheet.dart
+++ b/mobile/lib/features/trade/trade_bottom_sheet.dart
@@ -53,13 +53,13 @@ class TradeBottomSheet extends StatelessWidget {
         tabs: const ["Buy", "Sell"],
         tabBarViewChildren: const [
           TradeBottomSheetTab(
-            direction: Direction.buy,
+            direction: Direction.long,
           ),
           TradeBottomSheetTab(
-            direction: Direction.sell,
+            direction: Direction.short,
           ),
         ],
-        selectedIndex: direction == Direction.buy ? 0 : 1,
+        selectedIndex: direction == Direction.long ? 0 : 1,
         topRightWidget: Row(
           children: [
             const Text(

--- a/mobile/lib/features/trade/trade_bottom_sheet_confirmation.dart
+++ b/mobile/lib/features/trade/trade_bottom_sheet_confirmation.dart
@@ -52,7 +52,7 @@ class TradeBottomSheetConfirmation extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     TradeTheme tradeTheme = Theme.of(context).extension<TradeTheme>()!;
-    Color color = direction == Direction.buy ? tradeTheme.buy : tradeTheme.sell;
+    Color color = direction == Direction.long ? tradeTheme.buy : tradeTheme.sell;
 
     TradeValues tradeValues =
         Provider.of<TradeValuesChangeNotifier>(context).fromDirection(direction);

--- a/mobile/lib/features/trade/trade_bottom_sheet_tab.dart
+++ b/mobile/lib/features/trade/trade_bottom_sheet_tab.dart
@@ -20,8 +20,8 @@ class TradeBottomSheetTab extends StatelessWidget {
   Widget build(BuildContext context) {
     TradeTheme tradeTheme = Theme.of(context).extension<TradeTheme>()!;
 
-    String label = direction == Direction.buy ? "Buy" : "Sell";
-    Color color = direction == Direction.buy ? tradeTheme.buy : tradeTheme.sell;
+    String label = direction == Direction.long ? "Buy" : "Sell";
+    Color color = direction == Direction.long ? tradeTheme.buy : tradeTheme.sell;
 
     TradeValuesChangeNotifier provider = context.read<TradeValuesChangeNotifier>();
 

--- a/mobile/lib/features/trade/trade_screen.dart
+++ b/mobile/lib/features/trade/trade_screen.dart
@@ -147,7 +147,7 @@ class TradeScreen extends StatelessWidget {
                   child: FloatingActionButton.extended(
                     heroTag: "btnBuy",
                     onPressed: () {
-                      tradeBottomSheet(context: context, direction: Direction.buy);
+                      tradeBottomSheet(context: context, direction: Direction.long);
                     },
                     label: const Text("Buy"),
                     shape: tradeButtonShape,
@@ -159,7 +159,7 @@ class TradeScreen extends StatelessWidget {
                   child: FloatingActionButton.extended(
                     heroTag: "btnSell",
                     onPressed: () {
-                      tradeBottomSheet(context: context, direction: Direction.sell);
+                      tradeBottomSheet(context: context, direction: Direction.short);
                     },
                     label: const Text("Sell"),
                     shape: tradeButtonShape,

--- a/mobile/lib/features/trade/trade_value_change_notifier.dart
+++ b/mobile/lib/features/trade/trade_value_change_notifier.dart
@@ -7,8 +7,8 @@ import 'domain/trade_values.dart';
 
 class TradeValuesChangeNotifier extends ChangeNotifier {
   // The trade values are represented as Order domain, because that's essentially what they are
-  final TradeValues _buyTradeValues = _initOrder(Direction.buy);
-  final TradeValues _sellTradeValues = _initOrder(Direction.sell);
+  final TradeValues _buyTradeValues = _initOrder(Direction.long);
+  final TradeValues _sellTradeValues = _initOrder(Direction.short);
 
   // TODO: Replace dummy price with price from backend
   // TODO: Get price from separate change notifier; might be able to use a proxy change notifiers
@@ -24,14 +24,14 @@ class TradeValuesChangeNotifier extends ChangeNotifier {
     double defaultLeverage = 2;
 
     switch (direction) {
-      case Direction.buy:
+      case Direction.long:
         return TradeValues.create(
             quantity: defaultQuantity,
             leverage: Leverage(defaultLeverage),
             price: ask,
             fundingRate: fundingRateBuy,
             direction: direction);
-      case Direction.sell:
+      case Direction.short:
         return TradeValues.create(
             quantity: defaultQuantity,
             leverage: Leverage(defaultLeverage),
@@ -57,5 +57,5 @@ class TradeValuesChangeNotifier extends ChangeNotifier {
   }
 
   TradeValues fromDirection(Direction direction) =>
-      direction == Direction.buy ? _buyTradeValues : _sellTradeValues;
+      direction == Direction.long ? _buyTradeValues : _sellTradeValues;
 }

--- a/mobile/native/src/api.rs
+++ b/mobile/native/src/api.rs
@@ -1,5 +1,5 @@
 use crate::api_calculations;
-use crate::api_model::Position;
+use crate::api_model::Direction;
 use crate::logger;
 use flutter_rust_bridge::StreamSink;
 use flutter_rust_bridge::SyncReturn;
@@ -24,9 +24,9 @@ pub fn calculate_quantity(price: f64, margin: u64, leverage: f64) -> SyncReturn<
 pub fn calculate_liquidation_price(
     price: f64,
     leverage: f64,
-    position: Position,
+    direction: Direction,
 ) -> SyncReturn<f64> {
     SyncReturn(api_calculations::calculate_liquidation_price(
-        price, leverage, position,
+        price, leverage, direction,
     ))
 }

--- a/mobile/native/src/api_calculations/mod.rs
+++ b/mobile/native/src/api_calculations/mod.rs
@@ -1,4 +1,4 @@
-use crate::api_model::Position;
+use crate::api_model::Direction;
 use bdk::bitcoin;
 use bdk::bitcoin::Denomination;
 use rust_decimal::prelude::ToPrimitive;
@@ -41,16 +41,16 @@ pub fn calculate_quantity(opening_price: f64, margin: u64, leverage: f64) -> f64
     quantity.to_f64().expect("quantity to fit into f64")
 }
 
-pub fn calculate_liquidation_price(price: f64, leverage: f64, position: Position) -> f64 {
+pub fn calculate_liquidation_price(price: f64, leverage: f64, direction: Direction) -> f64 {
     let initial_price = Decimal::try_from(price).expect("Price to fit");
 
     tracing::trace!("Initial price: {}", price);
 
     let leverage = Decimal::try_from(leverage).expect("leverage to fix into decimal");
 
-    let liquidation_price = match position {
-        Position::Long => calculate_long_liquidation_price(leverage, initial_price),
-        Position::Short => calculate_short_liquidation_price(leverage, initial_price),
+    let liquidation_price = match direction {
+        Direction::Long => calculate_long_liquidation_price(leverage, initial_price),
+        Direction::Short => calculate_short_liquidation_price(leverage, initial_price),
     };
 
     let liquidation_price = liquidation_price.to_f64().expect("price to fit into f64");

--- a/mobile/native/src/api_model/mod.rs
+++ b/mobile/native/src/api_model/mod.rs
@@ -9,7 +9,7 @@ pub enum ContractSymbol {
 
 #[frb]
 #[derive(Debug, Clone, Copy)]
-pub enum Position {
+pub enum Direction {
     Long,
     Short,
 }

--- a/mobile/native/src/api_model/order.rs
+++ b/mobile/native/src/api_model/order.rs
@@ -1,5 +1,5 @@
 use crate::api_model::ContractSymbol;
-use crate::api_model::Position;
+use crate::api_model::Direction;
 use flutter_rust_bridge::frb;
 
 #[frb]
@@ -14,5 +14,5 @@ pub struct MarketOrder {
     #[frb(non_final)]
     pub contract_symbol: ContractSymbol,
     #[frb(non_final)]
-    pub position: Position,
+    pub direction: Direction,
 }


### PR DESCRIPTION
Order with direction buy or sell; we can either buy or sell with an order - which adds or reduces a position. 
If a position is "negative" it is a short position, if a position is positive it is a long position.

note on the specific PR: It is disputable what the calculation API for the liquidation price should expose, but since we are only using it in the context of order value calculations I opted for exposing `Direction` and map to position in the API. This is a small implementation detail.

---

When introducing `Order` I had a hard time using `Position` in it - it just does not make sense. We have `buy` and `sell` orders. For me the order indicates the *action* of buying or selling something - to either add to or reduce the position. 

But once we have a position and we are "exposed to the market" we are either long or short; where short could be regarded as negative and long as positive. Buy buying and selling we are adding or reducing the position.

For me, once we have a position, `Long` and `Short` is more relatable, and not `buy` and `sell`. But essentially this is the same, so if we want to use just `Direction` throughout that's fine with me.