### PR TITLE
chore: re-export external types in frb

### DIFF
--- a/crates/trade/src/lib.rs
+++ b/crates/trade/src/lib.rs
@@ -65,7 +65,7 @@ pub struct TradeParams {
     pub oracle_pk: XOnlyPublicKey,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 pub enum ContractSymbol {
     BtcUsd,
 }

--- a/mobile/native/src/api.rs
+++ b/mobile/native/src/api.rs
@@ -14,8 +14,10 @@ use crate::trade::order::api::Order;
 use crate::trade::position;
 use crate::trade::position::api::Position;
 use anyhow::Result;
+use flutter_rust_bridge::frb;
 use flutter_rust_bridge::StreamSink;
 use flutter_rust_bridge::SyncReturn;
+pub use trade::ContractSymbol;
 
 /// Initialise logging infrastructure for Rust
 pub fn init_logging(sink: StreamSink<logger::LogEntry>) {
@@ -68,6 +70,13 @@ pub fn calculate_margin(price: f64, quantity: f64, leverage: f64) -> SyncReturn<
 
 pub fn calculate_quantity(price: f64, margin: u64, leverage: f64) -> SyncReturn<f64> {
     SyncReturn(calculations::calculate_quantity(price, margin, leverage))
+}
+
+#[allow(dead_code)]
+#[frb(mirror(ContractSymbol))]
+#[derive(Debug, Clone, Copy)]
+pub enum _ContractSymbol {
+    BtcUsd,
 }
 
 pub fn calculate_liquidation_price(

--- a/mobile/native/src/common/api.rs
+++ b/mobile/native/src/common/api.rs
@@ -1,50 +1,5 @@
-use crate::trade::ContractSymbolTrade;
-use crate::trade::DirectionTrade;
-use flutter_rust_bridge::frb;
-
-#[frb]
-#[derive(Debug, Clone, Copy)]
-pub enum ContractSymbol {
-    BtcUsd,
-}
-
-#[frb]
 #[derive(Debug, Clone, Copy)]
 pub enum Direction {
     Long,
     Short,
-}
-
-impl From<Direction> for DirectionTrade {
-    fn from(value: Direction) -> Self {
-        match value {
-            Direction::Long => DirectionTrade::Long,
-            Direction::Short => DirectionTrade::Short,
-        }
-    }
-}
-
-impl From<DirectionTrade> for Direction {
-    fn from(value: DirectionTrade) -> Self {
-        match value {
-            DirectionTrade::Long => Direction::Long,
-            DirectionTrade::Short => Direction::Short,
-        }
-    }
-}
-
-impl From<ContractSymbol> for ContractSymbolTrade {
-    fn from(value: ContractSymbol) -> Self {
-        match value {
-            ContractSymbol::BtcUsd => ContractSymbolTrade::BtcUsd,
-        }
-    }
-}
-
-impl From<ContractSymbolTrade> for ContractSymbol {
-    fn from(value: ContractSymbolTrade) -> Self {
-        match value {
-            ContractSymbolTrade::BtcUsd => ContractSymbol::BtcUsd,
-        }
-    }
 }

--- a/mobile/native/src/ln_dlc/mod.rs
+++ b/mobile/native/src/ln_dlc/mod.rs
@@ -1,13 +1,12 @@
 use crate::api::Balances;
 use crate::api::WalletInfo;
+use crate::common::api::Direction;
 use crate::config;
 use crate::event;
 use crate::event::EventInternal;
 use crate::trade::position;
 use crate::trade::position::PositionStateTrade;
 use crate::trade::position::PositionTrade;
-use crate::trade::ContractSymbolTrade;
-use crate::trade::DirectionTrade;
 use anyhow::anyhow;
 use anyhow::bail;
 use anyhow::Context;
@@ -29,6 +28,7 @@ use std::str::FromStr;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::runtime::Runtime;
+use trade::ContractSymbol;
 use trade::TradeParams;
 
 static NODE: Storage<Arc<Node>> = Storage::new();
@@ -150,8 +150,8 @@ pub fn run(data_dir: String) -> Result<()> {
                     event::publish(&EventInternal::PositionUpdateNotification(PositionTrade {
                         leverage: 0.0,
                         quantity: 0.0,
-                        contract_symbol: ContractSymbolTrade::BtcUsd,
-                        direction: DirectionTrade::Long,
+                        contract_symbol: ContractSymbol::BtcUsd,
+                        direction: Direction::Long,
                         average_entry_price: 0.0,
                         liquidation_price: 0.0,
                         unrealized_pnl: 0,

--- a/mobile/native/src/trade/mod.rs
+++ b/mobile/native/src/trade/mod.rs
@@ -1,13 +1,2 @@
 pub mod order;
 pub mod position;
-
-#[derive(Debug, Clone, Copy)]
-pub enum ContractSymbolTrade {
-    BtcUsd,
-}
-
-#[derive(Debug, Clone, Copy)]
-pub enum DirectionTrade {
-    Long,
-    Short,
-}

--- a/mobile/native/src/trade/order/api.rs
+++ b/mobile/native/src/trade/order/api.rs
@@ -1,9 +1,9 @@
-use crate::common::api::ContractSymbol;
 use crate::common::api::Direction;
 use crate::trade::order::OrderStateTrade;
 use crate::trade::order::OrderTrade;
 use crate::trade::order::OrderTypeTrade;
 use flutter_rust_bridge::frb;
+use trade::ContractSymbol;
 use uuid::Uuid;
 
 #[frb]
@@ -72,8 +72,8 @@ impl From<OrderTrade> for Order {
         Order {
             leverage: value.leverage,
             quantity: value.quantity,
-            contract_symbol: value.contract_symbol.into(),
-            direction: value.direction.into(),
+            contract_symbol: value.contract_symbol,
+            direction: value.direction,
             order_type: Box::new(value.order_type.into()),
             status: value.status.into(),
             execution_price,
@@ -112,8 +112,8 @@ impl From<NewOrder> for OrderTrade {
             id: Uuid::new_v4(),
             leverage: value.leverage,
             quantity: value.quantity,
-            contract_symbol: value.contract_symbol.into(),
-            direction: value.direction.into(),
+            contract_symbol: value.contract_symbol,
+            direction: value.direction,
             order_type: (*value.order_type).into(),
             status: OrderStateTrade::Open,
         }

--- a/mobile/native/src/trade/order/handler.rs
+++ b/mobile/native/src/trade/order/handler.rs
@@ -1,3 +1,4 @@
+use crate::common::api::Direction;
 use crate::event;
 use crate::event::EventInternal;
 use crate::ln_dlc;
@@ -5,8 +6,6 @@ use crate::trade::order::OrderStateTrade;
 use crate::trade::order::OrderTrade;
 use crate::trade::order::OrderTypeTrade;
 use crate::trade::position;
-use crate::trade::ContractSymbolTrade;
-use crate::trade::DirectionTrade;
 use anyhow::Context;
 use anyhow::Result;
 use std::str::FromStr;
@@ -55,8 +54,8 @@ pub async fn get_order(id: String) -> Result<OrderTrade> {
         id,
         leverage: 2.0,
         quantity: 1000.0,
-        contract_symbol: ContractSymbolTrade::BtcUsd,
-        direction: DirectionTrade::Long,
+        contract_symbol: ContractSymbol::BtcUsd,
+        direction: Direction::Long,
         order_type: OrderTypeTrade::Market,
         status: OrderStateTrade::Filled {
             execution_price: 25000.0,
@@ -73,8 +72,8 @@ pub async fn get_orders() -> Result<Vec<OrderTrade>> {
         id: Uuid::new_v4(),
         leverage: 2.0,
         quantity: 1000.0,
-        contract_symbol: ContractSymbolTrade::BtcUsd,
-        direction: DirectionTrade::Long,
+        contract_symbol: ContractSymbol::BtcUsd,
+        direction: Direction::Long,
         order_type: OrderTypeTrade::Market,
         status: OrderStateTrade::Filled {
             execution_price: 25000.0,

--- a/mobile/native/src/trade/order/mod.rs
+++ b/mobile/native/src/trade/order/mod.rs
@@ -1,5 +1,5 @@
-use crate::trade::ContractSymbolTrade;
-use crate::trade::DirectionTrade;
+use crate::common::api::Direction;
+use trade::ContractSymbol;
 use uuid::Uuid;
 
 pub mod api;
@@ -63,8 +63,8 @@ pub struct OrderTrade {
     pub id: Uuid,
     pub leverage: f64,
     pub quantity: f64,
-    pub contract_symbol: ContractSymbolTrade,
-    pub direction: DirectionTrade,
+    pub contract_symbol: ContractSymbol,
+    pub direction: Direction,
     pub order_type: OrderTypeTrade,
     pub status: OrderStateTrade,
 }

--- a/mobile/native/src/trade/position/api.rs
+++ b/mobile/native/src/trade/position/api.rs
@@ -1,8 +1,8 @@
-use crate::common::api::ContractSymbol;
 use crate::common::api::Direction;
 use crate::trade::position::PositionStateTrade;
 use crate::trade::position::PositionTrade;
 use flutter_rust_bridge::frb;
+use trade::ContractSymbol;
 
 #[frb]
 #[derive(Debug, Clone)]
@@ -55,8 +55,8 @@ impl From<PositionTrade> for Position {
         Position {
             leverage: value.leverage,
             quantity: value.quantity,
-            contract_symbol: value.contract_symbol.into(),
-            direction: value.direction.into(),
+            contract_symbol: value.contract_symbol,
+            direction: value.direction,
             average_entry_price: value.average_entry_price,
             liquidation_price: value.liquidation_price,
             unrealized_pnl: value.unrealized_pnl,

--- a/mobile/native/src/trade/position/handler.rs
+++ b/mobile/native/src/trade/position/handler.rs
@@ -1,9 +1,9 @@
+use crate::common::api::Direction;
 use crate::ln_dlc;
 use crate::trade::position::PositionStateTrade;
 use crate::trade::position::PositionTrade;
-use crate::trade::ContractSymbolTrade;
-use crate::trade::DirectionTrade;
 use anyhow::Result;
+use trade::ContractSymbol;
 use trade::TradeParams;
 
 /// Sets up a trade with the counterparty
@@ -35,8 +35,8 @@ pub async fn get_positions() -> Result<Vec<PositionTrade>> {
     let dummy_position = PositionTrade {
         leverage: 2.0,
         quantity: 10000.0,
-        contract_symbol: ContractSymbolTrade::BtcUsd,
-        direction: DirectionTrade::Long,
+        contract_symbol: ContractSymbol::BtcUsd,
+        direction: Direction::Long,
         average_entry_price: 20000.0,
         liquidation_price: 14000.0,
         unrealized_pnl: -400,

--- a/mobile/native/src/trade/position/mod.rs
+++ b/mobile/native/src/trade/position/mod.rs
@@ -1,5 +1,5 @@
-use crate::trade::ContractSymbolTrade;
-use crate::trade::DirectionTrade;
+use crate::common::api::Direction;
+use trade::ContractSymbol;
 
 pub mod api;
 pub mod handler;
@@ -30,8 +30,8 @@ pub enum PositionStateTrade {
 pub struct PositionTrade {
     pub leverage: f64,
     pub quantity: f64,
-    pub contract_symbol: ContractSymbolTrade,
-    pub direction: DirectionTrade,
+    pub contract_symbol: ContractSymbol,
+    pub direction: Direction,
     pub average_entry_price: f64,
     pub liquidation_price: f64,
     /// The unrealized PL can be positive or negative


### PR DESCRIPTION
By using flutter rust bridge - mirror, we can re-export foreign types. This allows us to remove various duplicated types, their conversions and extensions such as `*Trade`.

Read more here:
https://cjycode.com/flutter_rust_bridge/feature/lang_external.html#types-in-other-crates