### PR TITLE
chore: Disable tls on test setup

### DIFF
--- a/faucet/default.conf
+++ b/faucet/default.conf
@@ -60,7 +60,7 @@ server {
       }
 
     location /lnd/ {
-        proxy_pass https://10.5.0.6:18080/;
+        proxy_pass http://10.5.0.6:18080/;
         proxy_http_version  1.1;
         proxy_cache_bypass  $http_upgrade;
 

--- a/faucet/lnd.conf
+++ b/faucet/lnd.conf
@@ -13,9 +13,10 @@ restlisten=10.5.0.6:18080
 
 ; Add `lnd` domain for TLS certificate to allow RPC connections from other
 ; containers.
-tlscertpath=~/.lnd/tls.cert
-tlskeypath=~/.lnd/tls.key
-tlsextradomain=lnd
+;tlscertpath=~/.lnd/tls.cert
+;tlskeypath=~/.lnd/tls.key
+;tlsextraip=35.189.57.114
+no-rest-tls=true
 
 ; Disable macaroon authentication. Macaroons are used as bearer credentials to
 ; authenticate all RPC access. If one wishes to opt out of macaroons, uncomment


### PR DESCRIPTION
Note, this communication is anyways only routed internally through the nginx proxy.

This is also in alignment to be useable for the testnet vm setup. The configuration is used there as well.