### PR TITLE
Feat/persist order

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3017,6 +3017,7 @@ dependencies = [
  "rust_decimal",
  "rust_decimal_macros",
  "serde",
+ "uuid",
 ]
 
 [[package]]

--- a/crates/trade/Cargo.toml
+++ b/crates/trade/Cargo.toml
@@ -12,3 +12,4 @@ bdk = { version = "0.24.0" }
 rust_decimal = { version = "1", features = ["serde-with-float"] }
 rust_decimal_macros = "1.26"
 serde = { version = "1.0.152", features = ["serde_derive"] }
+uuid = { version = "1.3.0", features = ["v4", "fast-rng", "macro-diagnostics", "serde"] }

--- a/crates/trade/src/lib.rs
+++ b/crates/trade/src/lib.rs
@@ -7,6 +7,7 @@ use std::fmt;
 use std::fmt::Formatter;
 use std::str::FromStr;
 use std::time::Duration;
+use uuid::Uuid;
 
 pub mod cfd;
 
@@ -24,8 +25,11 @@ pub struct TradeParams {
     /// The identity of the trading party that eas matched to our order by the orderbook.
     pub pubkey_counterparty: PublicKey,
 
-    /// The orderbook id of our order that was matched
-    pub order_id: String,
+    /// The id of the order
+    ///
+    /// The order has to be identifiable by the client when returned from the orderbook, so the
+    /// client is in charge of creating this ID and passing it to the orderbook.
+    pub order_id: Uuid,
 
     /// The orderbook id of the counterparty order
     ///

--- a/mobile/lib/features/trade/domain/order.dart
+++ b/mobile/lib/features/trade/domain/order.dart
@@ -2,7 +2,6 @@ import 'package:get_10101/features/trade/domain/contract_symbol.dart';
 import 'package:get_10101/features/trade/domain/direction.dart';
 import 'package:get_10101/features/trade/domain/leverage.dart';
 import 'package:get_10101/bridge_generated/bridge_definitions.dart' as bridge;
-import 'package:uuid/uuid.dart';
 
 enum OrderState {
   open,
@@ -42,36 +41,41 @@ class Order {
   final OrderState state;
   final OrderType type;
   final double? executionPrice;
+  final DateTime creationTimestamp;
 
   Order(
-      {required this.leverage,
+      {required this.id,
+      required this.leverage,
       required this.quantity,
       required this.contractSymbol,
       required this.direction,
       required this.state,
       required this.type,
-      this.executionPrice}) {
-    id = const Uuid().v4();
-  }
+      required this.creationTimestamp,
+      this.executionPrice});
 
   static Order fromApi(bridge.Order order) {
     return Order(
+        id: order.id,
         leverage: Leverage(order.leverage),
         quantity: order.quantity,
         contractSymbol: ContractSymbol.fromApi(order.contractSymbol),
         direction: Direction.fromApi(order.direction),
         state: OrderState.fromApi(order.state),
         type: OrderType.fromApi(order.orderType),
-        executionPrice: order.executionPrice);
+        executionPrice: order.executionPrice,
+        creationTimestamp: DateTime.fromMillisecondsSinceEpoch(order.creationTimestamp * 1000));
   }
 
   static bridge.Order apiDummy() {
     return const bridge.Order(
+        id: "",
         leverage: 0,
         quantity: 0,
         contractSymbol: bridge.ContractSymbol.BtcUsd,
         direction: bridge.Direction.Long,
         orderType: bridge.OrderType.market(),
-        state: bridge.OrderState.Open);
+        state: bridge.OrderState.Open,
+        creationTimestamp: 0);
   }
 }

--- a/mobile/lib/features/trade/domain/order.dart
+++ b/mobile/lib/features/trade/domain/order.dart
@@ -39,7 +39,7 @@ class Order {
   final double quantity;
   final ContractSymbol contractSymbol;
   final Direction direction;
-  final OrderState status;
+  final OrderState state;
   final OrderType type;
   final double? executionPrice;
 
@@ -48,7 +48,7 @@ class Order {
       required this.quantity,
       required this.contractSymbol,
       required this.direction,
-      required this.status,
+      required this.state,
       required this.type,
       this.executionPrice}) {
     id = const Uuid().v4();
@@ -60,7 +60,7 @@ class Order {
         quantity: order.quantity,
         contractSymbol: ContractSymbol.fromApi(order.contractSymbol),
         direction: Direction.fromApi(order.direction),
-        status: OrderState.fromApi(order.status),
+        state: OrderState.fromApi(order.state),
         type: OrderType.fromApi(order.orderType),
         executionPrice: order.executionPrice);
   }
@@ -72,6 +72,6 @@ class Order {
         contractSymbol: bridge.ContractSymbol.BtcUsd,
         direction: bridge.Direction.Long,
         orderType: bridge.OrderType.market(),
-        status: bridge.OrderState.Open);
+        state: bridge.OrderState.Open);
   }
 }

--- a/mobile/lib/features/trade/order_list_item.dart
+++ b/mobile/lib/features/trade/order_list_item.dart
@@ -16,7 +16,7 @@ class OrderListItem extends StatelessWidget {
 
     const double iconSize = 18;
     Icon statusIcon = () {
-      switch (order.status) {
+      switch (order.state) {
         case OrderState.open:
           return const Icon(
             Icons.pending,
@@ -60,7 +60,7 @@ class OrderListItem extends StatelessWidget {
         trailing: RichText(
           text: TextSpan(style: DefaultTextStyle.of(context).style, children: <InlineSpan>[
             WidgetSpan(alignment: PlaceholderAlignment.middle, child: statusIcon),
-            TextSpan(text: " ${order.status.name}")
+            TextSpan(text: " ${order.state.name}")
           ]),
         ),
         subtitle: RichText(

--- a/mobile/lib/features/trade/position_change_notifier.dart
+++ b/mobile/lib/features/trade/position_change_notifier.dart
@@ -1,4 +1,3 @@
-import 'dart:collection';
 import 'dart:developer';
 import 'package:flutter/material.dart';
 import 'package:get_10101/common/application/event_service.dart';
@@ -9,10 +8,11 @@ import 'package:get_10101/bridge_generated/bridge_definitions.dart' as bridge;
 import 'domain/position.dart';
 
 class PositionChangeNotifier extends ChangeNotifier implements Subscriber {
-  HashMap<ContractSymbol, Position> positions = HashMap();
+  late PositionService _positionService;
+  Map<ContractSymbol, Position> positions = {};
 
-  Future<void> _create(PositionService positionService) async {
-    List<Position> positions = await positionService.fetchPositions();
+  Future<void> initialize() async {
+    List<Position> positions = await _positionService.fetchPositions();
     for (Position position in positions) {
       this.positions[position.contractSymbol] = position;
     }
@@ -20,8 +20,8 @@ class PositionChangeNotifier extends ChangeNotifier implements Subscriber {
     notifyListeners();
   }
 
-  PositionChangeNotifier.create(PositionService positionService) {
-    _create(positionService);
+  PositionChangeNotifier(PositionService positionService) {
+    _positionService = positionService;
   }
 
   @override

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -61,8 +61,8 @@ void main() {
     ChangeNotifierProvider(create: (context) => TradeValuesChangeNotifier(TradeValuesService())),
     ChangeNotifierProvider(create: (context) => AmountDenominationChangeNotifier()),
     ChangeNotifierProvider(create: (context) => SubmitOrderChangeNotifier(OrderService())),
-    ChangeNotifierProvider(create: (context) => OrderChangeNotifier.create(OrderService())),
-    ChangeNotifierProvider(create: (context) => PositionChangeNotifier.create(PositionService())),
+    ChangeNotifierProvider(create: (context) => OrderChangeNotifier(OrderService())),
+    ChangeNotifierProvider(create: (context) => PositionChangeNotifier(PositionService())),
     ChangeNotifierProvider(create: (context) => WalletChangeNotifier(const WalletService())),
     Provider(create: (context) => Environment.parse()),
   ], child: const TenTenOneApp()));
@@ -203,6 +203,9 @@ class _TenTenOneAppState extends State<TenTenOneApp> {
       FLog.info(text: "App data will be stored in: $appSupportDir");
 
       await rust.api.run(config: config, appDir: appSupportDir.path);
+
+      await orderChangeNotifier.initialize();
+      await positionChangeNotifier.initialize();
 
       var lastLogin = await rust.api.updateLastLogin();
       FLog.debug(text: "Last login was at ${lastLogin.date}");

--- a/mobile/macos/Podfile.lock
+++ b/mobile/macos/Podfile.lock
@@ -8,14 +8,14 @@ PODS:
 
 DEPENDENCIES:
   - FlutterMacOS (from `Flutter/ephemeral`)
-  - path_provider_foundation (from `Flutter/ephemeral/.symlinks/plugins/path_provider_foundation/darwin`)
+  - path_provider_foundation (from `Flutter/ephemeral/.symlinks/plugins/path_provider_foundation/macos`)
   - share_plus (from `Flutter/ephemeral/.symlinks/plugins/share_plus/macos`)
 
 EXTERNAL SOURCES:
   FlutterMacOS:
     :path: Flutter/ephemeral
   path_provider_foundation:
-    :path: Flutter/ephemeral/.symlinks/plugins/path_provider_foundation/darwin
+    :path: Flutter/ephemeral/.symlinks/plugins/path_provider_foundation/macos
   share_plus:
     :path: Flutter/ephemeral/.symlinks/plugins/share_plus/macos
 
@@ -26,4 +26,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: 353c8bcc5d5b0994e508d035b5431cfe18c1dea7
 
-COCOAPODS: 1.12.0
+COCOAPODS: 1.11.3

--- a/mobile/native/migrations/2023-03-06-005404_orders/up.sql
+++ b/mobile/native/migrations/2023-03-06-005404_orders/up.sql
@@ -9,6 +9,8 @@ CREATE TABLE IF NOT EXISTS orders (
     state TEXT NOT NULL,
     -- might be null if market order
     limit_price NUMBER,
-    -- might be null if not yet filled
-    execution_price NUMBER
+    -- might be null if not yet matched
+    execution_price NUMBER,
+    -- might be null ig there was no failure
+    failure_reason TEXT
 )

--- a/mobile/native/migrations/2023-03-06-005404_orders/up.sql
+++ b/mobile/native/migrations/2023-03-06-005404_orders/up.sql
@@ -7,6 +7,7 @@ CREATE TABLE IF NOT EXISTS orders (
     direction TEXT NOT NULL,
     order_type TEXT NOT NULL,
     state TEXT NOT NULL,
+    creation_timestamp BIGINT NOT NULL,
     -- might be null if market order
     limit_price NUMBER,
     -- might be null if not yet matched

--- a/mobile/native/migrations/2023-03-06-005404_orders/up.sql
+++ b/mobile/native/migrations/2023-03-06-005404_orders/up.sql
@@ -6,7 +6,7 @@ CREATE TABLE IF NOT EXISTS orders (
     contract_symbol TEXT NOT NULL,
     direction TEXT NOT NULL,
     order_type TEXT NOT NULL,
-    STATUS TEXT NOT NULL,
+    state TEXT NOT NULL,
     -- might be null if market order
     limit_price NUMBER,
     -- might be null if not yet filled

--- a/mobile/native/src/api.rs
+++ b/mobile/native/src/api.rs
@@ -103,12 +103,6 @@ pub async fn submit_order(order: NewOrder) -> Result<()> {
 }
 
 #[tokio::main(flavor = "current_thread")]
-pub async fn get_order(id: String) -> Result<Order> {
-    let order = order::handler::get_order(id).await?.into();
-    Ok(order)
-}
-
-#[tokio::main(flavor = "current_thread")]
 pub async fn get_orders() -> Result<Vec<Order>> {
     let orders = order::handler::get_orders_for_ui()
         .await?

--- a/mobile/native/src/api.rs
+++ b/mobile/native/src/api.rs
@@ -110,7 +110,7 @@ pub async fn get_order(id: String) -> Result<Order> {
 
 #[tokio::main(flavor = "current_thread")]
 pub async fn get_orders() -> Result<Vec<Order>> {
-    let orders = order::handler::get_orders()
+    let orders = order::handler::get_orders_for_ui()
         .await?
         .into_iter()
         .map(|order| order.into())

--- a/mobile/native/src/db/custom_types.rs
+++ b/mobile/native/src/db/custom_types.rs
@@ -115,8 +115,12 @@ impl FromSql<sql_types::Text, Sqlite> for Direction {
 impl ToSql<sql_types::Text, Sqlite> for FailureReason {
     fn to_sql(&self, out: &mut Output<Sqlite>) -> serialize::Result {
         let text = match *self {
-            FailureReason::CoordinatorRequest => "CoordinatorRequest",
-            FailureReason::ProposeChannel => "ProposeChannel",
+            FailureReason::TradeRequest => "TradeRequest",
+            FailureReason::TradeResponse => "TradeResponse",
+            FailureReason::NodeAccess => "NodeAccess",
+            FailureReason::NoUsableChannel => "NoUsableChannel",
+            FailureReason::ProposeDlcChannel => "ProposeDlcChannel",
+            FailureReason::FailedToSetToFilling => "FailedToSetToFilling",
         };
         out.set_value(text);
         Ok(IsNull::No)
@@ -128,8 +132,12 @@ impl FromSql<sql_types::Text, Sqlite> for FailureReason {
         let string = <String as FromSql<Text, Sqlite>>::from_sql(bytes)?;
 
         return match string.as_str() {
-            "CoordinatorRequest" => Ok(FailureReason::CoordinatorRequest),
-            "ProposeChannel" => Ok(FailureReason::ProposeChannel),
+            "TradeRequest" => Ok(FailureReason::TradeRequest),
+            "TradeResponse" => Ok(FailureReason::TradeResponse),
+            "NodeAccess" => Ok(FailureReason::NodeAccess),
+            "NoUsableChannel" => Ok(FailureReason::NoUsableChannel),
+            "ProposeDlcChannel" => Ok(FailureReason::ProposeDlcChannel),
+            "FailedToSetToFilling" => Ok(FailureReason::FailedToSetToFilling),
             _ => Err("Unrecognized enum variant".into()),
         };
     }

--- a/mobile/native/src/db/custom_types.rs
+++ b/mobile/native/src/db/custom_types.rs
@@ -10,11 +10,10 @@ use diesel::serialize::IsNull;
 use diesel::serialize::Output;
 use diesel::serialize::ToSql;
 use diesel::serialize::{self};
-use diesel::sql_types;
 use diesel::sql_types::Text;
 use diesel::sqlite::Sqlite;
 
-impl ToSql<sql_types::Text, Sqlite> for OrderType {
+impl ToSql<Text, Sqlite> for OrderType {
     fn to_sql(&self, out: &mut Output<Sqlite>) -> serialize::Result {
         let text = match *self {
             OrderType::Market => "market".to_string(),
@@ -25,7 +24,7 @@ impl ToSql<sql_types::Text, Sqlite> for OrderType {
     }
 }
 
-impl FromSql<sql_types::Text, Sqlite> for OrderType {
+impl FromSql<Text, Sqlite> for OrderType {
     fn from_sql(bytes: backend::RawValue<Sqlite>) -> deserialize::Result<Self> {
         let string = <String as FromSql<Text, Sqlite>>::from_sql(bytes)?;
 
@@ -37,7 +36,7 @@ impl FromSql<sql_types::Text, Sqlite> for OrderType {
     }
 }
 
-impl ToSql<sql_types::Text, Sqlite> for OrderState {
+impl ToSql<Text, Sqlite> for OrderState {
     fn to_sql(&self, out: &mut Output<Sqlite>) -> serialize::Result {
         let text = match *self {
             OrderState::Initial => "initial".to_string(),
@@ -52,7 +51,7 @@ impl ToSql<sql_types::Text, Sqlite> for OrderState {
     }
 }
 
-impl FromSql<sql_types::Text, Sqlite> for OrderState {
+impl FromSql<Text, Sqlite> for OrderState {
     fn from_sql(bytes: backend::RawValue<Sqlite>) -> deserialize::Result<Self> {
         let string = <String as FromSql<Text, Sqlite>>::from_sql(bytes)?;
 
@@ -68,7 +67,7 @@ impl FromSql<sql_types::Text, Sqlite> for OrderState {
     }
 }
 
-impl ToSql<sql_types::Text, Sqlite> for ContractSymbol {
+impl ToSql<Text, Sqlite> for ContractSymbol {
     fn to_sql(&self, out: &mut Output<Sqlite>) -> serialize::Result {
         let text = match *self {
             ContractSymbol::BtcUsd => "BtcUsd",
@@ -78,7 +77,7 @@ impl ToSql<sql_types::Text, Sqlite> for ContractSymbol {
     }
 }
 
-impl FromSql<sql_types::Text, Sqlite> for ContractSymbol {
+impl FromSql<Text, Sqlite> for ContractSymbol {
     fn from_sql(bytes: backend::RawValue<Sqlite>) -> deserialize::Result<Self> {
         let string = <String as FromSql<Text, Sqlite>>::from_sql(bytes)?;
 
@@ -89,7 +88,7 @@ impl FromSql<sql_types::Text, Sqlite> for ContractSymbol {
     }
 }
 
-impl ToSql<sql_types::Text, Sqlite> for Direction {
+impl ToSql<Text, Sqlite> for Direction {
     fn to_sql(&self, out: &mut Output<Sqlite>) -> serialize::Result {
         let text = match *self {
             Direction::Long => "Long",
@@ -100,7 +99,7 @@ impl ToSql<sql_types::Text, Sqlite> for Direction {
     }
 }
 
-impl FromSql<sql_types::Text, Sqlite> for Direction {
+impl FromSql<Text, Sqlite> for Direction {
     fn from_sql(bytes: backend::RawValue<Sqlite>) -> deserialize::Result<Self> {
         let string = <String as FromSql<Text, Sqlite>>::from_sql(bytes)?;
 
@@ -112,7 +111,7 @@ impl FromSql<sql_types::Text, Sqlite> for Direction {
     }
 }
 
-impl ToSql<sql_types::Text, Sqlite> for FailureReason {
+impl ToSql<Text, Sqlite> for FailureReason {
     fn to_sql(&self, out: &mut Output<Sqlite>) -> serialize::Result {
         let text = match *self {
             FailureReason::TradeRequest => "TradeRequest",
@@ -127,7 +126,7 @@ impl ToSql<sql_types::Text, Sqlite> for FailureReason {
     }
 }
 
-impl FromSql<sql_types::Text, Sqlite> for FailureReason {
+impl FromSql<Text, Sqlite> for FailureReason {
     fn from_sql(bytes: backend::RawValue<Sqlite>) -> deserialize::Result<Self> {
         let string = <String as FromSql<Text, Sqlite>>::from_sql(bytes)?;
 

--- a/mobile/native/src/db/mod.rs
+++ b/mobile/native/src/db/mod.rs
@@ -79,6 +79,19 @@ pub fn get_order(order_id: Uuid) -> Result<trade::order::Order> {
     Ok(order.try_into()?)
 }
 
+pub fn get_orders_for_ui() -> Result<Vec<trade::order::Order>> {
+    let mut db = connection()?;
+    let orders = Order::get_without_rejected_and_initial(&mut db)?;
+
+    // TODO: Can probably be optimized with combinator
+    let mut mapped = vec![];
+    for order in orders {
+        mapped.push(order.try_into()?)
+    }
+
+    Ok(mapped)
+}
+
 /// Returns an order of there is currently an order that is being filled
 pub fn maybe_get_order_in_filling() -> Result<Option<trade::order::Order>> {
     let mut db = connection()?;

--- a/mobile/native/src/db/models.rs
+++ b/mobile/native/src/db/models.rs
@@ -170,6 +170,19 @@ impl Order {
             .first(conn)
     }
 
+    /// Fetch all orders that are not in initial and rejected state
+    pub fn get_without_rejected_and_initial(
+        conn: &mut SqliteConnection,
+    ) -> QueryResult<Vec<Order>> {
+        orders::table
+            .filter(
+                schema::orders::state
+                    .ne(OrderState::Initial)
+                    .and(schema::orders::state.ne(OrderState::Rejected)),
+            )
+            .load(conn)
+    }
+
     pub fn get_by_state(
         order_state: OrderState,
         conn: &mut SqliteConnection,

--- a/mobile/native/src/db/models.rs
+++ b/mobile/native/src/db/models.rs
@@ -384,17 +384,27 @@ impl TryFrom<(OrderState, Option<f64>, Option<FailureReason>)> for crate::trade:
 #[derive(Debug, Clone, Copy, PartialEq, FromSqlRow, AsExpression)]
 #[diesel(sql_type = Text)]
 pub enum FailureReason {
-    CoordinatorRequest,
-    ProposeChannel,
+    FailedToSetToFilling,
+    TradeRequest,
+    TradeResponse,
+    NodeAccess,
+    NoUsableChannel,
+    ProposeDlcChannel,
 }
 
 impl From<FailureReason> for crate::trade::order::FailureReason {
     fn from(value: FailureReason) -> Self {
         match value {
-            FailureReason::CoordinatorRequest => {
-                crate::trade::order::FailureReason::CoordinatorRequest
+            FailureReason::TradeRequest => crate::trade::order::FailureReason::TradeRequest,
+            FailureReason::TradeResponse => crate::trade::order::FailureReason::TradeResponse,
+            FailureReason::NodeAccess => crate::trade::order::FailureReason::NodeAccess,
+            FailureReason::NoUsableChannel => crate::trade::order::FailureReason::NoUsableChannel,
+            FailureReason::ProposeDlcChannel => {
+                crate::trade::order::FailureReason::ProposeDlcChannel
             }
-            FailureReason::ProposeChannel => crate::trade::order::FailureReason::ProposeChannel,
+            FailureReason::FailedToSetToFilling => {
+                crate::trade::order::FailureReason::FailedToSetToFilling
+            }
         }
     }
 }
@@ -402,10 +412,16 @@ impl From<FailureReason> for crate::trade::order::FailureReason {
 impl From<crate::trade::order::FailureReason> for FailureReason {
     fn from(value: crate::trade::order::FailureReason) -> Self {
         match value {
-            crate::trade::order::FailureReason::CoordinatorRequest => {
-                FailureReason::CoordinatorRequest
+            crate::trade::order::FailureReason::TradeRequest => FailureReason::TradeRequest,
+            crate::trade::order::FailureReason::TradeResponse => FailureReason::TradeResponse,
+            crate::trade::order::FailureReason::NodeAccess => FailureReason::NodeAccess,
+            crate::trade::order::FailureReason::NoUsableChannel => FailureReason::NoUsableChannel,
+            crate::trade::order::FailureReason::ProposeDlcChannel => {
+                FailureReason::ProposeDlcChannel
             }
-            crate::trade::order::FailureReason::ProposeChannel => FailureReason::ProposeChannel,
+            crate::trade::order::FailureReason::FailedToSetToFilling => {
+                FailureReason::FailedToSetToFilling
+            }
         }
     }
 }

--- a/mobile/native/src/ln_dlc/mod.rs
+++ b/mobile/native/src/ln_dlc/mod.rs
@@ -4,6 +4,7 @@ use crate::config;
 use crate::event;
 use crate::event::EventInternal;
 use crate::trade::order;
+use crate::trade::order::FailureReason;
 use crate::trade::position;
 use anyhow::anyhow;
 use anyhow::bail;
@@ -231,28 +232,35 @@ pub fn send_payment(invoice: &str) -> Result<()> {
     node.send_payment(&invoice)
 }
 
-pub async fn trade(trade_params: TradeParams) -> Result<()> {
+pub async fn trade(trade_params: TradeParams) -> Result<(), (FailureReason, anyhow::Error)> {
     let client = reqwest::Client::new();
     let contract_info = client
         .post(format!("http://{}/api/trade", config::get_http_endpoint()))
         .json(&trade_params)
         .send()
         .await
-        .context("Failed to submit trade request to coordinator")?
+        .context("Failed to request trade with coordinator")
+        .map_err(|e| (FailureReason::TradeRequest, e))?
         .json()
-        .await?;
+        .await
+        .context("Failed to deserialize response into JSON")
+        .map_err(|e| (FailureReason::TradeResponse, e))?;
 
-    let node = NODE.try_get().context("failed to get ln dlc node")?;
+    let node = NODE
+        .try_get()
+        .context("Failed to get ln dlc node")
+        .map_err(|e| (FailureReason::NodeAccess, e))?;
 
     let channel_details = node.list_usable_channels();
     let channel_details = channel_details
         .iter()
         .find(|c| c.counterparty.node_id == config::get_coordinator_info().pubkey)
-        .context("Channel details not found")?;
+        .context("Channel details not found")
+        .map_err(|e| (FailureReason::NoUsableChannel, e))?;
 
     node.propose_dlc_channel(channel_details, &contract_info)
         .await
-        .context("Failed to propose DLC channel with coordinator")?;
+        .map_err(|e| (FailureReason::ProposeDlcChannel, e))?;
     tracing::info!("Proposed dlc subchannel");
     Ok(())
 }

--- a/mobile/native/src/schema.rs
+++ b/mobile/native/src/schema.rs
@@ -18,6 +18,7 @@ diesel::table! {
         state -> Text,
         limit_price -> Nullable<Double>,
         execution_price -> Nullable<Double>,
+        failure_reason -> Nullable<Text>,
     }
 }
 

--- a/mobile/native/src/schema.rs
+++ b/mobile/native/src/schema.rs
@@ -1,12 +1,6 @@
 // @generated automatically by Diesel CLI.
 
 diesel::table! {
-    directions (direction) {
-        direction -> Text,
-    }
-}
-
-diesel::table! {
     last_login (id) {
         id -> Nullable<Integer>,
         date -> Text,
@@ -21,10 +15,10 @@ diesel::table! {
         contract_symbol -> Text,
         direction -> Text,
         order_type -> Text,
-        status -> Text,
+        state -> Text,
         limit_price -> Nullable<Double>,
         execution_price -> Nullable<Double>,
     }
 }
 
-diesel::allow_tables_to_appear_in_same_query!(directions, last_login, orders,);
+diesel::allow_tables_to_appear_in_same_query!(last_login, orders,);

--- a/mobile/native/src/schema.rs
+++ b/mobile/native/src/schema.rs
@@ -16,6 +16,7 @@ diesel::table! {
         direction -> Text,
         order_type -> Text,
         state -> Text,
+        creation_timestamp -> BigInt,
         limit_price -> Nullable<Double>,
         execution_price -> Nullable<Double>,
         failure_reason -> Nullable<Text>,

--- a/mobile/native/src/trade/order/api.rs
+++ b/mobile/native/src/trade/order/api.rs
@@ -47,7 +47,7 @@ pub struct Order {
     pub contract_symbol: ContractSymbol,
     pub direction: Direction,
     pub order_type: Box<OrderType>,
-    pub status: OrderState,
+    pub state: OrderState,
     pub execution_price: Option<f64>,
 }
 
@@ -62,7 +62,7 @@ impl From<order::OrderType> for OrderType {
 
 impl From<order::Order> for Order {
     fn from(value: order::Order) -> Self {
-        let execution_price = match value.status {
+        let execution_price = match value.state {
             order::OrderState::Filled { execution_price } => Some(execution_price),
             _ => None,
         };
@@ -73,7 +73,7 @@ impl From<order::Order> for Order {
             contract_symbol: value.contract_symbol,
             direction: value.direction,
             order_type: Box::new(value.order_type.into()),
-            status: value.status.into(),
+            state: value.state.into(),
             execution_price,
         }
     }
@@ -113,7 +113,7 @@ impl From<NewOrder> for order::Order {
             contract_symbol: value.contract_symbol,
             direction: value.direction,
             order_type: (*value.order_type).into(),
-            status: order::OrderState::Open,
+            state: order::OrderState::Open,
         }
     }
 }

--- a/mobile/native/src/trade/order/api.rs
+++ b/mobile/native/src/trade/order/api.rs
@@ -1,5 +1,6 @@
 use crate::trade::order;
 use flutter_rust_bridge::frb;
+use time::OffsetDateTime;
 use trade::ContractSymbol;
 use trade::Direction;
 use uuid::Uuid;
@@ -42,6 +43,7 @@ pub struct NewOrder {
 #[frb]
 #[derive(Debug, Clone)]
 pub struct Order {
+    pub id: String,
     pub leverage: f64,
     pub quantity: f64,
     pub contract_symbol: ContractSymbol,
@@ -49,6 +51,7 @@ pub struct Order {
     pub order_type: Box<OrderType>,
     pub state: OrderState,
     pub execution_price: Option<f64>,
+    pub creation_timestamp: i64,
 }
 
 impl From<order::OrderType> for OrderType {
@@ -68,6 +71,7 @@ impl From<order::Order> for Order {
         };
 
         Order {
+            id: value.id.to_string(),
             leverage: value.leverage,
             quantity: value.quantity,
             contract_symbol: value.contract_symbol,
@@ -75,6 +79,7 @@ impl From<order::Order> for Order {
             order_type: Box::new(value.order_type.into()),
             state: value.state.into(),
             execution_price,
+            creation_timestamp: value.creation_timestamp.unix_timestamp(),
         }
     }
 }
@@ -116,6 +121,7 @@ impl From<NewOrder> for order::Order {
             direction: value.direction,
             order_type: (*value.order_type).into(),
             state: order::OrderState::Open,
+            creation_timestamp: OffsetDateTime::now_utc(),
         }
     }
 }

--- a/mobile/native/src/trade/order/api.rs
+++ b/mobile/native/src/trade/order/api.rs
@@ -93,13 +93,15 @@ impl From<order::OrderState> for OrderState {
         match value {
             order::OrderState::Open => OrderState::Open,
             order::OrderState::Filled { .. } => OrderState::Filled,
-            order::OrderState::Failed => OrderState::Failed,
+            order::OrderState::Failed { .. } => OrderState::Failed,
             order::OrderState::Initial => unimplemented!(
                 "don't expose orders that were not submitted into the orderbook to the frontend!"
             ),
             order::OrderState::Rejected => unimplemented!(
                 "don't expose orders that were rejected by the orderbook to the frontend!"
             ),
+            // We don't expose this state, but treat it as Open in the UI
+            order::OrderState::Filling { .. } => OrderState::Open,
         }
     }
 }

--- a/mobile/native/src/trade/order/handler.rs
+++ b/mobile/native/src/trade/order/handler.rs
@@ -4,17 +4,13 @@ use crate::event::EventInternal;
 use crate::ln_dlc;
 use crate::trade::order::Order;
 use crate::trade::order::OrderState;
-use crate::trade::order::OrderType;
 use crate::trade::position;
 use anyhow::bail;
 use anyhow::Context;
 use anyhow::Result;
-use std::str::FromStr;
 use std::time::Duration;
 use trade::ContractSymbol;
-use trade::Direction;
 use trade::TradeParams;
-use uuid::Uuid;
 
 pub async fn submit_order(order: Order) -> Result<()> {
     db::insert_order(order)?;
@@ -67,26 +63,6 @@ pub fn order_filled() -> Result<Order> {
 
     let filled_order = db::get_order(order_being_filled.id)?;
     Ok(filled_order)
-}
-
-pub async fn get_order(id: String) -> Result<Order> {
-    // TODO: Fetch from database
-
-    let id = Uuid::from_str(id.as_str()).context("Failed to parse UUID")?;
-
-    let dummy_order = Order {
-        id,
-        leverage: 2.0,
-        quantity: 1000.0,
-        contract_symbol: ContractSymbol::BtcUsd,
-        direction: Direction::Long,
-        order_type: OrderType::Market,
-        state: OrderState::Filled {
-            execution_price: 25000.0,
-        },
-    };
-
-    Ok(dummy_order)
 }
 
 pub async fn get_orders_for_ui() -> Result<Vec<Order>> {

--- a/mobile/native/src/trade/order/handler.rs
+++ b/mobile/native/src/trade/order/handler.rs
@@ -57,7 +57,7 @@ pub async fn get_order(id: String) -> Result<Order> {
         contract_symbol: ContractSymbol::BtcUsd,
         direction: Direction::Long,
         order_type: OrderType::Market,
-        status: OrderState::Filled {
+        state: OrderState::Filled {
             execution_price: 25000.0,
         },
     };
@@ -75,7 +75,7 @@ pub async fn get_orders() -> Result<Vec<Order>> {
         contract_symbol: ContractSymbol::BtcUsd,
         direction: Direction::Long,
         order_type: OrderType::Market,
-        status: OrderState::Filled {
+        state: OrderState::Filled {
             execution_price: 25000.0,
         },
     };

--- a/mobile/native/src/trade/order/handler.rs
+++ b/mobile/native/src/trade/order/handler.rs
@@ -89,20 +89,6 @@ pub async fn get_order(id: String) -> Result<Order> {
     Ok(dummy_order)
 }
 
-pub async fn get_orders() -> Result<Vec<Order>> {
-    // TODO: Fetch from database
-
-    let dummy_order = Order {
-        id: Uuid::new_v4(),
-        leverage: 2.0,
-        quantity: 1000.0,
-        contract_symbol: ContractSymbol::BtcUsd,
-        direction: Direction::Long,
-        order_type: OrderType::Market,
-        state: OrderState::Filled {
-            execution_price: 25000.0,
-        },
-    };
-
-    Ok(vec![dummy_order])
+pub async fn get_orders_for_ui() -> Result<Vec<Order>> {
+    db::get_orders_for_ui()
 }

--- a/mobile/native/src/trade/order/mod.rs
+++ b/mobile/native/src/trade/order/mod.rs
@@ -14,6 +14,30 @@ pub enum OrderType {
     Limit { price: f64 },
 }
 
+#[derive(thiserror::Error, Debug)]
+pub enum TradeExecutionError {
+    #[error("Failed to request execution with coordinator")]
+    CoordinatorRequest,
+    #[error("Failed to propose channel creation")]
+    ProposeChannel,
+}
+
+/// Internal type so we still have Copy on order
+#[derive(Debug, Clone, Copy)]
+pub enum FailureReason {
+    CoordinatorRequest,
+    ProposeChannel,
+}
+
+impl From<FailureReason> for TradeExecutionError {
+    fn from(value: FailureReason) -> Self {
+        match value {
+            FailureReason::CoordinatorRequest => TradeExecutionError::CoordinatorRequest,
+            FailureReason::ProposeChannel => TradeExecutionError::ProposeChannel,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy)]
 pub enum OrderState {
     /// Not submitted to orderbook yet
@@ -39,12 +63,30 @@ pub enum OrderState {
     /// - Open->Filled (if we successfully set up the trade)
     Open,
 
-    /// Failed to set up a trade
+    /// The orderbook has matched the order and it is being filled
+    ///
+    /// Once the order is being filled we know the execution price and store it.
+    /// Since it's a non-custodial setup filling an order involves setting up a DLC.
+    /// This state is set once we receive the TradeParams from the orderbook.
+    /// This state covers the complete trade execution until we have a DLC or we run into a failure
+    /// scenario. We don't allow re-trying the trade execution; if the app is started and we
+    /// detect an order that is in the `Filling` state, we will have to evaluate if there is a DLC
+    /// currently being set up. If yes the order remains in `Filling` state, if there is no DLC
+    /// currently being set up we move the order into `Failed` state.
+    ///
+    /// Transitions:
+    /// Filling->Filled (if we eventually end up with a DLC)
+    /// Filling->Failed (if we experience an error when executing the trade or the DLC manager
+    /// reported back failure/rejection)
+    Filling { execution_price: f64 },
+
+    /// The order failed to be filled
+    ///
     /// In order to reach this state the orderbook must have provided trade params to start trade
-    /// execution, and the trade execution failed.
+    /// execution, and the trade execution failed; i.e. it did not result in setting up a DLC.
     /// For the MVP there won't be a retry mechanism, so this is treated as a final state.
     /// This is a final state.
-    Failed,
+    Failed { reason: FailureReason },
 
     /// Successfully set up trade
     ///
@@ -68,4 +110,22 @@ pub struct Order {
     pub direction: Direction,
     pub order_type: OrderType,
     pub state: OrderState,
+}
+
+impl Order {
+    /// This returns the executed price once known
+    ///
+    /// Logs an error if this function is called on a state where the execution price is not know
+    /// yet.
+    pub fn execution_price(&self) -> Option<f64> {
+        match self.state {
+            OrderState::Filling { execution_price } | OrderState::Filled { execution_price } => {
+                Some(execution_price)
+            }
+            _ => {
+                tracing::error!("Executed price not known in state {:?}", self.state);
+                None
+            }
+        }
+    }
 }

--- a/mobile/native/src/trade/order/mod.rs
+++ b/mobile/native/src/trade/order/mod.rs
@@ -1,3 +1,4 @@
+use time::OffsetDateTime;
 use trade::ContractSymbol;
 use trade::Direction;
 use uuid::Uuid;
@@ -97,6 +98,7 @@ pub struct Order {
     pub direction: Direction,
     pub order_type: OrderType,
     pub state: OrderState,
+    pub creation_timestamp: OffsetDateTime,
 }
 
 impl Order {

--- a/mobile/native/src/trade/order/mod.rs
+++ b/mobile/native/src/trade/order/mod.rs
@@ -67,5 +67,5 @@ pub struct Order {
     pub contract_symbol: ContractSymbol,
     pub direction: Direction,
     pub order_type: OrderType,
-    pub status: OrderState,
+    pub state: OrderState,
 }

--- a/mobile/native/src/trade/order/mod.rs
+++ b/mobile/native/src/trade/order/mod.rs
@@ -14,28 +14,15 @@ pub enum OrderType {
     Limit { price: f64 },
 }
 
-#[derive(thiserror::Error, Debug)]
-pub enum TradeExecutionError {
-    #[error("Failed to request execution with coordinator")]
-    CoordinatorRequest,
-    #[error("Failed to propose channel creation")]
-    ProposeChannel,
-}
-
 /// Internal type so we still have Copy on order
 #[derive(Debug, Clone, Copy)]
 pub enum FailureReason {
-    CoordinatorRequest,
-    ProposeChannel,
-}
-
-impl From<FailureReason> for TradeExecutionError {
-    fn from(value: FailureReason) -> Self {
-        match value {
-            FailureReason::CoordinatorRequest => TradeExecutionError::CoordinatorRequest,
-            FailureReason::ProposeChannel => TradeExecutionError::ProposeChannel,
-        }
-    }
+    FailedToSetToFilling,
+    TradeRequest,
+    TradeResponse,
+    NodeAccess,
+    NoUsableChannel,
+    ProposeDlcChannel,
 }
 
 #[derive(Debug, Clone, Copy)]

--- a/mobile/native/src/trade/position/handler.rs
+++ b/mobile/native/src/trade/position/handler.rs
@@ -1,4 +1,10 @@
+use crate::calculations::calculate_liquidation_price;
+use crate::db;
+use crate::event;
+use crate::event::EventInternal;
 use crate::ln_dlc;
+use crate::trade::order::Order;
+use crate::trade::order::OrderState;
 use crate::trade::position::Position;
 use crate::trade::position::PositionState;
 use anyhow::Result;
@@ -12,25 +18,25 @@ use trade::TradeParams;
 /// The DLC that represents the position will be stored in the database.
 /// Errors are handled within the scope of this function.
 pub async fn trade(trade_params: TradeParams) -> Result<()> {
+    db::update_order_state(
+        trade_params.order_id,
+        OrderState::Filling {
+            execution_price: trade_params.execution_price,
+        },
+    )?;
+
     ln_dlc::trade(trade_params).await?;
 
     // TODO: Failure -> Either we send out an event that notifies others (i.e. the order handler)
     //          that this fails, or we just write the failure state to the database here and then
     //          send out an event that the order failed.
 
-    // TODO: Save / update position info in the database (so it is available once the DLC was
-    // created and we can construct the position update for the user interface. -> No position
-    // yet? Create one from the DLC -> There is an open position? Update it with the new
-    // parameters according to the DLC -> There was a position, but the current trade closes it?
-    // Delete the position; move relevant position information to a table that keeps the
-    // history.
-
     Ok(())
 }
 
 /// Fetch the positions from the database
 pub async fn get_positions() -> Result<Vec<Position>> {
-    // TODO: Fetch from database
+    // TODO: Fetch position from database
 
     let dummy_position = Position {
         leverage: 2.0,
@@ -45,4 +51,47 @@ pub async fn get_positions() -> Result<Vec<Position>> {
     };
 
     Ok(vec![dummy_position])
+}
+
+pub fn order_filled(filled_order: Order, collateral: u64) -> Result<()> {
+    // TODO: Persist the position
+    // TODO: Decide if we have to create or update the position:
+    //  Probably best to have a "insert or update" function for the db that returns the position
+
+    // TODO: Edge case: Closing a position: we will have to decide if we remove from the `positions`
+    // table or just update the state of the position by introducing a `Closed` state.
+
+    // TODO: Maybe we should change the model to *ensure* that the execution price is present past a
+    // certain point; i.e. a `FilledOrder` struct?
+    let average_entry_price = filled_order.execution_price().unwrap_or(0.0);
+
+    event::publish(&EventInternal::PositionUpdateNotification(Position {
+        leverage: filled_order.leverage,
+        quantity: filled_order.quantity,
+        contract_symbol: filled_order.contract_symbol,
+        direction: filled_order.direction,
+        average_entry_price,
+        // TODO: Is it correct to use the average entry price to calculate the liquidation price? ->
+        // What would that mean in the UI if we already have a position and trade?
+        liquidation_price: calculate_liquidation_price(
+            average_entry_price,
+            filled_order.leverage,
+            filled_order.direction,
+        ),
+        // TODO: PnL calc
+        unrealized_pnl: 0,
+        position_state: PositionState::Open,
+        collateral,
+    }));
+
+    Ok(())
+}
+
+pub fn is_position_up_to_date(_dlc_collateral: &u64) -> bool {
+    // TODO load the position and compare the collateral.
+    // Only if there is a position and said position's collateral is the same as the same as the DLC
+    // collateral we don't need an update.
+
+    // dummy: at the moment we always update
+    false
 }

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -918,7 +918,7 @@ packages:
     source: hosted
     version: "3.0.4"
   uuid:
-    dependency: "direct main"
+    dependency: transitive
     description:
       name: uuid
       sha256: "648e103079f7c64a36dc7d39369cabb358d377078a051d6ae2ad3aa539519313"

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -23,7 +23,6 @@ dependencies:
   decimal: ^2.3.2
   slide_to_confirm: ^1.1.0
   path_provider: ^2.0.11
-  uuid: ^3.0.7
   freezed_annotation: ^2.2.0
   expandable: ^5.0.1
   qr_flutter: ^4.0.0

--- a/mobile/test/trade_test.dart
+++ b/mobile/test/trade_test.dart
@@ -91,8 +91,8 @@ void main() {
     await tester.pumpWidget(MultiProvider(providers: [
       ChangeNotifierProvider(create: (context) => TradeValuesChangeNotifier(tradeValueService)),
       ChangeNotifierProvider(create: (context) => submitOrderChangeNotifier),
-      ChangeNotifierProvider(create: (context) => OrderChangeNotifier.create(orderService)),
-      ChangeNotifierProvider(create: (context) => PositionChangeNotifier.create(positionService)),
+      ChangeNotifierProvider(create: (context) => OrderChangeNotifier(orderService)),
+      ChangeNotifierProvider(create: (context) => PositionChangeNotifier(positionService)),
       ChangeNotifierProvider(create: (context) => AmountDenominationChangeNotifier()),
       ChangeNotifierProvider(create: (context) => WalletChangeNotifier(walletService)),
     ], child: const TestWrapperWithTradeTheme(child: TradeScreen())));


### PR DESCRIPTION
This drives the order forward.

The order lifecylcle for happy path scenarios should be complete with this PR.
Note that this also updates some parts of the position lifecycle, as we now have an order that we can retrieve data from for the position.

 We also handle order failure scenarios *before* the execution of the DLC protocol; failure scenarios (e.g. reject) after protocol execution are not handled yet. I would do that on top of this work, because it will touch how we query the dlc manager for dlcs.

---

Notes on the lifecylcle:

- We currently assume that there can only be one `Order` in execution in the app. If one `Order` is being executed the next `Order` has to wait until the first one finished.
- We don't retry anything. If we fail when triggering the trade setup we always just set the `Order` to `Failed` (with a failure reason) and the user would have to try again.
- A position is only created /update only once a (new) DLC exists; this is when the `Order` lifecycle ends in a happy path scenario (the order is in final state `Filled` then). Note that we don't create a position prior to having a DLC - this is something that always bugged me in ItchySats. I think we finally achieve that the position is *bound* to the existence of the DLC :)

--- 

The structure of "which handler calls which other handler" (i.e. function calls in `position::handler` and `order::handler`) and the responsibilities for handling errors might need another iteration. I basically just plugged this together to see it work and would gradually make it better now. 