### PR TITLE
chore: orderbook returns an error if no match

### DIFF
--- a/coordinator/src/lib.rs
+++ b/coordinator/src/lib.rs
@@ -25,6 +25,7 @@ pub fn run_migration(conn: &mut PgConnection) {
 pub enum AppError {
     InternalServerError(String),
     BadRequest(String),
+    NoMatchFound(String),
 }
 
 impl IntoResponse for AppError {
@@ -32,6 +33,7 @@ impl IntoResponse for AppError {
         let (status, error_message) = match self {
             AppError::InternalServerError(msg) => (StatusCode::INTERNAL_SERVER_ERROR, msg),
             AppError::BadRequest(msg) => (StatusCode::BAD_REQUEST, msg),
+            AppError::NoMatchFound(msg) => (StatusCode::SERVICE_UNAVAILABLE, msg),
         };
 
         let body = Json(json!({


### PR DESCRIPTION
An order which cannot be matched right now should transition into a failed state for now. While in the future we want to be able to notify the trader later on once there is enough liquidity.

This will prevent us from having stale orders in the frontend. 