### PR TITLE
Verify open-close-open DLC channel behaviour 

### DIFF
--- a/crates/ln-dlc-node/src/node/dlc_channel.rs
+++ b/crates/ln-dlc-node/src/node/dlc_channel.rs
@@ -118,7 +118,7 @@ impl Node {
         Ok(())
     }
 
-    pub fn initiate_accept_dlc_channel_offer(&self, channel_id: &[u8; 32]) -> Result<()> {
+    pub fn accept_dlc_channel_offer(&self, channel_id: &[u8; 32]) -> Result<()> {
         let channel_id_hex = hex::encode(channel_id);
 
         tracing::info!(channel_id = %channel_id_hex, "Accepting DLC channel offer");
@@ -162,7 +162,7 @@ impl Node {
         Ok(())
     }
 
-    pub fn initiate_accept_dlc_channel_close_offer(&self, channel_id: &[u8; 32]) -> Result<()> {
+    pub fn accept_dlc_channel_close_offer(&self, channel_id: &[u8; 32]) -> Result<()> {
         let channel_id_hex = hex::encode(channel_id);
 
         tracing::info!(channel_id = %channel_id_hex, "Accepting DLC channel close offer");

--- a/crates/ln-dlc-node/src/node/dlc_channel.rs
+++ b/crates/ln-dlc-node/src/node/dlc_channel.rs
@@ -162,10 +162,10 @@ impl Node {
         Ok(())
     }
 
-    pub fn accept_dlc_channel_close_offer(&self, channel_id: &[u8; 32]) -> Result<()> {
+    pub fn accept_dlc_channel_collaborative_settlement(&self, channel_id: &[u8; 32]) -> Result<()> {
         let channel_id_hex = hex::encode(channel_id);
 
-        tracing::info!(channel_id = %channel_id_hex, "Accepting DLC channel close offer");
+        tracing::info!(channel_id = %channel_id_hex, "Accepting DLC channel collaborative settlement");
 
         let (sub_channel_close_accept, counterparty_pk) = self
             .sub_channel_manager

--- a/crates/ln-dlc-node/src/tests/dlc/collaborative_settlement.rs
+++ b/crates/ln-dlc-node/src/tests/dlc/collaborative_settlement.rs
@@ -1,21 +1,37 @@
+use crate::node::Node;
 use crate::tests::dlc::create::create_dlc_channel;
 use crate::tests::dlc::create::DlcChannelCreated;
+use crate::tests::dummy_contract_input;
 use crate::tests::init_tracing;
 use crate::tests::wait_until;
 use anyhow::anyhow;
+use anyhow::Context;
+use anyhow::Result;
 use dlc_manager::subchannel::SubChannelState;
 use dlc_manager::Storage;
 use std::time::Duration;
 
 #[tokio::test]
 #[ignore]
-async fn dlc_collaborative_settlement() {
+async fn dlc_collaborative_settlement_test() {
     init_tracing();
-
-    // Arrange
 
     let app_dlc_collateral = 50_000;
     let coordinator_dlc_collateral = 25_000;
+
+    dlc_collaborative_settlement(app_dlc_collateral, coordinator_dlc_collateral)
+        .await
+        .unwrap();
+}
+
+/// Start an app and a coordinator; create an LN channel between them with double the specified
+/// amounts; add a DLC channel with the specified amounts; and close the DLC channel giving the
+/// coordinator 50% losses.
+async fn dlc_collaborative_settlement(
+    app_dlc_collateral: u64,
+    coordinator_dlc_collateral: u64,
+) -> Result<(Node, Node)> {
+    // Arrange
 
     let DlcChannelCreated {
         coordinator,
@@ -23,29 +39,21 @@ async fn dlc_collaborative_settlement() {
         app,
         app_balance_channel_creation,
         channel_id,
-    } = create_dlc_channel(app_dlc_collateral, coordinator_dlc_collateral)
-        .await
-        .unwrap();
-
-    // TODO: Figure out why the balances look like they do after the DLC channel is open
-
-    tracing::info!(balance = ?app.get_ldk_balance(), "App balance after opening DLC channel");
-    tracing::info!(balance = ?coordinator.get_ldk_balance(), "Coordinator balance after opening DLC channel");
+    } = create_dlc_channel(app_dlc_collateral, coordinator_dlc_collateral).await?;
 
     // Act
 
     // The underlying API expects the settlement amount of the party who originally _accepted_ the
     // channel. Since we know in this case that the coordinator accepted the DLC channel, here we
     // specify the coordinator's settlement amount.
-    let coordinator_settlement_amount = 10_000;
+    let coordinator_settlement_amount = coordinator_dlc_collateral / 2;
     let coordinator_loss_amount = coordinator_dlc_collateral - coordinator_settlement_amount;
 
-    app.propose_dlc_channel_collaborative_settlement(&channel_id, coordinator_settlement_amount)
-        .unwrap();
+    app.propose_dlc_channel_collaborative_settlement(&channel_id, coordinator_settlement_amount)?;
 
     // Processs the app's offer to close the channel
     tokio::time::sleep(Duration::from_secs(2)).await;
-    coordinator.process_incoming_messages().unwrap();
+    coordinator.process_incoming_messages()?;
 
     let sub_channel = wait_until(Duration::from_secs(30), || async {
         let sub_channels = coordinator
@@ -61,11 +69,124 @@ async fn dlc_collaborative_settlement() {
 
         Ok(sub_channel.cloned())
     })
+    .await?;
+
+    coordinator.accept_dlc_channel_collaborative_settlement(&sub_channel.channel_id)?;
+
+    // Process the coordinator's accept message _and_ send the confirm
+    // message
+    tokio::time::sleep(Duration::from_secs(2)).await;
+    app.process_incoming_messages()?;
+
+    // Process the confirm message
+    tokio::time::sleep(Duration::from_secs(2)).await;
+    coordinator.process_incoming_messages()?;
+
+    // Process the close-finalize message
+    tokio::time::sleep(Duration::from_secs(2)).await;
+    app.process_incoming_messages()?;
+
+    // Assert
+
+    let sub_channel_coordinator = coordinator
+        .dlc_manager
+        .get_store()
+        .get_sub_channels()
+        .map_err(|e| anyhow!(e.to_string()))?
+        .into_iter()
+        .find(|sc| sc.channel_id == sub_channel.channel_id)
+        .context("No sub-channel for coordinator")?;
+
+    matches!(
+        sub_channel_coordinator.state,
+        SubChannelState::OffChainClosed
+    );
+
+    let sub_channel_app = app
+        .dlc_manager
+        .get_store()
+        .get_sub_channels()
+        .map_err(|e| anyhow!(e.to_string()))?
+        .into_iter()
+        .find(|sc| sc.channel_id == sub_channel.channel_id)
+        .context("No sub-channel for app")?;
+
+    let app_balance_after = app.get_ldk_balance().available;
+    let coordinator_balance_after = coordinator.get_ldk_balance().available;
+
+    matches!(sub_channel_app.state, SubChannelState::OffChainClosed);
+
+    assert_eq!(
+        app_balance_channel_creation + coordinator_loss_amount,
+        app_balance_after
+    );
+
+    assert_eq!(
+        coordinator_balance_channel_creation,
+        coordinator_balance_after + coordinator_loss_amount
+    );
+
+    Ok((app, coordinator))
+}
+
+#[tokio::test]
+#[ignore]
+async fn open_dlc_channel_after_closing_dlc_channel() {
+    init_tracing();
+
+    // Arrange
+
+    let app_dlc_collateral = 50_000;
+    let coordinator_dlc_collateral = 25_000;
+
+    let (app, coordinator) =
+        dlc_collaborative_settlement(app_dlc_collateral, coordinator_dlc_collateral)
+            .await
+            .unwrap();
+
+    let channel_details = app.channel_manager.list_usable_channels();
+    let channel_details = channel_details
+        .iter()
+        .find(|c| c.counterparty.node_id == coordinator.info.pubkey)
+        .context("No usable channels for app")
+        .unwrap();
+
+    // Act
+
+    let app_dlc_collateral = 20_000;
+    let coordinator_dlc_collateral = 10_000;
+
+    let oracle_pk = app.oracle_pk();
+    let contract_input =
+        dummy_contract_input(app_dlc_collateral, coordinator_dlc_collateral, oracle_pk);
+
+    app.propose_dlc_channel(channel_details, &contract_input)
+        .await
+        .unwrap();
+
+    // Processs the app's offer to close the channel
+    tokio::time::sleep(Duration::from_secs(2)).await;
+    coordinator.process_incoming_messages().unwrap();
+
+    let sub_channel = wait_until(Duration::from_secs(30), || async {
+        let sub_channels = coordinator
+            .dlc_manager
+            .get_store()
+            .get_sub_channels() // `get_offered_sub_channels` appears to have a bug
+            .map_err(|e| anyhow!(e.to_string()))?;
+
+        let sub_channel = sub_channels.iter().find(|sub_channel| {
+            sub_channel.counter_party == app.info.pubkey
+                && matches!(&sub_channel.state, SubChannelState::Offered(_))
+        });
+
+        Ok(sub_channel.cloned())
+    })
     .await
     .unwrap();
 
     coordinator
-        .accept_dlc_channel_collaborative_settlement(&sub_channel.channel_id)
+        .accept_dlc_channel_offer(&sub_channel.channel_id)
         .unwrap();
 
     // Process the coordinator's accept message _and_ send the confirm
@@ -77,25 +198,20 @@ async fn dlc_collaborative_settlement() {
     tokio::time::sleep(Duration::from_secs(2)).await;
     coordinator.process_incoming_messages().unwrap();
 
-    // Process the close-finalize message
-    tokio::time::sleep(Duration::from_secs(2)).await;
-    app.process_incoming_messages().unwrap();
-
     // Assert
 
     let sub_channel_coordinator = coordinator
         .dlc_manager
         .get_store()
         .get_sub_channels()
+        .map_err(|e| anyhow!("{e}"))
         .unwrap()
         .into_iter()
         .find(|sc| sc.channel_id == sub_channel.channel_id)
+        .context("No sub-channel for coordinator")
         .unwrap();
 
-    matches!(
-        sub_channel_coordinator.state,
-        SubChannelState::OffChainClosed
-    );
+    matches!(sub_channel_coordinator.state, SubChannelState::Signed(_));
 
     let sub_channel_app = app
         .dlc_manager
@@ -105,21 +221,8 @@ async fn dlc_collaborative_settlement() {
         .unwrap()
         .into_iter()
         .find(|sc| sc.channel_id == sub_channel.channel_id)
+        .context("No sub-channel for app")
         .unwrap();
 
-    matches!(sub_channel_app.state, SubChannelState::OffChainClosed);
-
-    let app_balance_after = app.get_ldk_balance().available;
-
-    assert_eq!(
-        app_balance_channel_creation + coordinator_loss_amount,
-        app_balance_after
-    );
-
-    let coordinator_balance_after = coordinator.get_ldk_balance().available;
-
-    assert_eq!(
-        coordinator_balance_channel_creation,
-        coordinator_balance_after + coordinator_loss_amount
-    );
+    matches!(sub_channel_app.state, SubChannelState::Signed(_));
 }

--- a/crates/ln-dlc-node/src/tests/dlc/collaborative_settlement.rs
+++ b/crates/ln-dlc-node/src/tests/dlc/collaborative_settlement.rs
@@ -65,7 +65,7 @@ async fn dlc_collaborative_settlement() {
     .unwrap();
 
     coordinator
-        .initiate_accept_dlc_channel_close_offer(&sub_channel.channel_id)
+        .accept_dlc_channel_close_offer(&sub_channel.channel_id)
         .unwrap();
 
     // Process the coordinator's accept message _and_ send the confirm

--- a/crates/ln-dlc-node/src/tests/dlc/collaborative_settlement.rs
+++ b/crates/ln-dlc-node/src/tests/dlc/collaborative_settlement.rs
@@ -65,7 +65,7 @@ async fn dlc_collaborative_settlement() {
     .unwrap();
 
     coordinator
-        .accept_dlc_channel_close_offer(&sub_channel.channel_id)
+        .accept_dlc_channel_collaborative_settlement(&sub_channel.channel_id)
         .unwrap();
 
     // Process the coordinator's accept message _and_ send the confirm

--- a/crates/ln-dlc-node/src/tests/dlc/create.rs
+++ b/crates/ln-dlc-node/src/tests/dlc/create.rs
@@ -95,7 +95,7 @@ pub async fn create_dlc_channel(
     })
     .await?;
 
-    coordinator.initiate_accept_dlc_channel_offer(&sub_channel.channel_id)?;
+    coordinator.accept_dlc_channel_offer(&sub_channel.channel_id)?;
 
     // Process the coordinator's accept message _and_ send the confirm
     // message


### PR DESCRIPTION
Actually finishes #50.

We should eventually also add assertions for the LN balances and DLC collateral values for all tests where the action results in creating a DLC.