### PR TITLE
Fix/nest wizard screen

### DIFF
--- a/mobile/lib/features/wallet/share_invoice_screen.dart
+++ b/mobile/lib/features/wallet/share_invoice_screen.dart
@@ -2,6 +2,7 @@ import 'dart:developer';
 
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:get_10101/features/wallet/create_invoice_screen.dart';
 import 'package:get_10101/features/wallet/domain/wallet_info.dart';
 import 'package:get_10101/features/wallet/wallet_change_notifier.dart';
 import 'package:get_10101/features/wallet/wallet_screen.dart';
@@ -13,7 +14,7 @@ import 'package:share_plus/share_plus.dart';
 import 'application/wallet_service.dart';
 
 class ShareInvoiceScreen extends StatelessWidget {
-  static const route = "${WalletScreen.route}/$subRouteName";
+  static const route = "${WalletScreen.route}/${CreateInvoiceScreen.subRouteName}/$subRouteName";
   static const subRouteName = "share_invoice";
   final WalletService walletService;
   final String invoice;

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -101,21 +101,22 @@ class _TenTenOneAppState extends State<TenTenOneApp> {
                 },
               ),
               GoRoute(
-                path: CreateInvoiceScreen.subRouteName,
-                // Use root navigator so the screen overlays the application shell
-                parentNavigatorKey: _rootNavigatorKey,
-                builder: (BuildContext context, GoRouterState state) {
-                  return const CreateInvoiceScreen();
-                },
-              ),
-              GoRoute(
-                path: ShareInvoiceScreen.subRouteName,
-                // Use root navigator so the screen overlays the application shell
-                parentNavigatorKey: _rootNavigatorKey,
-                builder: (BuildContext context, GoRouterState state) {
-                  return ShareInvoiceScreen(invoice: state.extra as String);
-                },
-              ),
+                  path: CreateInvoiceScreen.subRouteName,
+                  // Use root navigator so the screen overlays the application shell
+                  parentNavigatorKey: _rootNavigatorKey,
+                  builder: (BuildContext context, GoRouterState state) {
+                    return const CreateInvoiceScreen();
+                  },
+                  routes: [
+                    GoRoute(
+                      path: ShareInvoiceScreen.subRouteName,
+                      // Use root navigator so the screen overlays the application shell
+                      parentNavigatorKey: _rootNavigatorKey,
+                      builder: (BuildContext context, GoRouterState state) {
+                        return ShareInvoiceScreen(invoice: state.extra as String);
+                      },
+                    ),
+                  ]),
               GoRoute(
                 path: ScannerScreen.subRouteName,
                 parentNavigatorKey: _rootNavigatorKey,


### PR DESCRIPTION
fixes https://github.com/get10101/10101/issues/205
 
![2023-03-06 19 12 25](https://user-images.githubusercontent.com/5557790/223054332-4b6044a2-83a5-4217-a9de-73b88e05de2a.gif)

---

Note: This is a bit cumbersome because of the declarative nature of `go_router`. I did not find a way to navigate "back to the previous screen" without nesting the screens. It would be cool to have the possibility to just navigate by an index, but that requires a bit more thought, because the index would have to be assigned to the screens dynamically, and not as a static route name. I did not find an easy way to achieve this yet, so I decided that nesting the screens is the fastest way to fix this. Once we have wizards with more then ~3 screens (e.g. wallet backup...) we could consider implementing something more elaborate.