### PR TITLE
refactor: We use the `FillWith` of the orderbook for the `TradeParams`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -598,6 +598,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bdk",
+ "orderbook-commons",
  "serde",
  "time 0.3.20",
  "trade",

--- a/coordinator/src/node.rs
+++ b/coordinator/src/node.rs
@@ -84,7 +84,7 @@ impl Node {
         tracing::info!("build payout curve");
         let payout_function = build_payout_curve(
             total_collateral,
-            trade_params.execution_price,
+            trade_params.weighted_execution_price(),
             leverage_long,
             leverage_short,
         )?;
@@ -95,7 +95,7 @@ impl Node {
             .to_range_payouts(total_collateral, &get_rounding_intervals())
             .map_err(|e| anyhow!("{e:#}"))?
             .iter()
-            .find(|p| trade_params.execution_price < (p.start + p.count) as f64)
+            .find(|p| trade_params.weighted_execution_price() < (p.start + p.count) as f64)
             .map(|p| p.payout.accept)
             .context("Failed to find payout.")?;
 
@@ -124,13 +124,13 @@ impl Node {
 
         let contract_descriptor = build_contract_descriptor(
             total_collateral,
-            trade_params.execution_price,
+            trade_params.weighted_execution_price(),
             leverage_long,
             leverage_short,
         )?;
 
         let contract_symbol = trade_params.contract_symbol.label();
-        let maturity_time = trade_params.expiry_timestamp;
+        let maturity_time = trade_params.weighted_execution_price();
 
         // The contract input to be used for setting up the trade between the trader and the
         // coordinator
@@ -168,12 +168,12 @@ impl Node {
 
 fn get_margins(trade_params: &TradeParams) -> (u64, u64) {
     let margin_coordinator = calculate_margin(
-        trade_params.execution_price,
+        trade_params.weighted_execution_price(),
         trade_params.quantity,
         COORDINATOR_LEVERAGE,
     );
     let margin_trader = calculate_margin(
-        trade_params.execution_price,
+        trade_params.weighted_execution_price(),
         trade_params.quantity,
         trade_params.leverage,
     );

--- a/crates/coordintator-commons/Cargo.toml
+++ b/crates/coordintator-commons/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 [dependencies]
 anyhow = "1"
 bdk = { version = "0.24.0" }
+orderbook-commons = { path = "../orderbook-commons" }
 serde = { version = "1", features = ["derive"] }
 time = { version = "0.3.20", features = ["serde"] }
 trade = { path = "../trade" }

--- a/crates/coordintator-commons/src/lib.rs
+++ b/crates/coordintator-commons/src/lib.rs
@@ -1,11 +1,9 @@
 use bdk::bitcoin::secp256k1::PublicKey;
-use bdk::bitcoin::XOnlyPublicKey;
+use orderbook_commons::FilledWith;
 use serde::Deserialize;
 use serde::Serialize;
-use time::OffsetDateTime;
 use trade::ContractSymbol;
 use trade::Direction;
-use uuid::Uuid;
 
 /// The trade parameters defining the trade execution
 ///
@@ -14,74 +12,66 @@ use uuid::Uuid;
 /// parameters from the coordinator.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TradeParams {
-    /// Our identity
+    /// The identity of the trader
     pub pubkey: PublicKey,
-    /// Identity of the trade's counterparty
-    ///
-    /// The identity of the trading party that eas matched to our order by the orderbook.
-    pub pubkey_counterparty: PublicKey,
 
-    /// The id of the order
-    ///
-    /// The order has to be identifiable by the client when returned from the orderbook, so the
-    /// client is in charge of creating this ID and passing it to the orderbook.
-    pub order_id: Uuid,
-
-    /// The orderbook id of the counterparty order
-    ///
-    /// The orderbook id of the order that was matched with ours.
-    /// This can be used by the coordinator to make sure the trade is set up correctly.
-    pub order_id_counterparty: String,
-
-    /// The contract symbol for the order
+    /// The contract symbol for the trade to be set up
     pub contract_symbol: ContractSymbol,
 
-    /// Our leverage
+    /// The leverage of the trader
     ///
     /// This has to correspond to our order's leverage.
     pub leverage: f64,
 
-    /// The leverage of the order that was matched
+    /// The quantity of the trader
     ///
-    /// This is the leverage of the counterparty.
-    /// This can be used by the coordinator to make sure the trade is set up correctly.
-    pub leverage_counterparty: f64,
-
-    /// The quantity to be used
-    ///
-    /// This quantity may be the complete amount of either order or a fraction.
+    /// For the trade set up with the coordinator it is the quantity of the contract.
+    /// This quantity may be the complete quantity of an order or a fraction.
     pub quantity: f64,
 
-    /// The execution price as defined by the orderbook
-    ///
-    /// The trade is to be executed at this price.
-    pub execution_price: f64,
-
-    /// The expiry timestamp of the contract-to-be
-    ///
-    /// A timestamp that defines when the contract will expire.
-    /// The orderbook defines the timestamp so that the systems using the trade params to set up
-    /// the trade are aligned on one timestamp. The systems using the trade params should
-    /// validate this timestamp against their trade settings. If the expiry timestamp is older
-    /// than a defined threshold a system my discard the trade params as outdated.
-    ///
-    /// The oracle event-id is defined by contract symbol and the expiry timestamp.
-    pub expiry_timestamp: OffsetDateTime,
-
-    /// The public key of the oracle to be used
-    ///
-    /// The orderbook decides this when matching orders.
-    /// The oracle_pk is used to define what oracle is to be used in the contract.
-    /// This `oracle_pk` must correspond to one `oracle_pk` configured in the dlc-manager.
-    /// It is possible to configure multiple oracles in the dlc-manager; this
-    /// `oracle_pk` has to match one of them. This allows us to configure the dlc-managers
-    /// using two oracles, where one oracles can be used as backup if the other oracle is not
-    /// available. Eventually this can be changed to be a list of oracle PKs and a threshold of
-    /// how many oracle have to agree on the attestation.
-    pub oracle_pk: XOnlyPublicKey,
-
-    /// The direction of the trade
+    /// The direction of the trader
     ///
     /// The direction from the point of view of the trader.
+    /// The coordinator takes the counter-position when setting up the trade.
     pub direction: Direction,
+
+    /// The filling information from the orderbook
+    ///
+    /// This is used by the coordinator to be able to make sure both trading parties are acting.
+    /// The `quantity` has to match the cummed up quantities of the matches in `filled_with`.
+    pub filled_with: FilledWith,
+}
+
+impl TradeParams {
+    pub fn weighted_execution_price(&self) -> f64 {
+        if self.filled_with.matches.len() == 1 {
+            return self
+                .filled_with
+                .matches
+                .first()
+                .expect("to be exactly one")
+                .execution_price;
+        }
+
+        // TODO: Make sure this is correct
+
+        let sum_weighted_execution_price: f64 = self
+            .filled_with
+            .matches
+            .iter()
+            .map(|m| m.execution_price * m.quantity)
+            .collect::<Vec<f64>>()
+            .iter()
+            .sum();
+        let quantities: f64 = self
+            .filled_with
+            .matches
+            .iter()
+            .map(|m| m.quantity)
+            .collect::<Vec<f64>>()
+            .iter()
+            .sum();
+
+        sum_weighted_execution_price / quantities
+    }
 }

--- a/mobile/native/src/trade/position/handler.rs
+++ b/mobile/native/src/trade/position/handler.rs
@@ -17,9 +17,9 @@ use trade::Direction;
 /// The DLC that represents the position will be stored in the database.
 /// Errors are handled within the scope of this function.
 pub async fn trade(trade_params: TradeParams) -> Result<()> {
-    let order_id = trade_params.order_id;
+    let order_id = trade_params.filled_with.order_id;
 
-    order::handler::order_filling(order_id, trade_params.execution_price)?;
+    order::handler::order_filling(order_id, trade_params.weighted_execution_price())?;
 
     if let Err((reason, e)) = ln_dlc::trade(trade_params).await {
         order::handler::order_failed(Some(order_id), reason, e)?;


### PR DESCRIPTION
This brings the trade execution and the orderbook filling information closer together