### PR TITLE
chore: Use docker volume instead of file system for postgres

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -150,7 +150,7 @@ services:
       context: database
       dockerfile: Dockerfile
     volumes:
-      - ./pgdata:/var/lib/postgresql/data
+      - postgres:/var/lib/postgresql/data
     restart: always
     ports:
       - "5432:5432"
@@ -176,3 +176,4 @@ networks:
 
 volumes:
   bitcoin:
+  postgres:


### PR DESCRIPTION
I was stumbling over this error when starting the maker.

```
2023-03-08 10:12:46 ERROR r2d2: connection to server at "localhost" (::1), port 5432 failed: FATAL:  database "maker" does not exist
```

It appears I had an old postgresql database state on the filesystem which had to be cleared so that the init script will be executed again.

Although this is a workable solution, it's nicer to mount the postgres data into a docker volume instead the file system. This way a simple `docker-compse down -v` will also clear the postgres volume.