### PR TITLE
feat: add maker docker build

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -18,3 +18,6 @@ rustflags = [
   "-Wunused-import-braces",
   "-Wunused-qualifications",
 ]
+
+[target.armv7-unknown-linux-musleabihf]
+linker = "arm-linux-gnueabihf-ld"

--- a/.github/workflows/publish_docker.yml
+++ b/.github/workflows/publish_docker.yml
@@ -61,3 +61,23 @@ jobs:
           push: true
           build-args: |
           tags: ${{ steps.meta.outputs.tags }}
+
+      - run: cargo build --release --bin maker --target-dir ./target
+
+      - uses: docker/metadata-action@v4
+        id: meta
+        with:
+          images: ${{ env.REGISTRY }}/${{ github.repository }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=tag
+
+      - name: Build docker image and push
+        uses: docker/build-push-action@v3
+        with:
+          context: ./maker
+          secrets: |
+            GIT_AUTH_TOKEN=${{ secrets.GITHUB_TOKEN }}
+          push: true
+          build-args: |
+          tags: ${{ steps.meta.outputs.tags }}

--- a/coordinator/Cargo.toml
+++ b/coordinator/Cargo.toml
@@ -21,6 +21,8 @@ hex = "0.4"
 lightning = { version = "0.0.113", features = ["max_level_trace"] }
 ln-dlc-node = { path = "../crates/ln-dlc-node" }
 local-ip-address = "0.5.1"
+# adding this as explicit dependency as we need the "vendored" flag for cross compilation
+openssl = { version = "0.10.45", features = ["vendored"] }
 orderbook-client = { path = "../crates/orderbook-client" }
 orderbook-commons = { path = "../crates/orderbook-commons" }
 rand = "0.8.5"

--- a/maker/.dockerignore
+++ b/maker/.dockerignore
@@ -1,2 +1,2 @@
 *
-!target/release/coordinator
+!target/release/maker

--- a/maker/Cargo.toml
+++ b/maker/Cargo.toml
@@ -17,6 +17,8 @@ diesel_migrations = "2.0.0"
 futures = "0.3"
 hex = "0.4"
 ln-dlc-node = { path = "../crates/ln-dlc-node" }
+# adding this as explicit dependency as we need the "vendored" flag for cross compilation
+openssl = { version = "0.10.45", features = ["vendored"] }
 orderbook-commons = { path = "../crates/orderbook-commons" }
 rand = "0.8.5"
 reqwest = "0.11.14"


### PR DESCRIPTION
- [x] Publish latest maker docker image upon merge to main.
- [x] Replace `GITHUB_TOKEN` with a generated classic token. Note, `GITHUB_TOKEN` does only work when the workflow is triggered manually.