### PR TITLE
feat: Calculate cfd fees

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -292,7 +292,6 @@ dependencies = [
 [[package]]
 name = "bitcoin-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/get10101/rust-dlc?rev=3c57f779a1c6f10db19630af7e8d34a69d0e4c39#3c57f779a1c6f10db19630af7e8d34a69d0e4c39"
 dependencies = [
  "bitcoin",
  "bitcoincore-rpc",
@@ -782,7 +781,6 @@ dependencies = [
 [[package]]
 name = "dlc"
 version = "0.3.0"
-source = "git+https://github.com/get10101/rust-dlc?rev=3c57f779a1c6f10db19630af7e8d34a69d0e4c39#3c57f779a1c6f10db19630af7e8d34a69d0e4c39"
 dependencies = [
  "bitcoin",
  "miniscript",
@@ -794,7 +792,6 @@ dependencies = [
 [[package]]
 name = "dlc-manager"
 version = "0.3.0"
-source = "git+https://github.com/get10101/rust-dlc?rev=3c57f779a1c6f10db19630af7e8d34a69d0e4c39#3c57f779a1c6f10db19630af7e8d34a69d0e4c39"
 dependencies = [
  "async-trait",
  "bitcoin",
@@ -811,7 +808,6 @@ dependencies = [
 [[package]]
 name = "dlc-messages"
 version = "0.3.0"
-source = "git+https://github.com/get10101/rust-dlc?rev=3c57f779a1c6f10db19630af7e8d34a69d0e4c39#3c57f779a1c6f10db19630af7e8d34a69d0e4c39"
 dependencies = [
  "bitcoin",
  "dlc",
@@ -823,7 +819,6 @@ dependencies = [
 [[package]]
 name = "dlc-sled-storage-provider"
 version = "0.1.0"
-source = "git+https://github.com/get10101/rust-dlc?rev=3c57f779a1c6f10db19630af7e8d34a69d0e4c39#3c57f779a1c6f10db19630af7e8d34a69d0e4c39"
 dependencies = [
  "bitcoin",
  "dlc-manager",
@@ -836,7 +831,6 @@ dependencies = [
 [[package]]
 name = "dlc-trie"
 version = "0.3.0"
-source = "git+https://github.com/get10101/rust-dlc?rev=3c57f779a1c6f10db19630af7e8d34a69d0e4c39#3c57f779a1c6f10db19630af7e8d34a69d0e4c39"
 dependencies = [
  "bitcoin",
  "dlc",
@@ -1693,6 +1687,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bdk",
+ "dlc",
  "dlc-manager",
  "dlc-trie",
  "flutter_rust_bridge",
@@ -1852,7 +1847,6 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 [[package]]
 name = "p2pd-oracle-client"
 version = "0.1.0"
-source = "git+https://github.com/get10101/rust-dlc?rev=3c57f779a1c6f10db19630af7e8d34a69d0e4c39#3c57f779a1c6f10db19630af7e8d34a69d0e4c39"
 dependencies = [
  "chrono",
  "dlc-manager",
@@ -2515,7 +2509,6 @@ dependencies = [
 [[package]]
 name = "simple-wallet"
 version = "0.1.0"
-source = "git+https://github.com/get10101/rust-dlc?rev=3c57f779a1c6f10db19630af7e8d34a69d0e4c39#3c57f779a1c6f10db19630af7e8d34a69d0e4c39"
 dependencies = [
  "bitcoin",
  "dlc",

--- a/mobile/lib/features/trade/application/trade_values_service.dart
+++ b/mobile/lib/features/trade/application/trade_values_service.dart
@@ -1,7 +1,7 @@
+import 'package:get_10101/common/domain/model.dart';
+import 'package:get_10101/features/trade/domain/direction.dart';
 import 'package:get_10101/ffi.dart' as rust;
 import 'package:get_10101/features/trade/domain/leverage.dart';
-import '../../../common/domain/model.dart';
-import '../domain/direction.dart';
 
 class TradeValuesService {
   Amount calculateMargin(
@@ -23,5 +23,9 @@ class TradeValuesService {
       dynamic hint}) {
     return rust.api.calculateLiquidationPrice(
         price: price, leverage: leverage.leverage, direction: direction.toApi());
+  }
+
+  Amount calculateFee() {
+    return Amount(rust.api.calculateFees());
   }
 }

--- a/mobile/lib/features/trade/domain/trade_values.dart
+++ b/mobile/lib/features/trade/domain/trade_values.dart
@@ -41,8 +41,7 @@ class TradeValues {
     double liquidationPrice = tradeValuesService.calculateLiquidationPrice(
         price: price, leverage: leverage, direction: direction);
 
-    // TODO: Calculate fee based on price, quantity and funding rate
-    Amount fee = Amount(30);
+    Amount fee = tradeValuesService.calculateFee();
 
     return TradeValues(
         direction: direction,

--- a/mobile/native/Cargo.toml
+++ b/mobile/native/Cargo.toml
@@ -9,6 +9,7 @@ crate-type = ["cdylib", "staticlib"]
 [dependencies]
 anyhow = "1"
 bdk = { version = "0.24.0", features = ["key-value-db"] }
+dlc = { version = "0.3.0" }
 dlc-manager = { version = "0.3.0", features = ["use-serde"] } # required for the dlc_manager::Wallet trait
 dlc-trie = { version = "0.3.0" }
 flutter_rust_bridge = "1.63.1"

--- a/mobile/native/src/api.rs
+++ b/mobile/native/src/api.rs
@@ -78,6 +78,10 @@ pub enum PaymentFlow {
     Outbound,
 }
 
+pub fn calculate_fees() -> SyncReturn<u64> {
+    SyncReturn(calculations::calculate_fees())
+}
+
 pub fn calculate_margin(price: f64, quantity: f64, leverage: f64) -> SyncReturn<u64> {
     SyncReturn(calculations::calculate_margin(price, quantity, leverage))
 }

--- a/mobile/native/src/calculations/mod.rs
+++ b/mobile/native/src/calculations/mod.rs
@@ -1,4 +1,5 @@
 use crate::common::api::Direction;
+use dlc::channel::sub_channel::LN_GLUE_TX_WEIGHT;
 use rust_decimal::prelude::ToPrimitive;
 use rust_decimal::Decimal;
 use trade::cfd;
@@ -30,4 +31,14 @@ pub fn calculate_liquidation_price(price: f64, leverage: f64, direction: Directi
     tracing::trace!("Liquidation_price: {liquidation_price}");
 
     liquidation_price
+}
+
+pub fn calculate_fees() -> u64 {
+    // TODO: this should probably come from a configuration.
+    let fee_rate = 2;
+    let total_fee = (dlc::channel::sub_channel::dlc_channel_and_split_fee(fee_rate)
+        + dlc::util::weight_to_fee(LN_GLUE_TX_WEIGHT, fee_rate)) as f64;
+
+    // the party that offers the trade will pay the extra sat in case the fees are uneven.
+    (total_fee / 2.0).ceil() as u64
 }

--- a/mobile/test/trade_test.dart
+++ b/mobile/test/trade_test.dart
@@ -38,7 +38,9 @@ final GoRouter _router = GoRouter(
 
 class TestWrapperWithTradeTheme extends StatelessWidget {
   final Widget child;
+
   const TestWrapperWithTradeTheme({super.key, required this.child});
+
   @override
   Widget build(BuildContext context) {
     return MaterialApp.router(
@@ -78,6 +80,7 @@ void main() {
     when(tradeValueService.calculateQuantity(
             price: anyNamed('price'), leverage: anyNamed('leverage'), margin: anyNamed('margin')))
         .thenReturn(100);
+    when(tradeValueService.calculateFee()).thenReturn(Amount(833));
 
     SubmitOrderChangeNotifier submitOrderChangeNotifier = SubmitOrderChangeNotifier(orderService);
 


### PR DESCRIPTION
This adds the correct fees to the trading confirmation screen. However, these fees should probably be already shown on the trade screen. As you these fees are not that small.

This change uses the rust-dlc implementation for its calculation as this will implicitly be used when we are proposing a sub channel.