### PR TITLE
Set `lightning::chain` logs to `INFO`

### DIFF
--- a/coordinator/src/logger.rs
+++ b/coordinator/src/logger.rs
@@ -24,7 +24,8 @@ pub fn init_tracing(level: LevelFilter, json_format: bool) -> Result<()> {
         .add_directive("hyper=warn".parse()?)
         .add_directive("rustls=warn".parse()?)
         .add_directive("sled=warn".parse()?)
-        .add_directive("bdk=warn".parse()?); // bdk is quite spamy on debug
+        .add_directive("bdk=warn".parse()?) // bdk is quite spamy on debug
+        .add_directive("lightning::chain=info".parse()?);
 
     // Parse additional log directives from env variable
     let filter = match std::env::var_os(RUST_LOG_ENV).map(|s| s.into_string()) {

--- a/maker/src/logger.rs
+++ b/maker/src/logger.rs
@@ -24,7 +24,8 @@ pub fn init_tracing(level: LevelFilter, json_format: bool) -> Result<()> {
         .add_directive("hyper=warn".parse()?)
         .add_directive("rustls=warn".parse()?)
         .add_directive("sled=warn".parse()?)
-        .add_directive("bdk=warn".parse()?); // bdk is quite spamy on debug
+        .add_directive("bdk=warn".parse()?) // bdk is quite spamy on debug
+        .add_directive("lightning::chain=info".parse()?);
 
     // Parse additional log directives from env variable
     let filter = match std::env::var_os(RUST_LOG_ENV).map(|s| s.into_string()) {

--- a/mobile/native/src/logger.rs
+++ b/mobile/native/src/logger.rs
@@ -27,7 +27,8 @@ pub fn log_base_directives(env: EnvFilter, level: LevelFilter) -> Result<EnvFilt
         .add_directive("rustls=warn".parse()?)
         // set to debug to show ldk logs (they're also in logs.txt)
         .add_directive("sled=warn".parse()?)
-        .add_directive("bdk=warn".parse()?); // bdk is quite spamy on debug
+        .add_directive("bdk=warn".parse()?) // bdk is quite spamy on debug
+        .add_directive("lightning::chain=info".parse()?);
     Ok(filter)
 }
 


### PR DESCRIPTION
On `DEBUG` we don't appear to learn anything that important and they represent the vast majority of the logs.