### PR TITLE
feat: in memory position that can be closed in UI

### DIFF
--- a/mobile/lib/features/trade/domain/direction.dart
+++ b/mobile/lib/features/trade/domain/direction.dart
@@ -32,4 +32,13 @@ enum Direction {
         return "short";
     }
   }
+
+  Direction opposite() {
+    switch (this) {
+      case Direction.long:
+        return Direction.short;
+      case Direction.short:
+        return Direction.long;
+    }
+  }
 }

--- a/mobile/lib/features/trade/position_change_notifier.dart
+++ b/mobile/lib/features/trade/position_change_notifier.dart
@@ -10,13 +10,14 @@ import 'package:get_10101/bridge_generated/bridge_definitions.dart' as bridge;
 import 'domain/position.dart';
 
 class PositionChangeNotifier extends ChangeNotifier implements Subscriber {
-  late PositionService _positionService;
-  late OrderService _orderService;
+  final PositionService _positionService;
+  final OrderService _orderService;
 
   Map<ContractSymbol, Position> positions = {};
 
-  late double _bid;
-  late double _ask;
+  // TODO: fetch price from backend and wire in price updates
+  final double _bid = 23000;
+  final double _ask = 23100;
 
   Future<void> initialize() async {
     List<Position> positions = await _positionService.fetchPositions();
@@ -24,17 +25,10 @@ class PositionChangeNotifier extends ChangeNotifier implements Subscriber {
       this.positions[position.contractSymbol] = position;
     }
 
-    // TODO: fetch price from backend and wire in price updates
-    _bid = 23000;
-    _ask = 23100;
-
     notifyListeners();
   }
 
-  PositionChangeNotifier(PositionService positionService, OrderService orderService) {
-    _positionService = positionService;
-    _orderService = orderService;
-  }
+  PositionChangeNotifier(this._positionService, this._orderService);
 
   @override
   void notify(bridge.Event event) {

--- a/mobile/lib/features/trade/position_change_notifier.dart
+++ b/mobile/lib/features/trade/position_change_notifier.dart
@@ -42,6 +42,9 @@ class PositionChangeNotifier extends ChangeNotifier implements Subscriber {
       position.unrealizedPnl = Amount(_positionService.calculatePnl(position, _bid, _ask));
 
       positions[position.contractSymbol] = position;
+    } else if (event is bridge.Event_PositionClosedNotification) {
+      ContractSymbol contractSymbol = ContractSymbol.fromApi(event.field0.contractSymbol);
+      positions.remove(contractSymbol);
     } else {
       log("Received unexpected event: ${event.toString()}");
     }

--- a/mobile/lib/features/trade/position_list_item.dart
+++ b/mobile/lib/features/trade/position_list_item.dart
@@ -129,7 +129,18 @@ class PositionListItem extends StatelessWidget {
                     : () async {
                         await onClose();
                       },
-                child: const Text("Close Position"),
+                child: notNullPosition.positionState == PositionState.closing
+                    ? Row(
+                        children: const [
+                          SizedBox(
+                            width: 10,
+                            height: 10,
+                            child: CircularProgressIndicator(),
+                          ),
+                          Text("Closing ...")
+                        ],
+                      )
+                    : const Text("Close Position"),
               ),
             ],
           ),

--- a/mobile/lib/features/trade/position_list_item.dart
+++ b/mobile/lib/features/trade/position_list_item.dart
@@ -7,9 +7,10 @@ import 'package:get_10101/features/trade/trade_theme.dart';
 import 'contract_symbol_icon.dart';
 
 class PositionListItem extends StatelessWidget {
-  const PositionListItem({super.key, required this.position});
+  const PositionListItem({super.key, required this.position, required this.onClose});
 
   final Position? position;
+  final Function onClose;
 
   @override
   Widget build(BuildContext context) {
@@ -123,8 +124,8 @@ class PositionListItem extends StatelessWidget {
                 width: 10,
               ),
               ElevatedButton(
-                onPressed: () {
-                  // TODO: bottom sheet to close position
+                onPressed: () async {
+                  await onClose();
                 },
                 child: const Text("Close Position"),
               ),

--- a/mobile/lib/features/trade/position_list_item.dart
+++ b/mobile/lib/features/trade/position_list_item.dart
@@ -124,9 +124,11 @@ class PositionListItem extends StatelessWidget {
                 width: 10,
               ),
               ElevatedButton(
-                onPressed: () async {
-                  await onClose();
-                },
+                onPressed: notNullPosition.positionState == PositionState.closing
+                    ? null
+                    : () async {
+                        await onClose();
+                      },
                 child: const Text("Close Position"),
               ),
             ],

--- a/mobile/lib/features/trade/trade_screen.dart
+++ b/mobile/lib/features/trade/trade_screen.dart
@@ -98,6 +98,10 @@ class TradeScreen extends StatelessWidget {
     OrderChangeNotifier orderChangeNotifier = context.watch<OrderChangeNotifier>();
     PositionChangeNotifier positionChangeNotifier = context.watch<PositionChangeNotifier>();
 
+    SizedBox listBottomScrollSpace = const SizedBox(
+      height: 60,
+    );
+
     return Scaffold(
         body: Container(
           padding: const EdgeInsets.only(left: 15, right: 15),
@@ -121,8 +125,13 @@ class TradeScreen extends StatelessWidget {
                     ListView.builder(
                       shrinkWrap: true,
                       physics: const ClampingScrollPhysics(),
-                      itemCount: positionChangeNotifier.positions.length,
+                      itemCount: positionChangeNotifier.positions.length + 1,
                       itemBuilder: (BuildContext context, int index) {
+                        // Spacer at the bottom of the list
+                        if (index == positionChangeNotifier.positions.length) {
+                          return listBottomScrollSpace;
+                        }
+
                         Position position = positionChangeNotifier.positions.values.toList()[index];
 
                         return PositionListItem(
@@ -136,8 +145,13 @@ class TradeScreen extends StatelessWidget {
                     ListView.builder(
                       shrinkWrap: true,
                       physics: const ClampingScrollPhysics(),
-                      itemCount: orderChangeNotifier.orders.length,
+                      itemCount: orderChangeNotifier.orders.length + 1,
                       itemBuilder: (BuildContext context, int index) {
+                        // Spacer at the bottom of the list
+                        if (index == orderChangeNotifier.orders.length) {
+                          return listBottomScrollSpace;
+                        }
+
                         return OrderListItem(
                             order: orderChangeNotifier.orders.values.toList()[index]);
                       },

--- a/mobile/lib/features/trade/trade_screen.dart
+++ b/mobile/lib/features/trade/trade_screen.dart
@@ -4,6 +4,7 @@ import 'package:get_10101/common/value_data_row.dart';
 import 'package:get_10101/features/trade/contract_symbol_icon.dart';
 import 'package:get_10101/features/trade/domain/contract_symbol.dart';
 import 'package:get_10101/features/trade/domain/direction.dart';
+import 'package:get_10101/features/trade/domain/position.dart';
 import 'package:get_10101/features/trade/order_change_notifier.dart';
 import 'package:get_10101/features/trade/order_list_item.dart';
 import 'package:get_10101/features/trade/position_change_notifier.dart';
@@ -122,8 +123,14 @@ class TradeScreen extends StatelessWidget {
                       physics: const ClampingScrollPhysics(),
                       itemCount: positionChangeNotifier.positions.length,
                       itemBuilder: (BuildContext context, int index) {
+                        Position position = positionChangeNotifier.positions.values.toList()[index];
+
                         return PositionListItem(
-                            position: positionChangeNotifier.positions.values.toList()[index]);
+                          position: position,
+                          onClose: () async {
+                            await positionChangeNotifier.closePosition(position.contractSymbol);
+                          },
+                        );
                       },
                     ),
                     ListView.builder(

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -62,7 +62,8 @@ void main() {
     ChangeNotifierProvider(create: (context) => AmountDenominationChangeNotifier()),
     ChangeNotifierProvider(create: (context) => SubmitOrderChangeNotifier(OrderService())),
     ChangeNotifierProvider(create: (context) => OrderChangeNotifier(OrderService())),
-    ChangeNotifierProvider(create: (context) => PositionChangeNotifier(PositionService())),
+    ChangeNotifierProvider(
+        create: (context) => PositionChangeNotifier(PositionService(), OrderService())),
     ChangeNotifierProvider(create: (context) => WalletChangeNotifier(const WalletService())),
     Provider(create: (context) => Environment.parse()),
   ], child: const TenTenOneApp()));
@@ -192,6 +193,11 @@ class _TenTenOneAppState extends State<TenTenOneApp> {
 
       eventService.subscribe(
           positionChangeNotifier, bridge.Event.positionUpdateNotification(Position.apiDummy()));
+
+      eventService.subscribe(
+          positionChangeNotifier,
+          const bridge.Event.positionClosedNotification(
+              bridge.PositionClosed(contractSymbol: bridge.ContractSymbol.BtcUsd)));
 
       eventService.subscribe(
           walletChangeNotifier, bridge.Event.walletInfoUpdateNotification(WalletInfo.apiDummy()));

--- a/mobile/native/migrations/2023-03-20-005447_positions/down.sql
+++ b/mobile/native/migrations/2023-03-20-005447_positions/down.sql
@@ -1,0 +1,2 @@
+-- This file should undo anything in `up.sql`
+DROP TABLE IF EXISTS positions;

--- a/mobile/native/migrations/2023-03-20-005447_positions/up.sql
+++ b/mobile/native/migrations/2023-03-20-005447_positions/up.sql
@@ -1,0 +1,13 @@
+-- Your SQL goes here
+-- TODO: Review this model, using the contract symbol as PK is not wrong, but it will depend on how we want to treat positions after closing them
+CREATE TABLE IF NOT EXISTS positions (
+    contract_symbol TEXT PRIMARY KEY NOT NULL,
+    leverage NUMBER NOT NULL,
+    quantity NUMBER NOT NULL,
+    direction TEXT NOT NULL,
+    average_entry_price NUMBER NOT NULL,
+    liquidation_price NUMBER NOT NULL,
+    state TEXT NOT NULL,
+    collateral BIGINT NOT NULL,
+    creation_timestamp BIGINT NOT NULL
+)

--- a/mobile/native/src/db/custom_types.rs
+++ b/mobile/native/src/db/custom_types.rs
@@ -121,7 +121,7 @@ impl ToSql<Text, Sqlite> for FailureReason {
             FailureReason::NoUsableChannel => "NoUsableChannel",
             FailureReason::ProposeDlcChannel => "ProposeDlcChannel",
             FailureReason::FailedToSetToFilling => "FailedToSetToFilling",
-            FailureReason::CannotExtendOrReduce => "CannotExtendOrReduce",
+            FailureReason::OrderNotAcceptable => "OrderNotAcceptable",
         };
         out.set_value(text);
         Ok(IsNull::No)
@@ -139,7 +139,7 @@ impl FromSql<Text, Sqlite> for FailureReason {
             "NoUsableChannel" => Ok(FailureReason::NoUsableChannel),
             "ProposeDlcChannel" => Ok(FailureReason::ProposeDlcChannel),
             "FailedToSetToFilling" => Ok(FailureReason::FailedToSetToFilling),
-            "CannotExtendOrReduce" => Ok(FailureReason::CannotExtendOrReduce),
+            "OrderNotAcceptable" => Ok(FailureReason::OrderNotAcceptable),
             _ => Err("Unrecognized enum variant".into()),
         };
     }

--- a/mobile/native/src/db/custom_types.rs
+++ b/mobile/native/src/db/custom_types.rs
@@ -121,6 +121,7 @@ impl ToSql<Text, Sqlite> for FailureReason {
             FailureReason::NoUsableChannel => "NoUsableChannel",
             FailureReason::ProposeDlcChannel => "ProposeDlcChannel",
             FailureReason::FailedToSetToFilling => "FailedToSetToFilling",
+            FailureReason::CannotExtendOrReduce => "CannotExtendOrReduce",
         };
         out.set_value(text);
         Ok(IsNull::No)
@@ -138,6 +139,7 @@ impl FromSql<Text, Sqlite> for FailureReason {
             "NoUsableChannel" => Ok(FailureReason::NoUsableChannel),
             "ProposeDlcChannel" => Ok(FailureReason::ProposeDlcChannel),
             "FailedToSetToFilling" => Ok(FailureReason::FailedToSetToFilling),
+            "CannotExtendOrReduce" => Ok(FailureReason::CannotExtendOrReduce),
             _ => Err("Unrecognized enum variant".into()),
         };
     }

--- a/mobile/native/src/db/mod.rs
+++ b/mobile/native/src/db/mod.rs
@@ -185,3 +185,14 @@ pub fn delete_positions() -> Result<()> {
 
     Ok(())
 }
+
+pub fn update_position_state(
+    contract_symbol: ::trade::ContractSymbol,
+    position_state: trade::position::PositionState,
+) -> Result<()> {
+    let mut db = connection()?;
+    Position::update_state(contract_symbol.into(), position_state.into(), &mut db)
+        .context("Failed to update position state")?;
+
+    Ok(())
+}

--- a/mobile/native/src/db/mod.rs
+++ b/mobile/native/src/db/mod.rs
@@ -1,6 +1,7 @@
 use crate::api;
 use crate::db::models::Order;
 use crate::db::models::OrderState;
+use crate::db::models::Position;
 use crate::trade;
 use anyhow::anyhow;
 use anyhow::bail;
@@ -156,6 +157,31 @@ pub fn maybe_get_order_in_filling() -> Result<Option<trade::order::Order>> {
 pub fn delete_order(order_id: Uuid) -> Result<()> {
     let mut db = connection()?;
     Order::delete(order_id.to_string(), &mut db)?;
+
+    Ok(())
+}
+
+pub fn insert_position(position: trade::position::Position) -> Result<trade::position::Position> {
+    let mut db = connection()?;
+    let position = Position::insert(position.into(), &mut db)?;
+
+    Ok(position.into())
+}
+
+pub fn get_positions() -> Result<Vec<trade::position::Position>> {
+    let mut db = connection()?;
+    let positions = Position::get_all(&mut db)?;
+    let positions = positions
+        .into_iter()
+        .map(|position| position.into())
+        .collect();
+
+    Ok(positions)
+}
+
+pub fn delete_positions() -> Result<()> {
+    let mut db = connection()?;
+    Position::delete_all(&mut db)?;
 
     Ok(())
 }

--- a/mobile/native/src/db/models.rs
+++ b/mobile/native/src/db/models.rs
@@ -294,7 +294,7 @@ impl Position {
             .execute(conn)?;
 
         if effected_rows == 0 {
-            bail!("Could not update order")
+            bail!("Could not update position")
         }
 
         Ok(())
@@ -302,7 +302,6 @@ impl Position {
 
     // TODO: This is obviously only for the MVP :)
     /// deletes all positions in the database
-    /// Deletes given order from DB, in case of success, returns > 0, else 0 or Err
     pub fn delete_all(conn: &mut SqliteConnection) -> QueryResult<usize> {
         diesel::delete(positions::table).execute(conn)
     }

--- a/mobile/native/src/db/models.rs
+++ b/mobile/native/src/db/models.rs
@@ -509,7 +509,7 @@ pub enum FailureReason {
     NodeAccess,
     NoUsableChannel,
     ProposeDlcChannel,
-    CannotExtendOrReduce,
+    OrderNotAcceptable,
 }
 
 impl From<FailureReason> for crate::trade::order::FailureReason {
@@ -525,8 +525,8 @@ impl From<FailureReason> for crate::trade::order::FailureReason {
             FailureReason::FailedToSetToFilling => {
                 crate::trade::order::FailureReason::FailedToSetToFilling
             }
-            FailureReason::CannotExtendOrReduce => {
-                crate::trade::order::FailureReason::CannotExtendOrReduce
+            FailureReason::OrderNotAcceptable => {
+                crate::trade::order::FailureReason::OrderNotAcceptable
             }
         }
     }
@@ -545,8 +545,8 @@ impl From<crate::trade::order::FailureReason> for FailureReason {
             crate::trade::order::FailureReason::FailedToSetToFilling => {
                 FailureReason::FailedToSetToFilling
             }
-            crate::trade::order::FailureReason::CannotExtendOrReduce => {
-                FailureReason::CannotExtendOrReduce
+            crate::trade::order::FailureReason::OrderNotAcceptable => {
+                FailureReason::OrderNotAcceptable
             }
         }
     }

--- a/mobile/native/src/db/models.rs
+++ b/mobile/native/src/db/models.rs
@@ -2,6 +2,7 @@ use crate::api;
 use crate::schema;
 use crate::schema::last_login;
 use crate::schema::orders;
+use crate::schema::positions;
 use anyhow::bail;
 use anyhow::Result;
 use diesel;
@@ -239,6 +240,102 @@ impl TryFrom<Order> for crate::trade::order::Order {
         };
 
         Ok(order)
+    }
+}
+
+#[derive(Queryable, QueryableByName, Insertable, Debug, Clone, PartialEq)]
+#[diesel(table_name = positions)]
+pub(crate) struct Position {
+    pub contract_symbol: ContractSymbol,
+    pub leverage: f64,
+    pub quantity: f64,
+    pub direction: Direction,
+    pub average_entry_price: f64,
+    pub liquidation_price: f64,
+    pub state: PositionState,
+    pub collateral: i64,
+    pub creation_timestamp: i64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, FromSqlRow, AsExpression)]
+#[diesel(sql_type = Text)]
+pub enum PositionState {
+    Open,
+    Closing,
+}
+
+impl Position {
+    /// inserts the given position into the db. Returns the position if successful
+    pub fn insert(position: Position, conn: &mut SqliteConnection) -> Result<Position> {
+        let effected_rows = diesel::insert_into(positions::table)
+            .values(&position)
+            .execute(conn)?;
+
+        if effected_rows > 0 {
+            Ok(position)
+        } else {
+            bail!("Could not insert position")
+        }
+    }
+
+    pub fn get_all(conn: &mut SqliteConnection) -> QueryResult<Vec<Position>> {
+        positions::table.load(conn)
+    }
+
+    // TODO: This is obviously only for the MVP :)
+    /// deletes all positions in the database
+    /// Deletes given order from DB, in case of success, returns > 0, else 0 or Err
+    pub fn delete_all(conn: &mut SqliteConnection) -> QueryResult<usize> {
+        diesel::delete(positions::table).execute(conn)
+    }
+}
+
+impl From<Position> for crate::trade::position::Position {
+    fn from(value: Position) -> Self {
+        Self {
+            leverage: value.leverage,
+            quantity: value.quantity,
+            contract_symbol: value.contract_symbol.into(),
+            direction: value.direction.into(),
+            average_entry_price: value.average_entry_price,
+            liquidation_price: value.liquidation_price,
+            position_state: value.state.into(),
+            collateral: value.collateral as u64,
+        }
+    }
+}
+
+impl From<crate::trade::position::Position> for Position {
+    fn from(value: crate::trade::position::Position) -> Self {
+        Self {
+            contract_symbol: value.contract_symbol.into(),
+            leverage: value.leverage,
+            quantity: value.quantity,
+            direction: value.direction.into(),
+            average_entry_price: value.average_entry_price,
+            liquidation_price: value.liquidation_price,
+            state: value.position_state.into(),
+            collateral: value.collateral as i64,
+            creation_timestamp: OffsetDateTime::now_utc().unix_timestamp(),
+        }
+    }
+}
+
+impl From<crate::trade::position::PositionState> for PositionState {
+    fn from(value: crate::trade::position::PositionState) -> Self {
+        match value {
+            crate::trade::position::PositionState::Open => PositionState::Open,
+            crate::trade::position::PositionState::Closing => PositionState::Closing,
+        }
+    }
+}
+
+impl From<PositionState> for crate::trade::position::PositionState {
+    fn from(value: PositionState) -> Self {
+        match value {
+            PositionState::Open => crate::trade::position::PositionState::Open,
+            PositionState::Closing => crate::trade::position::PositionState::Closing,
+        }
     }
 }
 

--- a/mobile/native/src/event/api.rs
+++ b/mobile/native/src/event/api.rs
@@ -7,6 +7,7 @@ use crate::trade::position::api::Position;
 use core::convert::From;
 use flutter_rust_bridge::frb;
 use flutter_rust_bridge::StreamSink;
+use trade::ContractSymbol;
 
 #[frb]
 #[derive(Clone)]
@@ -16,6 +17,7 @@ pub enum Event {
     OrderUpdateNotification(Order),
     WalletInfoUpdateNotification(WalletInfo),
     PositionUpdateNotification(Position),
+    PositionClosedNotification(PositionClosed),
 }
 
 impl From<EventInternal> for Event {
@@ -35,8 +37,21 @@ impl From<EventInternal> for Event {
             EventInternal::PositionUpdateNotification(position) => {
                 Event::PositionUpdateNotification(position.into())
             }
+            EventInternal::PositionCloseNotification(contract_symbol) => {
+                Event::PositionClosedNotification(PositionClosed { contract_symbol })
+            }
         }
     }
+}
+
+/// Wrapper struct needed by frb
+///
+/// The mirrored `ContractSymbol` does not get picked up correctly when using it directly as
+/// type in an enum variant, so we wrap it in a struct.
+#[frb]
+#[derive(Clone, Copy)]
+pub struct PositionClosed {
+    pub contract_symbol: ContractSymbol,
 }
 
 #[derive(Clone)]

--- a/mobile/native/src/event/api.rs
+++ b/mobile/native/src/event/api.rs
@@ -71,6 +71,7 @@ impl Subscriber for FlutterSubscriber {
             EventType::WalletInfoUpdateNotification,
             EventType::OrderUpdateNotification,
             EventType::PositionUpdateNotification,
+            EventType::PositionClosedNotification,
         ]
     }
 }

--- a/mobile/native/src/event/mod.rs
+++ b/mobile/native/src/event/mod.rs
@@ -5,6 +5,7 @@ pub mod subscriber;
 use crate::api::WalletInfo;
 use coordinator_commons::TradeParams;
 use std::hash::Hash;
+use trade::ContractSymbol;
 
 use crate::event::event_hub::get;
 use crate::event::subscriber::Subscriber;
@@ -27,6 +28,7 @@ pub enum EventInternal {
     WalletInfoUpdateNotification(WalletInfo),
     OrderFilledWith(Box<TradeParams>),
     PositionUpdateNotification(Position),
+    PositionCloseNotification(ContractSymbol),
 }
 
 impl From<EventInternal> for EventType {
@@ -40,6 +42,7 @@ impl From<EventInternal> for EventType {
             }
             EventInternal::OrderFilledWith(_) => EventType::OrderFilledWith,
             EventInternal::PositionUpdateNotification(_) => EventType::PositionUpdateNotification,
+            EventInternal::PositionCloseNotification(_) => EventType::PositionClosedNotification,
         }
     }
 }
@@ -52,4 +55,5 @@ pub enum EventType {
     WalletInfoUpdateNotification,
     OrderFilledWith,
     PositionUpdateNotification,
+    PositionClosedNotification,
 }

--- a/mobile/native/src/ln_dlc/node.rs
+++ b/mobile/native/src/ln_dlc/node.rs
@@ -114,9 +114,10 @@ impl Node {
                                 }
                             };
 
-                            if let Err(e) =
-                                position::handler::position_update(filled_order, offer_collateral)
-                            {
+                            if let Err(e) = position::handler::update_position_after_order_filled(
+                                filled_order,
+                                offer_collateral,
+                            ) {
                                 tracing::error!(
                                     "Failed to handle position after receiving DLC: {e:#}"
                                 );

--- a/mobile/native/src/ln_dlc/node.rs
+++ b/mobile/native/src/ln_dlc/node.rs
@@ -113,7 +113,7 @@ impl Node {
                             };
 
                             if let Err(e) =
-                                position::handler::order_filled(filled_order, offer_collateral)
+                                position::handler::position_update(filled_order, offer_collateral)
                             {
                                 tracing::error!(
                                     "Failed to handle position after receiving DLC: {e:#}"

--- a/mobile/native/src/ln_dlc/node.rs
+++ b/mobile/native/src/ln_dlc/node.rs
@@ -100,7 +100,9 @@ impl Node {
                             .dlc_message_handler
                             .send_message(node_id, Message::SubChannel(reply_msg.clone()));
 
-                        if let SubChannelMessage::Finalize(_) = reply_msg {
+                        if let SubChannelMessage::Finalize(_)
+                        | SubChannelMessage::CloseFinalize(_) = reply_msg
+                        {
                             let offer_collateral =
                                 get_first_confirmed_dlc(&self.inner.dlc_manager)?.offer_collateral;
 

--- a/mobile/native/src/schema.rs
+++ b/mobile/native/src/schema.rs
@@ -23,4 +23,18 @@ diesel::table! {
     }
 }
 
-diesel::allow_tables_to_appear_in_same_query!(last_login, orders,);
+diesel::table! {
+    positions (contract_symbol) {
+        contract_symbol -> Text,
+        leverage -> Double,
+        quantity -> Double,
+        direction -> Text,
+        average_entry_price -> Double,
+        liquidation_price -> Double,
+        state -> Text,
+        collateral -> BigInt,
+        creation_timestamp -> BigInt,
+    }
+}
+
+diesel::allow_tables_to_appear_in_same_query!(last_login, orders, positions,);

--- a/mobile/native/src/trade/order/handler.rs
+++ b/mobile/native/src/trade/order/handler.rs
@@ -19,7 +19,7 @@ pub async fn submit_order(order: Order) -> Result<()> {
 
     if let Err(e) = position::handler::update_position_after_order_submitted(order) {
         order_failed(Some(order.id), FailureReason::OrderNotAcceptable, e)?;
-        bail!("Not part of MVP scope");
+        bail!("Could not submit order because extending/reducing the position is not part of the MVP scope");
     }
 
     db::insert_order(order)?;

--- a/mobile/native/src/trade/order/handler.rs
+++ b/mobile/native/src/trade/order/handler.rs
@@ -18,7 +18,7 @@ pub async fn submit_order(order: Order) -> Result<()> {
     let orderbook_client = OrderbookClient::new(Url::parse(&url)?);
 
     if let Err(e) = position::handler::update_position_after_order_submitted(order) {
-        order_failed(Some(order.id), FailureReason::CannotExtendOrReduce, e)?;
+        order_failed(Some(order.id), FailureReason::OrderNotAcceptable, e)?;
         bail!("Not part of MVP scope");
     }
 

--- a/mobile/native/src/trade/order/handler.rs
+++ b/mobile/native/src/trade/order/handler.rs
@@ -6,6 +6,7 @@ use crate::trade::order::orderbook_client::OrderbookClient;
 use crate::trade::order::FailureReason;
 use crate::trade::order::Order;
 use crate::trade::order::OrderState;
+use crate::trade::position;
 use anyhow::bail;
 use anyhow::Context;
 use anyhow::Result;
@@ -15,6 +16,11 @@ use uuid::Uuid;
 pub async fn submit_order(order: Order) -> Result<()> {
     let url = format!("http://{}", config::get_http_endpoint());
     let orderbook_client = OrderbookClient::new(Url::parse(&url)?);
+
+    if let Err(e) = position::handler::update_position_after_order_submitted(order) {
+        order_failed(Some(order.id), FailureReason::CannotExtendOrReduce, e)?;
+        bail!("Not part of MVP scope");
+    }
 
     db::insert_order(order)?;
 

--- a/mobile/native/src/trade/order/mod.rs
+++ b/mobile/native/src/trade/order/mod.rs
@@ -27,6 +27,8 @@ pub enum FailureReason {
     NodeAccess,
     NoUsableChannel,
     ProposeDlcChannel,
+    /// MVP scope: Can only close the order, not reduce or extend
+    CannotExtendOrReduce,
 }
 
 #[derive(Debug, Clone, Copy)]

--- a/mobile/native/src/trade/order/mod.rs
+++ b/mobile/native/src/trade/order/mod.rs
@@ -28,7 +28,7 @@ pub enum FailureReason {
     NoUsableChannel,
     ProposeDlcChannel,
     /// MVP scope: Can only close the order, not reduce or extend
-    CannotExtendOrReduce,
+    OrderNotAcceptable,
 }
 
 #[derive(Debug, Clone, Copy)]

--- a/mobile/native/src/trade/position/handler.rs
+++ b/mobile/native/src/trade/position/handler.rs
@@ -12,6 +12,10 @@ use anyhow::Result;
 use coordinator_commons::TradeParams;
 use orderbook_commons::FilledWith;
 use rust_decimal::prelude::ToPrimitive;
+use state::Storage;
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::sync::MutexGuard;
 use trade::ContractSymbol;
 use trade::Direction;
 
@@ -65,7 +69,21 @@ pub async fn get_positions() -> Result<Vec<Position>> {
     Ok(vec![dummy_position])
 }
 
-pub fn order_filled(filled_order: Order, collateral: u64) -> Result<()> {
+// TODO: Remove this temporary in-memory storage of the position and safe it in the database
+static POSITION: Storage<Arc<Mutex<Option<Position>>>> = Storage::new();
+
+pub(crate) fn get() -> MutexGuard<'static, Option<Position>> {
+    POSITION
+        .get()
+        .lock()
+        .expect("failed to get lock on event hub")
+}
+
+/// Update position once an order was filled
+///
+/// This crates or updates the position.
+/// If the position was closed we set it to `Closed` state.
+pub fn position_update(filled_order: Order, collateral: u64) -> Result<()> {
     // TODO: Persist the position
     // TODO: Decide if we have to create or update the position:
     //  Probably best to have a "insert or update" function for the db that returns the position
@@ -75,24 +93,43 @@ pub fn order_filled(filled_order: Order, collateral: u64) -> Result<()> {
 
     // TODO: Maybe we should change the model to *ensure* that the execution price is present past a
     // certain point; i.e. a `FilledOrder` struct?
-    let average_entry_price = filled_order.execution_price().unwrap_or(0.0);
 
-    event::publish(&EventInternal::PositionUpdateNotification(Position {
-        leverage: filled_order.leverage,
-        quantity: filled_order.quantity,
-        contract_symbol: filled_order.contract_symbol,
-        direction: filled_order.direction,
-        average_entry_price,
-        // TODO: Is it correct to use the average entry price to calculate the liquidation price? ->
-        // What would that mean in the UI if we already have a position and trade?
-        liquidation_price: calculate_liquidation_price(
-            average_entry_price,
-            filled_order.leverage,
-            filled_order.direction,
-        ),
-        position_state: PositionState::Open,
-        collateral,
-    }));
+    // store position in memory for now so we can show it to the user
+    match get().into() {
+        Some(_) => {
+            // If it was some we set it to None
+            POSITION.set(Arc::new(Mutex::new(None)));
+
+            event::publish(&EventInternal::PositionCloseNotification(
+                ContractSymbol::BtcUsd,
+            ));
+        }
+        None => {
+            let average_entry_price = filled_order.execution_price().unwrap_or(0.0);
+            let have_a_position = Position {
+                leverage: filled_order.leverage,
+                quantity: filled_order.quantity,
+                contract_symbol: filled_order.contract_symbol,
+                direction: filled_order.direction,
+                average_entry_price,
+                // TODO: Is it correct to use the average entry price to calculate the liquidation
+                // price? -> What would that mean in the UI if we already have a
+                // position and trade?
+                liquidation_price: calculate_liquidation_price(
+                    average_entry_price,
+                    filled_order.leverage,
+                    filled_order.direction,
+                ),
+                // TODO: Remove the PnL, that has to be calculated in the UI
+                position_state: PositionState::Open,
+                collateral,
+            };
+
+            POSITION.set(Arc::new(Mutex::new(Some(have_a_position.clone()))));
+
+            event::publish(&EventInternal::PositionUpdateNotification(have_a_position));
+        }
+    }
 
     Ok(())
 }

--- a/mobile/native/src/trade/position/handler.rs
+++ b/mobile/native/src/trade/position/handler.rs
@@ -53,10 +53,10 @@ pub async fn get_positions() -> Result<Vec<Position>> {
     db::get_positions()
 }
 
-/// Update position once an order was filled
+/// Update the position once an order was submitted
 ///
-/// This crates or updates the position.
-/// If the position was closed we set it to `Closed` state.
+/// If the new order submitted is an order that closes the current position, then the position will
+/// be updated to `Closing` state.
 pub fn update_position_after_order_submitted(submitted_order: Order) -> Result<()> {
     if let Some(position) = db::get_positions()?.first() {
         // closing the position
@@ -80,7 +80,7 @@ pub fn update_position_after_order_submitted(submitted_order: Order) -> Result<(
 pub fn update_position_after_order_filled(filled_order: Order, collateral: u64) -> Result<()> {
     // We don't have a position yet
     if db::get_positions()?.is_empty() {
-        tracing::debug!("We don't have a position at the moment, creating it");
+        tracing::debug!("We don't have a position at the moment, creating it for order: {filled_order:?} with collateral {collateral}");
 
         let average_entry_price = filled_order.execution_price().unwrap_or(0.0);
         let have_a_position = Position {

--- a/mobile/test/trade_test.dart
+++ b/mobile/test/trade_test.dart
@@ -92,7 +92,8 @@ void main() {
       ChangeNotifierProvider(create: (context) => TradeValuesChangeNotifier(tradeValueService)),
       ChangeNotifierProvider(create: (context) => submitOrderChangeNotifier),
       ChangeNotifierProvider(create: (context) => OrderChangeNotifier(orderService)),
-      ChangeNotifierProvider(create: (context) => PositionChangeNotifier(positionService)),
+      ChangeNotifierProvider(
+          create: (context) => PositionChangeNotifier(positionService, orderService)),
       ChangeNotifierProvider(create: (context) => AmountDenominationChangeNotifier()),
       ChangeNotifierProvider(create: (context) => WalletChangeNotifier(walletService)),
     ], child: const TestWrapperWithTradeTheme(child: TradeScreen())));


### PR DESCRIPTION
This is in line with our current simplified flow:

When a position is created we store it in memory.
When the position is closed we remove it. Updating (i.e. extending / reducing) a position is not implemented. 

---

Note that for closing we remove the position in user interface for now; there is no particular trade history planned, but the opening and closing of the position will be visible in the transaction history of the wallet.

Note: The PnL will only be displayed (at the moment it's constantly loading) once we have the price feed #132 