### PR TITLE
chore: Add internet permission for android

### DIFF
--- a/mobile/android/app/src/main/AndroidManifest.xml
+++ b/mobile/android/app/src/main/AndroidManifest.xml
@@ -1,5 +1,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="finance.get10101.app">
+
+    <uses-permission android:name="android.permission.INTERNET" />
+
    <application
         android:label="10101"
         android:name="${applicationName}"


### PR DESCRIPTION
This permission is required to be able to access the internet from the 10101 app.

Note, that this permission is already added on the debug `AndroidManifest.xml`. Also this permission was also set on PoC.