### PR TITLE
Add Clippy lint workspace configuration

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,8 @@
+[target.'cfg(feature = "cargo-clippy")']
+rustflags = [
+  "-Wclippy::dbg_macro",
+  "-Wclippy::print_stderr",
+  "-Wclippy::print_stdout",
+  "-Wunused-import-braces",
+  "-Wunused-qualifications",
+]

--- a/coordinator/src/logger.rs
+++ b/coordinator/src/logger.rs
@@ -31,6 +31,7 @@ pub fn init_tracing(level: LevelFilter, json_format: bool) -> Result<()> {
     let filter = match std::env::var_os(RUST_LOG_ENV).map(|s| s.into_string()) {
         Some(Ok(env)) => {
             for directive in env.split(',') {
+                #[allow(clippy::print_stdout)]
                 match directive.parse() {
                     Ok(d) => filter = filter.add_directive(d),
                     Err(e) => println!("WARN ignoring log directive: `{directive}`: {e}"),

--- a/coordinator/src/routes.rs
+++ b/coordinator/src/routes.rs
@@ -15,7 +15,6 @@ use axum::routing::post;
 use axum::Json;
 use axum::Router;
 use bitcoin::secp256k1::PublicKey;
-use diesel::r2d2;
 use diesel::r2d2::ConnectionManager;
 use diesel::r2d2::Pool;
 use diesel::PgConnection;
@@ -32,7 +31,7 @@ pub struct AppState {
     pub node: Arc<Node>,
     // Channel used to send messages to all connected clients.
     pub tx_pricefeed: broadcast::Sender<PriceFeedMessage>,
-    pub pool: r2d2::Pool<ConnectionManager<PgConnection>>,
+    pub pool: Pool<ConnectionManager<PgConnection>>,
 }
 
 pub fn router(node: Arc<Node>, pool: Pool<ConnectionManager<PgConnection>>) -> Router {

--- a/crates/bdk-ldk/src/lib.rs
+++ b/crates/bdk-ldk/src/lib.rs
@@ -405,7 +405,7 @@ where
 {
     fn broadcast_transaction(&self, tx: &Transaction) {
         if let Err(e) = self.client.broadcast(tx) {
-            eprintln!("Error broadcasting transaction: {e:#}");
+            tracing::error!("Error broadcasting transaction: {e:#}");
         }
     }
 }

--- a/crates/ln-dlc-node/src/dlc_custom_signer.rs
+++ b/crates/ln-dlc-node/src/dlc_custom_signer.rs
@@ -52,7 +52,7 @@ impl BaseSign for CustomSigner {
     fn get_per_commitment_point(
         &self,
         idx: u64,
-        secp_ctx: &secp256k1_zkp::Secp256k1<bitcoin::secp256k1::All>,
+        secp_ctx: &Secp256k1<bitcoin::secp256k1::All>,
     ) -> secp256k1_zkp::PublicKey {
         self.in_memory_signer
             .lock()
@@ -78,7 +78,7 @@ impl BaseSign for CustomSigner {
             .validate_holder_commitment(holder_tx, preimages)
     }
 
-    fn pubkeys(&self) -> &lightning::ln::chan_utils::ChannelPublicKeys {
+    fn pubkeys(&self) -> &ChannelPublicKeys {
         &self.channel_public_keys
     }
 
@@ -90,7 +90,7 @@ impl BaseSign for CustomSigner {
         &self,
         commitment_tx: &lightning::ln::chan_utils::CommitmentTransaction,
         preimages: Vec<lightning::ln::PaymentPreimage>,
-        secp_ctx: &secp256k1_zkp::Secp256k1<bitcoin::secp256k1::All>,
+        secp_ctx: &Secp256k1<bitcoin::secp256k1::All>,
     ) -> Result<
         (
             secp256k1_zkp::ecdsa::Signature,
@@ -104,11 +104,7 @@ impl BaseSign for CustomSigner {
             .sign_counterparty_commitment(commitment_tx, preimages, secp_ctx)
     }
 
-    fn validate_counterparty_revocation(
-        &self,
-        idx: u64,
-        secret: &secp256k1_zkp::SecretKey,
-    ) -> Result<(), ()> {
+    fn validate_counterparty_revocation(&self, idx: u64, secret: &SecretKey) -> Result<(), ()> {
         self.in_memory_signer
             .lock()
             .unwrap()
@@ -118,7 +114,7 @@ impl BaseSign for CustomSigner {
     fn sign_holder_commitment_and_htlcs(
         &self,
         commitment_tx: &lightning::ln::chan_utils::HolderCommitmentTransaction,
-        secp_ctx: &secp256k1_zkp::Secp256k1<bitcoin::secp256k1::All>,
+        secp_ctx: &Secp256k1<bitcoin::secp256k1::All>,
     ) -> Result<
         (
             secp256k1_zkp::ecdsa::Signature,
@@ -134,11 +130,11 @@ impl BaseSign for CustomSigner {
 
     fn sign_justice_revoked_output(
         &self,
-        justice_tx: &bitcoin::Transaction,
+        justice_tx: &Transaction,
         input: usize,
         amount: u64,
-        per_commitment_key: &secp256k1_zkp::SecretKey,
-        secp_ctx: &secp256k1_zkp::Secp256k1<bitcoin::secp256k1::All>,
+        per_commitment_key: &SecretKey,
+        secp_ctx: &Secp256k1<bitcoin::secp256k1::All>,
     ) -> Result<secp256k1_zkp::ecdsa::Signature, ()> {
         self.in_memory_signer
             .lock()
@@ -148,12 +144,12 @@ impl BaseSign for CustomSigner {
 
     fn sign_justice_revoked_htlc(
         &self,
-        justice_tx: &bitcoin::Transaction,
+        justice_tx: &Transaction,
         input: usize,
         amount: u64,
-        per_commitment_key: &secp256k1_zkp::SecretKey,
+        per_commitment_key: &SecretKey,
         htlc: &lightning::ln::chan_utils::HTLCOutputInCommitment,
-        secp_ctx: &secp256k1_zkp::Secp256k1<bitcoin::secp256k1::All>,
+        secp_ctx: &Secp256k1<bitcoin::secp256k1::All>,
     ) -> Result<secp256k1_zkp::ecdsa::Signature, ()> {
         self.in_memory_signer
             .lock()
@@ -170,12 +166,12 @@ impl BaseSign for CustomSigner {
 
     fn sign_counterparty_htlc_transaction(
         &self,
-        htlc_tx: &bitcoin::Transaction,
+        htlc_tx: &Transaction,
         input: usize,
         amount: u64,
         per_commitment_point: &secp256k1_zkp::PublicKey,
         htlc: &lightning::ln::chan_utils::HTLCOutputInCommitment,
-        secp_ctx: &secp256k1_zkp::Secp256k1<bitcoin::secp256k1::All>,
+        secp_ctx: &Secp256k1<bitcoin::secp256k1::All>,
     ) -> Result<secp256k1_zkp::ecdsa::Signature, ()> {
         self.in_memory_signer
             .lock()
@@ -193,7 +189,7 @@ impl BaseSign for CustomSigner {
     fn sign_closing_transaction(
         &self,
         closing_tx: &lightning::ln::chan_utils::ClosingTransaction,
-        secp_ctx: &secp256k1_zkp::Secp256k1<bitcoin::secp256k1::All>,
+        secp_ctx: &Secp256k1<bitcoin::secp256k1::All>,
     ) -> Result<secp256k1_zkp::ecdsa::Signature, ()> {
         self.in_memory_signer
             .lock()
@@ -204,7 +200,7 @@ impl BaseSign for CustomSigner {
     fn sign_channel_announcement(
         &self,
         msg: &lightning::ln::msgs::UnsignedChannelAnnouncement,
-        secp_ctx: &secp256k1_zkp::Secp256k1<bitcoin::secp256k1::All>,
+        secp_ctx: &Secp256k1<bitcoin::secp256k1::All>,
     ) -> Result<
         (
             secp256k1_zkp::ecdsa::Signature,
@@ -244,7 +240,7 @@ impl BaseSign for CustomSigner {
 impl ExtraSign for CustomSigner {
     fn sign_with_fund_key_callback<F>(&self, cb: &mut F)
     where
-        F: FnMut(&secp256k1_zkp::SecretKey),
+        F: FnMut(&SecretKey),
     {
         self.in_memory_signer
             .lock()

--- a/crates/ln-dlc-node/src/ln/event_handler.rs
+++ b/crates/ln-dlc-node/src/ln/event_handler.rs
@@ -219,7 +219,10 @@ impl EventHandler {
             Event::PaymentPathSuccessful { .. } => {}
             Event::PaymentPathFailed { .. } => {}
             Event::PaymentFailed { payment_hash, .. } => {
-                print!("\nEVENT: Failed to send payment to payment hash {:?}: exhausted payment retry attempts", hex::encode(payment_hash.0));
+                tracing::warn!(
+                    "Failed to send payment to payment hash {:?}: exhausted payment retry attempts",
+                    hex::encode(payment_hash.0)
+                );
 
                 let mut payments = self.outbound_payments.lock().unwrap();
                 if payments.contains_key(&payment_hash) {

--- a/crates/ln-dlc-node/src/ln_dlc_wallet.rs
+++ b/crates/ln-dlc-node/src/ln_dlc_wallet.rs
@@ -69,7 +69,7 @@ impl dlc_manager::Blockchain for LnDlcWallet {
         let network = self
             .ln_wallet
             .get_wallet()
-            .map_err(|e| Error::WalletError(Box::new(e)))?
+            .map_err(|e| WalletError(Box::new(e)))?
             .network();
         Ok(network)
     }

--- a/crates/ln-dlc-node/src/node/mod.rs
+++ b/crates/ln-dlc-node/src/node/mod.rs
@@ -96,7 +96,7 @@ pub struct Node {
     dlc_message_handler: Arc<DlcMessageHandler>,
     inbound_payments: PaymentInfoStorage,
 
-    pub(crate) user_config: lightning::util::config::UserConfig,
+    pub(crate) user_config: UserConfig,
 
     pending_trades: Arc<Mutex<HashSet<PublicKey>>>,
 }

--- a/crates/ln-dlc-node/src/tests/mod.rs
+++ b/crates/ln-dlc-node/src/tests/mod.rs
@@ -100,7 +100,7 @@ impl Node {
         Ok(node)
     }
 
-    async fn fund(&self, amount: bitcoin::Amount) -> Result<()> {
+    async fn fund(&self, amount: Amount) -> Result<()> {
         let starting_balance = self.get_confirmed_balance()?;
         let expected_balance = starting_balance + amount.to_sat();
 

--- a/crates/trade/src/lib.rs
+++ b/crates/trade/src/lib.rs
@@ -91,7 +91,7 @@ pub enum Direction {
 impl FromStr for ContractSymbol {
     type Err = anyhow::Error;
 
-    fn from_str(value: &str) -> std::result::Result<Self, Self::Err> {
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
         match value.to_lowercase().as_str() {
             "btcusd" => Ok(ContractSymbol::BtcUsd),
             // BitMEX representation

--- a/maker/src/logger.rs
+++ b/maker/src/logger.rs
@@ -31,6 +31,7 @@ pub fn init_tracing(level: LevelFilter, json_format: bool) -> Result<()> {
     let filter = match std::env::var_os(RUST_LOG_ENV).map(|s| s.into_string()) {
         Some(Ok(env)) => {
             for directive in env.split(',') {
+                #[allow(clippy::print_stdout)]
                 match directive.parse() {
                     Ok(d) => filter = filter.add_directive(d),
                     Err(e) => println!("WARN ignoring log directive: `{directive}`: {e}"),

--- a/maker/src/routes.rs
+++ b/maker/src/routes.rs
@@ -9,7 +9,6 @@ use axum::Json;
 use axum::Router;
 use bitcoin::hashes::hex::ToHex;
 use bitcoin::secp256k1::PublicKey;
-use diesel::r2d2;
 use diesel::r2d2::ConnectionManager;
 use diesel::r2d2::Pool;
 use diesel::PgConnection;
@@ -23,7 +22,7 @@ use std::sync::Arc;
 
 pub struct AppState {
     pub node: Arc<Node>,
-    pub pool: r2d2::Pool<ConnectionManager<PgConnection>>,
+    pub pool: Pool<ConnectionManager<PgConnection>>,
 }
 
 pub fn router(node: Arc<Node>, pool: Pool<ConnectionManager<PgConnection>>) -> Router {
@@ -263,7 +262,6 @@ pub async fn pay_invoice(
     State(state): State<Arc<AppState>>,
     Path(invoice): Path<String>,
 ) -> Result<Json<String>, AppError> {
-    dbg!(&invoice);
     let invoice = invoice
         .parse()
         .map_err(|e| AppError::BadRequest(format!("Invalid invoice provided {e:#}")))?;

--- a/mobile/native/src/db/custom_types.rs
+++ b/mobile/native/src/db/custom_types.rs
@@ -9,11 +9,10 @@ use diesel::serialize::IsNull;
 use diesel::serialize::Output;
 use diesel::serialize::ToSql;
 use diesel::serialize::{self};
-use diesel::sql_types;
 use diesel::sql_types::Text;
 use diesel::sqlite::Sqlite;
 
-impl ToSql<sql_types::Text, Sqlite> for OrderType {
+impl ToSql<Text, Sqlite> for OrderType {
     fn to_sql(&self, out: &mut Output<Sqlite>) -> serialize::Result {
         let text = match *self {
             OrderType::Market => "market".to_string(),
@@ -24,7 +23,7 @@ impl ToSql<sql_types::Text, Sqlite> for OrderType {
     }
 }
 
-impl FromSql<sql_types::Text, Sqlite> for OrderType {
+impl FromSql<Text, Sqlite> for OrderType {
     fn from_sql(bytes: backend::RawValue<Sqlite>) -> deserialize::Result<Self> {
         let string = <String as FromSql<Text, Sqlite>>::from_sql(bytes)?;
 
@@ -36,7 +35,7 @@ impl FromSql<sql_types::Text, Sqlite> for OrderType {
     }
 }
 
-impl ToSql<sql_types::Text, Sqlite> for OrderState {
+impl ToSql<Text, Sqlite> for OrderState {
     fn to_sql(&self, out: &mut Output<Sqlite>) -> serialize::Result {
         let text = match *self {
             OrderState::Initial => "initial".to_string(),
@@ -50,7 +49,7 @@ impl ToSql<sql_types::Text, Sqlite> for OrderState {
     }
 }
 
-impl FromSql<sql_types::Text, Sqlite> for OrderState {
+impl FromSql<Text, Sqlite> for OrderState {
     fn from_sql(bytes: backend::RawValue<Sqlite>) -> deserialize::Result<Self> {
         let string = <String as FromSql<Text, Sqlite>>::from_sql(bytes)?;
 
@@ -65,7 +64,7 @@ impl FromSql<sql_types::Text, Sqlite> for OrderState {
     }
 }
 
-impl ToSql<sql_types::Text, Sqlite> for ContractSymbol {
+impl ToSql<Text, Sqlite> for ContractSymbol {
     fn to_sql(&self, out: &mut Output<Sqlite>) -> serialize::Result {
         let text = match *self {
             ContractSymbol::BtcUsd => "BtcUsd",
@@ -75,7 +74,7 @@ impl ToSql<sql_types::Text, Sqlite> for ContractSymbol {
     }
 }
 
-impl FromSql<sql_types::Text, Sqlite> for ContractSymbol {
+impl FromSql<Text, Sqlite> for ContractSymbol {
     fn from_sql(bytes: backend::RawValue<Sqlite>) -> deserialize::Result<Self> {
         let string = <String as FromSql<Text, Sqlite>>::from_sql(bytes)?;
 
@@ -86,7 +85,7 @@ impl FromSql<sql_types::Text, Sqlite> for ContractSymbol {
     }
 }
 
-impl ToSql<sql_types::Text, Sqlite> for Direction {
+impl ToSql<Text, Sqlite> for Direction {
     fn to_sql(&self, out: &mut Output<Sqlite>) -> serialize::Result {
         let text = match *self {
             Direction::Long => "Long",
@@ -97,7 +96,7 @@ impl ToSql<sql_types::Text, Sqlite> for Direction {
     }
 }
 
-impl FromSql<sql_types::Text, Sqlite> for Direction {
+impl FromSql<Text, Sqlite> for Direction {
     fn from_sql(bytes: backend::RawValue<Sqlite>) -> deserialize::Result<Self> {
         let string = <String as FromSql<Text, Sqlite>>::from_sql(bytes)?;
 
@@ -149,7 +148,7 @@ pub mod tests {
         connection
             .batch_execute(
                 r#"
-        create table customstruct ( 
+        create table customstruct (
             id TEXT PRIMARY KEY NOT NULL,
             order_type TEXT NOT NULL,
             order_state TEXT NOT NULL,

--- a/mobile/native/src/lib.rs
+++ b/mobile/native/src/lib.rs
@@ -4,10 +4,12 @@ pub mod db;
 pub mod schema;
 
 mod api;
-mod bridge_generated;
 pub mod calculations;
 pub(crate) mod config;
 pub mod event;
 pub mod ln_dlc;
 pub mod logger;
 pub mod trade;
+
+#[allow(clippy::all, unused_import_braces, unused_qualifications)]
+mod bridge_generated;

--- a/mobile/native/src/logger.rs
+++ b/mobile/native/src/logger.rs
@@ -141,6 +141,7 @@ pub fn init_tracing(level: LevelFilter, json_format: bool) -> Result<()> {
         Some(Ok(env)) => {
             let mut filter = log_base_directives(EnvFilter::new(""), level)?;
             for directive in env.split(',') {
+                #[allow(clippy::print_stdout)]
                 match directive.parse() {
                     Ok(d) => filter = filter.add_directive(d),
                     Err(e) => println!("WARN ignoring log directive: `{directive}`: {e}"),


### PR DESCRIPTION
We've used a similar pattern in past projects.

One thing that has changed is that we use `[target.'cfg(feature = "cargo-clippy")']` instead of `[build]`. This allows us to enforce this lint configuration locally and not just on CI.

Using `rustflags` does mean that devs might encounter unexpected full rebuilds when switching between IDE and command line when using `cargo clippy`. This is a known [issue]. For emacs, I just solved this by setting a different Cargo `target-directory` to the one used by default. A similar approach should work for other IDEs.

[issue]: https://github.com/rust-lang/cargo/issues/8716.