### PR TITLE
chore: Increase max inbound htlc value of in flight payments

### DIFF
--- a/crates/ln-dlc-node/src/node.rs
+++ b/crates/ln-dlc-node/src/node.rs
@@ -771,9 +771,8 @@ pub(crate) fn app_config() -> UserConfig {
             // preferences.
             announced_channel: false,
             minimum_depth: 1,
-            // only 10% of the total channel value can be sent. e.g. with a volume of 30.000 sats
-            // only 3.000 sats can be sent.
-            max_inbound_htlc_value_in_flight_percent_of_channel: 10,
+            // There is no risk in the leaf channel to receive 100% of the channel capacity.
+            max_inbound_htlc_value_in_flight_percent_of_channel: 100,
             ..Default::default()
         },
         channel_handshake_limits: ChannelHandshakeLimits {
@@ -808,9 +807,8 @@ pub(crate) fn coordinator_config() -> UserConfig {
             // The minimum amount of confirmations before the inbound channel is deemed useable,
             // between the counterparties
             minimum_depth: 1,
-            // only 10% of the total channel value can be sent. e.g. with a volume of 30.000 sats
-            // only 3.000 sats can be sent.
-            max_inbound_htlc_value_in_flight_percent_of_channel: 10,
+            // We set this 100% as the coordinator is online 24/7 and can take the risk.
+            max_inbound_htlc_value_in_flight_percent_of_channel: 100,
             ..Default::default()
         },
         channel_handshake_limits: ChannelHandshakeLimits {


### PR DESCRIPTION
Upon creation of a just-in-time channel we use the max of either the `LIQUIDITY_ROUTING_FEE_MILLIONTHS` constant (10_000) or twice the amount of the in-flight payment to define the channel capacity.

In case we do not use the constant, the payment will fail with the current configuration on main, as the `max_inbound_htlc_value_in_flight_percent_of_channel` of the just-in-time-channel rejects pending HTLCs greater than 10% of the total channel capacity.

So, given our current calculation of the channel capacity, this value has to be at least 50%. However, we are setting it to 100% though - see reasoning in the comments.