### PR TITLE
Add test that clicks through the buy process until the order is submitted

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,3 +77,5 @@ jobs:
         run: just gen
       - name: Running cargo tests
         run: cargo test
+      - name: Running flutter tests
+        run: just flutter-test

--- a/.gitignore
+++ b/.gitignore
@@ -19,5 +19,8 @@ bridge_generated.h
 mobile/android/app/src/main/jniLibs/
 mobile/ios/Runner/libnative.a
 
+# generated files by mockito flutter package
+/mobile/test/*.mocks.dart
+
 #ignore keystores
 *.jks

--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ It is also important to run the following to generate the Flutter-Rust glue code
 just gen
 ```
 
+## Mobile App
+
 ### Run the mobile-app natively (on your Linux/MacOS/other OS)
 
 ```bash
@@ -72,6 +74,26 @@ just ios
 ```bash
 just run
 ```
+
+### Mobile Tests
+
+The flutter project contains flutter tests and tests in the native rust backend of the mobile app.
+
+Run the flutter tests:
+
+```
+just flutter-test
+```
+
+Note that this command takes care of re-generating the generated [`mockito`](https://pub.dev/packages/mockito) mocks before running the test.
+
+Run the native rust backend tests:
+
+```
+just native-test
+```
+
+## Coordinator
 
 ### Run the coordinator
 

--- a/justfile
+++ b/justfile
@@ -79,4 +79,12 @@ alias c := coordinator
 coordinator:
     cd coordinator && cargo run
 
+flutter-test:
+    cd mobile && flutter pub run build_runner build && flutter test
+
+native-test:
+    cd mobile/native
+
+test: flutter-test native-test
+
 # vim:expandtab:sw=4:ts=4

--- a/mobile/lib/features/trade/application/trade_values_service.dart
+++ b/mobile/lib/features/trade/application/trade_values_service.dart
@@ -1,0 +1,27 @@
+import 'package:get_10101/ffi.dart' as rust;
+import 'package:get_10101/features/trade/domain/leverage.dart';
+import '../../../common/domain/model.dart';
+import '../domain/direction.dart';
+
+class TradeValuesService {
+  Amount calculateMargin(
+      {required double price, required double quantity, required Leverage leverage, dynamic hint}) {
+    return Amount(
+        rust.api.calculateMargin(price: price, quantity: quantity, leverage: leverage.leverage));
+  }
+
+  double calculateQuantity(
+      {required double price, required Amount margin, required Leverage leverage, dynamic hint}) {
+    return rust.api
+        .calculateQuantity(price: price, margin: margin.sats, leverage: leverage.leverage);
+  }
+
+  double calculateLiquidationPrice(
+      {required double price,
+      required Leverage leverage,
+      required Direction direction,
+      dynamic hint}) {
+    return rust.api.calculateLiquidationPrice(
+        price: price, leverage: leverage.leverage, direction: direction.toApi());
+  }
+}

--- a/mobile/lib/features/trade/domain/direction.dart
+++ b/mobile/lib/features/trade/domain/direction.dart
@@ -23,4 +23,13 @@ enum Direction {
   }
 
   String get nameU => "${name[0].toUpperCase()}${name.substring(1).toLowerCase()}";
+
+  String get keySuffix {
+    switch (this) {
+      case Direction.long:
+        return "long";
+      case Direction.short:
+        return "short";
+    }
+  }
 }

--- a/mobile/lib/features/trade/order_change_notifier.dart
+++ b/mobile/lib/features/trade/order_change_notifier.dart
@@ -3,13 +3,11 @@ import 'package:get_10101/features/trade/application/order_service.dart';
 import 'package:get_10101/features/trade/domain/order.dart';
 
 class OrderChangeNotifier extends ChangeNotifier {
-  final OrderService orderService = OrderService();
-
+  final OrderService orderService;
   List<Order> orders = List.empty();
 
-  OrderChangeNotifier init() {
+  OrderChangeNotifier(this.orderService) {
     updateOrders();
-    return this;
   }
 
   updateOrders() async {

--- a/mobile/lib/features/trade/submit_order_change_notifier.dart
+++ b/mobile/lib/features/trade/submit_order_change_notifier.dart
@@ -19,9 +19,10 @@ class PendingOrder {
 }
 
 class SubmitOrderChangeNotifier extends ChangeNotifier {
-  final OrderService orderService = OrderService();
-
+  final OrderService orderService;
   PendingOrder? _pendingOrder;
+
+  SubmitOrderChangeNotifier(this.orderService);
 
   submitPendingOrder(TradeValues tradeValues) async {
     _pendingOrder = PendingOrder(tradeValues);

--- a/mobile/lib/features/trade/trade_bottom_sheet.dart
+++ b/mobile/lib/features/trade/trade_bottom_sheet.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:get_10101/features/trade/domain/direction.dart';
 import 'package:get_10101/features/trade/trade_bottom_sheet_tab.dart';
 import 'package:get_10101/features/trade/trade_tabs.dart';
+import 'package:get_10101/util/constants.dart';
 
 tradeBottomSheet({required BuildContext context, required Direction direction}) {
   showModalBottomSheet<void>(
@@ -41,8 +42,9 @@ tradeBottomSheet({required BuildContext context, required Direction direction}) 
 }
 
 class TradeBottomSheet extends StatelessWidget {
-  const TradeBottomSheet({required this.direction, super.key});
   final Direction direction;
+
+  const TradeBottomSheet({required this.direction, super.key});
 
   @override
   Widget build(BuildContext context) {
@@ -51,12 +53,15 @@ class TradeBottomSheet extends StatelessWidget {
       child: TradeTabs(
         tabBarPadding: const EdgeInsets.only(bottom: 10.0),
         tabs: const ["Buy", "Sell"],
+        keys: const [tradeScreenBottomSheetTabsBuy, tradeScreenBottomSheetTabsSell],
         tabBarViewChildren: const [
           TradeBottomSheetTab(
             direction: Direction.long,
+            buttonKey: tradeScreenBottomSheetButtonBuy,
           ),
           TradeBottomSheetTab(
             direction: Direction.short,
+            buttonKey: tradeScreenBottomSheetButtonSell,
           ),
         ],
         selectedIndex: direction == Direction.long ? 0 : 1,

--- a/mobile/lib/features/trade/trade_bottom_sheet_confirmation.dart
+++ b/mobile/lib/features/trade/trade_bottom_sheet_confirmation.dart
@@ -8,11 +8,20 @@ import 'package:get_10101/features/trade/domain/trade_values.dart';
 import 'package:get_10101/features/trade/submit_order_change_notifier.dart';
 import 'package:get_10101/features/trade/trade_theme.dart';
 import 'package:get_10101/features/trade/trade_value_change_notifier.dart';
+import 'package:get_10101/util/constants.dart';
 import 'package:go_router/go_router.dart';
 import 'package:provider/provider.dart';
 import 'package:slide_to_confirm/slide_to_confirm.dart';
 
 tradeBottomSheetConfirmation({required BuildContext context, required Direction direction}) {
+  final sliderKey = direction == Direction.long
+      ? tradeScreenBottomSheetConfirmationSliderBuy
+      : tradeScreenBottomSheetConfirmationSliderSell;
+
+  final sliderButtonKey = direction == Direction.long
+      ? tradeScreenBottomSheetConfirmationSliderButtonBuy
+      : tradeScreenBottomSheetConfirmationSliderButtonSell;
+
   showModalBottomSheet<void>(
     shape: const RoundedRectangleBorder(
       borderRadius: BorderRadius.vertical(
@@ -37,7 +46,13 @@ tradeBottomSheetConfirmation({required BuildContext context, required Direction 
                 currentFocus.unfocus();
               }
             },
-            child: SizedBox(height: 350, child: TradeBottomSheetConfirmation(direction: direction)),
+            child: SizedBox(
+                height: 350,
+                child: TradeBottomSheetConfirmation(
+                  direction: direction,
+                  sliderButtonKey: sliderButtonKey,
+                  sliderKey: sliderKey,
+                )),
           ),
         ),
       );
@@ -46,8 +61,12 @@ tradeBottomSheetConfirmation({required BuildContext context, required Direction 
 }
 
 class TradeBottomSheetConfirmation extends StatelessWidget {
-  const TradeBottomSheetConfirmation({required this.direction, super.key});
   final Direction direction;
+  final Key sliderKey;
+  final Key sliderButtonKey;
+
+  const TradeBottomSheetConfirmation(
+      {required this.direction, super.key, required this.sliderButtonKey, required this.sliderKey});
 
   @override
   Widget build(BuildContext context) {
@@ -69,7 +88,6 @@ class TradeBottomSheetConfirmation extends StatelessWidget {
             Center(
               child: Container(
                 padding: const EdgeInsets.symmetric(vertical: 10),
-                width: 250,
                 child: Column(
                   children: [
                     Wrap(
@@ -109,14 +127,18 @@ class TradeBottomSheetConfirmation extends StatelessWidget {
             ),
             const Spacer(),
             ConfirmationSlider(
+              key: sliderKey,
               text: "Swipe to confirm ${direction.nameU}",
               textStyle: TextStyle(color: color),
               height: 40,
               foregroundColor: color,
-              sliderButtonContent: const Icon(
-                Icons.chevron_right,
-                color: Colors.white,
-                size: 20,
+              sliderButtonContent: Container(
+                key: sliderButtonKey,
+                child: const Icon(
+                  Icons.chevron_right,
+                  color: Colors.white,
+                  size: 20,
+                ),
               ),
               onConfirmation: () async {
                 context.read<SubmitOrderChangeNotifier>().submitPendingOrder(tradeValues);

--- a/mobile/lib/features/trade/trade_bottom_sheet_tab.dart
+++ b/mobile/lib/features/trade/trade_bottom_sheet_tab.dart
@@ -13,8 +13,10 @@ import 'package:get_10101/features/trade/trade_theme.dart';
 import 'package:provider/provider.dart';
 
 class TradeBottomSheetTab extends StatelessWidget {
-  const TradeBottomSheetTab({required this.direction, super.key});
   final Direction direction;
+  final Key buttonKey;
+
+  const TradeBottomSheetTab({required this.direction, super.key, required this.buttonKey});
 
   @override
   Widget build(BuildContext context) {
@@ -146,6 +148,7 @@ class TradeBottomSheetTab extends StatelessWidget {
           crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
             ElevatedButton(
+                key: buttonKey,
                 onPressed: () {
                   tradeBottomSheetConfirmation(context: context, direction: direction);
                 },

--- a/mobile/lib/features/trade/trade_screen.dart
+++ b/mobile/lib/features/trade/trade_screen.dart
@@ -12,6 +12,7 @@ import 'package:get_10101/features/trade/candlestick_chart.dart';
 import 'package:get_10101/features/trade/trade_tabs.dart';
 import 'package:get_10101/features/trade/trade_theme.dart';
 import 'package:provider/provider.dart';
+import 'package:get_10101/util/constants.dart';
 
 class TradeScreen extends StatelessWidget {
   static const route = "/trade";
@@ -113,6 +114,7 @@ class TradeScreen extends StatelessWidget {
                     "Positions",
                     "Orders",
                   ],
+                  keys: const [tradeScreenTabsPositions, tradeScreenTabsOrders],
                   tabBarViewChildren: [
                     ListView.builder(
                       shrinkWrap: true,
@@ -147,6 +149,7 @@ class TradeScreen extends StatelessWidget {
               SizedBox(
                   width: tradeButtonWidth,
                   child: FloatingActionButton.extended(
+                    key: tradeScreenButtonBuy,
                     heroTag: "btnBuy",
                     onPressed: () {
                       tradeBottomSheet(context: context, direction: Direction.long);
@@ -159,6 +162,7 @@ class TradeScreen extends StatelessWidget {
               SizedBox(
                   width: tradeButtonWidth,
                   child: FloatingActionButton.extended(
+                    key: tradeScreenButtonSell,
                     heroTag: "btnSell",
                     onPressed: () {
                       tradeBottomSheet(context: context, direction: Direction.short);

--- a/mobile/lib/features/trade/trade_tabs.dart
+++ b/mobile/lib/features/trade/trade_tabs.dart
@@ -3,6 +3,7 @@ import 'package:get_10101/features/trade/trade_theme.dart';
 
 class TradeTabs extends StatelessWidget {
   final List<String> tabs;
+  final List<Key> keys;
   final List<Widget> tabBarViewChildren;
 
   /// Offset that is added to the label based on the longest tab label text.
@@ -18,6 +19,7 @@ class TradeTabs extends StatelessWidget {
 
   const TradeTabs(
       {required this.tabs,
+      required this.keys,
       required this.tabBarViewChildren,
       this.tabLabelPadding = const EdgeInsets.symmetric(horizontal: 3.0, vertical: 3.0),
       this.tabBarPadding = const EdgeInsets.symmetric(vertical: 10.0),
@@ -31,6 +33,7 @@ class TradeTabs extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     assert(tabs.length == tabBarViewChildren.length);
+    assert(tabs.length == keys.length);
 
     TradeTheme tradeTheme = Theme.of(context).extension<TradeTheme>()!;
 
@@ -74,22 +77,26 @@ class TradeTabs extends StatelessWidget {
                       unselectedLabelColor: tradeTheme.tabColor,
                       indicator:
                           BoxDecoration(borderRadius: tabBorderRadius, color: tradeTheme.tabColor),
-                      tabs: tabs
-                          .map((label) => Container(
-                                width: tabWidth,
-                                padding: tabLabelPadding,
-                                decoration: BoxDecoration(
-                                    borderRadius: tabBorderRadius,
-                                    border: Border.all(color: tradeTheme.tabColor, width: 1)),
-                                child: Align(
-                                  alignment: Alignment.center,
-                                  child: Text(
-                                    label,
-                                    style: textStyle,
-                                  ),
-                                ),
-                              ))
-                          .toList()),
+                      tabs: tabs.asMap().entries.map((entry) {
+                        int index = entry.key;
+                        String label = entry.value;
+
+                        return Container(
+                          key: keys[index],
+                          width: tabWidth,
+                          padding: tabLabelPadding,
+                          decoration: BoxDecoration(
+                              borderRadius: tabBorderRadius,
+                              border: Border.all(color: tradeTheme.tabColor, width: 1)),
+                          child: Align(
+                            alignment: Alignment.center,
+                            child: Text(
+                              label,
+                              style: textStyle,
+                            ),
+                          ),
+                        );
+                      }).toList()),
                   if (topRightWidget != null) topRightWidget!,
                 ],
               ),

--- a/mobile/lib/features/trade/trade_value_change_notifier.dart
+++ b/mobile/lib/features/trade/trade_value_change_notifier.dart
@@ -1,14 +1,17 @@
 import 'package:flutter/material.dart';
 import 'package:get_10101/common/domain/model.dart';
+import 'package:get_10101/features/trade/application/trade_values_service.dart';
 import 'package:get_10101/features/trade/domain/direction.dart';
 import 'package:get_10101/features/trade/domain/leverage.dart';
 
 import 'domain/trade_values.dart';
 
 class TradeValuesChangeNotifier extends ChangeNotifier {
+  final TradeValuesService tradeValuesService;
+
   // The trade values are represented as Order domain, because that's essentially what they are
-  final TradeValues _buyTradeValues = _initOrder(Direction.long);
-  final TradeValues _sellTradeValues = _initOrder(Direction.short);
+  late final TradeValues _buyTradeValues;
+  late final TradeValues _sellTradeValues;
 
   // TODO: Replace dummy price with price from backend
   // TODO: Get price from separate change notifier; might be able to use a proxy change notifiers
@@ -19,7 +22,12 @@ class TradeValuesChangeNotifier extends ChangeNotifier {
   static const double fundingRateBuy = 0.003;
   static const double fundingRateSell = -0.003;
 
-  static TradeValues _initOrder(Direction direction) {
+  TradeValuesChangeNotifier(this.tradeValuesService) {
+    _buyTradeValues = _initOrder(Direction.long);
+    _sellTradeValues = _initOrder(Direction.short);
+  }
+
+  TradeValues _initOrder(Direction direction) {
     double defaultQuantity = 100;
     double defaultLeverage = 2;
 
@@ -30,14 +38,16 @@ class TradeValuesChangeNotifier extends ChangeNotifier {
             leverage: Leverage(defaultLeverage),
             price: ask,
             fundingRate: fundingRateBuy,
-            direction: direction);
+            direction: direction,
+            tradeValuesService: tradeValuesService);
       case Direction.short:
         return TradeValues.create(
             quantity: defaultQuantity,
             leverage: Leverage(defaultLeverage),
             price: bid,
             fundingRate: fundingRateSell,
-            direction: direction);
+            direction: direction,
+            tradeValuesService: tradeValuesService);
     }
   }
 

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -4,6 +4,7 @@ import 'package:flutter/foundation.dart' as foundation;
 import 'package:flutter_native_splash/flutter_native_splash.dart';
 import 'package:flutter_rust_bridge/flutter_rust_bridge.dart';
 import 'package:get_10101/features/trade/application/order_service.dart';
+import 'package:get_10101/features/trade/application/trade_values_service.dart';
 import 'package:get_10101/features/trade/order_change_notifier.dart';
 import 'package:get_10101/features/trade/submit_order_change_notifier.dart';
 import 'package:get_10101/features/trade/trade_value_change_notifier.dart';
@@ -14,6 +15,7 @@ import 'package:get_10101/features/wallet/scanner_screen.dart';
 import 'package:get_10101/features/wallet/send_screen.dart';
 import 'package:get_10101/features/wallet/settings_screen.dart';
 import 'package:get_10101/common/app_bar_wrapper.dart';
+import 'package:get_10101/util/constants.dart';
 import 'package:go_router/go_router.dart';
 import 'package:provider/provider.dart';
 import 'common/amount_denomination_change_notifier.dart';
@@ -33,10 +35,10 @@ void main() {
 
   FLog.applyConfigurations(config);
   runApp(MultiProvider(providers: [
-    ChangeNotifierProvider(create: (context) => TradeValuesChangeNotifier()),
+    ChangeNotifierProvider(create: (context) => TradeValuesChangeNotifier(TradeValuesService())),
     ChangeNotifierProvider(create: (context) => AmountDenominationChangeNotifier()),
-    ChangeNotifierProvider(create: (context) => SubmitOrderChangeNotifier()),
-    ChangeNotifierProvider(create: (context) => OrderChangeNotifier().init()),
+    ChangeNotifierProvider(create: (context) => SubmitOrderChangeNotifier(OrderService())),
+    ChangeNotifierProvider(create: (context) => OrderChangeNotifier(OrderService())),
   ], child: const TenTenOneApp()));
 }
 
@@ -183,13 +185,13 @@ class ScaffoldWithNavBar extends StatelessWidget {
       appBar: const PreferredSize(
           preferredSize: Size.fromHeight(40), child: SafeArea(child: AppBarWrapper())),
       bottomNavigationBar: BottomNavigationBar(
-        items: const <BottomNavigationBarItem>[
+        items: <BottomNavigationBarItem>[
           BottomNavigationBarItem(
-            icon: Icon(Icons.wallet),
+            icon: Container(key: tabWallet, child: const Icon(Icons.wallet)),
             label: WalletScreen.label,
           ),
           BottomNavigationBarItem(
-            icon: Icon(Icons.bar_chart),
+            icon: Container(key: tabTrade, child: const Icon(Icons.bar_chart)),
             label: TradeScreen.label,
           ),
         ],

--- a/mobile/lib/util/constants.dart
+++ b/mobile/lib/util/constants.dart
@@ -1,0 +1,56 @@
+// This file contains global constants.
+// Note that global constants should only be use sparingly.
+// They make sense for e.g. keys to identify widgets for testing.
+// Hint: If you want to define a color it is recommended to use extend a Theme rather than adding a constant.
+
+import 'package:flutter/material.dart';
+
+// ############################################################################
+// Common keys
+
+const _tabs = "tabs/";
+const _button = "button/";
+const _slider = "slider/";
+
+// ############################################################################
+// Main keys
+
+const _wallet = "wallet/";
+const _trade = "trade/";
+
+// path on screen
+
+const _bottomSheet = "bottom_sheet/";
+const _confirmSheet = "confirm/";
+
+// concrete selectors
+
+const _buy = "buy";
+const _sell = "sell";
+const _positions = "positions";
+const _orders = "orders";
+
+const tradeScreenTabsOrders = Key(_trade + _tabs + _orders);
+const tradeScreenTabsPositions = Key(_trade + _tabs + _positions);
+
+const tradeScreenButtonBuy = Key(_trade + _button + _buy);
+const tradeScreenButtonSell = Key(_trade + _button + _sell);
+
+const tradeScreenBottomSheetTabsBuy = Key(_trade + _bottomSheet + _tabs + _buy);
+const tradeScreenBottomSheetTabsSell = Key(_trade + _bottomSheet + _tabs + _sell);
+
+const tradeScreenBottomSheetButtonBuy = Key(_trade + _bottomSheet + _button + _buy);
+const tradeScreenBottomSheetButtonSell = Key(_trade + _bottomSheet + _button + _sell);
+
+const tradeScreenBottomSheetConfirmationSliderBuy =
+    Key(_trade + _bottomSheet + _confirmSheet + _slider + _buy);
+const tradeScreenBottomSheetConfirmationSliderSell =
+    Key(_trade + _bottomSheet + _confirmSheet + _slider + _sell);
+
+const tradeScreenBottomSheetConfirmationSliderButtonBuy =
+    Key(_trade + _bottomSheet + _confirmSheet + _slider + _button + _buy);
+const tradeScreenBottomSheetConfirmationSliderButtonSell =
+    Key(_trade + _bottomSheet + _confirmSheet + _slider + _button + _sell);
+
+const tabWallet = Key(_tabs + _wallet);
+const tabTrade = Key(_tabs + _trade);

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -504,6 +504,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.4"
+  mockito:
+    dependency: "direct dev"
+    description:
+      name: mockito
+      sha256: "2a8a17b82b1bde04d514e75d90d634a0ac23f6cb4991f6098009dd56836aeafe"
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.3.2"
   nested:
     dependency: transitive
     description:

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -31,6 +31,7 @@ dev_dependencies:
   ffigen: ^7.2.4
   freezed: ^2.2.1
   build_runner: ^2.2.0
+  mockito: ^5.3.2
 
 flutter:
   uses-material-design: true

--- a/mobile/test/trade_test.dart
+++ b/mobile/test/trade_test.dart
@@ -1,0 +1,110 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get_10101/common/amount_denomination_change_notifier.dart';
+import 'package:get_10101/common/domain/model.dart';
+import 'package:get_10101/features/trade/order_change_notifier.dart';
+import 'package:get_10101/features/trade/submit_order_change_notifier.dart';
+import 'package:get_10101/features/trade/trade_screen.dart';
+import 'package:get_10101/features/trade/trade_theme.dart';
+import 'package:get_10101/features/trade/trade_value_change_notifier.dart';
+import 'package:get_10101/util/constants.dart';
+import 'package:go_router/go_router.dart';
+import 'package:mockito/annotations.dart';
+import 'package:mockito/mockito.dart';
+import 'package:provider/provider.dart';
+
+@GenerateNiceMocks([MockSpec<TradeValuesService>()])
+import 'package:get_10101/features/trade/application/trade_values_service.dart';
+
+@GenerateNiceMocks([MockSpec<OrderService>()])
+import 'package:get_10101/features/trade/application/order_service.dart';
+
+import 'trade_test.mocks.dart';
+
+final GoRouter _router = GoRouter(
+  initialLocation: TradeScreen.route,
+  routes: [
+    GoRoute(
+        path: TradeScreen.route,
+        builder: (BuildContext context, GoRouterState state) {
+          return const TradeScreen();
+        }),
+  ],
+);
+
+class TestWrapperWithTradeTheme extends StatelessWidget {
+  final Widget child;
+  const TestWrapperWithTradeTheme({super.key, required this.child});
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp.router(
+      // TODO: We could consider using the Navigator instead of GoRouter to close the bottom sheet again
+      // Need GoRouter otherwise closing the bottom sheet after confirmation fails
+      routerConfig: _router,
+      theme: ThemeData(
+        primarySwatch: Colors.blue,
+        extensions: const <ThemeExtension<dynamic>>[
+          // Need the trade theme otherwise the trade widgets that rely on it can't find it on the context and fail to render
+          TradeTheme(),
+        ],
+      ),
+    );
+  }
+}
+
+void main() {
+  testWidgets('Given trade screen when completing buy flow then market order is submitted',
+      (tester) async {
+    MockOrderService orderService = MockOrderService();
+    MockTradeValuesService tradeValueService = MockTradeValuesService();
+
+    // TODO: we could make this more resilient in the underlying components...
+    // return dummies otherwise the fields won't be initialized correctly
+    when(tradeValueService.calculateMargin(
+            price: anyNamed('price'),
+            quantity: anyNamed('quantity'),
+            leverage: anyNamed('leverage')))
+        .thenReturn(Amount(2000));
+    when(tradeValueService.calculateLiquidationPrice(
+            price: anyNamed('price'),
+            leverage: anyNamed('leverage'),
+            direction: anyNamed('direction')))
+        .thenReturn(10000);
+    when(tradeValueService.calculateQuantity(
+            price: anyNamed('price'), leverage: anyNamed('leverage'), margin: anyNamed('margin')))
+        .thenReturn(100);
+
+    SubmitOrderChangeNotifier submitOrderChangeNotifier = SubmitOrderChangeNotifier(orderService);
+
+    await tester.pumpWidget(MultiProvider(providers: [
+      ChangeNotifierProvider(create: (context) => TradeValuesChangeNotifier(tradeValueService)),
+      ChangeNotifierProvider(create: (context) => submitOrderChangeNotifier),
+      ChangeNotifierProvider(create: (context) => OrderChangeNotifier(orderService)),
+      ChangeNotifierProvider(create: (context) => AmountDenominationChangeNotifier()),
+    ], child: const TestWrapperWithTradeTheme(child: TradeScreen())));
+
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(tradeScreenButtonBuy), findsOneWidget);
+
+    // Open bottom sheet
+    await tester.tap(find.byKey(tradeScreenButtonBuy));
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(tradeScreenBottomSheetButtonBuy), findsOneWidget);
+
+    // click buy button in bottom sheet
+    await tester.tap(find.byKey(tradeScreenBottomSheetButtonBuy));
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(tradeScreenBottomSheetConfirmationSliderButtonBuy), findsOneWidget);
+
+    // TODO: This is not optimal because if we re-style the component this test will likely break.
+    // Drag to confirm
+    await tester.timedDrag(find.byKey(tradeScreenBottomSheetConfirmationSliderButtonBuy),
+        const Offset(275, 0), const Duration(seconds: 2),
+        pointer: 7);
+
+    verify(orderService.submitMarketOrder(any, any, any, any)).called(1);
+  });
+}

--- a/mobile/test/widget_test.dart
+++ b/mobile/test/widget_test.dart
@@ -1,6 +1,0 @@
-// import 'package:flutter/material.dart';
-// import 'package:flutter_test/flutter_test.dart';
-
-void main() {
-  // Your tests go here.
-}


### PR DESCRIPTION
I am not sure how valuable the test itself is - I will likely do another iteration on that.
The test passes and I think all the other work is valuable to go in; so I thought I'll open a PR now and potentially iterate once merged, so we have a "template" :)

This PR shows how to:

- use keys to identify widgets for testing
- use mockito to mock services
- how proper encapsulation is important for testing - with moving the rust API calcs into a dedicated service we are able to mock it