### PR TITLE
Bump flutter_rust_bridge to 1.68

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -876,9 +876,9 @@ dependencies = [
 
 [[package]]
 name = "flutter_rust_bridge"
-version = "1.65.1"
+version = "1.68.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb5018e69cd577543de533321dbf8519251950e9793baced08ad662abab1a640"
+checksum = "54f0d71ff30fc2ae7c18508b517488a89051d81e3bfc4d48d4a6cf54b5dab789"
 dependencies = [
  "allo-isolate",
  "anyhow",

--- a/mobile/native/Cargo.toml
+++ b/mobile/native/Cargo.toml
@@ -11,7 +11,7 @@ anyhow = "1"
 bdk = { version = "0.24.0", features = ["key-value-db"] }
 diesel = { version = "2.0.0", features = ["sqlite", "r2d2", "extras"] }
 diesel_migrations = "2.0.0"
-flutter_rust_bridge = "1.63.1"
+flutter_rust_bridge = "1.68.0"
 lightning-invoice = { version = "0.21" }
 ln-dlc-node = { path = "../../crates/ln-dlc-node" }
 reqwest = { version = "0.11", default-features = false, features = ["json"] }

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -322,10 +322,10 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_rust_bridge
-      sha256: f8f96059ffea18260c4009c3bc476f6300cf19fc180c89c7caf095bb8e30b4b7
+      sha256: "92d2a19d0e630acd15cea5901d89027d764424bd7d5adf515dfd99776dd572bf"
       url: "https://pub.dev"
     source: hosted
-    version: "1.63.1"
+    version: "1.68.0"
   flutter_speed_dial:
     dependency: "direct main"
     description:

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
   cupertino_icons: ^1.0.5
   ffi: ^2.0.1
   f_logs: ^2.0.1
-  flutter_rust_bridge: 1.63.1
+  flutter_rust_bridge: 1.68.0
   flutter_speed_dial: ^6.2.0
   meta: ^1.8.0
   go_router: ^6.0.2


### PR DESCRIPTION
This is our critical dependency, so it's worth being up-to-date (we were on 1.63)

Notable improvements:
    - support for Option, empty structs
    - comments in the API are migrated to Dart
    - parameter defaults, structs are const-constructible
    - (and more, see: https://github.com/fzyzcjy/flutter_rust_bridge/releases)