### PR TITLE
fix: Add arbitrary loads permission

### DIFF
--- a/mobile/ios/Runner/Info.plist
+++ b/mobile/ios/Runner/Info.plist
@@ -54,5 +54,7 @@
             <key>NSAllowsArbitraryLoads</key>
             <true/>
         </dict>
+        <key>ITSAppUsesNonExemptEncryption</key>
+        <false/>
 	</dict>
 </plist>

--- a/mobile/ios/Runner/Info.plist
+++ b/mobile/ios/Runner/Info.plist
@@ -49,5 +49,10 @@
 		<true/>
 		<key>UIStatusBarHidden</key>
 		<false/>
+        <key>NSAppTransportSecurity</key>
+            <dict>
+            <key>NSAllowsArbitraryLoads</key>
+            <true/>
+        </dict>
 	</dict>
 </plist>


### PR DESCRIPTION
I guess that will resolve https://github.com/get10101/10101/issues/298 as we need to call the coordinator api to create an invoice.

Unfortunately this can only be tested on a release version on TestFlight, as I presume flutter is adding that permission for a test build automatically.

Note, we had the same permission set on our PoC.