### PR TITLE
feat: Configurable node announcement

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,9 @@ Please refer to the [docker](https://docs.docker.com/) docs for more information
 
 #### Setup
 
-1. Start the coordinator with `cargo run --bin coordinator` or `just coordinator`
+1. Start the coordinator with `cargo run --bin coordinator -- --p2p-address=<your-local-ip>:9045` or `just coordinator --p2p-address=<your-local-ip>:9045`.
+
+   _Ensure that you are using your network ip address and not localhost. This is critical as the docker container will otherwise not be able to reach the coordinator._
 2. Open `http://localhost:8080/faucet/` (note: ensure to add the trailing `/` as otherwise nginx will try to redirect the call)
 3. Ensure you have enough balance on your bitcoin wallet. Hit the mine button a couple of times if not.
 4. Get a new address of your coordinator by running `curl http://localhost:8000/api/newaddress`
@@ -159,4 +161,6 @@ Please refer to the [docker](https://docs.docker.com/) docs for more information
 #### Fauceting your lightning wallet
 
 10. Create an invoice in your 10101 app by navigating to the receive screen.
+
+    _Note, that you have to provide the coordinator host to the mobile app like that `just run --dart-define="COORDINATOR_HOST=<your-local-ip>"`_
 11. Copy the invoice and enter it on the lightning faucet. Hit send and you will receive your funds momentarily.

--- a/coordinator/src/cli.rs
+++ b/coordinator/src/cli.rs
@@ -7,7 +7,7 @@ use std::path::PathBuf;
 #[derive(Parser)]
 pub struct Opts {
     /// The address to listen on for the lightning and dlc peer2peer API.
-    #[clap(long, default_value = "0.0.0.0:9045")]
+    #[clap(long, default_value = "127.0.0.1:9045")]
     pub p2p_address: SocketAddr,
 
     /// The IP address to listen on for the HTTP API.

--- a/crates/ln-dlc-node/src/util.rs
+++ b/crates/ln-dlc-node/src/util.rs
@@ -1,3 +1,6 @@
+use lightning::ln::msgs::NetAddress;
+use std::net::IpAddr;
+
 #[inline]
 pub fn hex_str(value: &[u8]) -> String {
     use std::fmt::Write as _; // import without risk of name clashing
@@ -7,4 +10,17 @@ pub fn hex_str(value: &[u8]) -> String {
         let _ = write!(s, "0x{v:02x}");
     }
     s
+}
+
+pub fn build_net_address(ip: IpAddr, port: u16) -> NetAddress {
+    match ip {
+        IpAddr::V4(ip) => NetAddress::IPv4 {
+            addr: ip.octets(),
+            port,
+        },
+        IpAddr::V6(ip) => NetAddress::IPv6 {
+            addr: ip.octets(),
+            port,
+        },
+    }
 }

--- a/justfile
+++ b/justfile
@@ -46,8 +46,9 @@ ios:
 	cd mobile/native && cargo lipo
 	cp target/universal/debug/libnative.a mobile/ios/Runner
 
-run:
-    cd mobile && flutter run
+
+run args="":
+    cd mobile && flutter run {{args}}
 
 clean:
     #!/usr/bin/env bash
@@ -76,8 +77,8 @@ flutter-format:
     cd mobile && dart format . --fix --line-length {{line_length}}
 
 alias c := coordinator
-coordinator:
-    cargo run --bin coordinator
+coordinator args="":
+    cargo run --bin coordinator -- {{args}}
 
 flutter-test:
     cd mobile && flutter pub run build_runner build && flutter test

--- a/mobile/ios/Podfile.lock
+++ b/mobile/ios/Podfile.lock
@@ -5,11 +5,14 @@ PODS:
   - path_provider_foundation (0.0.1):
     - Flutter
     - FlutterMacOS
+  - share_plus (0.0.1):
+    - Flutter
 
 DEPENDENCIES:
   - Flutter (from `Flutter`)
   - flutter_native_splash (from `.symlinks/plugins/flutter_native_splash/ios`)
   - path_provider_foundation (from `.symlinks/plugins/path_provider_foundation/ios`)
+  - share_plus (from `.symlinks/plugins/share_plus/ios`)
 
 EXTERNAL SOURCES:
   Flutter:
@@ -18,11 +21,14 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/flutter_native_splash/ios"
   path_provider_foundation:
     :path: ".symlinks/plugins/path_provider_foundation/ios"
+  share_plus:
+    :path: ".symlinks/plugins/share_plus/ios"
 
 SPEC CHECKSUMS:
   Flutter: f04841e97a9d0b0a8025694d0796dd46242b2854
   flutter_native_splash: 52501b97d1c0a5f898d687f1646226c1f93c56ef
   path_provider_foundation: 37748e03f12783f9de2cb2c4eadfaa25fe6d4852
+  share_plus: 056a1e8ac890df3e33cb503afffaf1e9b4fbae68
 
 PODFILE CHECKSUM: ef19549a9bc3046e7bb7d2fab4d021637c0c58a3
 

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -181,7 +181,6 @@ class _TenTenOneAppState extends State<TenTenOneApp> {
       PositionChangeNotifier positionChangeNotifier,
       WalletChangeNotifier walletChangeNotifier) async {
     try {
-      await walletChangeNotifier.refreshWalletInfo();
       setupRustLogging();
 
       // TODO: Move this code into an "InitService" or similar; we should not have bridge code in the widget
@@ -203,6 +202,8 @@ class _TenTenOneAppState extends State<TenTenOneApp> {
       FLog.info(text: "App data will be stored in: $appSupportDir");
 
       await rust.api.run(config: config, appDir: appSupportDir.path);
+
+      await walletChangeNotifier.refreshWalletInfo();
     } on FfiException catch (error) {
       FLog.error(text: "Failed to initialise: Error: ${error.message}", exception: error);
     } catch (error) {

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -27,6 +27,7 @@ import 'package:get_10101/features/wallet/wallet_screen.dart';
 import 'package:get_10101/common/app_bar_wrapper.dart';
 import 'package:get_10101/features/wallet/wallet_theme.dart';
 import 'package:get_10101/util/constants.dart';
+import 'package:get_10101/util/environment.dart';
 import 'package:go_router/go_router.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:provider/provider.dart';
@@ -63,6 +64,7 @@ void main() {
     ChangeNotifierProvider(create: (context) => OrderChangeNotifier.create(OrderService())),
     ChangeNotifierProvider(create: (context) => PositionChangeNotifier.create(PositionService())),
     ChangeNotifierProvider(create: (context) => WalletChangeNotifier(const WalletService())),
+    Provider(create: (context) => Environment.parse()),
   ], child: const TenTenOneApp()));
 }
 
@@ -151,8 +153,8 @@ class _TenTenOneAppState extends State<TenTenOneApp> {
   @override
   void initState() {
     super.initState();
-    init(context.read<OrderChangeNotifier>(), context.read<PositionChangeNotifier>(),
-        context.read<WalletChangeNotifier>());
+    init(context.read<bridge.Config>(), context.read<OrderChangeNotifier>(),
+        context.read<PositionChangeNotifier>(), context.read<WalletChangeNotifier>());
   }
 
   @override
@@ -174,6 +176,7 @@ class _TenTenOneAppState extends State<TenTenOneApp> {
   }
 
   Future<void> init(
+      bridge.Config config,
       OrderChangeNotifier orderChangeNotifier,
       PositionChangeNotifier positionChangeNotifier,
       WalletChangeNotifier walletChangeNotifier) async {
@@ -199,7 +202,7 @@ class _TenTenOneAppState extends State<TenTenOneApp> {
       final appSupportDir = await getApplicationSupportDirectory();
       FLog.info(text: "App data will be stored in: $appSupportDir");
 
-      await rust.api.run(appDir: appSupportDir.path);
+      await rust.api.run(config: config, appDir: appSupportDir.path);
     } on FfiException catch (error) {
       FLog.error(text: "Failed to initialise: Error: ${error.message}", exception: error);
     } catch (error) {

--- a/mobile/lib/util/environment.dart
+++ b/mobile/lib/util/environment.dart
@@ -1,0 +1,31 @@
+import 'package:get_10101/bridge_generated/bridge_definitions.dart';
+
+class Environment {
+  static Config parse() {
+    String host = const String.fromEnvironment('COORDINATOR_HOST', defaultValue: '127.0.0.1');
+    // coordinator PK is derived from our checked in regtest maker seed
+    String coordinatorPublicKey = const String.fromEnvironment("COORDINATOR_PK",
+        defaultValue: "02dd6abec97f9a748bf76ad502b004ce05d1b2d1f43a9e76bd7d85e767ffb022c9");
+    int lightningPort = const int.fromEnvironment("COORDINATOR_PORT_LIGHTNING", defaultValue: 9045);
+    int httpPort = const int.fromEnvironment("COORDINATOR_PORT_HTTP", defaultValue: 8000);
+    String electrsEndpoint =
+        const String.fromEnvironment("ELECTRS_ENDPOINT", defaultValue: "127.0.0.1:50000");
+
+    String p2pEndpoint = const String.fromEnvironment('COORDINATOR_P2P_ENDPOINT');
+    if (p2pEndpoint.contains("@")) {
+      final split = p2pEndpoint.split("@");
+      coordinatorPublicKey = split[0];
+      if (split[1].contains(':')) {
+        host = split[1].split(':')[0];
+        lightningPort = int.parse(split[1].split(':')[1]);
+      }
+    }
+
+    return Config(
+        host: host,
+        electrsEndpoint: electrsEndpoint,
+        coordinatorPubkey: coordinatorPublicKey,
+        p2PPort: lightningPort,
+        httpPort: httpPort);
+  }
+}

--- a/mobile/macos/Podfile.lock
+++ b/mobile/macos/Podfile.lock
@@ -3,20 +3,26 @@ PODS:
   - path_provider_foundation (0.0.1):
     - Flutter
     - FlutterMacOS
+  - share_plus (0.0.1):
+    - FlutterMacOS
 
 DEPENDENCIES:
   - FlutterMacOS (from `Flutter/ephemeral`)
   - path_provider_foundation (from `Flutter/ephemeral/.symlinks/plugins/path_provider_foundation/macos`)
+  - share_plus (from `Flutter/ephemeral/.symlinks/plugins/share_plus/macos`)
 
 EXTERNAL SOURCES:
   FlutterMacOS:
     :path: Flutter/ephemeral
   path_provider_foundation:
     :path: Flutter/ephemeral/.symlinks/plugins/path_provider_foundation/macos
+  share_plus:
+    :path: Flutter/ephemeral/.symlinks/plugins/share_plus/macos
 
 SPEC CHECKSUMS:
   FlutterMacOS: 8f6f14fa908a6fb3fba0cd85dbd81ec4b251fb24
   path_provider_foundation: 37748e03f12783f9de2cb2c4eadfaa25fe6d4852
+  share_plus: 76dd39142738f7a68dd57b05093b5e8193f220f7
 
 PODFILE CHECKSUM: 353c8bcc5d5b0994e508d035b5431cfe18c1dea7
 

--- a/mobile/native/src/api.rs
+++ b/mobile/native/src/api.rs
@@ -1,5 +1,7 @@
 use crate::calculations;
 use crate::common::api::Direction;
+use crate::config;
+use crate::config::api::Config;
 use crate::event;
 use crate::event::api::FlutterSubscriber;
 use crate::ln_dlc;
@@ -115,7 +117,8 @@ pub fn subscribe(stream: StreamSink<event::api::Event>) {
     event::subscribe(FlutterSubscriber::new(stream))
 }
 
-pub fn run(app_dir: String) -> Result<()> {
+pub fn run(config: Config, app_dir: String) -> Result<()> {
+    config::set(config);
     ln_dlc::run(app_dir)
 }
 

--- a/mobile/native/src/config/api.rs
+++ b/mobile/native/src/config/api.rs
@@ -1,0 +1,30 @@
+use crate::config::ConfigInternal;
+use flutter_rust_bridge::frb;
+
+#[frb]
+#[derive(Debug)]
+pub struct Config {
+    pub coordinator_pubkey: String,
+    pub electrs_endpoint: String,
+    pub host: String,
+    pub p2p_port: u16,
+    pub http_port: u16,
+}
+
+impl From<Config> for ConfigInternal {
+    fn from(config: Config) -> Self {
+        Self {
+            coordinator_pubkey: config.coordinator_pubkey.parse().expect("PK to be valid"),
+            electrs_endpoint: config
+                .electrs_endpoint
+                .parse()
+                .expect("electrs endpoint to be valid"),
+            http_endpoint: format!("{}:{}", config.host, config.http_port)
+                .parse()
+                .expect("host and http_port to be valid"),
+            p2p_endpoint: format!("{}:{}", config.host, config.p2p_port)
+                .parse()
+                .expect("host and p2p_port to be valid"),
+        }
+    }
+}

--- a/mobile/native/src/config/mod.rs
+++ b/mobile/native/src/config/mod.rs
@@ -1,0 +1,37 @@
+pub mod api;
+
+use crate::config::api::Config;
+use bdk::bitcoin::secp256k1::PublicKey;
+use ln_dlc_node::node::NodeInfo;
+use state::Storage;
+use std::net::SocketAddr;
+
+static CONFIG: Storage<ConfigInternal> = Storage::new();
+
+#[derive(Clone, Copy)]
+struct ConfigInternal {
+    coordinator_pubkey: PublicKey,
+    electrs_endpoint: SocketAddr,
+    http_endpoint: SocketAddr,
+    p2p_endpoint: SocketAddr,
+}
+
+pub fn set(config: Config) {
+    CONFIG.set(config.into());
+}
+
+pub fn get_coordinator_info() -> NodeInfo {
+    let config = CONFIG.get();
+    NodeInfo {
+        pubkey: config.coordinator_pubkey,
+        address: config.p2p_endpoint,
+    }
+}
+
+pub fn get_electrs_endpoint() -> SocketAddr {
+    CONFIG.get().electrs_endpoint
+}
+
+pub fn get_http_endpoint() -> SocketAddr {
+    CONFIG.get().http_endpoint
+}

--- a/mobile/native/src/lib.rs
+++ b/mobile/native/src/lib.rs
@@ -2,6 +2,7 @@ mod api;
 mod bridge_generated;
 pub mod calculations;
 pub mod common;
+pub(crate) mod config;
 pub mod event;
 pub mod ln_dlc;
 pub mod logger;

--- a/mobile/native/src/ln_dlc/mod.rs
+++ b/mobile/native/src/ln_dlc/mod.rs
@@ -97,7 +97,7 @@ pub fn run(data_dir: String) -> Result<()> {
         // TODO: Subscribe to events from the orderbook and publish OrderFilledWith event
 
         let address = {
-            let listener = TcpListener::bind("0.0.0.0:0").unwrap();
+            let listener = TcpListener::bind("0.0.0.0:0")?;
             listener.local_addr().expect("To get a free local address")
         };
 

--- a/mobile/native/src/ln_dlc/mod.rs
+++ b/mobile/native/src/ln_dlc/mod.rs
@@ -84,13 +84,6 @@ pub fn get_oracle_pubkey() -> Result<XOnlyPublicKey> {
         .get_public_key())
 }
 
-// TODO: this model should not be in the event!
-#[derive(Debug, Eq, Hash, PartialEq, Clone, Default)]
-pub struct Balance {
-    pub on_chain: u64,
-    pub off_chain: u64,
-}
-
 /// Lazily creates a multi threaded runtime with the the number of worker threads corresponding to
 /// the number of available cores.
 fn runtime() -> Result<&'static Runtime> {

--- a/mobile/native/src/ln_dlc/mod.rs
+++ b/mobile/native/src/ln_dlc/mod.rs
@@ -1,5 +1,6 @@
 use crate::api::Balances;
 use crate::api::WalletInfo;
+use crate::config;
 use crate::event;
 use crate::event::EventInternal;
 use crate::trade::position;
@@ -31,28 +32,7 @@ use std::time::Duration;
 use tokio::runtime::Runtime;
 use trade::TradeParams;
 
-const ELECTRS_ORIGIN: &str = "tcp://localhost:50000";
-
 static NODE: Storage<Arc<Node>> = Storage::new();
-
-const REGTEST_COORDINATOR_PK: &str =
-    "02dd6abec97f9a748bf76ad502b004ce05d1b2d1f43a9e76bd7d85e767ffb022c9";
-
-// TODO: this configuration should not be hardcoded.
-const HOST: &str = "127.0.0.1";
-const HTTP_PORT: u16 = 8000;
-const P2P_PORT: u16 = 9045;
-
-pub fn get_coordinator_info() -> NodeInfo {
-    NodeInfo {
-        pubkey: REGTEST_COORDINATOR_PK
-            .parse()
-            .expect("Hard-coded PK to be valid"),
-        address: format!("{HOST}:{P2P_PORT}") // todo: make ip configurable
-            .parse()
-            .expect("Hard-coded IP and port to be valid"),
-    }
-}
 
 pub fn get_wallet_info() -> Result<WalletInfo> {
     Ok(get_wallet_info_from_node(
@@ -130,7 +110,7 @@ pub fn run(data_dir: String) -> Result<()> {
                 network,
                 data_dir.as_path(),
                 address,
-                ELECTRS_ORIGIN.to_string(),
+                config::get_electrs_endpoint().to_string(),
                 seed,
                 ephemeral_randomness,
             )
@@ -140,7 +120,7 @@ pub fn run(data_dir: String) -> Result<()> {
         let background_processor = node.start().await?;
 
         // todo: should the library really be responsible for managing the task?
-        node.keep_connected(get_coordinator_info()).await?;
+        node.keep_connected(config::get_coordinator_info()).await?;
 
         let node_clone = node.clone();
         runtime.spawn(async move {
@@ -220,7 +200,7 @@ pub fn get_new_address() -> Result<String> {
 pub fn open_channel() -> Result<()> {
     let node = NODE.try_get().context("failed to get ln dlc node")?;
 
-    node.initiate_open_channel(get_coordinator_info(), 500000, 250000)?;
+    node.initiate_open_channel(config::get_coordinator_info(), 500000, 250000)?;
 
     Ok(())
 }
@@ -230,11 +210,11 @@ pub fn create_invoice(amount_sats: Option<u64>) -> Result<Invoice> {
 
     runtime.block_on(async {
         let node = NODE.try_get().context("failed to get ln dlc node")?;
-
         let client = reqwest::Client::new();
         let response = client
             .post(format!(
-                "http://{HOST}:{HTTP_PORT}/api/fake_scid/{}",
+                "http://{}/api/fake_scid/{}",
+                config::get_http_endpoint(),
                 node.info.pubkey
             )) // TODO: make host configurable
             .send()
@@ -253,7 +233,7 @@ pub fn create_invoice(amount_sats: Option<u64>) -> Result<Invoice> {
         node.create_interceptable_invoice(
             amount_sats,
             fake_channel_id,
-            get_coordinator_info().pubkey,
+            config::get_coordinator_info().pubkey,
             0,
             "test".to_string(),
         )
@@ -267,11 +247,9 @@ pub fn send_payment(invoice: &str) -> Result<()> {
 }
 
 pub async fn trade(trade_params: TradeParams) -> Result<()> {
-    let url = "http://localhost:8000/api/trade"; // TODO: we need the coordinators http address here
-
     let client = reqwest::Client::new();
     let contract_info = client
-        .post(url)
+        .post(format!("http://{}/api/trade", config::get_http_endpoint()))
         .json(&trade_params)
         .send()
         .await
@@ -284,7 +262,7 @@ pub async fn trade(trade_params: TradeParams) -> Result<()> {
     let channel_details = node.list_usable_channels();
     let channel_details = channel_details
         .iter()
-        .find(|c| c.counterparty.node_id == get_coordinator_info().pubkey)
+        .find(|c| c.counterparty.node_id == config::get_coordinator_info().pubkey)
         .context("Channel details not found")?;
 
     node.propose_dlc_channel(channel_details, &contract_info)

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -1022,5 +1022,5 @@ packages:
     source: hosted
     version: "2.0.3"
 sdks:
-  dart: ">=2.19.0 <3.0.0"
+  dart: ">=2.19.0 <4.0.0"
   flutter: ">=3.7.0-0"


### PR DESCRIPTION
I added quite some descriptions to the commit message. Please refer to https://github.com/get10101/10101/pull/201/commits/c1c02ebb1b1e2674d7d84a41d6c2206a1ea2682d for more details on this PR.

**tl;dr**: This PR fixes an issue with the lnd node and the coordinator not being connected anymore after a restart and allows for configuring the mobile app.

The critical aspect here is that the address the `ln_dlc node` will be bound to is also the address that is used for the node announcement. So you need to start your coordinator with the ip address of your local network.

```
cargo run --bin coordinator -- --p2p-address=10.0.0.20:9045
```
or use the just file analogous.

In order to start the mobile app you need to specify the coordinator p2p-address as well, as the coordinator does not listen to localhost anymore.

```
just run --dart-define="COORDINATOR_P2P_ENDPOINT=02dd6abec97f9a748bf76ad502b004ce05d1b2d1f43a9e76bd7d85e767ffb022c9@10.0.0.20:9045"
```

resolves #191 

----

Note, alternatively we could have added the local ip to the node announcement addresses also automatically in the code so that we wouldn't have to provide any arguments. But this is only relevant for our testing environment and might not justify adding a new dependency for that. (local_ip) Also it would be confusing if we'd publish externally unreachable addresses with our node announcements.