### PR TITLE
chore: add `lint-flutter` job as bors dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
         # The solution using a `find` command is from here: https://github.com/dart-lang/dart_style/issues/864
         run: dart format --output=none --set-exit-if-changed --line-length 100 $(find . -name "*.dart" -not \( -name "*.*freezed.dart" -o -name "*.mocks.dart"  \) )
       - name: Analyze flutter code
-        run: flutter analyze --fatal-infos
+        run: just lint-flutter
 
   tests:
     runs-on: ubuntu-latest

--- a/bors.toml
+++ b/bors.toml
@@ -1,6 +1,7 @@
 status = [
   "formatting",
   "lint-commits",
+  "lint-flutter",
   "clippy",
   "tests-ln-dlc-node",
 ]

--- a/mobile/lib/features/trade/domain/order.dart
+++ b/mobile/lib/features/trade/domain/order.dart
@@ -66,12 +66,12 @@ class Order {
   }
 
   static bridge.Order apiDummy() {
-    return bridge.Order(
+    return const bridge.Order(
         leverage: 0,
         quantity: 0,
         contractSymbol: bridge.ContractSymbol.BtcUsd,
         direction: bridge.Direction.Long,
-        orderType: const bridge.OrderType.market(),
+        orderType: bridge.OrderType.market(),
         status: bridge.OrderState.Open);
   }
 }

--- a/mobile/lib/features/trade/domain/position.dart
+++ b/mobile/lib/features/trade/domain/position.dart
@@ -56,7 +56,7 @@ class Position {
   }
 
   static bridge.Position apiDummy() {
-    return bridge.Position(
+    return const bridge.Position(
       leverage: 0,
       quantity: 0,
       contractSymbol: bridge.ContractSymbol.BtcUsd,

--- a/mobile/lib/features/wallet/domain/wallet_info.dart
+++ b/mobile/lib/features/wallet/domain/wallet_info.dart
@@ -28,7 +28,7 @@ class WalletInfo {
 
   static bridge.WalletInfo apiDummy() {
     return bridge.WalletInfo(
-      balances: bridge.Balances(onChain: -1, lightning: -1),
+      balances: const bridge.Balances(onChain: -1, lightning: -1),
       history: List.empty(growable: false),
     );
   }


### PR DESCRIPTION
`main` is currently red because `lint-flutter` does actually not pass.

Sidenote: I can actually not reproduce this locally 😅