### PR TITLE
Downgrade log message when receiving list of all orders

### DIFF
--- a/mobile/native/src/orderbook.rs
+++ b/mobile/native/src/orderbook.rs
@@ -71,7 +71,7 @@ pub fn subscribe(secret_key: SecretKey) -> Result<()> {
                             },
                             OrderbookMsg::AllOrders(initial_orders) => {
                                 if !orders.is_empty() {
-                                    tracing::warn!("Received all orders from orderbook, but we already have some orders. This should not happen");
+                                    tracing::debug!("Received new set of initial orders from orderbook, replacing the previously stored orders");
                                 }
                                 else {
                                     tracing::debug!(?orders, "Received all orders from orderbook");


### PR DESCRIPTION
This would have come if the websocket stream got broken & reestablished.

After we get this message we swap all orders we had previously with new list of initial orders - and then proceed to accumulate deltas.

Closes #323 