### PR TITLE
fix: Switch roles in dlc channel

### DIFF
--- a/crates/ln-dlc-node/src/node.rs
+++ b/crates/ln-dlc-node/src/node.rs
@@ -1056,8 +1056,8 @@ impl Node {
         // The contract input to be used for setting up the trade between the trader and the
         // coordinator
         let contract_input = ContractInput {
-            offer_collateral: margin_coordinator,
-            accept_collateral: margin_trader,
+            offer_collateral: margin_trader,
+            accept_collateral: margin_coordinator,
             maturity_time: maturity_time as u32,
             fee_rate: 2,
             contract_infos: vec![ContractInputInfo {

--- a/mobile/native/src/ln_dlc/mod.rs
+++ b/mobile/native/src/ln_dlc/mod.rs
@@ -179,7 +179,11 @@ pub fn run(data_dir: String) -> Result<()> {
                         liquidation_price: 0.0,
                         unrealized_pnl: 0,
                         position_state: PositionStateTrade::Open,
-                        collateral: contract.accepted_contract.accept_params.collateral,
+                        collateral: contract
+                            .accepted_contract
+                            .offered_contract
+                            .offer_params
+                            .collateral,
                     }));
                 }
 


### PR DESCRIPTION
I am unsure if this is intended to stay that way, but if the mobile app is proposing the dlc channel, the mobile app is offering and the coordinator is accepting. Correspondingly, these values are currently switched.

This change fixes that issue.