### PR TITLE
Feat/database exposes crud for bl

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1704,6 +1704,7 @@ dependencies = [
  "rust_decimal_macros",
  "serde",
  "state",
+ "thiserror",
  "time 0.3.20",
  "tokio",
  "tracing",

--- a/mobile/native/Cargo.toml
+++ b/mobile/native/Cargo.toml
@@ -19,6 +19,7 @@ rust_decimal = { version = "1", features = ["serde-with-float"] }
 rust_decimal_macros = "1.26"
 serde = { version = "1.0.152", features = ["serde_derive"] }
 state = "0.5.3"
+thiserror = "1"
 time = { version = "0.3.20", features = ["formatting"] }
 tokio = { version = "1.25.0", features = ["macros", "rt", "rt-multi-thread", "sync", "time"] }
 tracing = "0.1.37"

--- a/mobile/native/src/api.rs
+++ b/mobile/native/src/api.rs
@@ -2,7 +2,6 @@ use crate::calculations;
 use crate::config;
 use crate::config::api::Config;
 use crate::db;
-use crate::db::models::LastLogin;
 use crate::event;
 use crate::event::api::FlutterSubscriber;
 use crate::ln_dlc;
@@ -160,6 +159,11 @@ pub fn create_invoice_without_amount() -> Result<String> {
 
 pub fn send_payment(invoice: String) -> Result<()> {
     ln_dlc::send_payment(&invoice)
+}
+
+pub struct LastLogin {
+    pub id: i32,
+    pub date: String,
 }
 
 pub fn update_last_login() -> Result<LastLogin> {

--- a/mobile/native/src/db/mod.rs
+++ b/mobile/native/src/db/mod.rs
@@ -1,4 +1,4 @@
-use crate::db::models::LastLogin;
+use crate::api;
 use anyhow::anyhow;
 use anyhow::Context;
 use anyhow::Result;
@@ -45,9 +45,9 @@ fn connection() -> Result<PooledConnection<ConnectionManager<SqliteConnection>>>
         .map_err(|e| anyhow!("cannot acquire database connection: {e:#}"))
 }
 
-pub fn update_last_login() -> Result<LastLogin> {
+pub fn update_last_login() -> Result<api::LastLogin> {
     let mut db = connection()?;
     let now = OffsetDateTime::now_utc();
-    let last_login = LastLogin::update_last_login(now, &mut db)?;
+    let last_login = models::LastLogin::update_last_login(now, &mut db)?.into();
     Ok(last_login)
 }

--- a/mobile/native/src/db/models.rs
+++ b/mobile/native/src/db/models.rs
@@ -14,7 +14,6 @@ use diesel::FromSqlRow;
 use diesel::Queryable;
 use time::format_description;
 use time::OffsetDateTime;
-use uuid::Uuid;
 
 const SQLITE_DATETIME_FMT: &str = "[year]-[month]-[day] [hour]:[minute]:[second] [offset_hour \
          sign:mandatory]:[offset_minute]:[offset_second]";
@@ -108,16 +107,16 @@ impl Order {
         }
     }
 
-    pub fn get(order_id: Uuid, conn: &mut SqliteConnection) -> QueryResult<Order> {
+    pub fn get(order_id: String, conn: &mut SqliteConnection) -> QueryResult<Order> {
         orders::table
-            .filter(schema::orders::id.eq(order_id.to_string()))
+            .filter(schema::orders::id.eq(order_id))
             .first(conn)
     }
 
     /// Deletes given order from DB, in case of success, returns > 0, else 0 or Err
-    pub fn delete(order_id: Uuid, conn: &mut SqliteConnection) -> QueryResult<usize> {
+    pub fn delete(order_id: String, conn: &mut SqliteConnection) -> QueryResult<usize> {
         diesel::delete(orders::table)
-            .filter(orders::id.eq(order_id.to_string()))
+            .filter(orders::id.eq(order_id))
             .execute(conn)
     }
 }
@@ -311,15 +310,15 @@ pub mod test {
         .unwrap();
 
         // load the order to see if it was randomly changed
-        let loaded_order = Order::get(uuid, &mut connection).unwrap();
+        let loaded_order = Order::get(uuid.to_string(), &mut connection).unwrap();
         assert_eq!(order, loaded_order);
 
         // delete it
-        let deleted_rows = Order::delete(uuid, &mut connection).unwrap();
+        let deleted_rows = Order::delete(uuid.to_string(), &mut connection).unwrap();
         assert_eq!(deleted_rows, 1);
 
         // check if it is really gone
-        match Order::get(uuid, &mut connection) {
+        match Order::get(uuid.to_string(), &mut connection) {
             Err(Error::NotFound) => { // all good
             }
             _ => {

--- a/mobile/native/src/db/models.rs
+++ b/mobile/native/src/db/models.rs
@@ -1,3 +1,4 @@
+use crate::api;
 use crate::schema;
 use crate::schema::last_login;
 use crate::schema::orders;
@@ -20,16 +21,25 @@ const SQLITE_DATETIME_FMT: &str = "[year]-[month]-[day] [hour]:[minute]:[second]
 
 #[derive(Queryable, QueryableByName, Debug, Clone)]
 #[diesel(table_name = last_login)]
-pub struct LastLogin {
+pub(crate) struct LastLogin {
     #[diesel(sql_type = Integer)]
     pub id: i32,
     #[diesel(sql_type = Text)]
     pub date: String,
 }
 
+impl From<LastLogin> for api::LastLogin {
+    fn from(value: LastLogin) -> Self {
+        api::LastLogin {
+            id: value.id,
+            date: value.date,
+        }
+    }
+}
+
 #[derive(Insertable, Debug, Clone)]
 #[diesel(table_name = last_login)]
-pub struct NewLastLogin {
+pub(crate) struct NewLastLogin {
     #[diesel(sql_type = Integer)]
     pub id: i32,
     #[diesel(sql_type = Text)]
@@ -72,7 +82,7 @@ impl LastLogin {
 
 #[derive(Queryable, QueryableByName, Insertable, Debug, Clone, PartialEq)]
 #[diesel(table_name = orders)]
-pub struct Order {
+pub(crate) struct Order {
     pub id: String,
     pub leverage: f64,
     pub quantity: f64,


### PR DESCRIPTION
Expose `Order` related CRUD on the db interface so we can use it in the business logic (BL).
This is pre-work for #223
I will go on with using this work in the BL, we can merge this PR separately already to keep the changeset smaller :)