### PR TITLE
Revert "chore: Remove open channel from api"

### DIFF
--- a/crates/ln-dlc-node/src/tests/mod.rs
+++ b/crates/ln-dlc-node/src/tests/mod.rs
@@ -177,37 +177,6 @@ impl Node {
         Ok(channel_details)
     }
 
-    /// Initiates the open private channel protocol.
-    ///
-    /// Returns a temporary channel ID as a 32-byte long array.
-    pub fn initiate_open_channel(
-        &self,
-        peer: NodeInfo,
-        channel_amount_sat: u64,
-        initial_send_amount_sats: u64,
-    ) -> Result<[u8; 32]> {
-        let mut user_config = self.user_config;
-        user_config.channel_handshake_config.announced_channel = false;
-        let temp_channel_id = self
-            .channel_manager
-            .create_channel(
-                peer.pubkey,
-                channel_amount_sat,
-                initial_send_amount_sats * 1000,
-                0,
-                Some(user_config),
-            )
-            .map_err(|e| anyhow!("Could not create channel with {} due to {e:?}", peer))?;
-
-        tracing::info!(
-            %peer,
-            temp_channel_id = %hex::encode(temp_channel_id),
-            "Started channel creation"
-        );
-
-        Ok(temp_channel_id)
-    }
-
     async fn accept_dlc_channel(&self, channel_id: &[u8; 32]) -> Result<()> {
         self.initiate_accept_dlc_channel_offer(channel_id)?;
 

--- a/mobile/lib/features/wallet/application/wallet_service.dart
+++ b/mobile/lib/features/wallet/application/wallet_service.dart
@@ -16,6 +16,15 @@ class WalletService {
     }
   }
 
+  Future<void> openChannel() async {
+    try {
+      await rust.api.openChannel();
+      FLog.info(text: "Open Channel successfully started.");
+    } catch (error) {
+      FLog.error(text: "Error: $error", exception: error);
+    }
+  }
+
   Future<String?> createInvoice() async {
     try {
       String invoice = await rust.api.createInvoice();

--- a/mobile/lib/features/wallet/receive_screen.dart
+++ b/mobile/lib/features/wallet/receive_screen.dart
@@ -47,6 +47,11 @@ class _ReceiveScreenState extends State<ReceiveScreen> {
               },
               child: const Text("Create Invoice")),
           SelectableText("Invoice: $invoice"),
+          ElevatedButton(
+              onPressed: () async {
+                await widget.walletService.openChannel();
+              },
+              child: const Text("Open Channel!"))
         ],
       )),
     );

--- a/mobile/native/src/api.rs
+++ b/mobile/native/src/api.rs
@@ -143,6 +143,10 @@ pub fn get_new_address() -> SyncReturn<String> {
     SyncReturn(ln_dlc::get_new_address().unwrap())
 }
 
+pub fn open_channel() -> Result<()> {
+    ln_dlc::open_channel()
+}
+
 pub fn create_invoice() -> Result<String> {
     Ok(ln_dlc::create_invoice()?.to_string())
 }

--- a/mobile/native/src/ln_dlc/mod.rs
+++ b/mobile/native/src/ln_dlc/mod.rs
@@ -162,6 +162,16 @@ pub fn get_new_address() -> Result<String> {
     Ok(address.to_string())
 }
 
+/// TODO: remove this function once the lightning faucet is more stable. This is only added for
+/// testing purposes - so that we can quickly get funds into the lightning wallet.
+pub fn open_channel() -> Result<()> {
+    let node = NODE.try_get().context("failed to get ln dlc node")?;
+
+    node.initiate_open_channel(get_coordinator_info(), 500000, 250000)?;
+
+    Ok(())
+}
+
 pub fn create_invoice() -> Result<Invoice> {
     let runtime = runtime()?;
 


### PR DESCRIPTION
@da-kami: I've reverted the commit, removing the open channel button.

I had to change one additional configuration, being that the coordinator must not enforce his channel announcement preferences (public inbound channels only), since the app only accepts private channels.

This will now allow us again to open a private channel from the app - I hope we will only work with that temporarily, as this does not reflect the real flow.

This reverts commit 3e2fac2f