### PR TITLE
Expose Electrum blockchain in LnDlcWallet

### DIFF
--- a/crates/bdk-ldk/src/lib.rs
+++ b/crates/bdk-ldk/src/lib.rs
@@ -24,6 +24,7 @@ use lightning::chain::Confirm;
 use lightning::chain::Filter;
 use lightning::chain::WatchedOutput;
 use std::collections::HashMap;
+use std::sync::Arc;
 use std::sync::Mutex;
 use std::sync::MutexGuard;
 
@@ -75,7 +76,7 @@ impl Default for TxFilter {
 /// needed to use lightning with LDK.  Note: The bdk::Blockchain you use
 /// must implement the IndexedChain trait.
 pub struct LightningWallet<B, D> {
-    client: Box<B>,
+    client: Arc<B>,
     wallet: Mutex<Wallet<D>>,
     filter: Mutex<TxFilter>,
 }
@@ -86,7 +87,7 @@ where
     D: BatchDatabase,
 {
     /// create a new lightning wallet from your bdk wallet
-    pub fn new(client: Box<B>, wallet: Wallet<D>) -> Self {
+    pub fn new(client: Arc<B>, wallet: Wallet<D>) -> Self {
         LightningWallet {
             client,
             wallet: Mutex::new(wallet),

--- a/crates/bdk-ldk/tests/electrum.rs
+++ b/crates/bdk-ldk/tests/electrum.rs
@@ -3,6 +3,7 @@ use bdk::blockchain::ElectrumBlockchain;
 use bdk::database::MemoryDatabase;
 use bdk::electrum_client::Client;
 use bdk_ldk::LightningWallet;
+use std::sync::Arc;
 
 #[test]
 fn can_init_sample_electrum_lightning_wallet() {
@@ -15,5 +16,5 @@ fn can_init_sample_electrum_lightning_wallet() {
         MemoryDatabase::default(),
     ).unwrap();
 
-    let _lightning = LightningWallet::new(Box::new(blockchain), wallet);
+    let _lightning = LightningWallet::new(Arc::new(blockchain), wallet);
 }

--- a/crates/ln-dlc-node/src/node/mod.rs
+++ b/crates/ln-dlc-node/src/node/mod.rs
@@ -218,7 +218,7 @@ impl Node {
             let blockchain_client =
                 ElectrumBlockchain::from(bdk::electrum_client::Client::new(&electrs_origin)?);
             Arc::new(LnDlcWallet::new(
-                Box::new(blockchain_client),
+                Arc::new(blockchain_client),
                 on_chain_wallet.inner,
                 storage.clone(),
             ))


### PR DESCRIPTION
At times, we need to query Electrum; having it exposed is much more convenient instead of exposing the API part by part.