### PR TITLE
Receive payment UI

### DIFF
--- a/crates/ln-dlc-node/src/node.rs
+++ b/crates/ln-dlc-node/src/node.rs
@@ -768,20 +768,20 @@ impl Node {
     /// invoice
     pub fn create_interceptable_invoice(
         &self,
-        amount_in_sats: u64,
+        amount_in_sats: Option<u64>,
         intercepted_channel_id: u64,
         hop_before_me: PublicKey,
         invoice_expiry: u32,
         description: String,
     ) -> Result<Invoice> {
+        let amount_msat = amount_in_sats.map(|x| x * 1000);
         let (payment_hash, payment_secret) = self
             .channel_manager
-            .create_inbound_payment(Some(amount_in_sats * 1000), invoice_expiry)
+            .create_inbound_payment(amount_msat, invoice_expiry)
             .unwrap();
         let node_secret = self.keys_manager.get_node_secret(Recipient::Node).unwrap();
-        let signed_invoice = InvoiceBuilder::new(Currency::Regtest)
+        let invoice_builder = InvoiceBuilder::new(Currency::Regtest)
             .description(description)
-            .amount_milli_satoshis(amount_in_sats * 1000)
             .payment_hash(sha256::Hash::from_slice(&payment_hash.0)?)
             .payment_secret(payment_secret)
             .timestamp(SystemTime::now())
@@ -802,7 +802,14 @@ impl Node {
                 cltv_expiry_delta: MIN_CLTV_EXPIRY_DELTA,
                 htlc_minimum_msat: None,
                 htlc_maximum_msat: None,
-            }]))
+            }]));
+
+        let invoice_builder = match amount_msat {
+            Some(msats) => invoice_builder.amount_milli_satoshis(msats),
+            None => invoice_builder,
+        };
+
+        let signed_invoice = invoice_builder
             .build_raw()
             .unwrap()
             .sign::<_, ()>(|hash| {

--- a/crates/ln-dlc-node/src/tests/just_in_time_channel.rs
+++ b/crates/ln-dlc-node/src/tests/just_in_time_channel.rs
@@ -95,7 +95,7 @@ async fn just_in_time_channel() {
     let invoice_expiry = 0; // an expiry of 0 means the invoice never expires
     let invoice = payee
         .create_interceptable_invoice(
-            invoice_amount,
+            Some(invoice_amount),
             intercept_scid,
             coordinator.info.pubkey,
             invoice_expiry,

--- a/crates/ln-dlc-node/src/tests/onboard_from_lnd.rs
+++ b/crates/ln-dlc-node/src/tests/onboard_from_lnd.rs
@@ -35,7 +35,7 @@ async fn onboard_from_lnd() {
     let fake_scid = coordinator.create_intercept_scid(payee.info.pubkey);
     let invoice = payee
         .create_interceptable_invoice(
-            invoice_amount,
+            Some(invoice_amount),
             fake_scid,
             coordinator.info.pubkey,
             0,

--- a/mobile/lib/features/wallet/application/wallet_service.dart
+++ b/mobile/lib/features/wallet/application/wallet_service.dart
@@ -26,9 +26,15 @@ class WalletService {
     }
   }
 
-  Future<String?> createInvoice(Amount amount) async {
+  Future<String?> createInvoice(Amount? amount) async {
     try {
-      String invoice = await rust.api.createInvoice(amountSats: amount.sats);
+      String invoice;
+      if (amount != null) {
+        invoice = await rust.api.createInvoiceWithAmount(amountSats: amount.sats);
+      } else {
+        invoice = await rust.api.createInvoiceWithoutAmount();
+      }
+
       FLog.info(text: "Successfully created invoice.");
       return invoice;
     } catch (error) {

--- a/mobile/lib/features/wallet/application/wallet_service.dart
+++ b/mobile/lib/features/wallet/application/wallet_service.dart
@@ -1,4 +1,5 @@
 import 'package:f_logs/f_logs.dart';
+import 'package:get_10101/common/domain/model.dart';
 import 'package:get_10101/features/wallet/domain/wallet_info.dart';
 import 'package:get_10101/ffi.dart' as rust;
 
@@ -25,9 +26,9 @@ class WalletService {
     }
   }
 
-  Future<String?> createInvoice() async {
+  Future<String?> createInvoice(Amount amount) async {
     try {
-      String invoice = await rust.api.createInvoice();
+      String invoice = await rust.api.createInvoice(amountSats: amount.sats);
       FLog.info(text: "Successfully created invoice.");
       return invoice;
     } catch (error) {

--- a/mobile/lib/features/wallet/balance_row.dart
+++ b/mobile/lib/features/wallet/balance_row.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_svg/svg.dart';
 import 'package:get_10101/common/amount_text.dart';
 import 'package:get_10101/common/domain/model.dart';
-import 'package:get_10101/features/wallet/receive_screen.dart';
+import 'package:get_10101/features/wallet/share_invoice_screen.dart';
 import 'package:get_10101/features/wallet/send_screen.dart';
 import 'package:get_10101/features/wallet/wallet_change_notifier.dart';
 import 'package:get_10101/features/wallet/wallet_theme.dart';
@@ -173,7 +173,7 @@ class BalanceRowButton extends StatelessWidget {
                 if (flow == PaymentFlow.outbound) {
                   context.go(SendScreen.route);
                 } else {
-                  context.go(ReceiveScreen.route);
+                  context.go(ShareInvoiceScreen.route);
                 }
               },
         style: ElevatedButton.styleFrom(

--- a/mobile/lib/features/wallet/balance_row.dart
+++ b/mobile/lib/features/wallet/balance_row.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_svg/svg.dart';
 import 'package:get_10101/common/amount_text.dart';
 import 'package:get_10101/common/domain/model.dart';
-import 'package:get_10101/features/wallet/share_invoice_screen.dart';
+import 'package:get_10101/features/wallet/create_invoice_screen.dart';
 import 'package:get_10101/features/wallet/send_screen.dart';
 import 'package:get_10101/features/wallet/wallet_change_notifier.dart';
 import 'package:get_10101/features/wallet/wallet_theme.dart';
@@ -173,7 +173,7 @@ class BalanceRowButton extends StatelessWidget {
                 if (flow == PaymentFlow.outbound) {
                   context.go(SendScreen.route);
                 } else {
-                  context.go(ShareInvoiceScreen.route);
+                  context.go(CreateInvoiceScreen.route);
                 }
               },
         style: ElevatedButton.styleFrom(

--- a/mobile/lib/features/wallet/create_invoice_screen.dart
+++ b/mobile/lib/features/wallet/create_invoice_screen.dart
@@ -1,0 +1,94 @@
+import 'dart:developer';
+
+import 'package:flutter/material.dart';
+import 'package:get_10101/common/amount_text_input_form_field.dart';
+import 'package:get_10101/common/domain/model.dart';
+import 'package:get_10101/features/wallet/domain/wallet_info.dart';
+import 'package:get_10101/features/wallet/share_invoice_screen.dart';
+import 'package:get_10101/features/wallet/wallet_change_notifier.dart';
+import 'package:get_10101/features/wallet/wallet_screen.dart';
+import 'package:go_router/go_router.dart';
+import 'package:provider/provider.dart';
+
+import 'application/wallet_service.dart';
+
+class CreateInvoiceScreen extends StatefulWidget {
+  static const route = "${WalletScreen.route}/$subRouteName";
+  static const subRouteName = "create_invoice";
+  final WalletService walletService;
+
+  const CreateInvoiceScreen({super.key, this.walletService = const WalletService()});
+
+  @override
+  State<CreateInvoiceScreen> createState() => _CreateInvoiceScreenState();
+}
+
+class _CreateInvoiceScreenState extends State<CreateInvoiceScreen> {
+  Amount? amount;
+  final TextEditingController _amountController = TextEditingController();
+
+  @override
+  Widget build(BuildContext context) {
+    WalletInfo info = context.watch<WalletChangeNotifier>().walletInfo;
+    log("Refresh receive screen: ${info.balances.onChain}");
+
+    return Scaffold(
+      appBar: AppBar(title: const Text("Receive funds")),
+      body: SafeArea(
+        child: Container(
+          constraints: const BoxConstraints.expand(),
+          child: Column(crossAxisAlignment: CrossAxisAlignment.stretch, children: [
+            const Center(
+              child: Padding(
+                padding: EdgeInsets.only(top: 25.0),
+                child: Text(
+                  "What is the amount?",
+                  style: TextStyle(fontSize: 18.0, fontWeight: FontWeight.bold),
+                ),
+              ),
+            ),
+            Padding(
+              padding: const EdgeInsets.all(32.0),
+              child: AmountInputField(
+                value: amount != null ? amount! : Amount(0),
+                hint: "e.g. 2,000 sats",
+                label: "Amount",
+                controller: _amountController,
+                onChanged: (value) {
+                  if (value.isEmpty) {
+                    return;
+                  }
+
+                  setState(() => amount = Amount.parse(value));
+                },
+              ),
+            ),
+            Expanded(
+              child: Padding(
+                padding: const EdgeInsets.all(32.0),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  mainAxisAlignment: MainAxisAlignment.end,
+                  children: [
+                    ElevatedButton(
+                        onPressed: amount == null
+                            ? null
+                            : () {
+                                widget.walletService.createInvoice(amount!).then((invoice) {
+                                  if (invoice != null) {
+                                    GoRouter.of(context)
+                                        .go(ShareInvoiceScreen.route, extra: invoice);
+                                  }
+                                });
+                              },
+                        child: const Text("Next")),
+                  ],
+                ),
+              ),
+            )
+          ]),
+        ),
+      ),
+    );
+  }
+}

--- a/mobile/lib/features/wallet/create_invoice_screen.dart
+++ b/mobile/lib/features/wallet/create_invoice_screen.dart
@@ -63,6 +63,18 @@ class _CreateInvoiceScreenState extends State<CreateInvoiceScreen> {
                 },
               ),
             ),
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 32.0),
+              child: OutlinedButton(
+                  onPressed: () => {
+                        widget.walletService.createInvoice(null).then((invoice) {
+                          if (invoice != null) {
+                            GoRouter.of(context).go(ShareInvoiceScreen.route, extra: invoice);
+                          }
+                        })
+                      },
+                  child: const Text("I don't want to specify amount")),
+            ),
             Expanded(
               child: Padding(
                 padding: const EdgeInsets.all(32.0),
@@ -71,7 +83,7 @@ class _CreateInvoiceScreenState extends State<CreateInvoiceScreen> {
                   mainAxisAlignment: MainAxisAlignment.end,
                   children: [
                     ElevatedButton(
-                        onPressed: amount == null
+                        onPressed: (amount == null || amount == Amount(0))
                             ? null
                             : () {
                                 widget.walletService.createInvoice(amount!).then((invoice) {

--- a/mobile/lib/features/wallet/receive_screen.dart
+++ b/mobile/lib/features/wallet/receive_screen.dart
@@ -1,11 +1,15 @@
 import 'dart:developer';
 
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:get_10101/features/wallet/application/wallet_service.dart';
 import 'package:get_10101/features/wallet/domain/wallet_info.dart';
 import 'package:get_10101/features/wallet/wallet_change_notifier.dart';
 import 'package:get_10101/features/wallet/wallet_screen.dart';
+import 'package:go_router/go_router.dart';
 import 'package:provider/provider.dart';
+import 'package:qr_flutter/qr_flutter.dart';
+import 'package:share_plus/share_plus.dart';
 
 class ReceiveScreen extends StatefulWidget {
   static const route = "${WalletScreen.route}/$subRouteName";
@@ -27,32 +31,129 @@ class _ReceiveScreenState extends State<ReceiveScreen> {
 
     log("Refresh receive screen: ${info.balances.onChain}");
 
+    const EdgeInsets buttonSpacing = EdgeInsets.symmetric(vertical: 8.0, horizontal: 24.0);
+
     return Scaffold(
-      appBar: AppBar(title: const Text("Receive")),
+      appBar: AppBar(title: const Text("Receive funds")),
       body: SafeArea(
-          child: Column(
-        crossAxisAlignment: CrossAxisAlignment.center,
-        children: [
-          const SizedBox(height: 50),
-          SelectableText("Address: ${widget.walletService.getNewAddress()}"),
-          Text("Balance: ${info.balances.lightning.sats} / ${info.balances.onChain.sats}"),
-          ElevatedButton(
-              onPressed: () {
-                setState(() async {
-                  String? invoice = await widget.walletService.createInvoice();
-                  if (invoice != null) {
-                    this.invoice = invoice;
-                  }
-                });
-              },
-              child: const Text("Create Invoice")),
-          SelectableText("Invoice: $invoice"),
-          ElevatedButton(
-              onPressed: () async {
-                await widget.walletService.openChannel();
-              },
-              child: const Text("Open Channel!"))
-        ],
+          child: Container(
+        constraints: const BoxConstraints.expand(),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Expanded(
+              child: Column(crossAxisAlignment: CrossAxisAlignment.center, children: [
+                const Padding(
+                  padding: EdgeInsets.only(top: 25.0, bottom: 50.0),
+                  child: Text(
+                    "Share payment request",
+                    style: TextStyle(fontSize: 18.0, fontWeight: FontWeight.bold),
+                  ),
+                ),
+                ElevatedButton(
+                    onPressed: () async {
+                      await widget.walletService.openChannel();
+                    },
+                    child: const Text("Open Channel!")),
+                ElevatedButton(
+                    onPressed: () async {
+                      String? invoice = await widget.walletService.createInvoice();
+                      if (invoice != null) {
+                        setState(() => this.invoice = invoice);
+                      }
+                    },
+                    child: const Text("Create Invoice")),
+                Expanded(
+                  child: Center(
+                    child: QrImage(
+                      data: invoice,
+                      version: QrVersions.auto,
+                      size: 200.0,
+                    ),
+                  ),
+                ),
+              ]),
+            ),
+            Row(children: [
+              Flexible(
+                flex: 1,
+                child: Padding(
+                  padding: buttonSpacing,
+                  child: OutlinedButton(
+                    onPressed: () {
+                      Clipboard.setData(ClipboardData(text: invoice)).then((_) {
+                        ScaffoldMessenger.of(context).showSnackBar(
+                            const SnackBar(content: Text('Invoice copied to clipboard')));
+                      });
+                    },
+                    style: ElevatedButton.styleFrom(
+                      shape: const RoundedRectangleBorder(
+                          borderRadius: BorderRadius.all(Radius.circular(5.0))),
+                    ),
+                    child: Row(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      children: const [
+                        Padding(
+                          padding: EdgeInsets.symmetric(horizontal: 8.0),
+                          child: Icon(Icons.copy),
+                        ),
+                        Text("Copy"),
+                      ],
+                    ),
+                  ),
+                ),
+              ),
+              Flexible(
+                flex: 1,
+                child: Padding(
+                  padding: buttonSpacing,
+                  child: OutlinedButton(
+                    onPressed: () => Share.share(invoice),
+                    style: ElevatedButton.styleFrom(
+                      shape: const RoundedRectangleBorder(
+                          borderRadius: BorderRadius.all(Radius.circular(5.0))),
+                    ),
+                    child: Row(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      children: const [
+                        Padding(
+                          padding: EdgeInsets.symmetric(horizontal: 8.0),
+                          child: Icon(Icons.send),
+                        ),
+                        Text("Share"),
+                      ],
+                    ),
+                  ),
+                ),
+              )
+            ]),
+            const Padding(
+              padding: EdgeInsets.all(8.0),
+              child: Center(
+                child: Text(
+                  "You will see the incoming payment once you send the funds.",
+                  style: TextStyle(color: Colors.grey),
+                ),
+              ),
+            ),
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 8.0),
+              child: ElevatedButton(
+                onPressed: () {
+                  // Pop both create invoice screen and share invoice screen
+                  GoRouter.of(context).pop();
+                  GoRouter.of(context).pop();
+                },
+                style: ElevatedButton.styleFrom(
+                  shape: const RoundedRectangleBorder(
+                      borderRadius: BorderRadius.all(Radius.circular(5.0))),
+                ),
+                child: const Text("Done"),
+              ),
+            ),
+            const SizedBox(height: 30.0),
+          ],
+        ),
       )),
     );
   }

--- a/mobile/lib/features/wallet/share_invoice_screen.dart
+++ b/mobile/lib/features/wallet/share_invoice_screen.dart
@@ -11,18 +11,18 @@ import 'package:provider/provider.dart';
 import 'package:qr_flutter/qr_flutter.dart';
 import 'package:share_plus/share_plus.dart';
 
-class ReceiveScreen extends StatefulWidget {
+class ShareInvoiceScreen extends StatefulWidget {
   static const route = "${WalletScreen.route}/$subRouteName";
-  static const subRouteName = "receive";
+  static const subRouteName = "share_invoice";
   final WalletService walletService;
 
-  const ReceiveScreen({super.key, this.walletService = const WalletService()});
+  const ShareInvoiceScreen({super.key, this.walletService = const WalletService()});
 
   @override
-  State<ReceiveScreen> createState() => _ReceiveScreenState();
+  State<ShareInvoiceScreen> createState() => _ShareInvoiceScreenState();
 }
 
-class _ReceiveScreenState extends State<ReceiveScreen> {
+class _ShareInvoiceScreenState extends State<ShareInvoiceScreen> {
   String invoice = "";
 
   @override

--- a/mobile/lib/features/wallet/share_invoice_screen.dart
+++ b/mobile/lib/features/wallet/share_invoice_screen.dart
@@ -2,7 +2,6 @@ import 'dart:developer';
 
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:get_10101/features/wallet/application/wallet_service.dart';
 import 'package:get_10101/features/wallet/domain/wallet_info.dart';
 import 'package:get_10101/features/wallet/wallet_change_notifier.dart';
 import 'package:get_10101/features/wallet/wallet_screen.dart';
@@ -11,19 +10,16 @@ import 'package:provider/provider.dart';
 import 'package:qr_flutter/qr_flutter.dart';
 import 'package:share_plus/share_plus.dart';
 
-class ShareInvoiceScreen extends StatefulWidget {
+import 'application/wallet_service.dart';
+
+class ShareInvoiceScreen extends StatelessWidget {
   static const route = "${WalletScreen.route}/$subRouteName";
   static const subRouteName = "share_invoice";
   final WalletService walletService;
+  final String invoice;
 
-  const ShareInvoiceScreen({super.key, this.walletService = const WalletService()});
-
-  @override
-  State<ShareInvoiceScreen> createState() => _ShareInvoiceScreenState();
-}
-
-class _ShareInvoiceScreenState extends State<ShareInvoiceScreen> {
-  String invoice = "";
+  const ShareInvoiceScreen(
+      {super.key, this.walletService = const WalletService(), required this.invoice});
 
   @override
   Widget build(BuildContext context) {
@@ -52,17 +48,9 @@ class _ShareInvoiceScreenState extends State<ShareInvoiceScreen> {
                 ),
                 ElevatedButton(
                     onPressed: () async {
-                      await widget.walletService.openChannel();
+                      await walletService.openChannel();
                     },
                     child: const Text("Open Channel!")),
-                ElevatedButton(
-                    onPressed: () async {
-                      String? invoice = await widget.walletService.createInvoice();
-                      if (invoice != null) {
-                        setState(() => this.invoice = invoice);
-                      }
-                    },
-                    child: const Text("Create Invoice")),
                 Expanded(
                   child: Center(
                     child: QrImage(

--- a/mobile/lib/features/wallet/wallet_screen.dart
+++ b/mobile/lib/features/wallet/wallet_screen.dart
@@ -3,7 +3,6 @@ import 'package:flutter_speed_dial/flutter_speed_dial.dart';
 import 'package:get_10101/common/amount_text.dart';
 import 'package:get_10101/features/wallet/balance_row.dart';
 import 'package:get_10101/features/wallet/wallet_theme.dart';
-import 'package:get_10101/features/wallet/receive_screen.dart';
 import 'package:get_10101/features/wallet/send_screen.dart';
 import 'package:get_10101/features/wallet/wallet_change_notifier.dart';
 import 'package:get_10101/util/send_receive_icons.dart';
@@ -71,7 +70,7 @@ class _WalletScreenState extends State<WalletScreen> {
           Divider(color: theme.dividerColor),
           ElevatedButton(
             onPressed: () {
-              context.go(ReceiveScreen.route);
+              context.go(ShareInvoiceScreen.route);
             },
             child: const Text("Fund Wallet"),
           ),
@@ -94,7 +93,7 @@ class _WalletScreenState extends State<WalletScreen> {
             child: const Icon(SendReceiveIcons.receive, size: 20.0),
             label: 'Receive',
             labelStyle: const TextStyle(fontSize: 18.0),
-            onTap: () => context.go(ReceiveScreen.route),
+            onTap: () => context.go(ShareInvoiceScreen.route),
           ),
           SpeedDialChild(
             child: const Icon(SendReceiveIcons.sendWithQr, size: 24.0),

--- a/mobile/lib/features/wallet/wallet_screen.dart
+++ b/mobile/lib/features/wallet/wallet_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_speed_dial/flutter_speed_dial.dart';
 import 'package:get_10101/common/amount_text.dart';
 import 'package:get_10101/features/wallet/balance_row.dart';
+import 'package:get_10101/features/wallet/create_invoice_screen.dart';
 import 'package:get_10101/features/wallet/wallet_theme.dart';
 import 'package:get_10101/features/wallet/send_screen.dart';
 import 'package:get_10101/features/wallet/wallet_change_notifier.dart';
@@ -70,7 +71,7 @@ class _WalletScreenState extends State<WalletScreen> {
           Divider(color: theme.dividerColor),
           ElevatedButton(
             onPressed: () {
-              context.go(ShareInvoiceScreen.route);
+              context.go(CreateInvoiceScreen.route);
             },
             child: const Text("Fund Wallet"),
           ),
@@ -93,7 +94,7 @@ class _WalletScreenState extends State<WalletScreen> {
             child: const Icon(SendReceiveIcons.receive, size: 20.0),
             label: 'Receive',
             labelStyle: const TextStyle(fontSize: 18.0),
-            onTap: () => context.go(ShareInvoiceScreen.route),
+            onTap: () => context.go(CreateInvoiceScreen.route),
           ),
           SpeedDialChild(
             child: const Icon(SendReceiveIcons.sendWithQr, size: 24.0),

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -16,7 +16,7 @@ import 'package:get_10101/features/trade/trade_value_change_notifier.dart';
 import 'package:get_10101/features/trade/settings_screen.dart';
 import 'package:get_10101/features/trade/trade_theme.dart';
 import 'package:get_10101/features/wallet/application/wallet_service.dart';
-import 'package:get_10101/features/wallet/receive_screen.dart';
+import 'package:get_10101/features/wallet/share_invoice_screen.dart';
 import 'package:get_10101/features/wallet/scanner_screen.dart';
 import 'package:get_10101/features/wallet/send_screen.dart';
 import 'package:get_10101/features/wallet/settings_screen.dart';
@@ -98,11 +98,11 @@ class _TenTenOneAppState extends State<TenTenOneApp> {
                 },
               ),
               GoRoute(
-                path: ReceiveScreen.subRouteName,
+                path: ShareInvoiceScreen.subRouteName,
                 // Use root navigator so the screen overlays the application shell
                 parentNavigatorKey: _rootNavigatorKey,
                 builder: (BuildContext context, GoRouterState state) {
-                  return const ReceiveScreen();
+                  return const ShareInvoiceScreen();
                 },
               ),
               GoRoute(

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -16,6 +16,7 @@ import 'package:get_10101/features/trade/trade_value_change_notifier.dart';
 import 'package:get_10101/features/trade/settings_screen.dart';
 import 'package:get_10101/features/trade/trade_theme.dart';
 import 'package:get_10101/features/wallet/application/wallet_service.dart';
+import 'package:get_10101/features/wallet/create_invoice_screen.dart';
 import 'package:get_10101/features/wallet/share_invoice_screen.dart';
 import 'package:get_10101/features/wallet/scanner_screen.dart';
 import 'package:get_10101/features/wallet/send_screen.dart';
@@ -98,11 +99,19 @@ class _TenTenOneAppState extends State<TenTenOneApp> {
                 },
               ),
               GoRoute(
+                path: CreateInvoiceScreen.subRouteName,
+                // Use root navigator so the screen overlays the application shell
+                parentNavigatorKey: _rootNavigatorKey,
+                builder: (BuildContext context, GoRouterState state) {
+                  return const CreateInvoiceScreen();
+                },
+              ),
+              GoRoute(
                 path: ShareInvoiceScreen.subRouteName,
                 // Use root navigator so the screen overlays the application shell
                 parentNavigatorKey: _rootNavigatorKey,
                 builder: (BuildContext context, GoRouterState state) {
-                  return const ShareInvoiceScreen();
+                  return ShareInvoiceScreen(invoice: state.extra as String);
                 },
               ),
               GoRoute(

--- a/mobile/linux/flutter/generated_plugin_registrant.cc
+++ b/mobile/linux/flutter/generated_plugin_registrant.cc
@@ -6,6 +6,10 @@
 
 #include "generated_plugin_registrant.h"
 
+#include <url_launcher_linux/url_launcher_plugin.h>
 
 void fl_register_plugins(FlPluginRegistry* registry) {
+  g_autoptr(FlPluginRegistrar) url_launcher_linux_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "UrlLauncherPlugin");
+  url_launcher_plugin_register_with_registrar(url_launcher_linux_registrar);
 }

--- a/mobile/linux/flutter/generated_plugins.cmake
+++ b/mobile/linux/flutter/generated_plugins.cmake
@@ -3,6 +3,7 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
+  url_launcher_linux
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST

--- a/mobile/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/mobile/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -6,7 +6,9 @@ import FlutterMacOS
 import Foundation
 
 import path_provider_foundation
+import share_plus
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
+  SharePlusMacosPlugin.register(with: registry.registrar(forPlugin: "SharePlusMacosPlugin"))
 }

--- a/mobile/native/src/api.rs
+++ b/mobile/native/src/api.rs
@@ -127,8 +127,12 @@ pub fn open_channel() -> Result<()> {
     ln_dlc::open_channel()
 }
 
-pub fn create_invoice(amount_sats: u64) -> Result<String> {
-    Ok(ln_dlc::create_invoice(amount_sats)?.to_string())
+pub fn create_invoice_with_amount(amount_sats: u64) -> Result<String> {
+    Ok(ln_dlc::create_invoice(Some(amount_sats))?.to_string())
+}
+
+pub fn create_invoice_without_amount() -> Result<String> {
+    Ok(ln_dlc::create_invoice(None)?.to_string())
 }
 
 pub fn send_payment(invoice: String) -> Result<()> {

--- a/mobile/native/src/api.rs
+++ b/mobile/native/src/api.rs
@@ -30,28 +30,8 @@ pub struct Balances {
     pub lightning: u64,
 }
 
-#[tokio::main(flavor = "current_thread")]
-pub async fn refresh_wallet_info() -> WalletInfo {
-    WalletInfo {
-        balances: Balances {
-            on_chain: 300,
-            lightning: 104,
-        },
-        history: vec![
-            Transaction {
-                address: "loremipsum".to_string(),
-                flow: PaymentFlow::Inbound,
-                amount_sats: 300,
-                wallet_type: WalletType::OnChain,
-            },
-            Transaction {
-                address: "dolorsitamet".to_string(),
-                flow: PaymentFlow::Inbound,
-                amount_sats: 104,
-                wallet_type: WalletType::Lightning,
-            },
-        ],
-    }
+pub fn refresh_wallet_info() -> Result<WalletInfo> {
+    ln_dlc::get_wallet_info()
 }
 
 #[derive(Clone, Debug, Default)]

--- a/mobile/native/src/api.rs
+++ b/mobile/native/src/api.rs
@@ -127,8 +127,8 @@ pub fn open_channel() -> Result<()> {
     ln_dlc::open_channel()
 }
 
-pub fn create_invoice() -> Result<String> {
-    Ok(ln_dlc::create_invoice()?.to_string())
+pub fn create_invoice(amount_sats: u64) -> Result<String> {
+    Ok(ln_dlc::create_invoice(amount_sats)?.to_string())
 }
 
 pub fn send_payment(invoice: String) -> Result<()> {

--- a/mobile/native/src/ln_dlc/mod.rs
+++ b/mobile/native/src/ln_dlc/mod.rs
@@ -228,7 +228,7 @@ pub fn open_channel() -> Result<()> {
     Ok(())
 }
 
-pub fn create_invoice() -> Result<Invoice> {
+pub fn create_invoice(amount_sats: u64) -> Result<Invoice> {
     let runtime = runtime()?;
 
     runtime.block_on(async {
@@ -254,7 +254,7 @@ pub fn create_invoice() -> Result<Invoice> {
         let fake_channel_id: u64 = text.parse()?;
 
         node.create_interceptable_invoice(
-            1000,
+            amount_sats,
             fake_channel_id,
             get_coordinator_info().pubkey,
             0,

--- a/mobile/native/src/ln_dlc/mod.rs
+++ b/mobile/native/src/ln_dlc/mod.rs
@@ -228,7 +228,7 @@ pub fn open_channel() -> Result<()> {
     Ok(())
 }
 
-pub fn create_invoice(amount_sats: u64) -> Result<Invoice> {
+pub fn create_invoice(amount_sats: Option<u64>) -> Result<Invoice> {
     let runtime = runtime()?;
 
     runtime.block_on(async {

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -185,6 +185,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.1.1"
+  cross_file:
+    dependency: transitive
+    description:
+      name: cross_file
+      sha256: "0b0036e8cccbfbe0555fd83c1d31a6f30b77a96b598b35a5d36dd41f718695e9"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.3+4"
   crypto:
     dependency: transitive
     description:
@@ -680,6 +688,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.22.0"
+  qr:
+    dependency: transitive
+    description:
+      name: qr
+      sha256: "5c4208b4dc0d55c3184d10d83ee0ded6212dc2b5e2ba17c5a0c0aab279128d21"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.0"
+  qr_flutter:
+    dependency: "direct main"
+    description:
+      name: qr_flutter
+      sha256: c5c121c54cb6dd837b9b9d57eb7bc7ec6df4aee741032060c8833a678c80b87e
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.0.0"
   quiver:
     dependency: transitive
     description:
@@ -704,6 +728,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.4.0+6"
+  share_plus:
+    dependency: "direct main"
+    description:
+      name: share_plus
+      sha256: "8c6892037b1824e2d7e8f59d54b3105932899008642e6372e5079c6939b4b625"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.3.1"
+  share_plus_platform_interface:
+    dependency: transitive
+    description:
+      name: share_plus_platform_interface
+      sha256: "82ddd4ab9260c295e6e39612d4ff00390b9a7a21f1bb1da771e2f232d80ab8a1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.0"
   shelf:
     dependency: transitive
     description:
@@ -845,6 +885,38 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.4"
+  url_launcher_linux:
+    dependency: transitive
+    description:
+      name: url_launcher_linux
+      sha256: e29039160ab3730e42f3d811dc2a6d5f2864b90a70fb765ea60144b03307f682
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.3"
+  url_launcher_platform_interface:
+    dependency: transitive
+    description:
+      name: url_launcher_platform_interface
+      sha256: "6c9ca697a5ae218ce56cece69d46128169a58aa8653c1b01d26fcd4aad8c4370"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.2"
+  url_launcher_web:
+    dependency: transitive
+    description:
+      name: url_launcher_web
+      sha256: "574cfbe2390666003c3a1d129bdc4574aaa6728f0c00a4829a81c316de69dd9b"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.15"
+  url_launcher_windows:
+    dependency: transitive
+    description:
+      name: url_launcher_windows
+      sha256: "97c9067950a0d09cbd93e2e3f0383d1403989362b97102fbf446473a48079a4b"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.4"
   uuid:
     dependency: "direct main"
     description:

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -1022,5 +1022,5 @@ packages:
     source: hosted
     version: "2.0.3"
 sdks:
-  dart: ">=2.19.0 <4.0.0"
+  dart: ">=2.19.0 <3.0.0"
   flutter: ">=3.7.0-0"

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -26,6 +26,8 @@ dependencies:
   uuid: ^3.0.7
   freezed_annotation: ^2.2.0
   expandable: ^5.0.1
+  qr_flutter: ^4.0.0
+  share_plus: ^6.3.1
 
 dev_dependencies:
   flutter_launcher_icons: "^0.11.0"

--- a/mobile/windows/flutter/generated_plugin_registrant.cc
+++ b/mobile/windows/flutter/generated_plugin_registrant.cc
@@ -6,6 +6,12 @@
 
 #include "generated_plugin_registrant.h"
 
+#include <share_plus/share_plus_windows_plugin_c_api.h>
+#include <url_launcher_windows/url_launcher_windows.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
+  SharePlusWindowsPluginCApiRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("SharePlusWindowsPluginCApi"));
+  UrlLauncherWindowsRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("UrlLauncherWindows"));
 }

--- a/mobile/windows/flutter/generated_plugins.cmake
+++ b/mobile/windows/flutter/generated_plugins.cmake
@@ -3,6 +3,8 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
+  share_plus
+  url_launcher_windows
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST


### PR DESCRIPTION
This PR adds the invoice creation and sharing UI.

**Acceptance criteria progress (from #178):**
- [x] Upon clicking fund wallet the "create lightning payment request" workflow is opened. (we will introduce the wallet selection at a later stage)
- [x] Use the device keypad
    - Need to test this still but I believe it should work?
- [ ] Format number with commas on the thousands
    - I used the currently existing AmountInputField which does not yet do this - could be out of scope for this PR?
- [x] Add copy and share button.
    - I found a library to simply implement the share function so I just did it in this PR too
- [ ] Done should return to the wallet overview (and trigger a refresh wallet)
    - I've made Done return to wherever the user was 2 steps ago in the stack (usually will be wallet overview)
    - Wallet does not yet refresh


Closes #178.