### PR TITLE
chore: Read channel data from file system upon restart

### DIFF
--- a/coordinator/src/bin/coordinator.rs
+++ b/coordinator/src/bin/coordinator.rs
@@ -50,7 +50,7 @@ async fn main() -> Result<()> {
             seed,
             ephemeral_randomness,
         )
-        .await,
+        .await?,
     );
 
     tokio::spawn({

--- a/crates/ln-dlc-node/src/lib.rs
+++ b/crates/ln-dlc-node/src/lib.rs
@@ -7,6 +7,7 @@ use dlc_messages::message_handler::MessageHandler as DlcMessageHandler;
 use dlc_sled_storage_provider::SledStorageProvider;
 use lightning::chain;
 use lightning::chain::chainmonitor;
+use lightning::chain::channelmonitor::ChannelMonitor;
 use lightning::chain::Filter;
 use lightning::ln::channelmanager::InterceptId;
 use lightning::ln::peer_handler::IgnoringMessageHandler;
@@ -38,6 +39,13 @@ pub mod node;
 
 #[cfg(test)]
 mod tests;
+
+type ConfirmableMonitor = (
+    ChannelMonitor<CustomSigner>,
+    Arc<LnDlcWallet>,
+    Arc<LnDlcWallet>,
+    Arc<TracingLogger>,
+);
 
 type ChainMonitor = chainmonitor::ChainMonitor<
     CustomSigner,

--- a/crates/ln-dlc-node/src/node.rs
+++ b/crates/ln-dlc-node/src/node.rs
@@ -21,6 +21,7 @@ use anyhow::Error;
 use anyhow::Result;
 use bdk::blockchain::ElectrumBlockchain;
 use bdk::Balance;
+use bitcoin::blockdata::constants::genesis_block;
 use bitcoin::hashes::sha256;
 use bitcoin::hashes::Hash;
 use bitcoin::secp256k1::PublicKey;
@@ -382,8 +383,13 @@ impl Node {
             );
         }
 
-        // TODO: Provide persisted one if restarting
-        let network_graph = Arc::new(NetworkGraph::new(hash, logger.clone()));
+        let genesis = genesis_block(network).header.block_hash();
+        let network_graph_path = format!("{ldk_data_dir}/network_graph");
+        let network_graph = Arc::new(disk::read_network(
+            Path::new(&network_graph_path),
+            genesis,
+            logger.clone(),
+        ));
 
         let gossip_sync = Arc::new(P2PGossipSync::new(
             network_graph.clone(),

--- a/crates/ln-dlc-node/src/tests/mod.rs
+++ b/crates/ln-dlc-node/src/tests/mod.rs
@@ -95,7 +95,7 @@ impl Node {
             ephemeral_randomness,
             user_config,
         )
-        .await;
+        .await?;
 
         let bg_processor = node.start().await?;
         mem::forget(bg_processor); // to keep it running

--- a/mobile/native/src/ln_dlc/mod.rs
+++ b/mobile/native/src/ln_dlc/mod.rs
@@ -125,7 +125,7 @@ pub fn run(data_dir: String) -> Result<()> {
                 seed,
                 ephemeral_randomness,
             )
-            .await,
+            .await?,
         );
 
         let background_processor = node.start().await?;


### PR DESCRIPTION
The ln_dlc node did save channel data to the disk, but never recovered any channel date from disk. This PR fixes that issues and will allow the node to restart without loosing its channel data.

More specifically this PR will fix the following error (which will be printed by the coordinator or app, if a channel was opened before a restart).
```
ERROR lightning::ln::channelmanager: Failed to find corresponding channel
```

Additionally, the network graph is also read from disk. Eventually, all this data should be stored into and read from the database.