### PR TITLE
chore: Add release workflow for android apk

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -1,0 +1,144 @@
+name: "Create release"
+
+on:
+  pull_request:
+    types:
+      - closed
+
+env:
+  FLUTTER_VERSION: "3.7.7"
+  RUST_VERSION: "1.68.0"
+
+jobs:
+  build:
+    runs-on: macos-latest
+    if: github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'release/')
+    outputs:
+      ANDROID_APK_NAME: ${{ steps.build.outputs.ANDROID_APK_NAME }}
+    steps:
+      - uses: actions/checkout@v2
+
+      # #499, https://github.com/actions/virtual-environments/issues/5595
+      - name: Configure ndk
+        run: |
+          ANDROID_HOME=$HOME/Library/Android/sdk
+          SDKMANAGER=$ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager
+
+          echo y | $SDKMANAGER "ndk;21.4.7075529"
+
+          ln -sfn $ANDROID_HOME/ndk/21.4.7075529 $ANDROID_HOME/ndk-bundle
+
+      - name: Setup | Rust
+        uses: ATiltedTree/setup-rust@v1
+        with:
+          rust-version: ${{ env.RUST_VERSION }}
+          components: rustfmt
+
+      - uses: actions/setup-java@v3
+        with:
+          distribution: "temurin"
+          java-version: "11.x"
+          cache: "gradle"
+
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: "stable"
+          flutter-version: ${{ env.FLUTTER_VERSION }}
+          architecture: x64
+
+      - uses: actions/cache@v3
+        id: cache-deps
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            ./rust/target
+          key: ${{ runner.os }}-cargo-integrate-android-${{ hashFiles('**/Cargo.lock') }}-${{ steps.checkout.outputs.rustc_hash }}
+
+      - name: Install just
+        if: steps.cache-deps.outputs.cache-hit != 'true'
+        run: cargo install just
+
+      - name: Install FFI bindings
+        if: steps.cache-deps.outputs.cache-hit != 'true'
+        run: just deps-gen
+
+      - name: Generate FFI bindings
+        run: just gen
+
+      - name: Add Rust targets
+        run: rustup target add armv7-linux-androideabi aarch64-linux-android
+
+      - name: Install `cargo-ndk`
+        if: steps.cache-deps.outputs.cache-hit != 'true'
+        run: cargo install cargo-ndk --force
+
+      - name: Build Rust lib
+        working-directory: ./mobile/native
+        run: cargo ndk -o ../android/app/src/main/jniLibs build
+
+      - name: Parse version from pubspec.yaml
+        id: version
+        uses: jbutcher5/read-yaml@1.6
+        with:
+          file: "mobile/pubspec.yaml"
+          key-path: '["version"]'
+
+      - name: Build Android APK release
+        id: build
+        run: |
+          mkdir keystore
+          echo $ENCODED_KEYSTORE | base64 -d > keystore/upload-keystore.jks
+          BUILD_NAME=${{ steps.version.outputs.data }}
+          BUILD_NUMBER=$(git rev-list HEAD --count)
+          cd mobile
+          flutter build apk --dart-define="ELECTRS_ENDPOINT=${{ env.ELECTRS_ENDPOINT }}" --dart-define="COORDINATOR_P2P_ENDPOINT=${{ env.COORDINATOR_P2P_ENDPOINT }}" --build-name=$BUILD_NAME --build-number=$BUILD_NUMBER --release
+          mv build/app/outputs/flutter-apk/app-release.apk build/app/outputs/flutter-apk/get10101-$BUILD_NAME.apk
+          echo "ANDROID_APK_NAME=$(echo get10101-$BUILD_NAME.apk)" >> $GITHUB_OUTPUT
+        env:
+          SIGNING_KEY_ALIAS: ${{ secrets.ANDROID_UPLOAD_SIGNING_KEY_ALIAS }}
+          SIGNING_KEY_PASSWORD: ${{ secrets.ANDROID_UPLOAD_SIGNING_KEY_PASSWORD }}
+          SIGNING_STORE_PASSWORD: ${{ secrets.ANDROID_UPLOAD_SIGNING_STORE_PASSWORD }}
+          ENCODED_KEYSTORE: ${{ secrets.ANDROID_UPLOAD_KEYSTORE }}
+
+      - name: Upload APK to job
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{steps.build.outputs.ANDROID_APK_NAME}}
+          path: mobile/build/app/outputs/flutter-apk/${{steps.build.outputs.ANDROID_APK_NAME}}
+
+  release:
+    needs: build
+    if: github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'release/')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Extract version from branch name
+        id: extract-version
+        shell: python
+        run: |
+          branch_name = "${{ github.event.pull_request.head.ref }}"
+          version = branch_name.split("/")[1]
+
+          print(f"::set-output name=version::{version}")
+
+      - name: Extract changelog section for release
+        id: changelog
+        uses: coditory/changelog-parser@v1
+        with:
+          version: ${{ steps.extract-version.outputs.version }}
+
+      - uses: actions/download-artifact@v3
+        with:
+          name: ${{ needs.build.outputs.ANDROID_APK_NAME }}
+
+      - name: Create release
+        uses: ncipollo/release-action@v1
+        with:
+          artifacts: ${{ needs.build.outputs.ANDROID_APK_NAME }}
+          body: ${{ steps.changelog.outputs.description }}
+          token: ${{ secrets.GH_ACTION_TOKEN }}
+          tag: ${{ steps.extract-version.outputs.version }}

--- a/.github/workflows/draft_new_release.yml
+++ b/.github/workflows/draft_new_release.yml
@@ -1,0 +1,77 @@
+name: "Draft new release"
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "The new version in X.Y.Z format."
+        required: true
+
+jobs:
+  draft-new-release:
+    name: "Draft a new release"
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    env:
+      RELEASE_BRANCH: release/${{ github.event.inputs.version }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.GH_ACTION_TOKEN }}
+
+      - name: Create release branch
+        run: git checkout -b ${{ env.RELEASE_BRANCH }}
+
+      - name: Initialize mandatory git config
+        run: |
+          git config user.name "${{ secrets.GET10101_NAME }}"
+          git config user.email ${{ secrets.GET10101_EMAIL }}
+
+      - name: Update changelog
+        uses: thomaseizinger/keep-a-changelog-new-release@v1
+        with:
+          version: ${{ github.event.inputs.version }}
+
+      - name: Bump pubspec version
+        uses: fjogeleit/yaml-update-action@v0.12.2
+        with:
+          valueFile: "mobile/pubspec.yaml"
+          propertyPath: "version"
+          value: ${{ github.event.inputs.version }}
+          commitChange: false
+          updateFile: true
+
+      - name: Commit changelog and manifest files
+        id: make-commit
+        run: |
+          curl -fsSL https://dprint.dev/install.sh | sh
+          /home/runner/.dprint/bin/dprint fmt
+
+          git add CHANGELOG.md mobile/pubspec.yaml
+          git commit --message "Prepare release ${{ github.event.inputs.version }}"
+
+          echo "::set-output name=commit::$(git rev-parse HEAD)"
+
+      - name: Create pull request
+        run: |
+          # Force push to allow for easier re-runs of the action
+          git push origin ${{ env.RELEASE_BRANCH }} --force
+          # Use heredoc to define multiline string: https://stackoverflow.com/a/23930212/2489334
+          BODY=$(cat <<-EOF
+          Hi @${{ github.actor }}!
+          This PR was created in response to a manual trigger of the release workflow here: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}.
+          I've bumped the versions in the manifest files in this commit: ${{ steps.make-commit.outputs.commit }}.
+          Merging this PR will create a GitHub release!
+          EOF
+          )
+          gh pr create \
+            --reviewer ${{ github.actor }} \
+            --title "Release version ${{ github.event.inputs.version }}" \
+            --head ${{ env.RELEASE_BRANCH }} \
+            --body "$BODY"
+        env:
+          # Using a bot account is important to trigger subsequent workflows.
+          # See https://devopsdirective.com/posts/2020/07/stupid-github-actions/#2----recursive-action.
+          GITHUB_TOKEN: ${{ secrets.GH_ACTION_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- add mobile app project template from https://cjycode.com/flutter_rust_bridge/template.html
-
-[Unreleased]: https://github.com/itchysats/10101/compare/ea1aacbc2ee9398d3da405d024e31e937dce4a62...HEAD
+- Self-Custodial CFD Trading based on DLC and lightning


### PR DESCRIPTION
Mostly copied from our poc workflow and adapted to the new folder structure, just and required versions.

Note, it seems the cache is not really working. Should be looked at in a follow up PR.

Tested on my fork: https://github.com/holzeis/10101/releases/tag/0.0.1