### PR TITLE
Make `ln-dlc-node` tests a bit more resilient

### DIFF
--- a/crates/ln-dlc-node/src/lib.rs
+++ b/crates/ln-dlc-node/src/lib.rs
@@ -122,6 +122,7 @@ struct PaymentInfo {
     amt_msat: MillisatAmount,
 }
 
+#[derive(Debug)]
 enum HTLCStatus {
     Pending,
     Succeeded,

--- a/crates/ln-dlc-node/src/tests/add_dlc.rs
+++ b/crates/ln-dlc-node/src/tests/add_dlc.rs
@@ -21,10 +21,7 @@ async fn given_lightning_channel_then_can_add_dlc_channel() {
 
     app.keep_connected(coordinator.info).await.unwrap();
 
-    coordinator
-        .fund(Amount::from_btc(0.1).unwrap())
-        .await
-        .unwrap();
+    coordinator.fund(Amount::from_sat(200_000)).await.unwrap();
 
     coordinator.open_channel(&app, 50000, 50000).await.unwrap();
     let channel_details = app.channel_manager.list_usable_channels();

--- a/crates/ln-dlc-node/src/tests/add_dlc.rs
+++ b/crates/ln-dlc-node/src/tests/add_dlc.rs
@@ -4,7 +4,6 @@ use crate::tests::init_tracing;
 use crate::tests::wait_until;
 use anyhow::anyhow;
 use bitcoin::Amount;
-use dlc_manager::contract::Contract;
 use dlc_manager::sub_channel_manager::SubChannelState;
 use dlc_manager::Oracle;
 use dlc_manager::Storage;
@@ -105,23 +104,4 @@ async fn given_lightning_channel_then_can_add_dlc_channel() {
         .unwrap();
 
     matches!(sub_channel_app.state, SubChannelState::Signed(_));
-
-    if let Contract::Confirmed(contract) =
-        &coordinator.dlc_manager.get_store().get_contracts().unwrap()[0]
-    {
-        let cets = &contract
-            .accepted_contract
-            .dlc_transactions
-            .cets
-            .iter()
-            .map(|c| {
-                (
-                    c.output[0].value,
-                    c.output.get(1).map(|t| t.value).unwrap_or_default(),
-                )
-            })
-            .collect::<Vec<_>>();
-
-        dbg!(cets);
-    };
 }

--- a/crates/ln-dlc-node/src/tests/add_dlc.rs
+++ b/crates/ln-dlc-node/src/tests/add_dlc.rs
@@ -21,7 +21,6 @@ async fn given_lightning_channel_then_can_add_dlc_channel() {
 
     app.keep_connected(coordinator.info).await.unwrap();
 
-    app.fund(Amount::from_btc(0.1).unwrap()).await.unwrap();
     coordinator
         .fund(Amount::from_btc(0.1).unwrap())
         .await

--- a/crates/ln-dlc-node/src/tests/add_dlc.rs
+++ b/crates/ln-dlc-node/src/tests/add_dlc.rs
@@ -27,10 +27,7 @@ async fn given_lightning_channel_then_can_add_dlc_channel() {
         .await
         .unwrap();
 
-    coordinator
-        .open_channel(&app.info, 50000, 50000)
-        .await
-        .unwrap();
+    coordinator.open_channel(&app, 50000, 50000).await.unwrap();
     let channel_details = app.channel_manager.list_usable_channels();
     let channel_details = channel_details
         .iter()

--- a/crates/ln-dlc-node/src/tests/just_in_time_channel.rs
+++ b/crates/ln-dlc-node/src/tests/just_in_time_channel.rs
@@ -27,12 +27,12 @@ async fn just_in_time_channel() {
     coordinator.fund(Amount::from_sat(100_000)).await.unwrap();
 
     let coordinator_outbound_liquidity_sat = 25_000;
-    let payer_inbound_liquidity_sat = 25_000;
+    let payer_outbound_liquidity_sat = 25_000;
     let payer_coordinator_channel_details = coordinator
         .open_channel(
             &payer,
             coordinator_outbound_liquidity_sat,
-            payer_inbound_liquidity_sat,
+            payer_outbound_liquidity_sat,
         )
         .await
         .unwrap();

--- a/crates/ln-dlc-node/src/tests/just_in_time_channel.rs
+++ b/crates/ln-dlc-node/src/tests/just_in_time_channel.rs
@@ -21,8 +21,6 @@ async fn just_in_time_channel() {
     payer.keep_connected(coordinator.info).await.unwrap();
     payee.keep_connected(coordinator.info).await.unwrap();
 
-    // Fund the on-chain wallets of the nodes who will open a channel
-    payer.fund(Amount::from_sat(100_000)).await.unwrap();
     coordinator.fund(Amount::from_sat(100_000)).await.unwrap();
 
     let coordinator_outbound_liquidity_sat = 25_000;

--- a/crates/ln-dlc-node/src/tests/just_in_time_channel.rs
+++ b/crates/ln-dlc-node/src/tests/just_in_time_channel.rs
@@ -2,6 +2,7 @@ use crate::ln::event_handler::JUST_IN_TIME_CHANNEL_OUTBOUND_LIQUIDITY_SAT;
 use crate::node::Node;
 use crate::node::LIQUIDITY_ROUTING_FEE_MILLIONTHS;
 use crate::tests::init_tracing;
+use crate::tests::min_outbound_liquidity_channel_creator;
 use anyhow::Context;
 use anyhow::Result;
 use bitcoin::Amount;
@@ -23,8 +24,10 @@ async fn just_in_time_channel() {
 
     coordinator.fund(Amount::from_sat(100_000)).await.unwrap();
 
-    let coordinator_outbound_liquidity_sat = 25_000;
     let payer_outbound_liquidity_sat = 25_000;
+    let coordinator_outbound_liquidity_sat =
+        min_outbound_liquidity_channel_creator(&payer, payer_outbound_liquidity_sat);
+
     let payer_coordinator_channel_details = coordinator
         .open_channel(
             &payer,

--- a/crates/ln-dlc-node/src/tests/just_in_time_channel.rs
+++ b/crates/ln-dlc-node/src/tests/just_in_time_channel.rs
@@ -30,7 +30,7 @@ async fn just_in_time_channel() {
     let payer_inbound_liquidity_sat = 25_000;
     let payer_coordinator_channel_details = coordinator
         .open_channel(
-            &payer.info,
+            &payer,
             coordinator_outbound_liquidity_sat,
             payer_inbound_liquidity_sat,
         )

--- a/crates/ln-dlc-node/src/tests/mod.rs
+++ b/crates/ln-dlc-node/src/tests/mod.rs
@@ -259,12 +259,13 @@ fn random_tmp_dir() -> PathBuf {
 
 #[allow(dead_code)]
 fn log_channel_id(node: &Node, index: usize, pair: &str) {
-    let details = node
-        .channel_manager
-        .list_channels()
-        .get(index)
-        .unwrap()
-        .clone();
+    let details = match node.channel_manager.list_channels().get(index) {
+        Some(details) => details.clone(),
+        None => {
+            tracing::info!(%index, %pair, "No channel");
+            return;
+        }
+    };
 
     let channel_id = hex::encode(details.channel_id);
     let short_channel_id = details.short_channel_id;

--- a/crates/ln-dlc-node/src/tests/multi_hop_payment.rs
+++ b/crates/ln-dlc-node/src/tests/multi_hop_payment.rs
@@ -1,5 +1,6 @@
 use crate::node::Node;
 use crate::tests::init_tracing;
+use crate::tests::min_outbound_liquidity_channel_creator;
 use bitcoin::Amount;
 
 #[tokio::test]
@@ -16,12 +17,20 @@ async fn multi_hop_payment() {
     payer.keep_connected(coordinator.info).await.unwrap();
     payee.keep_connected(coordinator.info).await.unwrap();
 
-    coordinator.fund(Amount::from_sat(100_000)).await.unwrap();
+    coordinator.fund(Amount::from_sat(50_000)).await.unwrap();
 
+    let payer_outbound_liquidity_sat = 20_000;
+    let coordinator_outbound_liquidity_sat =
+        min_outbound_liquidity_channel_creator(&payer, payer_outbound_liquidity_sat);
     coordinator
-        .open_channel(&payer, 20_000, 20_000)
+        .open_channel(
+            &payer,
+            coordinator_outbound_liquidity_sat,
+            payer_outbound_liquidity_sat,
+        )
         .await
         .unwrap();
+
     coordinator.open_channel(&payee, 20_000, 0).await.unwrap();
 
     let payer_balance_before = payer.get_ldk_balance();

--- a/crates/ln-dlc-node/src/tests/multi_hop_payment.rs
+++ b/crates/ln-dlc-node/src/tests/multi_hop_payment.rs
@@ -12,24 +12,30 @@ async fn multi_hop_payment() {
     // Arrange
 
     let payer = Node::start_test_app("payer").await.unwrap();
-    let router = Node::start_test_coordinator("router").await.unwrap();
+    let coordinator = Node::start_test_coordinator("coordinator").await.unwrap();
     let payee = Node::start_test_app("payee").await.unwrap();
 
-    payer.keep_connected(router.info).await.unwrap();
-    payee.keep_connected(router.info).await.unwrap();
+    payer.keep_connected(coordinator.info).await.unwrap();
+    payee.keep_connected(coordinator.info).await.unwrap();
 
     payer.fund(Amount::from_sat(50_000)).await.unwrap();
-    router.fund(Amount::from_sat(100_000)).await.unwrap();
+    coordinator.fund(Amount::from_sat(100_000)).await.unwrap();
 
-    router.open_channel(&payer, 20_000, 20_000).await.unwrap();
-    router.open_channel(&payee, 20_000, 20_000).await.unwrap();
+    coordinator
+        .open_channel(&payer, 20_000, 20_000)
+        .await
+        .unwrap();
+    coordinator
+        .open_channel(&payee, 20_000, 20_000)
+        .await
+        .unwrap();
 
     let payer_balance_before = payer.get_ldk_balance();
-    let router_balance_before = router.get_ldk_balance();
+    let coordinator_balance_before = coordinator.get_ldk_balance();
     let payee_balance_before = payee.get_ldk_balance();
 
     payer.sync();
-    router.sync();
+    coordinator.sync();
     payee.sync();
 
     // Act
@@ -43,13 +49,13 @@ async fn multi_hop_payment() {
     tokio::time::sleep(Duration::from_secs(1)).await;
 
     payer.sync();
-    router.sync();
+    coordinator.sync();
     payee.sync();
 
     // Assert
 
     let payer_balance_after = payer.get_ldk_balance();
-    let router_balance_after = router.get_ldk_balance();
+    let coordinator_balance_after = coordinator.get_ldk_balance();
     let payee_balance_after = payee.get_ldk_balance();
 
     let routing_fee = 1; // according to the default `ChannelConfig`
@@ -60,7 +66,7 @@ async fn multi_hop_payment() {
     );
 
     assert_eq!(
-        router_balance_after.available - router_balance_before.available,
+        coordinator_balance_after.available - coordinator_balance_before.available,
         routing_fee
     );
 

--- a/crates/ln-dlc-node/src/tests/multi_hop_payment.rs
+++ b/crates/ln-dlc-node/src/tests/multi_hop_payment.rs
@@ -22,10 +22,7 @@ async fn multi_hop_payment() {
         .open_channel(&payer, 20_000, 20_000)
         .await
         .unwrap();
-    coordinator
-        .open_channel(&payee, 20_000, 20_000)
-        .await
-        .unwrap();
+    coordinator.open_channel(&payee, 20_000, 0).await.unwrap();
 
     let payer_balance_before = payer.get_ldk_balance();
     let coordinator_balance_before = coordinator.get_ldk_balance();

--- a/crates/ln-dlc-node/src/tests/multi_hop_payment.rs
+++ b/crates/ln-dlc-node/src/tests/multi_hop_payment.rs
@@ -1,8 +1,6 @@
-use bitcoin::Amount;
-
 use crate::node::Node;
 use crate::tests::init_tracing;
-use std::time::Duration;
+use bitcoin::Amount;
 
 #[tokio::test]
 #[ignore]
@@ -44,14 +42,17 @@ async fn multi_hop_payment() {
 
     payer.send_payment(&invoice).unwrap();
 
-    // For the payment to be claimed before the wallet syncs
-    tokio::time::sleep(Duration::from_secs(1)).await;
+    payee
+        .wait_for_payment_claimed(invoice.payment_hash())
+        .await
+        .unwrap();
 
+    // Assert
+
+    // Sync LN wallet after payment is claimed to update the balances
     payer.sync();
     coordinator.sync();
     payee.sync();
-
-    // Assert
 
     let payer_balance_after = payer.get_ldk_balance();
     let coordinator_balance_after = coordinator.get_ldk_balance();

--- a/crates/ln-dlc-node/src/tests/multi_hop_payment.rs
+++ b/crates/ln-dlc-node/src/tests/multi_hop_payment.rs
@@ -21,14 +21,8 @@ async fn multi_hop_payment() {
     payer.fund(Amount::from_sat(50_000)).await.unwrap();
     router.fund(Amount::from_sat(100_000)).await.unwrap();
 
-    router
-        .open_channel(&payer.info, 20_000, 20_000)
-        .await
-        .unwrap();
-    router
-        .open_channel(&payee.info, 20_000, 20_000)
-        .await
-        .unwrap();
+    router.open_channel(&payer, 20_000, 20_000).await.unwrap();
+    router.open_channel(&payee, 20_000, 20_000).await.unwrap();
 
     let payer_balance_before = payer.get_ldk_balance();
     let router_balance_before = router.get_ldk_balance();

--- a/crates/ln-dlc-node/src/tests/multi_hop_payment.rs
+++ b/crates/ln-dlc-node/src/tests/multi_hop_payment.rs
@@ -18,7 +18,6 @@ async fn multi_hop_payment() {
     payer.keep_connected(coordinator.info).await.unwrap();
     payee.keep_connected(coordinator.info).await.unwrap();
 
-    payer.fund(Amount::from_sat(50_000)).await.unwrap();
     coordinator.fund(Amount::from_sat(100_000)).await.unwrap();
 
     coordinator

--- a/crates/ln-dlc-node/src/tests/single_hop_payment.rs
+++ b/crates/ln-dlc-node/src/tests/single_hop_payment.rs
@@ -17,7 +17,7 @@ async fn single_hop_payment() {
 
     payer.fund(Amount::from_btc(0.1).unwrap()).await.unwrap();
 
-    payer.open_channel(&payee.info, 30_000, 0).await.unwrap();
+    payer.open_channel(&payee, 30_000, 0).await.unwrap();
 
     let payer_balance_before = payer.get_ldk_balance();
     let payee_balance_before = payee.get_ldk_balance();

--- a/crates/ln-dlc-node/src/tests/single_hop_payment.rs
+++ b/crates/ln-dlc-node/src/tests/single_hop_payment.rs
@@ -1,7 +1,6 @@
 use crate::node::Node;
 use crate::tests::init_tracing;
 use bitcoin::Amount;
-use std::time::Duration;
 
 #[tokio::test]
 #[ignore]
@@ -32,13 +31,16 @@ async fn single_hop_payment() {
 
     payer.send_payment(&invoice).unwrap();
 
-    // For the payment to be claimed before the wallet syncs
-    tokio::time::sleep(Duration::from_secs(1)).await;
-
-    payer.sync();
-    payee.sync();
+    payee
+        .wait_for_payment_claimed(invoice.payment_hash())
+        .await
+        .unwrap();
 
     // Assert
+
+    // Sync LN wallet after payment is claimed to update the balances
+    payer.sync();
+    payee.sync();
 
     let payer_balance_after = payer.get_ldk_balance();
     let payee_balance_after = payee.get_ldk_balance();

--- a/dprint.json
+++ b/dprint.json
@@ -18,6 +18,7 @@
     "**/dist",
     "**/build",
     "**/ios/Pods",
+    "**/pgdata",
     "coordinator/migrations/00000000000000_diesel_initial_setup/up.sql"
   ],
   "plugins": [


### PR DESCRIPTION
This was some work that I've been collecting as I've been trying to verify that the LN channel is usable after a DLC channel has been opened beside it.