### PR TITLE
fix: Failed to create just in time channel due to disconnected peer

### DIFF
--- a/crates/ln-dlc-node/src/dlc_custom_signer.rs
+++ b/crates/ln-dlc-node/src/dlc_custom_signer.rs
@@ -1,6 +1,8 @@
 //! This file has temporarily been copied from `https://github.com/p2pderivatives/rust-dlc/pull/97`.
 //! We should reimplement some of these traits for production.
 
+use anyhow::anyhow;
+use anyhow::Result;
 use bitcoin::Script;
 use bitcoin::Transaction;
 use bitcoin::TxOut;
@@ -283,14 +285,16 @@ impl CustomKeysManager {
         change_destination_script: Script,
         feerate_sat_per_1000_weight: u32,
         secp_ctx: &Secp256k1<C>,
-    ) -> Result<Transaction, ()> {
-        self.keys_manager.spend_spendable_outputs(
-            descriptors,
-            outputs,
-            change_destination_script,
-            feerate_sat_per_1000_weight,
-            secp_ctx,
-        )
+    ) -> Result<Transaction> {
+        self.keys_manager
+            .spend_spendable_outputs(
+                descriptors,
+                outputs,
+                change_destination_script,
+                feerate_sat_per_1000_weight,
+                secp_ctx,
+            )
+            .map_err(|_| anyhow!("Could not spend spendable outputs"))
     }
 }
 

--- a/crates/ln-dlc-node/src/lib.rs
+++ b/crates/ln-dlc-node/src/lib.rs
@@ -98,5 +98,5 @@ struct PaymentInfo {
     timestamp: OffsetDateTime,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 struct MillisatAmount(Option<u64>);

--- a/crates/ln-dlc-node/src/ln/event_handler.rs
+++ b/crates/ln-dlc-node/src/ln/event_handler.rs
@@ -13,9 +13,6 @@ use crate::PaymentInfoStorage;
 use crate::PendingInterceptedHtlcs;
 use anyhow::anyhow;
 use bitcoin::secp256k1::Secp256k1;
-use bitcoin::Network;
-use bitcoin_bech32::WitnessProgram;
-use dlc_manager::Blockchain;
 use lightning::chain::chaininterface::BroadcasterInterface;
 use lightning::chain::chaininterface::ConfirmationTarget;
 use lightning::chain::chaininterface::FeeEstimator;
@@ -78,24 +75,6 @@ impl EventHandler {
                 output_script,
                 ..
             } => {
-                let network = self
-                    .wallet
-                    .get_network()
-                    .expect("Failed to get bitcoin network");
-
-                let network = match network {
-                    Network::Regtest => bitcoin_bech32::constants::Network::Regtest,
-                    Network::Signet => bitcoin_bech32::constants::Network::Signet,
-                    Network::Testnet => bitcoin_bech32::constants::Network::Testnet,
-                    Network::Bitcoin => bitcoin_bech32::constants::Network::Bitcoin,
-                };
-
-                // Construct the raw transaction with one output, that is paid the amount of the
-                // channel.
-                let _addr = WitnessProgram::from_scriptpubkey(&output_script[..], network)
-                    .expect("Lightning funding tx should always be to a SegWit output")
-                    .to_address();
-
                 let target_blocks = 2;
 
                 // Have wallet put the inputs into the transaction such that the output

--- a/crates/ln-dlc-node/src/tests/just_in_time_channel.rs
+++ b/crates/ln-dlc-node/src/tests/just_in_time_channel.rs
@@ -68,14 +68,6 @@ async fn just_in_time_channel() {
     // than the payee's
     // `max_inbound_htlc_value_in_flight_percent_of_channel`
     // configuration value for said channel.
-    //
-    // At this point in time, we fix the channel size to
-    // `JUST_IN_TIME_CHANNEL_OUTBOUND_LIQUIDITY_SAT` (10_000 sats) and
-    // the default value of
-    // `max_inbound_htlc_value_in_flight_percent_of_channel` is set to
-    // 10 percent. This means that we won't succeed in routing the
-    // payment through the just-in-time channel if the amount is
-    // greater than 1_000 sats.
     let invoice_amount = 1_000;
 
     let flat_routing_fee = 1; // according to the default `ChannelConfig`

--- a/crates/ln-dlc-node/src/tests/mod.rs
+++ b/crates/ln-dlc-node/src/tests/mod.rs
@@ -1,6 +1,7 @@
 use crate::ln::app_config;
 use crate::ln::coordinator_config;
 use crate::node::Node;
+use crate::node::NodeInfo;
 use crate::seed::Bip39Seed;
 use crate::util;
 use anyhow::anyhow;
@@ -184,6 +185,10 @@ impl Node {
         .await?;
 
         Ok(channel_details)
+    }
+
+    pub fn disconnect(&self, peer: NodeInfo) {
+        self.peer_manager.disconnect_by_node_id(peer.pubkey, false)
     }
 }
 


### PR DESCRIPTION
The change also includes error handling in case the payment could not be forwarded and sets the HTLC to failed.

resolves #330 