### PR TITLE
Add endpoint to get `coordinator` DLC channels

### DIFF
--- a/coordinator/src/node.rs
+++ b/coordinator/src/node.rs
@@ -173,7 +173,7 @@ impl Node {
     /// caller to extend or reduce the position. _This is currently
     /// not supported_.
     fn decide_trade_action(&self, trade_params: &TradeParams) -> Result<TradeAction> {
-        let action = match self.inner.get_sub_channel_signed(&trade_params.pubkey)? {
+        let action = match self.inner.get_dlc_channel_signed(&trade_params.pubkey)? {
             Some(subchannel) => {
                 // FIXME: Should query the database for more
                 // information

--- a/crates/ln-dlc-node/src/lib.rs
+++ b/crates/ln-dlc-node/src/lib.rs
@@ -39,6 +39,7 @@ pub mod seed;
 mod tests;
 
 pub use ln::ChannelDetails;
+pub use ln::DlcChannelDetails;
 pub use node::dlc_channel::Dlc;
 
 type ConfirmableMonitor = (

--- a/crates/ln-dlc-node/src/ln/dlc_channel_details.rs
+++ b/crates/ln-dlc-node/src/ln/dlc_channel_details.rs
@@ -1,0 +1,82 @@
+use bitcoin::hashes::hex::ToHex;
+use bitcoin::secp256k1::PublicKey;
+use dlc_manager::subchannel::SubChannel;
+use dlc_manager::ChannelId;
+use serde::Serialize;
+use serde::Serializer;
+
+#[derive(Serialize, Debug)]
+pub struct DlcChannelDetails {
+    #[serde(serialize_with = "channel_id_as_hex")]
+    pub channel_id: ChannelId,
+    #[serde(serialize_with = "pk_as_hex")]
+    pub counter_party: PublicKey,
+    pub update_idx: u64,
+    pub state: SubChannelState,
+    pub fee_rate_per_vb: u64,
+    pub fund_value_satoshis: u64,
+    /// Whether the local party is the one who offered the sub channel.
+    pub is_offer: bool,
+}
+
+#[derive(Serialize, Debug)]
+pub enum SubChannelState {
+    Offered,
+    Accepted,
+    Signed,
+    Closing,
+    OnChainClosed,
+    CounterOnChainClosed,
+    CloseOffered,
+    CloseAccepted,
+    CloseConfirmed,
+    OffChainClosed,
+    ClosedPunished,
+}
+
+impl From<SubChannel> for DlcChannelDetails {
+    fn from(sc: SubChannel) -> Self {
+        DlcChannelDetails {
+            channel_id: sc.channel_id,
+            counter_party: sc.counter_party,
+            update_idx: sc.update_idx,
+            state: SubChannelState::from(sc.state),
+            fee_rate_per_vb: sc.fee_rate_per_vb,
+            fund_value_satoshis: sc.fund_value_satoshis,
+            is_offer: sc.is_offer,
+        }
+    }
+}
+
+impl From<dlc_manager::subchannel::SubChannelState> for SubChannelState {
+    fn from(value: dlc_manager::subchannel::SubChannelState) -> Self {
+        use dlc_manager::subchannel::SubChannelState::*;
+        match value {
+            Offered(_) => SubChannelState::Offered,
+            Accepted(_) => SubChannelState::Accepted,
+            Signed(_) => SubChannelState::Signed,
+            Closing(_) => SubChannelState::Closing,
+            OnChainClosed => SubChannelState::OnChainClosed,
+            CounterOnChainClosed => SubChannelState::CounterOnChainClosed,
+            CloseOffered(_) => SubChannelState::CloseOffered,
+            CloseAccepted(_) => SubChannelState::CloseAccepted,
+            CloseConfirmed(_) => SubChannelState::CloseConfirmed,
+            OffChainClosed => SubChannelState::OffChainClosed,
+            ClosedPunished(_) => SubChannelState::ClosedPunished,
+        }
+    }
+}
+
+fn channel_id_as_hex<S>(channel_id: &ChannelId, s: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    s.serialize_str(&hex::encode(channel_id))
+}
+
+fn pk_as_hex<S>(pk: &PublicKey, s: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    s.serialize_str(&pk.to_hex())
+}

--- a/crates/ln-dlc-node/src/ln/mod.rs
+++ b/crates/ln-dlc-node/src/ln/mod.rs
@@ -1,11 +1,13 @@
 mod channel_details;
 mod config;
+mod dlc_channel_details;
 mod event_handler;
 mod logger;
 
 pub use channel_details::ChannelDetails;
 pub(crate) use config::app_config;
 pub(crate) use config::coordinator_config;
+pub use dlc_channel_details::DlcChannelDetails;
 pub(crate) use event_handler::EventHandler;
 pub(crate) use logger::TracingLogger;
 

--- a/crates/ln-dlc-node/src/node/dlc_channel.rs
+++ b/crates/ln-dlc-node/src/node/dlc_channel.rs
@@ -144,6 +144,16 @@ impl Node {
         Ok(dlc_channel)
     }
 
+    pub fn list_dlc_channels(&self) -> Result<Vec<SubChannel>> {
+        let dlc_channels = self
+            .dlc_manager
+            .get_store()
+            .get_sub_channels()
+            .map_err(|e| anyhow!(e.to_string()))?;
+
+        Ok(dlc_channels)
+    }
+
     fn get_dlc_channel(
         &self,
         matcher: impl FnMut(&&SubChannel) -> bool,
@@ -152,16 +162,6 @@ impl Node {
         let dlc_channel = dlc_channels.iter().find(matcher);
 
         Ok(dlc_channel.cloned())
-    }
-
-    fn list_dlc_channels(&self) -> Result<Vec<SubChannel>> {
-        let dlc_channels = self
-            .dlc_manager
-            .get_store()
-            .get_sub_channels()
-            .map_err(|e| anyhow!(e.to_string()))?;
-
-        Ok(dlc_channels)
     }
 
     #[cfg(test)]

--- a/crates/ln-dlc-node/src/node/dlc_channel.rs
+++ b/crates/ln-dlc-node/src/node/dlc_channel.rs
@@ -115,43 +115,42 @@ impl Node {
         Ok(())
     }
 
-    pub fn get_sub_channel_offer(&self, pubkey: &PublicKey) -> Result<Option<SubChannel>> {
-        let matcher = |sub_channel: &&SubChannel| {
-            sub_channel.counter_party == *pubkey
-                && matches!(&sub_channel.state, SubChannelState::Offered(_))
+    pub fn get_dlc_channel_offer(&self, pubkey: &PublicKey) -> Result<Option<SubChannel>> {
+        let matcher = |dlc_channel: &&SubChannel| {
+            dlc_channel.counter_party == *pubkey
+                && matches!(&dlc_channel.state, SubChannelState::Offered(_))
         };
+        let dlc_channel = self.get_dlc_channel(&matcher)?; // `get_offered_sub_channels` appears to have a bug
 
-        let sub_channel = self.get_sub_channel(&matcher)?; // `get_offered_sub_channels` appears to have a bug
-        Ok(sub_channel)
+        Ok(dlc_channel)
     }
 
-    pub fn get_sub_channel_signed(&self, pubkey: &PublicKey) -> Result<Option<SubChannel>> {
-        let matcher = |sub_channel: &&SubChannel| {
-            sub_channel.counter_party == *pubkey
-                && matches!(&sub_channel.state, SubChannelState::Signed(_))
+    pub fn get_dlc_channel_signed(&self, pubkey: &PublicKey) -> Result<Option<SubChannel>> {
+        let matcher = |dlc_channel: &&SubChannel| {
+            dlc_channel.counter_party == *pubkey
+                && matches!(&dlc_channel.state, SubChannelState::Signed(_))
         };
-
-        let sub_channel = self.get_sub_channel(&matcher)?;
-        Ok(sub_channel)
+        let dlc_channel = self.get_dlc_channel(&matcher)?;
+        Ok(dlc_channel)
     }
 
-    pub fn get_sub_channel_close_offer(&self, pubkey: &PublicKey) -> Result<Option<SubChannel>> {
-        let matcher = |sub_channel: &&SubChannel| {
-            sub_channel.counter_party == *pubkey
-                && matches!(&sub_channel.state, SubChannelState::CloseOffered(_))
+    pub fn get_dlc_channel_close_offer(&self, pubkey: &PublicKey) -> Result<Option<SubChannel>> {
+        let matcher = |dlc_channel: &&SubChannel| {
+            dlc_channel.counter_party == *pubkey
+                && matches!(&dlc_channel.state, SubChannelState::CloseOffered(_))
         };
-        let sub_channel = self.get_sub_channel(&matcher)?;
+        let dlc_channel = self.get_dlc_channel(&matcher)?;
 
-        Ok(sub_channel)
+        Ok(dlc_channel)
     }
 
-    fn get_sub_channel(
+    fn get_dlc_channel(
         &self,
         matcher: impl FnMut(&&SubChannel) -> bool,
     ) -> Result<Option<SubChannel>> {
         let dlc_channels = self.list_dlc_channels()?;
-
         let dlc_channel = dlc_channels.iter().find(matcher);
+
         Ok(dlc_channel.cloned())
     }
 

--- a/crates/ln-dlc-node/src/node/dlc_channel.rs
+++ b/crates/ln-dlc-node/src/node/dlc_channel.rs
@@ -147,16 +147,22 @@ impl Node {
 
     fn get_sub_channel(
         &self,
-        matcher: &dyn Fn(&&SubChannel) -> bool,
+        matcher: impl FnMut(&&SubChannel) -> bool,
     ) -> Result<Option<SubChannel>> {
-        let sub_channels = self
+        let dlc_channels = self.list_dlc_channels()?;
+
+        let dlc_channel = dlc_channels.iter().find(matcher);
+        Ok(dlc_channel.cloned())
+    }
+
+    fn list_dlc_channels(&self) -> Result<Vec<SubChannel>> {
+        let dlc_channels = self
             .dlc_manager
             .get_store()
             .get_sub_channels()
             .map_err(|e| anyhow!(e.to_string()))?;
 
-        let sub_channel = sub_channels.iter().find(matcher);
-        Ok(sub_channel.cloned())
+        Ok(dlc_channels)
     }
 
     #[cfg(test)]

--- a/crates/ln-dlc-node/src/node/dlc_channel.rs
+++ b/crates/ln-dlc-node/src/node/dlc_channel.rs
@@ -1,8 +1,4 @@
-use crate::node::DlcManager;
 use crate::node::Node;
-use crate::node::SubChannelManager;
-use crate::DlcMessageHandler;
-use crate::PeerManager;
 use anyhow::anyhow;
 use anyhow::Result;
 use bitcoin::secp256k1::PublicKey;
@@ -163,11 +159,12 @@ impl Node {
         Ok(sub_channel.cloned())
     }
 
+    #[cfg(test)]
     pub fn process_incoming_messages(&self) -> Result<()> {
-        let dlc_message_handler: &DlcMessageHandler = &self.dlc_message_handler;
-        let dlc_manager: &DlcManager = &self.dlc_manager;
-        let sub_channel_manager: &SubChannelManager = &self.sub_channel_manager;
-        let peer_manager: &PeerManager = &self.peer_manager;
+        let dlc_message_handler = &self.dlc_message_handler;
+        let dlc_manager = &self.dlc_manager;
+        let sub_channel_manager = &self.sub_channel_manager;
+        let peer_manager = &self.peer_manager;
         let messages = dlc_message_handler.get_and_clear_received_messages();
 
         for (node_id, msg) in messages {

--- a/crates/ln-dlc-node/src/node/dlc_channel.rs
+++ b/crates/ln-dlc-node/src/node/dlc_channel.rs
@@ -164,20 +164,10 @@ impl Node {
     }
 
     pub fn process_incoming_messages(&self) -> Result<()> {
-        Node::process_incoming_messages_internal(
-            &self.dlc_message_handler,
-            &self.dlc_manager,
-            &self.sub_channel_manager,
-            &self.peer_manager,
-        )
-    }
-
-    pub(crate) fn process_incoming_messages_internal(
-        dlc_message_handler: &DlcMessageHandler,
-        dlc_manager: &DlcManager,
-        sub_channel_manager: &SubChannelManager,
-        peer_manager: &PeerManager,
-    ) -> Result<()> {
+        let dlc_message_handler: &DlcMessageHandler = &self.dlc_message_handler;
+        let dlc_manager: &DlcManager = &self.dlc_manager;
+        let sub_channel_manager: &SubChannelManager = &self.sub_channel_manager;
+        let peer_manager: &PeerManager = &self.peer_manager;
         let messages = dlc_message_handler.get_and_clear_received_messages();
 
         for (node_id, msg) in messages {
@@ -215,8 +205,9 @@ impl Node {
             }
         }
 
-        // NOTE: According to the docs of `process_events` we shouldn't have to call this since we
-        // use `lightning-net-tokio`. But we copied this from `p2pderivatives/ldk-sample`
+        // NOTE: According to the docs of `process_events` we shouldn't have to call this since
+        // we use `lightning-net-tokio`. But we copied this from
+        // `p2pderivatives/ldk-sample`
         if dlc_message_handler.has_pending_messages() {
             peer_manager.process_events();
         }


### PR DESCRIPTION
Can be useful for debugging, as it is sometimes hard to figure out the state of a DLC channel by looking at the logs (or the UI 😛).