### PR TITLE
fix: Compute payout is greater than total collateral

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -825,7 +825,7 @@ dependencies = [
 [[package]]
 name = "dlc"
 version = "0.4.0"
-source = "git+https://github.com/get10101/rust-dlc?rev=ef3fe72c5e0f8930010fb13b6ea5dc3d91457c0f#ef3fe72c5e0f8930010fb13b6ea5dc3d91457c0f"
+source = "git+https://github.com/get10101/rust-dlc?rev=2194d6bce901b85684998bff57d8a2ccd9d35a4c#2194d6bce901b85684998bff57d8a2ccd9d35a4c"
 dependencies = [
  "bitcoin",
  "miniscript",
@@ -837,7 +837,7 @@ dependencies = [
 [[package]]
 name = "dlc-manager"
 version = "0.4.0"
-source = "git+https://github.com/get10101/rust-dlc?rev=ef3fe72c5e0f8930010fb13b6ea5dc3d91457c0f#ef3fe72c5e0f8930010fb13b6ea5dc3d91457c0f"
+source = "git+https://github.com/get10101/rust-dlc?rev=2194d6bce901b85684998bff57d8a2ccd9d35a4c#2194d6bce901b85684998bff57d8a2ccd9d35a4c"
 dependencies = [
  "async-trait",
  "bitcoin",
@@ -853,7 +853,7 @@ dependencies = [
 [[package]]
 name = "dlc-messages"
 version = "0.4.0"
-source = "git+https://github.com/get10101/rust-dlc?rev=ef3fe72c5e0f8930010fb13b6ea5dc3d91457c0f#ef3fe72c5e0f8930010fb13b6ea5dc3d91457c0f"
+source = "git+https://github.com/get10101/rust-dlc?rev=2194d6bce901b85684998bff57d8a2ccd9d35a4c#2194d6bce901b85684998bff57d8a2ccd9d35a4c"
 dependencies = [
  "bitcoin",
  "dlc",
@@ -865,7 +865,7 @@ dependencies = [
 [[package]]
 name = "dlc-sled-storage-provider"
 version = "0.1.0"
-source = "git+https://github.com/get10101/rust-dlc?rev=ef3fe72c5e0f8930010fb13b6ea5dc3d91457c0f#ef3fe72c5e0f8930010fb13b6ea5dc3d91457c0f"
+source = "git+https://github.com/get10101/rust-dlc?rev=2194d6bce901b85684998bff57d8a2ccd9d35a4c#2194d6bce901b85684998bff57d8a2ccd9d35a4c"
 dependencies = [
  "bitcoin",
  "dlc-manager",
@@ -878,7 +878,7 @@ dependencies = [
 [[package]]
 name = "dlc-trie"
 version = "0.4.0"
-source = "git+https://github.com/get10101/rust-dlc?rev=ef3fe72c5e0f8930010fb13b6ea5dc3d91457c0f#ef3fe72c5e0f8930010fb13b6ea5dc3d91457c0f"
+source = "git+https://github.com/get10101/rust-dlc?rev=2194d6bce901b85684998bff57d8a2ccd9d35a4c#2194d6bce901b85684998bff57d8a2ccd9d35a4c"
 dependencies = [
  "bitcoin",
  "dlc",
@@ -1987,7 +1987,7 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 [[package]]
 name = "p2pd-oracle-client"
 version = "0.1.0"
-source = "git+https://github.com/get10101/rust-dlc?rev=ef3fe72c5e0f8930010fb13b6ea5dc3d91457c0f#ef3fe72c5e0f8930010fb13b6ea5dc3d91457c0f"
+source = "git+https://github.com/get10101/rust-dlc?rev=2194d6bce901b85684998bff57d8a2ccd9d35a4c#2194d6bce901b85684998bff57d8a2ccd9d35a4c"
 dependencies = [
  "chrono",
  "dlc-manager",
@@ -2650,7 +2650,7 @@ dependencies = [
 [[package]]
 name = "simple-wallet"
 version = "0.1.0"
-source = "git+https://github.com/get10101/rust-dlc?rev=ef3fe72c5e0f8930010fb13b6ea5dc3d91457c0f#ef3fe72c5e0f8930010fb13b6ea5dc3d91457c0f"
+source = "git+https://github.com/get10101/rust-dlc?rev=2194d6bce901b85684998bff57d8a2ccd9d35a4c#2194d6bce901b85684998bff57d8a2ccd9d35a4c"
 dependencies = [
  "bitcoin",
  "dlc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,13 +3,13 @@ members = ["coordinator", "maker", "mobile/native/", "crates/*"]
 resolver = "2"
 
 [patch.crates-io]
-dlc-manager = { git = "https://github.com/get10101/rust-dlc", rev = "ef3fe72c5e0f8930010fb13b6ea5dc3d91457c0f" }
-dlc-messages = { git = "https://github.com/get10101/rust-dlc", rev = "ef3fe72c5e0f8930010fb13b6ea5dc3d91457c0f" }
-dlc = { git = "https://github.com/get10101/rust-dlc", rev = "ef3fe72c5e0f8930010fb13b6ea5dc3d91457c0f" }
-dlc-sled-storage-provider = { git = "https://github.com/get10101/rust-dlc", rev = "ef3fe72c5e0f8930010fb13b6ea5dc3d91457c0f" }
-p2pd-oracle-client = { git = "https://github.com/get10101/rust-dlc", rev = "ef3fe72c5e0f8930010fb13b6ea5dc3d91457c0f" }
-dlc-trie = { git = "https://github.com/get10101/rust-dlc", rev = "ef3fe72c5e0f8930010fb13b6ea5dc3d91457c0f" }
-simple-wallet = { git = "https://github.com/get10101/rust-dlc", rev = "ef3fe72c5e0f8930010fb13b6ea5dc3d91457c0f" }
+dlc-manager = { git = "https://github.com/get10101/rust-dlc", rev = "2194d6bce901b85684998bff57d8a2ccd9d35a4c" }
+dlc-messages = { git = "https://github.com/get10101/rust-dlc", rev = "2194d6bce901b85684998bff57d8a2ccd9d35a4c" }
+dlc = { git = "https://github.com/get10101/rust-dlc", rev = "2194d6bce901b85684998bff57d8a2ccd9d35a4c" }
+dlc-sled-storage-provider = { git = "https://github.com/get10101/rust-dlc", rev = "2194d6bce901b85684998bff57d8a2ccd9d35a4c" }
+p2pd-oracle-client = { git = "https://github.com/get10101/rust-dlc", rev = "2194d6bce901b85684998bff57d8a2ccd9d35a4c" }
+dlc-trie = { git = "https://github.com/get10101/rust-dlc", rev = "2194d6bce901b85684998bff57d8a2ccd9d35a4c" }
+simple-wallet = { git = "https://github.com/get10101/rust-dlc", rev = "2194d6bce901b85684998bff57d8a2ccd9d35a4c" }
 lightning = { git = "https://github.com/p2pderivatives/rust-lightning/", rev = "dff302382d04700f23d79fb3275c1798d775fef6" }
 lightning-background-processor = { git = "https://github.com/p2pderivatives/rust-lightning/", rev = "dff302382d04700f23d79fb3275c1798d775fef6" }
 lightning-block-sync = { git = "https://github.com/p2pderivatives/rust-lightning/", rev = "dff302382d04700f23d79fb3275c1798d775fef6" }


### PR DESCRIPTION
Resolves #289. 
Resolves #306.

The `rust-dlc` [branch](https://github.com/p2pderivatives/rust-dlc/pull/97) that we depend on has already been rebased onto `master`, so we can fix the bug like this.
