### PR TITLE
fix: Execute the coordinator from the root directory

### DIFF
--- a/justfile
+++ b/justfile
@@ -77,7 +77,7 @@ flutter-format:
 
 alias c := coordinator
 coordinator:
-    cd coordinator && cargo run
+    cargo run --bin coordinator
 
 flutter-test:
     cd mobile && flutter pub run build_runner build && flutter test


### PR DESCRIPTION
So that the seed file checked in on root in the data directory is used. Otherwise a new data directory will be generated within the coordinator directory.