### PR TITLE
Introduce missing order execution price into the model

### DIFF
--- a/mobile/lib/features/trade/domain/order.dart
+++ b/mobile/lib/features/trade/domain/order.dart
@@ -41,6 +41,7 @@ class Order {
   final Direction direction;
   final OrderState status;
   final OrderType type;
+  final double? executionPrice;
 
   Order(
       {required this.leverage,
@@ -48,7 +49,8 @@ class Order {
       required this.contractSymbol,
       required this.direction,
       required this.status,
-      required this.type}) {
+      required this.type,
+      this.executionPrice}) {
     id = const Uuid().v4();
   }
 
@@ -59,7 +61,8 @@ class Order {
         contractSymbol: ContractSymbol.fromApi(order.contractSymbol),
         direction: Direction.fromApi(order.direction),
         status: OrderState.fromApi(order.status),
-        type: OrderType.fromApi(order.orderType));
+        type: OrderType.fromApi(order.orderType),
+        executionPrice: order.executionPrice);
   }
 
   static bridge.Order apiDummy() {

--- a/mobile/native/src/trade/order/handler.rs
+++ b/mobile/native/src/trade/order/handler.rs
@@ -35,7 +35,9 @@ pub async fn get_order(id: String) -> Result<OrderTrade> {
         contract_symbol: ContractSymbolTrade::BtcUsd,
         direction: DirectionTrade::Long,
         order_type: OrderTypeTrade::Market,
-        status: OrderStateTrade::Filled,
+        status: OrderStateTrade::Filled {
+            execution_price: 25000.0,
+        },
     };
 
     Ok(dummy_order)
@@ -51,7 +53,9 @@ pub async fn get_orders() -> Result<Vec<OrderTrade>> {
         contract_symbol: ContractSymbolTrade::BtcUsd,
         direction: DirectionTrade::Long,
         order_type: OrderTypeTrade::Market,
-        status: OrderStateTrade::Filled,
+        status: OrderStateTrade::Filled {
+            execution_price: 25000.0,
+        },
     };
 
     Ok(vec![dummy_order])

--- a/mobile/native/src/trade/order/mod.rs
+++ b/mobile/native/src/trade/order/mod.rs
@@ -51,7 +51,10 @@ pub enum OrderStateTrade {
     /// the order is reflected in a position. Note that only complete filling is supported,
     /// partial filling not depicted yet.
     /// This is a final state
-    Filled,
+    Filled {
+        /// The execution price that the order was filled with
+        execution_price: f64,
+    },
 }
 
 #[derive(Debug, Clone, Copy)]


### PR DESCRIPTION
Once we execute an order we know the execution price and have to keep it around.

- In rust business logic is makes sense to depict this as falue on the `Filled` enum variant.
- For the `Order` exposed on the API I opted for a nullable fields, because complex enum variants are not fun to be mapped into Dart.