### PR TITLE
Fix LN wallet double balance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -800,7 +800,7 @@ dependencies = [
 [[package]]
 name = "dlc"
 version = "0.4.0"
-source = "git+https://github.com/get10101/rust-dlc?branch=feature/ln-dlc-channels#b3d31730874ffe422d27d4bbdbb508532a5ba8ee"
+source = "git+https://github.com/get10101/rust-dlc?rev=ef3fe72c5e0f8930010fb13b6ea5dc3d91457c0f#ef3fe72c5e0f8930010fb13b6ea5dc3d91457c0f"
 dependencies = [
  "bitcoin",
  "miniscript",
@@ -812,7 +812,7 @@ dependencies = [
 [[package]]
 name = "dlc-manager"
 version = "0.4.0"
-source = "git+https://github.com/get10101/rust-dlc?branch=feature/ln-dlc-channels#b3d31730874ffe422d27d4bbdbb508532a5ba8ee"
+source = "git+https://github.com/get10101/rust-dlc?rev=ef3fe72c5e0f8930010fb13b6ea5dc3d91457c0f#ef3fe72c5e0f8930010fb13b6ea5dc3d91457c0f"
 dependencies = [
  "async-trait",
  "bitcoin",
@@ -828,7 +828,7 @@ dependencies = [
 [[package]]
 name = "dlc-messages"
 version = "0.4.0"
-source = "git+https://github.com/get10101/rust-dlc?branch=feature/ln-dlc-channels#b3d31730874ffe422d27d4bbdbb508532a5ba8ee"
+source = "git+https://github.com/get10101/rust-dlc?rev=ef3fe72c5e0f8930010fb13b6ea5dc3d91457c0f#ef3fe72c5e0f8930010fb13b6ea5dc3d91457c0f"
 dependencies = [
  "bitcoin",
  "dlc",
@@ -840,7 +840,7 @@ dependencies = [
 [[package]]
 name = "dlc-sled-storage-provider"
 version = "0.1.0"
-source = "git+https://github.com/get10101/rust-dlc?branch=feature/ln-dlc-channels#b3d31730874ffe422d27d4bbdbb508532a5ba8ee"
+source = "git+https://github.com/get10101/rust-dlc?rev=ef3fe72c5e0f8930010fb13b6ea5dc3d91457c0f#ef3fe72c5e0f8930010fb13b6ea5dc3d91457c0f"
 dependencies = [
  "bitcoin",
  "dlc-manager",
@@ -853,7 +853,7 @@ dependencies = [
 [[package]]
 name = "dlc-trie"
 version = "0.4.0"
-source = "git+https://github.com/get10101/rust-dlc?branch=feature/ln-dlc-channels#b3d31730874ffe422d27d4bbdbb508532a5ba8ee"
+source = "git+https://github.com/get10101/rust-dlc?rev=ef3fe72c5e0f8930010fb13b6ea5dc3d91457c0f#ef3fe72c5e0f8930010fb13b6ea5dc3d91457c0f"
 dependencies = [
  "bitcoin",
  "dlc",
@@ -1438,7 +1438,7 @@ dependencies = [
 [[package]]
 name = "lightning"
 version = "0.0.113"
-source = "git+https://github.com/p2pderivatives/rust-lightning/?branch=split-tx-experiment#be41078f333577f7d513ea26543dcc79b0588698"
+source = "git+https://github.com/p2pderivatives/rust-lightning/?rev=dff302382d04700f23d79fb3275c1798d775fef6#dff302382d04700f23d79fb3275c1798d775fef6"
 dependencies = [
  "bitcoin",
 ]
@@ -1446,7 +1446,7 @@ dependencies = [
 [[package]]
 name = "lightning-background-processor"
 version = "0.0.113"
-source = "git+https://github.com/p2pderivatives/rust-lightning/?branch=split-tx-experiment#be41078f333577f7d513ea26543dcc79b0588698"
+source = "git+https://github.com/p2pderivatives/rust-lightning/?rev=dff302382d04700f23d79fb3275c1798d775fef6#dff302382d04700f23d79fb3275c1798d775fef6"
 dependencies = [
  "bitcoin",
  "lightning",
@@ -1456,7 +1456,7 @@ dependencies = [
 [[package]]
 name = "lightning-block-sync"
 version = "0.0.113"
-source = "git+https://github.com/p2pderivatives/rust-lightning/?branch=split-tx-experiment#be41078f333577f7d513ea26543dcc79b0588698"
+source = "git+https://github.com/p2pderivatives/rust-lightning/?rev=dff302382d04700f23d79fb3275c1798d775fef6#dff302382d04700f23d79fb3275c1798d775fef6"
 dependencies = [
  "bitcoin",
  "chunked_transfer",
@@ -1482,7 +1482,7 @@ dependencies = [
 [[package]]
 name = "lightning-net-tokio"
 version = "0.0.113"
-source = "git+https://github.com/p2pderivatives/rust-lightning/?branch=split-tx-experiment#be41078f333577f7d513ea26543dcc79b0588698"
+source = "git+https://github.com/p2pderivatives/rust-lightning/?rev=dff302382d04700f23d79fb3275c1798d775fef6#dff302382d04700f23d79fb3275c1798d775fef6"
 dependencies = [
  "bitcoin",
  "lightning",
@@ -1492,7 +1492,7 @@ dependencies = [
 [[package]]
 name = "lightning-persister"
 version = "0.0.113"
-source = "git+https://github.com/p2pderivatives/rust-lightning/?branch=split-tx-experiment#be41078f333577f7d513ea26543dcc79b0588698"
+source = "git+https://github.com/p2pderivatives/rust-lightning/?rev=dff302382d04700f23d79fb3275c1798d775fef6#dff302382d04700f23d79fb3275c1798d775fef6"
 dependencies = [
  "bitcoin",
  "libc",
@@ -1503,7 +1503,7 @@ dependencies = [
 [[package]]
 name = "lightning-rapid-gossip-sync"
 version = "0.0.113"
-source = "git+https://github.com/p2pderivatives/rust-lightning/?branch=split-tx-experiment#be41078f333577f7d513ea26543dcc79b0588698"
+source = "git+https://github.com/p2pderivatives/rust-lightning/?rev=dff302382d04700f23d79fb3275c1798d775fef6#dff302382d04700f23d79fb3275c1798d775fef6"
 dependencies = [
  "bitcoin",
  "lightning",
@@ -1916,7 +1916,7 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 [[package]]
 name = "p2pd-oracle-client"
 version = "0.1.0"
-source = "git+https://github.com/get10101/rust-dlc?branch=feature/ln-dlc-channels#b3d31730874ffe422d27d4bbdbb508532a5ba8ee"
+source = "git+https://github.com/get10101/rust-dlc?rev=ef3fe72c5e0f8930010fb13b6ea5dc3d91457c0f#ef3fe72c5e0f8930010fb13b6ea5dc3d91457c0f"
 dependencies = [
  "chrono",
  "dlc-manager",
@@ -2579,7 +2579,7 @@ dependencies = [
 [[package]]
 name = "simple-wallet"
 version = "0.1.0"
-source = "git+https://github.com/get10101/rust-dlc?branch=feature/ln-dlc-channels#b3d31730874ffe422d27d4bbdbb508532a5ba8ee"
+source = "git+https://github.com/get10101/rust-dlc?rev=ef3fe72c5e0f8930010fb13b6ea5dc3d91457c0f#ef3fe72c5e0f8930010fb13b6ea5dc3d91457c0f"
 dependencies = [
  "bitcoin",
  "dlc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,16 +3,16 @@ members = ["coordinator", "maker", "mobile/native/", "crates/*"]
 resolver = "2"
 
 [patch.crates-io]
-dlc-manager = { git = "https://github.com/get10101/rust-dlc", branch = "feature/ln-dlc-channels" }
-dlc-messages = { git = "https://github.com/get10101/rust-dlc", branch = "feature/ln-dlc-channels" }
-dlc = { git = "https://github.com/get10101/rust-dlc", branch = "feature/ln-dlc-channels" }
-dlc-sled-storage-provider = { git = "https://github.com/get10101/rust-dlc", branch = "feature/ln-dlc-channels" }
-p2pd-oracle-client = { git = "https://github.com/get10101/rust-dlc", branch = "feature/ln-dlc-channels" }
-dlc-trie = { git = "https://github.com/get10101/rust-dlc", branch = "feature/ln-dlc-channels" }
-simple-wallet = { git = "https://github.com/get10101/rust-dlc", branch = "feature/ln-dlc-channels" }
-lightning = { git = "https://github.com/p2pderivatives/rust-lightning/", branch = "split-tx-experiment" }
-lightning-background-processor = { git = "https://github.com/p2pderivatives/rust-lightning/", branch = "split-tx-experiment" }
-lightning-block-sync = { git = "https://github.com/p2pderivatives/rust-lightning/", branch = "split-tx-experiment" }
-lightning-net-tokio = { git = "https://github.com/p2pderivatives/rust-lightning/", branch = "split-tx-experiment" }
-lightning-persister = { git = "https://github.com/p2pderivatives/rust-lightning/", branch = "split-tx-experiment" }
-lightning-rapid-gossip-sync = { git = "https://github.com/p2pderivatives/rust-lightning/", branch = "split-tx-experiment" }
+dlc-manager = { git = "https://github.com/get10101/rust-dlc", rev = "ef3fe72c5e0f8930010fb13b6ea5dc3d91457c0f" }
+dlc-messages = { git = "https://github.com/get10101/rust-dlc", rev = "ef3fe72c5e0f8930010fb13b6ea5dc3d91457c0f" }
+dlc = { git = "https://github.com/get10101/rust-dlc", rev = "ef3fe72c5e0f8930010fb13b6ea5dc3d91457c0f" }
+dlc-sled-storage-provider = { git = "https://github.com/get10101/rust-dlc", rev = "ef3fe72c5e0f8930010fb13b6ea5dc3d91457c0f" }
+p2pd-oracle-client = { git = "https://github.com/get10101/rust-dlc", rev = "ef3fe72c5e0f8930010fb13b6ea5dc3d91457c0f" }
+dlc-trie = { git = "https://github.com/get10101/rust-dlc", rev = "ef3fe72c5e0f8930010fb13b6ea5dc3d91457c0f" }
+simple-wallet = { git = "https://github.com/get10101/rust-dlc", rev = "ef3fe72c5e0f8930010fb13b6ea5dc3d91457c0f" }
+lightning = { git = "https://github.com/p2pderivatives/rust-lightning/", rev = "dff302382d04700f23d79fb3275c1798d775fef6" }
+lightning-background-processor = { git = "https://github.com/p2pderivatives/rust-lightning/", rev = "dff302382d04700f23d79fb3275c1798d775fef6" }
+lightning-block-sync = { git = "https://github.com/p2pderivatives/rust-lightning/", rev = "dff302382d04700f23d79fb3275c1798d775fef6" }
+lightning-net-tokio = { git = "https://github.com/p2pderivatives/rust-lightning/", rev = "dff302382d04700f23d79fb3275c1798d775fef6" }
+lightning-persister = { git = "https://github.com/p2pderivatives/rust-lightning/", rev = "dff302382d04700f23d79fb3275c1798d775fef6" }
+lightning-rapid-gossip-sync = { git = "https://github.com/p2pderivatives/rust-lightning/", rev = "dff302382d04700f23d79fb3275c1798d775fef6" }

--- a/crates/ln-dlc-node/src/tests/dlc/create.rs
+++ b/crates/ln-dlc-node/src/tests/dlc/create.rs
@@ -16,10 +16,10 @@ use std::time::Duration;
 async fn given_lightning_channel_then_can_add_dlc_channel() {
     init_tracing();
 
-    let app_balance = 50_000;
-    let coordinator_balance = 50_000;
+    let app_dlc_collateral = 50_000;
+    let coordinator_dlc_collateral = 25_000;
 
-    create_dlc_channel(app_balance, coordinator_balance)
+    create_dlc_channel(app_dlc_collateral, coordinator_dlc_collateral)
         .await
         .unwrap();
 }


### PR DESCRIPTION
By updating a couple of dependencies.

The bug caused the LN wallet balance to appear to be doubled whilst a DLC channel was open.