### PR TITLE
refactor: Move trade params to `coordinator-commons`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -564,6 +564,7 @@ dependencies = [
  "bdk",
  "bitcoin",
  "clap",
+ "coordinator-commons",
  "diesel",
  "diesel_migrations",
  "dlc-manager",
@@ -589,6 +590,18 @@ dependencies = [
  "tracing-subscriber",
  "trade",
  "url",
+]
+
+[[package]]
+name = "coordinator-commons"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "bdk",
+ "serde",
+ "time 0.3.20",
+ "trade",
+ "uuid",
 ]
 
 [[package]]
@@ -1738,6 +1751,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bdk",
+ "coordinator-commons",
  "diesel",
  "diesel_migrations",
  "flutter_rust_bridge",
@@ -3049,8 +3063,6 @@ dependencies = [
  "rust_decimal",
  "rust_decimal_macros",
  "serde",
- "time 0.3.20",
- "uuid",
 ]
 
 [[package]]

--- a/coordinator/Cargo.toml
+++ b/coordinator/Cargo.toml
@@ -10,6 +10,7 @@ axum = { version = "0.6.7", features = ["ws"] }
 bdk = { version = "0.24.0", features = ["key-value-db"] }
 bitcoin = "0.29"
 clap = { version = "4", features = ["derive"] }
+coordinator-commons = { path = "../crates/coordintator-commons" }
 diesel = { version = "2.0.0", features = ["r2d2", "postgres"] }
 diesel_migrations = "2.0.0"
 dlc-manager = { version = "0.4.0", features = ["use-serde"] }

--- a/coordinator/src/node.rs
+++ b/coordinator/src/node.rs
@@ -2,6 +2,7 @@ use anyhow::anyhow;
 use anyhow::Context;
 use anyhow::Result;
 use bitcoin::secp256k1::PublicKey;
+use coordinator_commons::TradeParams;
 use dlc_manager::contract::contract_input::ContractInput;
 use dlc_manager::contract::contract_input::ContractInputInfo;
 use dlc_manager::contract::contract_input::OracleInput;
@@ -21,7 +22,6 @@ use trade::cfd::calculate_long_liquidation_price;
 use trade::cfd::calculate_margin;
 use trade::cfd::calculate_short_liquidation_price;
 use trade::Direction;
-use trade::TradeParams;
 
 // todo: in case of leverage 1.0 the liquidation will be set to 21000000. I guess this will result
 // in issues when the overall upper boundary is smaller than that. It looks like the payout function

--- a/coordinator/src/routes.rs
+++ b/coordinator/src/routes.rs
@@ -16,6 +16,7 @@ use axum::routing::post;
 use axum::Json;
 use axum::Router;
 use bitcoin::secp256k1::PublicKey;
+use coordinator_commons::TradeParams;
 use diesel::r2d2::ConnectionManager;
 use diesel::r2d2::Pool;
 use diesel::PgConnection;
@@ -27,7 +28,6 @@ use std::sync::Arc;
 use tokio::sync::broadcast;
 use tokio::sync::mpsc;
 use tokio::sync::Mutex;
-use trade::TradeParams;
 
 pub struct AppState {
     pub node: Node,

--- a/crates/coordintator-commons/Cargo.toml
+++ b/crates/coordintator-commons/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "coordinator-commons"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+anyhow = "1"
+bdk = { version = "0.24.0" }
+serde = { version = "1", features = ["derive"] }
+time = { version = "0.3.20", features = ["serde"] }
+trade = { path = "../trade" }
+uuid = { version = "1.3.0", features = ["serde"] }

--- a/crates/coordintator-commons/src/lib.rs
+++ b/crates/coordintator-commons/src/lib.rs
@@ -1,0 +1,87 @@
+use bdk::bitcoin::secp256k1::PublicKey;
+use bdk::bitcoin::XOnlyPublicKey;
+use serde::Deserialize;
+use serde::Serialize;
+use time::OffsetDateTime;
+use trade::ContractSymbol;
+use trade::Direction;
+use uuid::Uuid;
+
+/// The trade parameters defining the trade execution
+///
+/// Emitted by the orderbook when a match is found.
+/// Both trading parties will receive trade params and then request trade execution with said trade
+/// parameters from the coordinator.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TradeParams {
+    /// Our identity
+    pub pubkey: PublicKey,
+    /// Identity of the trade's counterparty
+    ///
+    /// The identity of the trading party that eas matched to our order by the orderbook.
+    pub pubkey_counterparty: PublicKey,
+
+    /// The id of the order
+    ///
+    /// The order has to be identifiable by the client when returned from the orderbook, so the
+    /// client is in charge of creating this ID and passing it to the orderbook.
+    pub order_id: Uuid,
+
+    /// The orderbook id of the counterparty order
+    ///
+    /// The orderbook id of the order that was matched with ours.
+    /// This can be used by the coordinator to make sure the trade is set up correctly.
+    pub order_id_counterparty: String,
+
+    /// The contract symbol for the order
+    pub contract_symbol: ContractSymbol,
+
+    /// Our leverage
+    ///
+    /// This has to correspond to our order's leverage.
+    pub leverage: f64,
+
+    /// The leverage of the order that was matched
+    ///
+    /// This is the leverage of the counterparty.
+    /// This can be used by the coordinator to make sure the trade is set up correctly.
+    pub leverage_counterparty: f64,
+
+    /// The quantity to be used
+    ///
+    /// This quantity may be the complete amount of either order or a fraction.
+    pub quantity: f64,
+
+    /// The execution price as defined by the orderbook
+    ///
+    /// The trade is to be executed at this price.
+    pub execution_price: f64,
+
+    /// The expiry timestamp of the contract-to-be
+    ///
+    /// A timestamp that defines when the contract will expire.
+    /// The orderbook defines the timestamp so that the systems using the trade params to set up
+    /// the trade are aligned on one timestamp. The systems using the trade params should
+    /// validate this timestamp against their trade settings. If the expiry timestamp is older
+    /// than a defined threshold a system my discard the trade params as outdated.
+    ///
+    /// The oracle event-id is defined by contract symbol and the expiry timestamp.
+    pub expiry_timestamp: OffsetDateTime,
+
+    /// The public key of the oracle to be used
+    ///
+    /// The orderbook decides this when matching orders.
+    /// The oracle_pk is used to define what oracle is to be used in the contract.
+    /// This `oracle_pk` must correspond to one `oracle_pk` configured in the dlc-manager.
+    /// It is possible to configure multiple oracles in the dlc-manager; this
+    /// `oracle_pk` has to match one of them. This allows us to configure the dlc-managers
+    /// using two oracles, where one oracles can be used as backup if the other oracle is not
+    /// available. Eventually this can be changed to be a list of oracle PKs and a threshold of
+    /// how many oracle have to agree on the attestation.
+    pub oracle_pk: XOnlyPublicKey,
+
+    /// The direction of the trade
+    ///
+    /// The direction from the point of view of the trader.
+    pub direction: Direction,
+}

--- a/crates/trade/Cargo.toml
+++ b/crates/trade/Cargo.toml
@@ -12,5 +12,3 @@ bdk = { version = "0.24.0" }
 rust_decimal = { version = "1", features = ["serde-with-float"] }
 rust_decimal_macros = "1.26"
 serde = { version = "1.0.152", features = ["serde_derive"] }
-time = { version = "0.3.20", features = ["serde"] }
-uuid = { version = "1.3.0", features = ["v4", "fast-rng", "macro-diagnostics", "serde"] }

--- a/crates/trade/src/lib.rs
+++ b/crates/trade/src/lib.rs
@@ -1,94 +1,11 @@
 use anyhow::bail;
-use bdk::bitcoin::secp256k1::PublicKey;
-use bdk::bitcoin::XOnlyPublicKey;
 use serde::Deserialize;
 use serde::Serialize;
 use std::fmt;
 use std::fmt::Formatter;
 use std::str::FromStr;
-use time::OffsetDateTime;
-use uuid::Uuid;
 
 pub mod cfd;
-
-/// The trade parameters defining the trade execution
-///
-/// Emitted by the orderbook when a match is found.
-/// Both trading parties will receive trade params and then request trade execution with said trade
-/// parameters from the coordinator.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct TradeParams {
-    /// Our identity
-    pub pubkey: PublicKey,
-    /// Identity of the trade's counterparty
-    ///
-    /// The identity of the trading party that eas matched to our order by the orderbook.
-    pub pubkey_counterparty: PublicKey,
-
-    /// The id of the order
-    ///
-    /// The order has to be identifiable by the client when returned from the orderbook, so the
-    /// client is in charge of creating this ID and passing it to the orderbook.
-    pub order_id: Uuid,
-
-    /// The orderbook id of the counterparty order
-    ///
-    /// The orderbook id of the order that was matched with ours.
-    /// This can be used by the coordinator to make sure the trade is set up correctly.
-    pub order_id_counterparty: String,
-
-    /// The contract symbol for the order
-    pub contract_symbol: ContractSymbol,
-
-    /// Our leverage
-    ///
-    /// This has to correspond to our order's leverage.
-    pub leverage: f64,
-
-    /// The leverage of the order that was matched
-    ///
-    /// This is the leverage of the counterparty.
-    /// This can be used by the coordinator to make sure the trade is set up correctly.
-    pub leverage_counterparty: f64,
-
-    /// The quantity to be used
-    ///
-    /// This quantity may be the complete amount of either order or a fraction.
-    pub quantity: f64,
-
-    /// The execution price as defined by the orderbook
-    ///
-    /// The trade is to be executed at this price.
-    pub execution_price: f64,
-
-    /// The expiry timestamp of the contract-to-be
-    ///
-    /// A timestamp that defines when the contract will expire.
-    /// The orderbook defines the timestamp so that the systems using the trade params to set up
-    /// the trade are aligned on one timestamp. The systems using the trade params should
-    /// validate this timestamp against their trade settings. If the expiry timestamp is older
-    /// than a defined threshold a system my discard the trade params as outdated.
-    ///
-    /// The oracle event-id is defined by contract symbol and the expiry timestamp.
-    pub expiry_timestamp: OffsetDateTime,
-
-    /// The public key of the oracle to be used
-    ///
-    /// The orderbook decides this when matching orders.
-    /// The oracle_pk is used to define what oracle is to be used in the contract.
-    /// This `oracle_pk` must correspond to one `oracle_pk` configured in the dlc-manager.
-    /// It is possible to configure multiple oracles in the dlc-manager; this
-    /// `oracle_pk` has to match one of them. This allows us to configure the dlc-managers
-    /// using two oracles, where one oracles can be used as backup if the other oracle is not
-    /// available. Eventually this can be changed to be a list of oracle PKs and a threshold of
-    /// how many oracle have to agree on the attestation.
-    pub oracle_pk: XOnlyPublicKey,
-
-    /// The direction of the trade
-    ///
-    /// The direction from the point of view of the trader.
-    pub direction: Direction,
-}
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq)]
 pub enum ContractSymbol {

--- a/mobile/native/Cargo.toml
+++ b/mobile/native/Cargo.toml
@@ -9,6 +9,7 @@ crate-type = ["cdylib", "staticlib"]
 [dependencies]
 anyhow = "1"
 bdk = { version = "0.24.0", features = ["key-value-db"] }
+coordinator-commons = { path = "../../crates/coordintator-commons" }
 diesel = { version = "2.0.0", features = ["sqlite", "r2d2", "extras"] }
 diesel_migrations = "2.0.0"
 flutter_rust_bridge = "1.68.0"

--- a/mobile/native/src/event/mod.rs
+++ b/mobile/native/src/event/mod.rs
@@ -3,8 +3,8 @@ mod event_hub;
 pub mod subscriber;
 
 use crate::api::WalletInfo;
+use coordinator_commons::TradeParams;
 use std::hash::Hash;
-use trade::TradeParams;
 
 use crate::event::event_hub::get;
 use crate::event::subscriber::Subscriber;

--- a/mobile/native/src/ln_dlc/mod.rs
+++ b/mobile/native/src/ln_dlc/mod.rs
@@ -17,6 +17,7 @@ use bdk::bitcoin::secp256k1::rand::thread_rng;
 use bdk::bitcoin::secp256k1::rand::RngCore;
 use bdk::bitcoin::secp256k1::SecretKey;
 use bdk::bitcoin::XOnlyPublicKey;
+use coordinator_commons::TradeParams;
 use lightning_invoice::Invoice;
 use ln_dlc_node::node::NodeInfo;
 use ln_dlc_node::seed::Bip39Seed;
@@ -28,7 +29,6 @@ use std::str::FromStr;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::runtime::Runtime;
-use trade::TradeParams;
 
 static NODE: Storage<Arc<Node>> = Storage::new();
 

--- a/mobile/native/src/trade/order/handler.rs
+++ b/mobile/native/src/trade/order/handler.rs
@@ -9,12 +9,12 @@ use crate::trade::position;
 use anyhow::bail;
 use anyhow::Context;
 use anyhow::Result;
+use coordinator_commons::TradeParams;
 use std::ops::Add;
 use std::time::Duration;
 use time::OffsetDateTime;
 use trade::ContractSymbol;
 use trade::Direction;
-use trade::TradeParams;
 use uuid::Uuid;
 
 pub async fn submit_order(order: Order) -> Result<()> {

--- a/mobile/native/src/trade/position/handler.rs
+++ b/mobile/native/src/trade/position/handler.rs
@@ -7,9 +7,9 @@ use crate::trade::order::Order;
 use crate::trade::position::Position;
 use crate::trade::position::PositionState;
 use anyhow::Result;
+use coordinator_commons::TradeParams;
 use trade::ContractSymbol;
 use trade::Direction;
-use trade::TradeParams;
 
 /// Sets up a trade with the counterparty
 ///


### PR DESCRIPTION
The `TradeParams` are specific to the coordinator, it makes sense to move them to a `coordinator-commons` crate. This has the advantage that we will avoid cyclic dependencies, because we can use `orderbook-commons` to reference the `FilledWith` in `coordinator-commons` and are able to use the global common types of `trade` in other crates.

---

This is in preparation of adapting the `TradeParams` to use `FilledWith` of the `orderbook-commons` crate.