### PR TITLE
refactor: Start the lifecycle of the order after submission to orderbook

### DIFF
--- a/crates/orderbook-commons/Cargo.toml
+++ b/crates/orderbook-commons/Cargo.toml
@@ -11,5 +11,5 @@ secp256k1 = { version = "0.24.3", features = ["serde"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sha2 = { version = "0.10", default-features = false }
-time = "0.3.20"
+time = { version = "0.3.20", features = ["serde"] }
 uuid = { version = "1.3.0", features = ["serde"] }

--- a/mobile/native/src/db/custom_types.rs
+++ b/mobile/native/src/db/custom_types.rs
@@ -39,7 +39,6 @@ impl FromSql<Text, Sqlite> for OrderType {
 impl ToSql<Text, Sqlite> for OrderState {
     fn to_sql(&self, out: &mut Output<Sqlite>) -> serialize::Result {
         let text = match *self {
-            OrderState::Initial => "initial".to_string(),
             OrderState::Rejected => "rejected".to_string(),
             OrderState::Open => "open".to_string(),
             OrderState::Failed => "failed".to_string(),
@@ -56,7 +55,6 @@ impl FromSql<Text, Sqlite> for OrderState {
         let string = <String as FromSql<Text, Sqlite>>::from_sql(bytes)?;
 
         return match string.as_str() {
-            "initial" => Ok(OrderState::Initial),
             "rejected" => Ok(OrderState::Rejected),
             "open" => Ok(OrderState::Open),
             "failed" => Ok(OrderState::Failed),

--- a/mobile/native/src/db/mod.rs
+++ b/mobile/native/src/db/mod.rs
@@ -81,7 +81,7 @@ pub fn get_order(order_id: Uuid) -> Result<trade::order::Order> {
 
 pub fn get_orders_for_ui() -> Result<Vec<trade::order::Order>> {
     let mut db = connection()?;
-    let orders = Order::get_without_rejected_and_initial(&mut db)?;
+    let orders = Order::get_without_rejected(&mut db)?;
 
     // TODO: Can probably be optimized with combinator
     let mut mapped = vec![];

--- a/mobile/native/src/db/models.rs
+++ b/mobile/native/src/db/models.rs
@@ -172,15 +172,9 @@ impl Order {
     }
 
     /// Fetch all orders that are not in initial and rejected state
-    pub fn get_without_rejected_and_initial(
-        conn: &mut SqliteConnection,
-    ) -> QueryResult<Vec<Order>> {
+    pub fn get_without_rejected(conn: &mut SqliteConnection) -> QueryResult<Vec<Order>> {
         orders::table
-            .filter(
-                schema::orders::state
-                    .ne(OrderState::Initial)
-                    .and(schema::orders::state.ne(OrderState::Rejected)),
-            )
+            .filter(schema::orders::state.ne(OrderState::Rejected))
             .load(conn)
     }
 
@@ -324,7 +318,6 @@ impl TryFrom<(OrderType, Option<f64>)> for crate::trade::order::OrderType {
 #[derive(Debug, Clone, Copy, PartialEq, FromSqlRow, AsExpression)]
 #[diesel(sql_type = Text)]
 pub enum OrderState {
-    Initial,
     Rejected,
     Open,
     Filling,
@@ -335,7 +328,6 @@ pub enum OrderState {
 impl From<crate::trade::order::OrderState> for (OrderState, Option<f64>, Option<FailureReason>) {
     fn from(value: crate::trade::order::OrderState) -> Self {
         match value {
-            crate::trade::order::OrderState::Initial => (OrderState::Initial, None, None),
             crate::trade::order::OrderState::Rejected => (OrderState::Rejected, None, None),
             crate::trade::order::OrderState::Open => (OrderState::Open, None, None),
             crate::trade::order::OrderState::Failed { reason } => {
@@ -358,7 +350,6 @@ impl TryFrom<(OrderState, Option<f64>, Option<FailureReason>)> for crate::trade:
         value: (OrderState, Option<f64>, Option<FailureReason>),
     ) -> std::result::Result<Self, Self::Error> {
         let order_state = match value.0 {
-            OrderState::Initial => crate::trade::order::OrderState::Initial,
             OrderState::Rejected => crate::trade::order::OrderState::Rejected,
             OrderState::Open => crate::trade::order::OrderState::Open,
             OrderState::Failed => match value.2 {
@@ -436,7 +427,6 @@ pub mod test {
     use crate::db::models::Order;
     use crate::db::models::OrderState;
     use crate::db::MIGRATIONS;
-    use crate::trade::order::FailureReason;
     use diesel::result::Error;
     use diesel::Connection;
     use diesel::SqliteConnection;
@@ -488,7 +478,7 @@ pub mod test {
         let direction = trade::Direction::Long;
         let (order_type, limit_price) = crate::trade::order::OrderType::Market.into();
         let (status, execution_price, failure_reason) =
-            crate::trade::order::OrderState::Initial.into();
+            crate::trade::order::OrderState::Open.into();
         let creation_timestamp = OffsetDateTime::UNIX_EPOCH;
 
         let order = Order {
@@ -513,7 +503,7 @@ pub mod test {
                 contract_symbol,
                 direction,
                 order_type: crate::trade::order::OrderType::Market,
-                state: crate::trade::order::OrderState::Initial,
+                state: crate::trade::order::OrderState::Open,
                 creation_timestamp,
             }
             .into(),
@@ -530,7 +520,7 @@ pub mod test {
                 contract_symbol,
                 direction: trade::Direction::Long,
                 order_type: crate::trade::order::OrderType::Market,
-                state: crate::trade::order::OrderState::Initial,
+                state: crate::trade::order::OrderState::Open,
                 creation_timestamp,
             }
             .into(),
@@ -576,7 +566,8 @@ pub mod test {
     }
 
     #[test]
-    pub fn given_several_orders_when_fetching_orders_for_ui_only_relevant_orders_are_loaded() {
+    pub fn given_rejected_order_when_loading_without_rejected_from_the_database_then_rejected_not_loaded(
+    ) {
         let mut connection = SqliteConnection::establish(":memory:").unwrap();
         connection.run_pending_migrations(MIGRATIONS).unwrap();
 
@@ -595,7 +586,7 @@ pub mod test {
                 contract_symbol,
                 direction,
                 order_type: crate::trade::order::OrderType::Market,
-                state: crate::trade::order::OrderState::Initial,
+                state: crate::trade::order::OrderState::Rejected,
                 creation_timestamp,
             }
             .into(),
@@ -603,7 +594,7 @@ pub mod test {
         )
         .unwrap();
 
-        let orders = Order::get_without_rejected_and_initial(&mut connection).unwrap();
+        let orders = Order::get_without_rejected(&mut connection).unwrap();
         assert_eq!(orders.len(), 0);
 
         let uuid1 = uuid::Uuid::new_v4();
@@ -615,7 +606,7 @@ pub mod test {
                 contract_symbol,
                 direction,
                 order_type: crate::trade::order::OrderType::Market,
-                state: crate::trade::order::OrderState::Initial,
+                state: crate::trade::order::OrderState::Open,
                 creation_timestamp,
             }
             .into(),
@@ -623,40 +614,17 @@ pub mod test {
         )
         .unwrap();
 
-        let orders = Order::get_without_rejected_and_initial(&mut connection).unwrap();
-        assert_eq!(orders.len(), 0);
-
-        Order::update_state(
-            uuid.to_string(),
-            crate::trade::order::OrderState::Open.into(),
-            &mut connection,
-        )
-        .unwrap();
-
-        let orders = Order::get_without_rejected_and_initial(&mut connection).unwrap();
+        let orders = Order::get_without_rejected(&mut connection).unwrap();
         assert_eq!(orders.len(), 1);
 
         Order::update_state(
             uuid1.to_string(),
-            crate::trade::order::OrderState::Open.into(),
+            crate::trade::order::OrderState::Rejected.into(),
             &mut connection,
         )
         .unwrap();
 
-        let orders = Order::get_without_rejected_and_initial(&mut connection).unwrap();
-        assert_eq!(orders.len(), 2);
-
-        Order::update_state(
-            uuid1.to_string(),
-            crate::trade::order::OrderState::Failed {
-                reason: FailureReason::FailedToSetToFilling,
-            }
-            .into(),
-            &mut connection,
-        )
-        .unwrap();
-
-        let orders = Order::get_without_rejected_and_initial(&mut connection).unwrap();
-        assert_eq!(orders.len(), 2);
+        let orders = Order::get_without_rejected(&mut connection).unwrap();
+        assert_eq!(orders.len(), 0);
     }
 }

--- a/mobile/native/src/trade/order/api.rs
+++ b/mobile/native/src/trade/order/api.rs
@@ -1,9 +1,7 @@
 use crate::trade::order;
 use flutter_rust_bridge::frb;
-use time::OffsetDateTime;
 use trade::ContractSymbol;
 use trade::Direction;
-use uuid::Uuid;
 
 #[frb]
 #[derive(Debug, Clone, Copy)]
@@ -99,9 +97,6 @@ impl From<order::OrderState> for OrderState {
             order::OrderState::Open => OrderState::Open,
             order::OrderState::Filled { .. } => OrderState::Filled,
             order::OrderState::Failed { .. } => OrderState::Failed,
-            order::OrderState::Initial => unimplemented!(
-                "don't expose orders that were not submitted into the orderbook to the frontend!"
-            ),
             order::OrderState::Rejected => unimplemented!(
                 "don't expose orders that were rejected by the orderbook to the frontend!"
             ),
@@ -111,17 +106,14 @@ impl From<order::OrderState> for OrderState {
     }
 }
 
-impl From<NewOrder> for order::Order {
+impl From<NewOrder> for order::NewOrder {
     fn from(value: NewOrder) -> Self {
-        order::Order {
-            id: Uuid::new_v4(),
+        order::NewOrder {
             leverage: value.leverage,
             quantity: value.quantity,
             contract_symbol: value.contract_symbol,
             direction: value.direction,
             order_type: (*value.order_type).into(),
-            state: order::OrderState::Open,
-            creation_timestamp: OffsetDateTime::now_utc(),
         }
     }
 }

--- a/mobile/native/src/trade/order/handler.rs
+++ b/mobile/native/src/trade/order/handler.rs
@@ -3,6 +3,7 @@ use crate::event;
 use crate::event::EventInternal;
 use crate::ln_dlc;
 use crate::trade::order::FailureReason;
+use crate::trade::order::NewOrder;
 use crate::trade::order::Order;
 use crate::trade::order::OrderState;
 use crate::trade::position;
@@ -17,7 +18,21 @@ use trade::Direction;
 use trade::TradeParams;
 use uuid::Uuid;
 
-pub async fn submit_order(order: Order) -> Result<()> {
+pub async fn submit_order(order: NewOrder) -> Result<()> {
+    // TODO: Submit to orderbook -> This will define the Uuid of the order
+    // In case we fail to submit to the orderbook we assign our own internal uuid and then return
+    // failure.
+    let order = Order {
+        id: Uuid::new_v4(),
+        leverage: order.leverage,
+        quantity: order.quantity,
+        contract_symbol: order.contract_symbol,
+        direction: order.direction,
+        order_type: order.order_type,
+        state: OrderState::Open,
+        creation_timestamp: OffsetDateTime::now_utc(),
+    };
+
     db::insert_order(order)?;
 
     ui_update(order);

--- a/mobile/native/src/trade/order/mod.rs
+++ b/mobile/native/src/trade/order/mod.rs
@@ -28,19 +28,11 @@ pub enum FailureReason {
 
 #[derive(Debug, Clone, Copy)]
 pub enum OrderState {
-    /// Not submitted to orderbook yet
-    ///
-    /// In order to be able to track how many failed orders we have we store the order in the
-    /// database and update it once the orderbook returns success.
-    /// Transitions:
-    /// - Initial->Open
-    /// - Initial->Rejected
-    Initial,
-
     /// Rejected by the orderbook upon submission
     ///
     /// If the orderbook returns failure upon submission.
-    /// This is a final state.
+    /// Note that we will not be able to query this order from the orderbook again, because it was
+    /// rejected upon submission. This is a final state.
     Rejected,
 
     /// Successfully submit to orderbook
@@ -87,6 +79,15 @@ pub enum OrderState {
         /// The execution price that the order was filled with
         execution_price: f64,
     },
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct NewOrder {
+    pub leverage: f64,
+    pub quantity: f64,
+    pub contract_symbol: ContractSymbol,
+    pub direction: Direction,
+    pub order_type: OrderType,
 }
 
 #[derive(Debug, Clone, Copy)]


### PR DESCRIPTION
The previous flow was unnecessarily complicated. The lifecycle of an order should start once we got a reply from the orderbook.

If we succeed to submit the order we assign the `Uuid` returned from the orderbook to the order and safe it in the database. If the fail to submit the order we assign our own `Uuid` to the order and safe it in the database (in `Rejected` state, which is final and we won't query the orderbook with orders in this state). Given that the lifecycle now starts with the result of the submission to the orderbook we don't need an `Initial` state anymore.