### PR TITLE
Align clippy flags for all builds

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,5 +1,17 @@
+# Inspired by https://github.com/EmbarkStudios/rust-ecosystem/pull/68.
+[build]
+rustflags = [
+  "-Wclippy::disallowed_methods",
+  "-Wclippy::dbg_macro",
+  "-Wclippy::print_stderr",
+  "-Wclippy::print_stdout",
+  "-Wunused-import-braces",
+  "-Wunused-qualifications",
+]
+
 [target.'cfg(feature = "cargo-clippy")']
 rustflags = [
+  "-Wclippy::disallowed_methods",
   "-Wclippy::dbg_macro",
   "-Wclippy::print_stderr",
   "-Wclippy::print_stdout",


### PR DESCRIPTION
This reduces the chance of cache invalidation between the runs of rust-analyzer, cargo build/run and clippy.

On my machine (with no global Rust config atm), it made huge improvements, ie. no rebuilds from scratch anymore.

There might better ways, but I can't justify spending more time on this right now. Some possible further direction:
 - add a separate build profile for rust-analyzer & clippy