### PR TITLE
Print `ln-dlc-node` slow tests logs by default on CI

### DIFF
--- a/.github/workflows/tests-ln-dlc-node.yml
+++ b/.github/workflows/tests-ln-dlc-node.yml
@@ -47,7 +47,7 @@ jobs:
         run: |
           curl -d '{"address":"bcrt1qylgu6ffkp3p0m8tw8kp4tt2dmdh755f4r5dq7s", "amount":"0.1"}' -H "Content-Type: application/json" -X POST http://localhost:3000/faucet
       - name: Run slow tests
-        run: cargo test -p ln-dlc-node -- --ignored
+        run: cargo test -p ln-dlc-node -- --ignored --nocapture
 
   tests-ln-dlc-node:
     runs-on: ubuntu-latest


### PR DESCRIPTION
To see what's happening if they hang forever for some reason.