### PR TITLE
feat: Configurable network

### DIFF
--- a/coordinator/src/bin/coordinator.rs
+++ b/coordinator/src/bin/coordinator.rs
@@ -1,6 +1,5 @@
 use anyhow::Context;
 use anyhow::Result;
-use bitcoin::Network;
 use coordinator::cli::Opts;
 use coordinator::logger;
 use coordinator::routes::router;
@@ -23,7 +22,7 @@ async fn main() -> Result<()> {
     let data_dir = opts.data_dir()?;
     let address = opts.p2p_address;
     let http_address = opts.http_address;
-    let network = Network::Regtest;
+    let network = opts.network();
 
     logger::init_tracing(LevelFilter::DEBUG, false)?;
 

--- a/coordinator/src/cli.rs
+++ b/coordinator/src/cli.rs
@@ -24,12 +24,38 @@ pub struct Opts {
     /// Will skip announcing the node on the local ip address. Set this flag for production.
     #[clap(long)]
     skip_local_network_announcement: bool,
+
+    #[clap(value_enum, default_value = "regtest")]
+    pub network: Network,
+}
+
+#[derive(Debug, Clone, Copy, clap::ValueEnum)]
+pub enum Network {
+    Regtest,
+    Signet,
+    Testnet,
+    Mainnet,
+}
+
+impl From<Network> for bitcoin::Network {
+    fn from(network: Network) -> Self {
+        match network {
+            Network::Regtest => bitcoin::Network::Regtest,
+            Network::Signet => bitcoin::Network::Signet,
+            Network::Testnet => bitcoin::Network::Testnet,
+            Network::Mainnet => bitcoin::Network::Bitcoin,
+        }
+    }
 }
 
 impl Opts {
     // use this method to parse the options from the cli.
     pub fn read() -> Opts {
         Opts::parse()
+    }
+
+    pub fn network(&self) -> bitcoin::Network {
+        self.network.into()
     }
 
     pub fn data_dir(&self) -> Result<PathBuf> {

--- a/crates/ln-dlc-node/src/ln/event_handler.rs
+++ b/crates/ln-dlc-node/src/ln/event_handler.rs
@@ -13,7 +13,9 @@ use crate::PaymentInfoStorage;
 use crate::PendingInterceptedHtlcs;
 use anyhow::anyhow;
 use bitcoin::secp256k1::Secp256k1;
+use bitcoin::Network;
 use bitcoin_bech32::WitnessProgram;
+use dlc_manager::Blockchain;
 use lightning::chain::chaininterface::BroadcasterInterface;
 use lightning::chain::chaininterface::ConfirmationTarget;
 use lightning::chain::chaininterface::FeeEstimator;
@@ -75,14 +77,23 @@ impl EventHandler {
                 output_script,
                 ..
             } => {
+                let network = self
+                    .wallet
+                    .get_network()
+                    .expect("Failed to get bitcoin network");
+
+                let network = match network {
+                    Network::Regtest => bitcoin_bech32::constants::Network::Regtest,
+                    Network::Signet => bitcoin_bech32::constants::Network::Signet,
+                    Network::Testnet => bitcoin_bech32::constants::Network::Testnet,
+                    Network::Bitcoin => bitcoin_bech32::constants::Network::Bitcoin,
+                };
+
                 // Construct the raw transaction with one output, that is paid the amount of the
                 // channel.
-                let _addr = WitnessProgram::from_scriptpubkey(
-                    &output_script[..],
-                    bitcoin_bech32::constants::Network::Regtest,
-                )
-                .expect("Lightning funding tx should always be to a SegWit output")
-                .to_address();
+                let _addr = WitnessProgram::from_scriptpubkey(&output_script[..], network)
+                    .expect("Lightning funding tx should always be to a SegWit output")
+                    .to_address();
 
                 let target_blocks = 2;
 

--- a/crates/ln-dlc-node/src/ln_dlc_wallet.rs
+++ b/crates/ln-dlc-node/src/ln_dlc_wallet.rs
@@ -66,8 +66,12 @@ impl dlc_manager::Blockchain for LnDlcWallet {
     }
 
     fn get_network(&self) -> Result<Network, Error> {
-        // todo: replace with actual network value
-        Ok(bitcoin::Network::Regtest)
+        let network = self
+            .ln_wallet
+            .get_wallet()
+            .map_err(|e| Error::WalletError(Box::new(e)))?
+            .network();
+        Ok(network)
     }
 
     fn get_blockchain_height(&self) -> Result<u64, Error> {

--- a/mobile/lib/util/environment.dart
+++ b/mobile/lib/util/environment.dart
@@ -10,6 +10,7 @@ class Environment {
     int httpPort = const int.fromEnvironment("COORDINATOR_PORT_HTTP", defaultValue: 8000);
     String electrsEndpoint =
         const String.fromEnvironment("ELECTRS_ENDPOINT", defaultValue: "127.0.0.1:50000");
+    String network = const String.fromEnvironment('NETWORK', defaultValue: "regtest");
 
     String p2pEndpoint = const String.fromEnvironment('COORDINATOR_P2P_ENDPOINT');
     if (p2pEndpoint.contains("@")) {
@@ -26,6 +27,7 @@ class Environment {
         electrsEndpoint: electrsEndpoint,
         coordinatorPubkey: coordinatorPublicKey,
         p2PPort: lightningPort,
-        httpPort: httpPort);
+        httpPort: httpPort,
+        network: network);
   }
 }

--- a/mobile/native/src/config/api.rs
+++ b/mobile/native/src/config/api.rs
@@ -1,4 +1,5 @@
 use crate::config::ConfigInternal;
+use bdk::bitcoin::Network;
 use flutter_rust_bridge::frb;
 
 #[frb]
@@ -9,6 +10,7 @@ pub struct Config {
     pub host: String,
     pub p2p_port: u16,
     pub http_port: u16,
+    pub network: String,
 }
 
 impl From<Config> for ConfigInternal {
@@ -25,6 +27,16 @@ impl From<Config> for ConfigInternal {
             p2p_endpoint: format!("{}:{}", config.host, config.p2p_port)
                 .parse()
                 .expect("host and p2p_port to be valid"),
+            network: parse_network(&config.network),
         }
+    }
+}
+
+fn parse_network(network: &str) -> Network {
+    match network {
+        "signet" => Network::Signet,
+        "testnet" => Network::Testnet,
+        "mainnet" => Network::Bitcoin,
+        _ => Network::Regtest,
     }
 }

--- a/mobile/native/src/config/mod.rs
+++ b/mobile/native/src/config/mod.rs
@@ -1,6 +1,7 @@
 pub mod api;
 
 use crate::config::api::Config;
+use bdk::bitcoin;
 use bdk::bitcoin::secp256k1::PublicKey;
 use ln_dlc_node::node::NodeInfo;
 use state::Storage;
@@ -14,6 +15,7 @@ struct ConfigInternal {
     electrs_endpoint: SocketAddr,
     http_endpoint: SocketAddr,
     p2p_endpoint: SocketAddr,
+    network: bitcoin::Network,
 }
 
 pub fn set(config: Config) {
@@ -34,4 +36,8 @@ pub fn get_electrs_endpoint() -> SocketAddr {
 
 pub fn get_http_endpoint() -> SocketAddr {
     CONFIG.get().http_endpoint
+}
+
+pub fn get_network() -> bitcoin::Network {
+    CONFIG.get().network
 }

--- a/mobile/native/src/ln_dlc/mod.rs
+++ b/mobile/native/src/ln_dlc/mod.rs
@@ -12,7 +12,6 @@ use anyhow::Context;
 use anyhow::Result;
 use bdk::bitcoin::secp256k1::rand::thread_rng;
 use bdk::bitcoin::secp256k1::rand::RngCore;
-use bdk::bitcoin::Network;
 use bdk::bitcoin::XOnlyPublicKey;
 use lightning_invoice::Invoice;
 use ln_dlc_node::node::Node;
@@ -75,7 +74,7 @@ fn runtime() -> Result<&'static Runtime> {
 }
 
 pub fn run(data_dir: String) -> Result<()> {
-    let network = Network::Regtest;
+    let network = config::get_network();
     let runtime = runtime()?;
 
     runtime.block_on(async move {

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -165,10 +165,10 @@ packages:
     dependency: transitive
     description:
       name: collection
-      sha256: "4a07be6cb69c84d677a6c3096fcf960cc3285a8330b4603e0d463d15d9bd934c"
+      sha256: cfc915e6923fe5ce6e153b0723c753045de46de1b4d63771530504004a45fae0
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.1"
+    version: "1.17.0"
   colorize:
     dependency: transitive
     description:
@@ -460,10 +460,10 @@ packages:
     dependency: transitive
     description:
       name: js
-      sha256: f2c445dce49627136094980615a031419f7f3eb393237e4ecd97ac15dea343f3
+      sha256: "5528c2f391ededb7775ec1daa69e65a2d61276f7552de2b5f7b8d34ee9fd4ab7"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.7"
+    version: "0.6.5"
   json_annotation:
     dependency: transitive
     description:
@@ -492,10 +492,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: c94db23593b89766cda57aab9ac311e3616cf87c6fa4e9749df032f66f30dcb8
+      sha256: "16db949ceee371e9b99d22f88fa3a73c4e59fd0afed0bd25fc336eb76c198b72"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.14"
+    version: "0.12.13"
   material_color_utilities:
     dependency: transitive
     description:
@@ -508,10 +508,10 @@ packages:
     dependency: "direct main"
     description:
       name: meta
-      sha256: "12307e7f0605ce3da64cf0db90e5fcab0869f3ca03f76be6bb2991ce0a55e82b"
+      sha256: "6c268b42ed578a53088d834796959e4a1814b5e9e164f147f580a386e5decf42"
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.0"
+    version: "1.8.0"
   mime:
     dependency: transitive
     description:
@@ -548,10 +548,10 @@ packages:
     dependency: transitive
     description:
       name: path
-      sha256: "8829d8a55c13fc0e37127c29fedf290c102f4e40ae94ada574091fe0ff96c917"
+      sha256: db9d4f58c908a4ba5953fcee2ae317c94889433e5024c27ce74a37f94267945b
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.3"
+    version: "1.8.2"
   path_parsing:
     dependency: transitive
     description:
@@ -849,10 +849,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "6182294da5abf431177fccc1ee02401f6df30f766bc6130a0852c6b6d7ee6b2d"
+      sha256: ad540f65f92caa91bf21dfc8ffb8c589d6e4dc0c2267818b4cc2792857706206
       url: "https://pub.dev"
     source: hosted
-    version: "0.4.18"
+    version: "0.4.16"
   timing:
     dependency: transitive
     description:


### PR DESCRIPTION
This will allow to pass the network as argument on the coordinator as well as on the mobile app. Both default to regtest.

Set on coordinator like this.

```
just coordinator signet
```

Set on mobile app like this.
```
just run --dart-define="NETWORK=signet"
```

resolves #202 

