### PR TITLE
chore: Use same price for pnl and collab settlement

### DIFF
--- a/coordinator/src/node.rs
+++ b/coordinator/src/node.rs
@@ -32,14 +32,7 @@ use trade::cfd::BTCUSD_MAX_PRICE;
 use trade::Direction;
 
 /// The leverage used by the coordinator for all trades.
-///
-/// TODO: In case of leverage 1.0 the liquidation will be set to
-/// 21_000_000. I guess this will result in issues when the overall
-/// upper boundary is smaller than that. It looks like the payout
-/// function will never finish in that case. Setting this value
-/// temporarily to 2.0 so that the liquidation price is below that
-/// total upper boundary.
-const COORDINATOR_LEVERAGE: f64 = 2.0;
+const COORDINATOR_LEVERAGE: f64 = 1.0;
 
 pub struct Node {
     pub inner: Arc<ln_dlc_node::node::Node>,

--- a/coordinator/src/node.rs
+++ b/coordinator/src/node.rs
@@ -68,7 +68,7 @@ impl Node {
 
         let contract_descriptor = build_contract_descriptor(
             total_collateral,
-            trade_params.weighted_execution_price(),
+            trade_params.average_execution_price(),
             leverage_long,
             leverage_short,
         )
@@ -129,7 +129,7 @@ impl Node {
         // rebuild the payout function. We must save the initial price
         // when creating the position and use it here again for
         // closing.
-        let initial_price = trade_params.weighted_execution_price();
+        let initial_price = trade_params.average_execution_price();
 
         let payout_function = build_payout_function(
             total_collateral,
@@ -210,7 +210,7 @@ enum TradeAction {
 
 fn margin_trader(trade_params: &TradeParams) -> u64 {
     calculate_margin(
-        trade_params.weighted_execution_price(),
+        trade_params.average_execution_price(),
         trade_params.quantity,
         trade_params.leverage,
     )
@@ -218,7 +218,7 @@ fn margin_trader(trade_params: &TradeParams) -> u64 {
 
 fn margin_coordinator(trade_params: &TradeParams) -> u64 {
     calculate_margin(
-        trade_params.weighted_execution_price(),
+        trade_params.average_execution_price(),
         trade_params.quantity,
         COORDINATOR_LEVERAGE,
     )

--- a/crates/coordintator-commons/src/lib.rs
+++ b/crates/coordintator-commons/src/lib.rs
@@ -44,7 +44,7 @@ pub struct TradeParams {
 }
 
 impl TradeParams {
-    pub fn weighted_execution_price(&self) -> Decimal {
+    pub fn average_execution_price(&self) -> Decimal {
         self.filled_with.average_execution_price()
     }
 }

--- a/crates/trade/src/cfd.rs
+++ b/crates/trade/src/cfd.rs
@@ -1,5 +1,4 @@
 use crate::Direction;
-use crate::Price;
 use anyhow::Context;
 use anyhow::Result;
 use bdk::bitcoin;
@@ -73,7 +72,7 @@ pub fn calculate_short_liquidation_price(leverage: Decimal, price: Decimal) -> D
 /// the total margin available.
 pub fn calculate_pnl(
     opening_price: Decimal,
-    closing_price: Price,
+    closing_price: Decimal,
     quantity: f64,
     long_leverage: f64,
     short_leverage: f64,
@@ -81,11 +80,6 @@ pub fn calculate_pnl(
 ) -> Result<i64> {
     let long_margin = calculate_margin(opening_price, quantity, long_leverage);
     let short_margin = calculate_margin(opening_price, quantity, short_leverage);
-
-    let closing_price = match direction {
-        Direction::Long => closing_price.bid,
-        Direction::Short => closing_price.ask,
-    };
 
     let uncapped_pnl_long = {
         let quantity = Decimal::try_from(quantity).expect("quantity to fit into decimal");
@@ -117,10 +111,7 @@ pub mod tests {
     #[test]
     fn given_position_when_price_same_then_zero_pnl() {
         let opening_price = Decimal::from(20000);
-        let closing_price = Price {
-            bid: Decimal::from(20000),
-            ask: Decimal::from(20000),
-        };
+        let closing_price = Decimal::from(20000);
         let quantity = 1.0;
         let long_leverage = 2.0;
         let short_leverage = 1.0;
@@ -151,11 +142,7 @@ pub mod tests {
     #[test]
     fn given_long_position_when_price_doubles_then_we_get_double() {
         let opening_price = Decimal::from(20000);
-        let closing_price = Price {
-            // 10% up
-            bid: Decimal::from(40000),
-            ask: Decimal::ZERO,
-        };
+        let closing_price = Decimal::from(40000);
         let quantity = 100.0;
         let long_leverage = 2.0;
         let short_leverage = 1.0;
@@ -176,11 +163,7 @@ pub mod tests {
     #[test]
     fn given_long_position_when_price_halfs_then_we_loose_all() {
         let opening_price = Decimal::from(20000);
-        let closing_price = Price {
-            // 10% up
-            bid: Decimal::from(10000),
-            ask: Decimal::ZERO,
-        };
+        let closing_price = Decimal::from(10000);
         let quantity = 100.0;
         let long_leverage = 2.0;
         let short_leverage = 1.0;
@@ -202,11 +185,7 @@ pub mod tests {
     #[test]
     fn given_short_position_when_price_doubles_then_we_loose_all() {
         let opening_price = Decimal::from(20000);
-        let closing_price = Price {
-            // 10% up
-            bid: Decimal::ZERO,
-            ask: Decimal::from(40000),
-        };
+        let closing_price = Decimal::from(40000);
         let quantity = 100.0;
         let long_leverage = 1.0;
         let short_leverage = 2.0;
@@ -227,11 +206,7 @@ pub mod tests {
     #[test]
     fn given_short_position_when_price_halfs_then_we_get_double() {
         let opening_price = Decimal::from(20000);
-        let closing_price = Price {
-            // 10% up
-            bid: Decimal::ZERO,
-            ask: Decimal::from(10000),
-        };
+        let closing_price = Decimal::from(10000);
         let quantity = 100.0;
         let long_leverage = 1.0;
         let short_leverage = 2.0;

--- a/mobile/native/src/calculations/mod.rs
+++ b/mobile/native/src/calculations/mod.rs
@@ -31,6 +31,11 @@ pub fn calculate_pnl(
 
     let opening_price = Decimal::try_from(opening_price).expect("price to fit into decimal");
 
+    let closing_price = match direction {
+        Direction::Long => closing_price.bid,
+        Direction::Short => closing_price.ask,
+    };
+
     cfd::calculate_pnl(
         opening_price,
         closing_price,

--- a/mobile/native/src/trade/position/handler.rs
+++ b/mobile/native/src/trade/position/handler.rs
@@ -34,7 +34,7 @@ pub async fn trade(filled: FilledWith) -> Result<()> {
     };
 
     let execution_price = trade_params
-        .weighted_execution_price()
+        .average_execution_price()
         .to_f64()
         .expect("to fit into f64");
     order::handler::order_filling(order.id, execution_price)


### PR DESCRIPTION
resolves #301 

This uses the pnl calculation to derive the `accept_settlement_amount`. However, since we do not have the opening price at hand, the calculation will still not be correct. For this we need to load the position from the database (which should store the opening price).