### PR TITLE
Fix issues when trying to run docker-compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ You can add `-d` to run the environment in the background.
 Please refer to the [docker](https://docs.docker.com/) docs for more information on how to use docker / docker-compose.
 
 Our development environment is based on [nigiri](https://github.com/vulpemventures/nigiri).
-If you are a `nigiri` user, make sure stop it before starting `10101`, and that you prune the Docker containers by running:
+If you are a `nigiri` user, make sure to stop it before running the `10101` docker-compose setup, and that you prune the Docker containers by running:
 
 ```bash
 nigiri stop

--- a/README.md
+++ b/README.md
@@ -142,6 +142,16 @@ docker-compose up
 You can add `-d` to run the environment in the background.
 Please refer to the [docker](https://docs.docker.com/) docs for more information on how to use docker / docker-compose.
 
+Our development environment is based on [nigiri](https://github.com/vulpemventures/nigiri).
+If you are a `nigiri` user, make sure stop it before starting `10101`, and that you prune the Docker containers by running:
+
+```bash
+nigiri stop
+docker container prune
+```
+
+Otherwise, you might have troubles starting 10101, due to port conflicts on containers.
+
 ### How to faucet your lightning wallet.
 
 #### Setup

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -74,7 +74,7 @@ services:
     environment:
       API_URL: http://localhost:3000
     ports:
-      - "5000:5000"
+      - "5050:5000"
     restart: unless-stopped
     networks:
       vtto:


### PR DESCRIPTION
it took me a while to notice that we were using `nigiri`. 
I've realised that the easiest way to work around it is to not run 10101 and nigiri at the same time for the time being; I've described how to clear docker state.

Also, I'm using AirPlay and port `5000` blocked me from running the setup. 