### PR TITLE
Position user interface and simulation dummies in rust

### DIFF
--- a/mobile/lib/common/value_data_row.dart
+++ b/mobile/lib/common/value_data_row.dart
@@ -3,14 +3,22 @@ import 'package:flutter/material.dart';
 import 'amount_text.dart';
 import 'fiat_text.dart';
 
-enum ValueType { amount, fiat, percentage }
+enum ValueType { amount, fiat, percentage, contracts }
 
 class ValueDataRow extends StatelessWidget {
   final ValueType type;
   final String label;
   final dynamic value;
+  final TextStyle valueTextStyle;
+  final TextStyle labelTextStyle;
 
-  const ValueDataRow({super.key, required this.type, required this.value, required this.label});
+  const ValueDataRow(
+      {super.key,
+      required this.type,
+      required this.value,
+      required this.label,
+      this.valueTextStyle = const TextStyle(),
+      this.labelTextStyle = const TextStyle()});
 
   @override
   Widget build(BuildContext context) {
@@ -18,19 +26,31 @@ class ValueDataRow extends StatelessWidget {
 
     switch (type) {
       case ValueType.amount:
-        widget = AmountText(amount: value);
+        widget = AmountText(
+          amount: value,
+          textStyle: valueTextStyle,
+        );
         break;
       case ValueType.fiat:
-        widget = FiatText(amount: value);
+        widget = FiatText(amount: value, textStyle: valueTextStyle);
         break;
       case ValueType.percentage:
-        widget = Text("$value %");
+        widget = Text("$value %", style: valueTextStyle);
+        break;
+      case ValueType.contracts:
+        widget = Text("$value contracts", style: valueTextStyle);
         break;
     }
 
     return Row(
       mainAxisAlignment: MainAxisAlignment.spaceBetween,
-      children: [Text(label), widget],
+      children: [
+        Text(
+          label,
+          style: labelTextStyle,
+        ),
+        widget
+      ],
     );
   }
 }

--- a/mobile/lib/features/trade/application/position_service.dart
+++ b/mobile/lib/features/trade/application/position_service.dart
@@ -1,0 +1,11 @@
+import 'package:get_10101/features/trade/domain/position.dart';
+import 'package:get_10101/ffi.dart' as rust;
+
+class PositionService {
+  Future<List<Position>> fetchPositions() async {
+    List<rust.Position> apiPositions = await rust.api.getPositions();
+    List<Position> positions = apiPositions.map((position) => Position.fromApi(position)).toList();
+
+    return positions;
+  }
+}

--- a/mobile/lib/features/trade/domain/position.dart
+++ b/mobile/lib/features/trade/domain/position.dart
@@ -2,12 +2,22 @@ import 'package:get_10101/features/trade/domain/contract_symbol.dart';
 import 'package:get_10101/features/trade/domain/direction.dart';
 import 'package:get_10101/features/trade/domain/leverage.dart';
 import 'package:get_10101/common/domain/model.dart';
+import 'package:get_10101/bridge_generated/bridge_definitions.dart' as bridge;
 
 enum PositionState {
   open,
 
   /// once the user pressed button to close position the button should be disabled otherwise the user can click it multiple times which would result in multiple orders and an open position in the other direction
-  closing
+  closing;
+
+  static PositionState fromApi(bridge.PositionState positionState) {
+    switch (positionState) {
+      case bridge.PositionState.Open:
+        return PositionState.open;
+      case bridge.PositionState.Closing:
+        return PositionState.closing;
+    }
+  }
 }
 
 class Position {
@@ -17,7 +27,7 @@ class Position {
   final Direction direction;
   final double averageEntryPrice;
   final double liquidationPrice;
-  final Amount unrealizedPnL;
+  final Amount unrealizedPnl;
   final PositionState positionState;
 
   Position(
@@ -28,5 +38,29 @@ class Position {
       required this.contractSymbol,
       required this.direction,
       required this.positionState,
-      required this.unrealizedPnL});
+      required this.unrealizedPnl});
+
+  static Position fromApi(bridge.Position position) {
+    return Position(
+        leverage: Leverage(position.leverage),
+        quantity: position.quantity,
+        contractSymbol: ContractSymbol.fromApi(position.contractSymbol),
+        direction: Direction.fromApi(position.direction),
+        positionState: PositionState.fromApi(position.positionState),
+        averageEntryPrice: position.averageEntryPrice,
+        liquidationPrice: position.liquidationPrice,
+        unrealizedPnl: Amount(position.unrealizedPnl));
+  }
+
+  static bridge.Position apiDummy() {
+    return bridge.Position(
+        leverage: 0,
+        quantity: 0,
+        contractSymbol: bridge.ContractSymbol.BtcUsd,
+        direction: bridge.Direction.Long,
+        positionState: bridge.PositionState.Open,
+        averageEntryPrice: 0,
+        liquidationPrice: 0,
+        unrealizedPnl: 0);
+  }
 }

--- a/mobile/lib/features/trade/domain/position.dart
+++ b/mobile/lib/features/trade/domain/position.dart
@@ -1,0 +1,32 @@
+import 'package:get_10101/features/trade/domain/contract_symbol.dart';
+import 'package:get_10101/features/trade/domain/direction.dart';
+import 'package:get_10101/features/trade/domain/leverage.dart';
+import 'package:get_10101/common/domain/model.dart';
+
+enum PositionState {
+  open,
+
+  /// once the user pressed button to close position the button should be disabled otherwise the user can click it multiple times which would result in multiple orders and an open position in the other direction
+  closing
+}
+
+class Position {
+  final Leverage leverage;
+  final double quantity;
+  final ContractSymbol contractSymbol;
+  final Direction direction;
+  final double averageEntryPrice;
+  final double liquidationPrice;
+  final Amount unrealizedPnL;
+  final PositionState positionState;
+
+  Position(
+      {required this.averageEntryPrice,
+      required this.liquidationPrice,
+      required this.leverage,
+      required this.quantity,
+      required this.contractSymbol,
+      required this.direction,
+      required this.positionState,
+      required this.unrealizedPnL});
+}

--- a/mobile/lib/features/trade/order_change_notifier.dart
+++ b/mobile/lib/features/trade/order_change_notifier.dart
@@ -1,6 +1,5 @@
 import 'dart:collection';
 import 'dart:developer';
-
 import 'package:flutter/material.dart';
 import 'package:get_10101/bridge_generated/bridge_definitions.dart' as bridge;
 import 'package:get_10101/common/application/event_service.dart';

--- a/mobile/lib/features/trade/position_change_notifier.dart
+++ b/mobile/lib/features/trade/position_change_notifier.dart
@@ -1,0 +1,31 @@
+import 'package:flutter/material.dart';
+import 'package:get_10101/common/domain/model.dart';
+import 'package:get_10101/features/trade/domain/contract_symbol.dart';
+import 'package:get_10101/features/trade/domain/direction.dart';
+import 'package:get_10101/features/trade/domain/leverage.dart';
+
+import 'domain/position.dart';
+
+class PositionChangeNotifier extends ChangeNotifier {
+  // TODO: Remove dummy position once we actually handle updates from the backend
+  final Position _dummy = Position(
+      averageEntryPrice: 19000,
+      liquidationPrice: 14000,
+      leverage: Leverage(2),
+      quantity: 100,
+      contractSymbol: ContractSymbol.btcusd,
+      direction: Direction.long,
+      unrealizedPnL: Amount(-400),
+      positionState: PositionState.open);
+
+  Position? position;
+
+  PositionChangeNotifier() {
+    position = _dummy;
+  }
+
+  updatePosition(Position position) async {
+    this.position = position;
+    notifyListeners();
+  }
+}

--- a/mobile/lib/features/trade/position_list_item.dart
+++ b/mobile/lib/features/trade/position_list_item.dart
@@ -64,10 +64,10 @@ class PositionListItem extends StatelessWidget {
                   children: [
                     ValueDataRow(
                       type: ValueType.amount,
-                      value: notNullPosition.unrealizedPnL,
+                      value: notNullPosition.unrealizedPnl,
                       label: "Unrealized P/L",
                       valueTextStyle: dataRowStyle.apply(
-                          color: notNullPosition.unrealizedPnL.sats.isNegative
+                          color: notNullPosition.unrealizedPnl.sats.isNegative
                               ? tradeTheme.loss
                               : tradeTheme.profit),
                       labelTextStyle: dataRowStyle,

--- a/mobile/lib/features/trade/position_list_item.dart
+++ b/mobile/lib/features/trade/position_list_item.dart
@@ -1,0 +1,142 @@
+import 'package:expandable/expandable.dart';
+import 'package:flutter/material.dart';
+import 'package:get_10101/common/value_data_row.dart';
+import 'package:get_10101/features/trade/domain/position.dart';
+import 'package:get_10101/features/trade/trade_theme.dart';
+
+import 'contract_symbol_icon.dart';
+
+class PositionListItem extends StatelessWidget {
+  const PositionListItem({super.key, required this.position});
+
+  final Position? position;
+
+  @override
+  Widget build(BuildContext context) {
+    if (position == null) {
+      return const NoPositionsListItem();
+    }
+
+    TradeTheme tradeTheme = Theme.of(context).extension<TradeTheme>()!;
+
+    // dart cannot promote...
+    Position notNullPosition = position!;
+    TextStyle dataRowStyle = const TextStyle(fontSize: 16);
+
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(10.0),
+        child: ExpandablePanel(
+          theme: const ExpandableThemeData(
+            hasIcon: false,
+            tapBodyToExpand: true,
+            tapHeaderToExpand: true,
+          ),
+          header: Column(
+            children: [
+              Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: [
+                  Row(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      const ContractSymbolIcon(),
+                      const SizedBox(
+                        width: 10,
+                      ),
+                      Text(
+                        notNullPosition.contractSymbol.label,
+                        style: const TextStyle(fontWeight: FontWeight.bold),
+                      ),
+                    ],
+                  ),
+                  Chip(
+                    label: Text(notNullPosition.positionState.name),
+                    backgroundColor: Colors.transparent,
+                    shape: const StadiumBorder(side: BorderSide()),
+                  )
+                ],
+              ),
+              Padding(
+                padding: const EdgeInsets.symmetric(vertical: 10),
+                child: Wrap(
+                  runSpacing: 10,
+                  children: [
+                    ValueDataRow(
+                      type: ValueType.amount,
+                      value: notNullPosition.unrealizedPnL,
+                      label: "Unrealized P/L",
+                      valueTextStyle: dataRowStyle.apply(
+                          color: notNullPosition.unrealizedPnL.sats.isNegative
+                              ? tradeTheme.loss
+                              : tradeTheme.profit),
+                      labelTextStyle: dataRowStyle,
+                    ),
+                    ValueDataRow(
+                      type: ValueType.contracts,
+                      value: notNullPosition.quantity,
+                      label: "Quantity",
+                      valueTextStyle: dataRowStyle,
+                      labelTextStyle: dataRowStyle,
+                    ),
+                    ValueDataRow(
+                      type: ValueType.fiat,
+                      value: notNullPosition.liquidationPrice,
+                      label: "Liquidation price",
+                      valueTextStyle: dataRowStyle,
+                      labelTextStyle: dataRowStyle,
+                    ),
+                    ValueDataRow(
+                      type: ValueType.fiat,
+                      value: notNullPosition.averageEntryPrice,
+                      label: "Average entry price",
+                      valueTextStyle: dataRowStyle,
+                      labelTextStyle: dataRowStyle,
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+          collapsed: Container(),
+          expanded: Row(
+            mainAxisAlignment: MainAxisAlignment.end,
+            crossAxisAlignment: CrossAxisAlignment.center,
+            children: [
+              OutlinedButton(
+                onPressed: () {
+                  // TODO: Navigate to details child screen (that also includes close button at the bottom)
+                },
+                child: const Text("Show Details"),
+              ),
+              const SizedBox(
+                width: 10,
+              ),
+              ElevatedButton(
+                onPressed: () {
+                  // TODO: bottom sheet to close position
+                },
+                child: const Text("Close Position"),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class NoPositionsListItem extends StatelessWidget {
+  const NoPositionsListItem({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Card(
+      child: ListTile(
+        leading: ContractSymbolIcon(),
+        title: Text("You don't have any position yet..."),
+        subtitle: Text("Trade now to open a position!"),
+      ),
+    );
+  }
+}

--- a/mobile/lib/features/trade/trade_screen.dart
+++ b/mobile/lib/features/trade/trade_screen.dart
@@ -117,14 +117,14 @@ class TradeScreen extends StatelessWidget {
                   ],
                   keys: const [tradeScreenTabsPositions, tradeScreenTabsOrders],
                   tabBarViewChildren: [
-                    ListView(
+                    ListView.builder(
                       shrinkWrap: true,
                       physics: const ClampingScrollPhysics(),
-                      children: [
-                        PositionListItem(
-                          position: positionChangeNotifier.position,
-                        )
-                      ],
+                      itemCount: positionChangeNotifier.positions.length,
+                      itemBuilder: (BuildContext context, int index) {
+                        return PositionListItem(
+                            position: positionChangeNotifier.positions.values.toList()[index]);
+                      },
                     ),
                     ListView.builder(
                       shrinkWrap: true,

--- a/mobile/lib/features/trade/trade_screen.dart
+++ b/mobile/lib/features/trade/trade_screen.dart
@@ -6,6 +6,8 @@ import 'package:get_10101/features/trade/domain/contract_symbol.dart';
 import 'package:get_10101/features/trade/domain/direction.dart';
 import 'package:get_10101/features/trade/order_change_notifier.dart';
 import 'package:get_10101/features/trade/order_list_item.dart';
+import 'package:get_10101/features/trade/position_change_notifier.dart';
+import 'package:get_10101/features/trade/position_list_item.dart';
 import 'package:get_10101/features/trade/submit_order_change_notifier.dart';
 import 'package:get_10101/features/trade/trade_bottom_sheet.dart';
 import 'package:get_10101/features/trade/candlestick_chart.dart';
@@ -23,8 +25,6 @@ class TradeScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     TradeTheme tradeTheme = Theme.of(context).extension<TradeTheme>()!;
-
-    List<String> positions = List<String>.generate(100, (i) => 'Position $i');
 
     const RoundedRectangleBorder tradeButtonShape = RoundedRectangleBorder(
       borderRadius: BorderRadius.all(
@@ -95,6 +95,7 @@ class TradeScreen extends StatelessWidget {
     }
 
     OrderChangeNotifier orderChangeNotifier = context.watch<OrderChangeNotifier>();
+    PositionChangeNotifier positionChangeNotifier = context.watch<PositionChangeNotifier>();
 
     return Scaffold(
         body: Container(
@@ -116,15 +117,14 @@ class TradeScreen extends StatelessWidget {
                   ],
                   keys: const [tradeScreenTabsPositions, tradeScreenTabsOrders],
                   tabBarViewChildren: [
-                    ListView.builder(
+                    ListView(
                       shrinkWrap: true,
                       physics: const ClampingScrollPhysics(),
-                      itemCount: positions.length,
-                      itemBuilder: (BuildContext context, int index) {
-                        return ListTile(
-                          title: Text(positions[index]),
-                        );
-                      },
+                      children: [
+                        PositionListItem(
+                          position: positionChangeNotifier.position,
+                        )
+                      ],
                     ),
                     ListView.builder(
                       shrinkWrap: true,

--- a/mobile/lib/features/trade/trade_theme.dart
+++ b/mobile/lib/features/trade/trade_theme.dart
@@ -11,6 +11,9 @@ class TradeTheme extends ThemeExtension<TradeTheme> {
   final Color buy;
   final Color sell;
 
+  final Color profit;
+  final Color loss;
+
   final Color tabColor;
   final Color leveragePlusButtonColor;
   final Color leverageMinusButtonColor;
@@ -20,6 +23,8 @@ class TradeTheme extends ThemeExtension<TradeTheme> {
   const TradeTheme(
       {this.buy = green600,
       this.sell = red600,
+      this.profit = Colors.green,
+      this.loss = Colors.red,
       this.tabColor = Colors.grey,
       this.leveragePlusButtonColor = Colors.grey,
       this.leverageMinusButtonColor = Colors.grey,
@@ -30,6 +35,8 @@ class TradeTheme extends ThemeExtension<TradeTheme> {
   TradeTheme copyWith({
     Color? buy,
     Color? sell,
+    Color? profit,
+    Color? loss,
     ShapeBorder? tradeButtonShape,
     double? tradeButtonWidth,
     Color? tabColor,
@@ -37,6 +44,8 @@ class TradeTheme extends ThemeExtension<TradeTheme> {
     return TradeTheme(
       buy: buy ?? this.buy,
       sell: sell ?? this.sell,
+      profit: profit ?? this.profit,
+      loss: loss ?? this.loss,
       tabColor: tabColor ?? this.tabColor,
     );
   }
@@ -49,6 +58,8 @@ class TradeTheme extends ThemeExtension<TradeTheme> {
     return TradeTheme(
       buy: Color.lerp(buy, other.buy, t) ?? Colors.white,
       sell: Color.lerp(sell, other.sell, t) ?? Colors.white,
+      profit: Color.lerp(profit, other.profit, t) ?? Colors.white,
+      loss: Color.lerp(loss, other.loss, t) ?? Colors.white,
       tabColor: Color.lerp(tabColor, other.tabColor, t) ?? Colors.white,
     );
   }
@@ -57,6 +68,8 @@ class TradeTheme extends ThemeExtension<TradeTheme> {
   String toString() => 'TradeTheme('
       'buy: $buy, '
       'sell: $sell, '
+      'profit: $profit, '
+      'loss: $loss, '
       'tabColor: $tabColor, '
       ')';
 }

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -8,6 +8,7 @@ import 'package:get_10101/common/application/event_service.dart';
 import 'package:get_10101/features/trade/application/order_service.dart';
 import 'package:get_10101/features/trade/application/trade_values_service.dart';
 import 'package:get_10101/features/trade/order_change_notifier.dart';
+import 'package:get_10101/features/trade/position_change_notifier.dart';
 import 'package:get_10101/features/trade/submit_order_change_notifier.dart';
 import 'package:get_10101/features/trade/trade_value_change_notifier.dart';
 import 'package:get_10101/features/trade/settings_screen.dart';
@@ -57,6 +58,7 @@ void main() {
     ChangeNotifierProvider(create: (context) => AmountDenominationChangeNotifier()),
     ChangeNotifierProvider(create: (context) => SubmitOrderChangeNotifier(OrderService())),
     ChangeNotifierProvider(create: (context) => OrderChangeNotifier.create(OrderService())),
+    ChangeNotifierProvider(create: (context) => PositionChangeNotifier()),
     ChangeNotifierProvider(create: (context) => WalletChangeNotifier(const WalletService())),
   ], child: const TenTenOneApp()));
 }

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -6,7 +6,9 @@ import 'package:flutter_rust_bridge/flutter_rust_bridge.dart';
 import 'package:get_10101/bridge_generated/bridge_definitions.dart' as bridge;
 import 'package:get_10101/common/application/event_service.dart';
 import 'package:get_10101/features/trade/application/order_service.dart';
+import 'package:get_10101/features/trade/application/position_service.dart';
 import 'package:get_10101/features/trade/application/trade_values_service.dart';
+import 'package:get_10101/features/trade/domain/position.dart';
 import 'package:get_10101/features/trade/order_change_notifier.dart';
 import 'package:get_10101/features/trade/position_change_notifier.dart';
 import 'package:get_10101/features/trade/submit_order_change_notifier.dart';
@@ -58,7 +60,7 @@ void main() {
     ChangeNotifierProvider(create: (context) => AmountDenominationChangeNotifier()),
     ChangeNotifierProvider(create: (context) => SubmitOrderChangeNotifier(OrderService())),
     ChangeNotifierProvider(create: (context) => OrderChangeNotifier.create(OrderService())),
-    ChangeNotifierProvider(create: (context) => PositionChangeNotifier()),
+    ChangeNotifierProvider(create: (context) => PositionChangeNotifier.create(PositionService())),
     ChangeNotifierProvider(create: (context) => WalletChangeNotifier(const WalletService())),
   ], child: const TenTenOneApp()));
 }
@@ -140,7 +142,8 @@ class _TenTenOneAppState extends State<TenTenOneApp> {
   @override
   void initState() {
     super.initState();
-    init(context.read<OrderChangeNotifier>(), context.read<WalletChangeNotifier>());
+    init(context.read<OrderChangeNotifier>(), context.read<PositionChangeNotifier>(),
+        context.read<WalletChangeNotifier>());
   }
 
   @override
@@ -162,7 +165,9 @@ class _TenTenOneAppState extends State<TenTenOneApp> {
   }
 
   Future<void> init(
-      OrderChangeNotifier orderChangeNotifier, WalletChangeNotifier walletChangeNotifier) async {
+      OrderChangeNotifier orderChangeNotifier,
+      PositionChangeNotifier positionChangeNotifier,
+      WalletChangeNotifier walletChangeNotifier) async {
     try {
       await walletChangeNotifier.refreshWalletInfo();
       setupRustLogging();
@@ -172,6 +177,9 @@ class _TenTenOneAppState extends State<TenTenOneApp> {
       final EventService eventService = EventService.create();
       eventService.subscribe(
           orderChangeNotifier, bridge.Event.orderUpdateNotification(Order.apiDummy()));
+
+      eventService.subscribe(
+          positionChangeNotifier, bridge.Event.positionUpdateNotification(Position.apiDummy()));
 
       eventService.subscribe(
           walletChangeNotifier, bridge.Event.walletInfoUpdateNotification(WalletInfo.apiDummy()));

--- a/mobile/native/src/api.rs
+++ b/mobile/native/src/api.rs
@@ -2,12 +2,14 @@ use crate::api_model;
 use crate::api_model::event::flutter_subscriber::FlutterSubscriber;
 use crate::api_model::order::NewOrder;
 use crate::api_model::order::Order;
+use crate::api_model::position::Position;
 use crate::api_model::Direction;
 use crate::calculations;
 use crate::event;
 use crate::ln_dlc;
 use crate::logger;
 use crate::trade::order;
+use crate::trade::position;
 use anyhow::Result;
 use flutter_rust_bridge::StreamSink;
 use flutter_rust_bridge::SyncReturn;
@@ -116,6 +118,17 @@ pub async fn get_orders() -> Result<Vec<Order>> {
         .collect::<Vec<Order>>();
 
     Ok(orders)
+}
+
+#[tokio::main(flavor = "current_thread")]
+pub async fn get_positions() -> Result<Vec<Position>> {
+    let positions = position::handler::get_positions()
+        .await?
+        .into_iter()
+        .map(|order| order.into())
+        .collect::<Vec<Position>>();
+
+    Ok(positions)
 }
 
 pub fn subscribe(stream: StreamSink<api_model::event::Event>) {

--- a/mobile/native/src/api_model/event/flutter_subscriber.rs
+++ b/mobile/native/src/api_model/event/flutter_subscriber.rs
@@ -20,6 +20,7 @@ impl Subscriber for FlutterSubscriber {
             EventInternal::Init(_)
                 | EventInternal::WalletInfoUpdateNotification(_)
                 | EventInternal::OrderUpdateNotification(_)
+                | EventInternal::PositionUpdateNotification(_)
         )
     }
 }

--- a/mobile/native/src/api_model/event/mod.rs
+++ b/mobile/native/src/api_model/event/mod.rs
@@ -1,5 +1,6 @@
 use crate::api::WalletInfo;
 use crate::api_model::order::Order;
+use crate::api_model::position::Position;
 use crate::event::EventInternal;
 use flutter_rust_bridge::frb;
 
@@ -12,6 +13,7 @@ pub enum Event {
     Log(String),
     OrderUpdateNotification(Order),
     WalletInfoUpdateNotification(WalletInfo),
+    PositionUpdateNotification(Position),
 }
 
 impl From<EventInternal> for Event {
@@ -24,6 +26,12 @@ impl From<EventInternal> for Event {
             }
             EventInternal::WalletInfoUpdateNotification(value) => {
                 Event::WalletInfoUpdateNotification(value)
+            }
+            EventInternal::OrderFilledWith(_) => {
+                unreachable!("This internal event is not exposed to the UI")
+            }
+            EventInternal::PositionUpdateNotification(position) => {
+                Event::PositionUpdateNotification(position.into())
             }
         }
     }

--- a/mobile/native/src/api_model/mod.rs
+++ b/mobile/native/src/api_model/mod.rs
@@ -1,5 +1,6 @@
 pub mod event;
 pub mod order;
+pub mod position;
 use crate::trade::ContractSymbolTrade;
 use crate::trade::DirectionTrade;
 use flutter_rust_bridge::frb;

--- a/mobile/native/src/api_model/position.rs
+++ b/mobile/native/src/api_model/position.rs
@@ -1,0 +1,65 @@
+use crate::api_model::ContractSymbol;
+use crate::api_model::Direction;
+use crate::trade::position::PositionStateTrade;
+use crate::trade::position::PositionTrade;
+use flutter_rust_bridge::frb;
+
+#[frb]
+#[derive(Debug, Clone)]
+pub enum PositionState {
+    /// The position is open
+    ///
+    /// Open in the sense, that there is an active position that is being rolled-over.
+    /// Note that a "closed" position does not exist, but is just removed.
+    /// During the process of getting closed (after creating the counter-order that will wipe out
+    /// the position), the position is in state "Closing".
+    ///
+    /// Transitions:
+    /// Open->Closing
+    Open,
+    /// The position is in the process of being closed
+    ///
+    /// The user has created an order that will wipe out the position.
+    /// Once this order has been filled the "closed" the position is not shown in the user
+    /// interface, so we don't have a "closed" state because no position data will be provided to
+    /// the user interface.
+    Closing,
+}
+
+#[frb]
+#[derive(Debug, Clone)]
+pub struct Position {
+    pub leverage: f64,
+    pub quantity: f64,
+    pub contract_symbol: ContractSymbol,
+    pub direction: Direction,
+    pub average_entry_price: f64,
+    pub liquidation_price: f64,
+    /// The unrealized PL can be positive or negative
+    pub unrealized_pnl: i64,
+    pub position_state: PositionState,
+}
+
+impl From<PositionStateTrade> for PositionState {
+    fn from(value: PositionStateTrade) -> Self {
+        match value {
+            PositionStateTrade::Open => PositionState::Open,
+            PositionStateTrade::Closing => PositionState::Closing,
+        }
+    }
+}
+
+impl From<PositionTrade> for Position {
+    fn from(value: PositionTrade) -> Self {
+        Position {
+            leverage: value.leverage,
+            quantity: value.quantity,
+            contract_symbol: value.contract_symbol.into(),
+            direction: value.direction.into(),
+            average_entry_price: value.average_entry_price,
+            liquidation_price: value.liquidation_price,
+            unrealized_pnl: value.unrealized_pnl,
+            position_state: value.position_state.into(),
+        }
+    }
+}

--- a/mobile/native/src/event/mod.rs
+++ b/mobile/native/src/event/mod.rs
@@ -9,6 +9,8 @@ use strum_macros::EnumIter;
 use crate::event::event_hub::get;
 use crate::event::subscriber::Subscriber;
 use crate::trade::order::OrderTrade;
+use crate::trade::position::PositionTrade;
+use crate::trade::position::TradeParams;
 
 pub fn subscribe(subscriber: impl Subscriber + 'static + Send + Sync + Clone) {
     get().subscribe(subscriber);
@@ -24,6 +26,8 @@ pub enum EventInternal {
     Log(String),
     OrderUpdateNotification(OrderTrade),
     WalletInfoUpdateNotification(WalletInfo),
+    OrderFilledWith(TradeParams),
+    PositionUpdateNotification(PositionTrade),
 }
 
 impl PartialEq for EventInternal {

--- a/mobile/native/src/trade/mod.rs
+++ b/mobile/native/src/trade/mod.rs
@@ -1,4 +1,5 @@
 pub mod order;
+pub mod position;
 
 #[derive(Debug, Clone, Copy)]
 pub enum ContractSymbolTrade {

--- a/mobile/native/src/trade/position/handler.rs
+++ b/mobile/native/src/trade/position/handler.rs
@@ -1,0 +1,59 @@
+use crate::event;
+use crate::event::EventInternal;
+use crate::trade::position::PositionStateTrade;
+use crate::trade::position::PositionTrade;
+use crate::trade::position::TradeParams;
+use crate::trade::ContractSymbolTrade;
+use crate::trade::DirectionTrade;
+use anyhow::Result;
+
+/// Sets up a trade with the counterparty
+///
+/// In a success scenario this results in creating, updating or deleting a position.
+/// The DLC that represents the position will be stored in the database.
+/// Errors are handled within the scope of this function.
+pub async fn trade(_trade_params: TradeParams) {
+    // TODO: Send trade parameters to coordinator
+
+    // TODO: Success: We have a DLC!
+    // TODO: Failure -> Either we send out an event that notifies others (i.e. the order handler)
+    //          that this fails, or we just write the failure state to the database here and then
+    //          send out an event that the order failed.
+
+    // TODO: Update the position in the database
+    // -> No position yet? Create one from the DLC
+    // -> There is an open position? Update it with the new parameters according to the DLC
+    // -> There was a position, but the current trade closes it? Delete the position; move relevant
+    // position information to a table that keeps the history.
+
+    // TODO: Send out position update
+
+    event::publish(&EventInternal::PositionUpdateNotification(PositionTrade {
+        leverage: 1.50,
+        quantity: 15000.0,
+        contract_symbol: ContractSymbolTrade::BtcUsd,
+        direction: DirectionTrade::Long,
+        average_entry_price: 23400.0,
+        liquidation_price: 14500.0,
+        unrealized_pnl: 600,
+        position_state: PositionStateTrade::Open,
+    }));
+}
+
+/// Fetch the positions from the database
+pub async fn get_positions() -> Result<Vec<PositionTrade>> {
+    // TODO: Fetch from database
+
+    let dummy_position = PositionTrade {
+        leverage: 2.0,
+        quantity: 10000.0,
+        contract_symbol: ContractSymbolTrade::BtcUsd,
+        direction: DirectionTrade::Long,
+        average_entry_price: 20000.0,
+        liquidation_price: 14000.0,
+        unrealized_pnl: -400,
+        position_state: PositionStateTrade::Open,
+    };
+
+    Ok(vec![dummy_position])
+}

--- a/mobile/native/src/trade/position/mod.rs
+++ b/mobile/native/src/trade/position/mod.rs
@@ -1,0 +1,58 @@
+use crate::trade::ContractSymbolTrade;
+use crate::trade::DirectionTrade;
+pub mod handler;
+pub mod subscriber;
+
+#[derive(Debug, Clone)]
+pub enum PositionStateTrade {
+    /// The position is open
+    ///
+    /// Open in the sense, that there is an active position that is being rolled-over.
+    /// Note that a "closed" position does not exist, but is just removed.
+    /// During the process of getting closed (after creating the counter-order that will wipe out
+    /// the position), the position is in state "Closing".
+    ///
+    /// Transitions:
+    /// Open->Closing
+    Open,
+    /// The position is in the process of being closed
+    ///
+    /// The user has created an order that will wipe out the position.
+    /// Once this order has been filled the "closed" the position is not shown in the user
+    /// interface, so we don't have a "closed" state because no position data will be provided to
+    /// the user interface.
+    Closing,
+}
+
+#[derive(Debug, Clone)]
+pub struct PositionTrade {
+    pub leverage: f64,
+    pub quantity: f64,
+    pub contract_symbol: ContractSymbolTrade,
+    pub direction: DirectionTrade,
+    pub average_entry_price: f64,
+    pub liquidation_price: f64,
+    /// The unrealized PL can be positive or negative
+    pub unrealized_pnl: i64,
+    pub position_state: PositionStateTrade,
+}
+
+impl Default for PositionTrade {
+    fn default() -> Self {
+        PositionTrade {
+            leverage: 0.0,
+            quantity: 0.0,
+            contract_symbol: ContractSymbolTrade::BtcUsd,
+            direction: DirectionTrade::Long,
+            average_entry_price: 0.0,
+            liquidation_price: 0.0,
+            unrealized_pnl: 0,
+            position_state: PositionStateTrade::Open,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct TradeParams {
+    // TODO Trade parameters needed to contact coordinator for trade execution
+}

--- a/mobile/native/src/trade/position/subscriber.rs
+++ b/mobile/native/src/trade/position/subscriber.rs
@@ -1,0 +1,27 @@
+use crate::event;
+use crate::event::EventInternal;
+use crate::trade::position::handler;
+
+#[derive(Clone)]
+pub struct Subscriber {}
+
+/// Subscribes to event relevant for flutter and forwards them to the stream sink.
+impl event::subscriber::Subscriber for Subscriber {
+    fn notify(&self, event: &EventInternal) {
+        match event {
+            EventInternal::OrderFilledWith(trade_params) => {
+                tokio::spawn({
+                    let trade_params = trade_params.clone();
+                    async move {
+                        handler::trade(trade_params.clone()).await;
+                    }
+                });
+            }
+            _ => unreachable!("Received Unexpected Event"),
+        }
+    }
+
+    fn filter(&self, event: &EventInternal) -> bool {
+        matches!(event, EventInternal::OrderFilledWith(_))
+    }
+}

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -225,6 +225,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.2"
+  expandable:
+    dependency: "direct main"
+    description:
+      name: expandable
+      sha256: "9604d612d4d1146dafa96c6d8eec9c2ff0994658d6d09fed720ab788c7f5afc2"
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.0.1"
   f_logs:
     dependency: "direct main"
     description:

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -25,6 +25,7 @@ dependencies:
   path_provider: ^2.0.11
   uuid: ^3.0.7
   freezed_annotation: ^2.2.0
+  expandable: ^5.0.1
 
 dev_dependencies:
   flutter_launcher_icons: "^0.11.0"

--- a/mobile/test/trade_test.dart
+++ b/mobile/test/trade_test.dart
@@ -3,6 +3,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:get_10101/common/amount_denomination_change_notifier.dart';
 import 'package:get_10101/common/domain/model.dart';
 import 'package:get_10101/features/trade/order_change_notifier.dart';
+import 'package:get_10101/features/trade/position_change_notifier.dart';
 import 'package:get_10101/features/trade/submit_order_change_notifier.dart';
 import 'package:get_10101/features/trade/trade_screen.dart';
 import 'package:get_10101/features/trade/trade_theme.dart';
@@ -18,6 +19,9 @@ import 'package:get_10101/features/trade/application/trade_values_service.dart';
 
 @GenerateNiceMocks([MockSpec<OrderService>()])
 import 'package:get_10101/features/trade/application/order_service.dart';
+
+@GenerateNiceMocks([MockSpec<PositionService>()])
+import 'package:get_10101/features/trade/application/position_service.dart';
 
 import 'trade_test.mocks.dart';
 
@@ -56,6 +60,7 @@ void main() {
   testWidgets('Given trade screen when completing buy flow then market order is submitted',
       (tester) async {
     MockOrderService orderService = MockOrderService();
+    MockPositionService positionService = MockPositionService();
     MockTradeValuesService tradeValueService = MockTradeValuesService();
 
     // TODO: we could make this more resilient in the underlying components...
@@ -80,6 +85,7 @@ void main() {
       ChangeNotifierProvider(create: (context) => TradeValuesChangeNotifier(tradeValueService)),
       ChangeNotifierProvider(create: (context) => submitOrderChangeNotifier),
       ChangeNotifierProvider(create: (context) => OrderChangeNotifier.create(orderService)),
+      ChangeNotifierProvider(create: (context) => PositionChangeNotifier.create(positionService)),
       ChangeNotifierProvider(create: (context) => AmountDenominationChangeNotifier()),
     ], child: const TestWrapperWithTradeTheme(child: TradeScreen())));
 


### PR DESCRIPTION
Position user interface + wired into rust with rust simulating an update with dummies (upon an event from the orderbook).

This does not include closing the position yet.

---

This shows the change of the position after 10 seconds, simulating the lifecycle to some extent:

1. We fetch the position initially 
2. We subscribe to notifications for the position handler from the orderbook event in `run`
3. We subscribe to notifications for position updates for the flutter event subscriber
4. We simulate an orderbook event after 10 seconds
5. We "handle" the event in the position handler and send out a different dummy position
6. The position is updated in the UI :)

![2023-02-23 19 22 20](https://user-images.githubusercontent.com/5557790/220855599-e47a5839-4539-401d-bb91-81b25b5d233f.gif)

note: I don't know why the color green is broken in the gif 😅 

---

This is how the close button is currently implemented; we can iterate on that if it's too hidden:

![2023-02-23 19 23 04](https://user-images.githubusercontent.com/5557790/220855664-ecbb5086-ce64-4dd7-a404-e22391a0bd27.gif)

