### PR TITLE
Watch LN channels using original funding TXO

### DIFF
--- a/crates/ln-dlc-node/src/node/channel_manager.rs
+++ b/crates/ln-dlc-node/src/node/channel_manager.rs
@@ -120,7 +120,14 @@ pub(crate) fn build(
     // Give ChannelMonitors to ChainMonitor to watch
     for confirmable_monitor in confirmable_monitors.drain(..) {
         let channel_monitor = confirmable_monitor.0;
-        let funding_txo = channel_monitor.get_funding_txo().0;
+
+        // ATTENTION: This must be `get_original_funding_txo` and _not_ `get_funding_txo`, because
+        // we are using LN-DLC channels. `rust-dlc` is manipulating the funding TXO so that LDK
+        // considers the `glue_transaction` as the `funding_transaction` for certain purposes.
+        //
+        // For other purposes, LDK must still refer back to the original `funding_transaction`. This
+        // is one such case.
+        let funding_txo = channel_monitor.get_original_funding_txo().0;
         assert_eq!(
             chain_monitor.watch_channel(funding_txo, channel_monitor),
             ChannelMonitorUpdateStatus::Completed


### PR DESCRIPTION
Fixes #299.
Fixes #308.

With the introduction of `rust-dlc` LN-DLC channels, `rust-lightning` was forked to introduce some minor changes. Among those, `rust-lightning` must now be able to consider the `glue_transaction` as the actual funding transaction in certain scenarios, whilst still considering the _original_ `funding_transaction` as the funding transaction for other scenarios.

One scenario where `rust-lightning` still expects the original `funding_transaction` is when setting up the `ChainMonitor` to watch channels on startup.

Our code was partially ported from `10101-poc`, where we did not use LN-DLC channels provided by `rust-dlc`. As such, we kept a version of the `ChainMonitor` setup which still called `get_funding_txo`, even though we are now expected to call `get_original_funding_txo` there. The correct setup was already exemplified [here](https://github.com/p2pderivatives/ldk-sample/blob/fc8bac24a66c9a8fcf817b9c2f76780b89480d5d/src/main.rs#L561), but we missed this detail.

---

As you can see this PR does not include a test, which is a shame. @holzeis and I were able to reproduce the issues listed above and subsequently verify that this code change fixes them.

We weren't able to write a Rust `ln-dlc-node` test with a `Node` restart because it's [seemingly impossible to open a `sled` DB soon after dropping it](https://github.com/spacejam/sled/issues/1234#issuecomment-754769425). Instead we modified some test utils and wrote a _couple_ of tests which shared state between them. Here's the patch for posterity: https://github.com/get10101/10101/commit/9f46fcd8e558a9e2716efea48765d2f953b93b98.