### PR TITLE
Harmonize order state handling

### DIFF
--- a/mobile/native/src/trade/order/api.rs
+++ b/mobile/native/src/trade/order/api.rs
@@ -102,9 +102,9 @@ impl From<order::OrderState> for OrderState {
             order::OrderState::Initial => unimplemented!(
                 "don't expose orders that were not submitted into the orderbook to the frontend!"
             ),
-            order::OrderState::Rejected => unimplemented!(
-                "don't expose orders that were rejected by the orderbook to the frontend!"
-            ),
+            // TODO: At the moment the UI does not depict Rejected, we map it to Failed; for better
+            // feedback we should change that eventually
+            order::OrderState::Rejected => OrderState::Failed,
             // We don't expose this state, but treat it as Open in the UI
             order::OrderState::Filling { .. } => OrderState::Open,
         }

--- a/mobile/native/src/trade/order/handler.rs
+++ b/mobile/native/src/trade/order/handler.rs
@@ -27,16 +27,11 @@ pub async fn submit_order(order: Order) -> Result<()> {
     if let Err(err) = orderbook_client.post_new_order(order.into()).await {
         let order_id = order.id.to_string();
         tracing::error!(order_id, "Failed to post new order. Error: {err:#}");
-        db::update_order_state(order.id, OrderState::Rejected)?;
+        update_order_state(order.id, OrderState::Rejected)?;
         bail!("Could not post order to orderbook");
     }
-    db::update_order_state(order.id, OrderState::Open)?;
 
-    let order = Order {
-        state: OrderState::Open,
-        ..order
-    };
-    ui_update(order);
+    update_order_state(order.id, OrderState::Open)?;
 
     Ok(())
 }


### PR DESCRIPTION
Just some minor cleanup

Harmonize how the order state is updated.
Initially we opted for not exposing `Rejected` because we would exit with an error in the order submission dialog; however, it is not guaranteed that the user will see this error. To keep things simple we map the internal `Rejected` state to `Failed` in the user interface, and update the order accordingly. This guarantees that the user will know that the order failed.