### PR TITLE
Fix/forward payment on existing channel

### DIFF
--- a/crates/ln-dlc-node/src/tests/just_in_time_channel/mod.rs
+++ b/crates/ln-dlc-node/src/tests/just_in_time_channel/mod.rs
@@ -1,0 +1,2 @@
+mod create;
+mod multiple_payments;

--- a/crates/ln-dlc-node/src/tests/just_in_time_channel/multiple_payments.rs
+++ b/crates/ln-dlc-node/src/tests/just_in_time_channel/multiple_payments.rs
@@ -1,0 +1,71 @@
+use crate::ln::JUST_IN_TIME_CHANNEL_OUTBOUND_LIQUIDITY_SAT;
+use crate::node::Node;
+use crate::tests::init_tracing;
+use crate::tests::just_in_time_channel::create::send_interceptable_payment;
+use crate::tests::min_outbound_liquidity_channel_creator;
+use bitcoin::Amount;
+
+#[tokio::test]
+#[ignore]
+async fn just_in_time_channel_with_multiple_payments() {
+    init_tracing();
+
+    // Arrange
+
+    let user_a = Node::start_test_app("user_a").await.unwrap();
+    let coordinator = Node::start_test_coordinator("coordinator").await.unwrap();
+    let user_b = Node::start_test_app("user_b").await.unwrap();
+
+    user_a.connect_to_peer(coordinator.info).await.unwrap();
+    user_b.connect_to_peer(coordinator.info).await.unwrap();
+
+    coordinator.fund(Amount::from_sat(100_000)).await.unwrap();
+
+    let payer_outbound_liquidity_sat = 25_000;
+    let coordinator_outbound_liquidity_sat =
+        min_outbound_liquidity_channel_creator(&user_a, payer_outbound_liquidity_sat);
+
+    coordinator
+        .open_channel(
+            &user_a,
+            coordinator_outbound_liquidity_sat,
+            payer_outbound_liquidity_sat,
+        )
+        .await
+        .unwrap();
+
+    // this creates the just in time channel between the coordinator and user_b
+    send_interceptable_payment(
+        &user_a,
+        &user_b,
+        &coordinator,
+        5_000,
+        Some(JUST_IN_TIME_CHANNEL_OUTBOUND_LIQUIDITY_SAT),
+    )
+    .await
+    .unwrap();
+
+    // after creating the just-in-time channel. The coordinator should have exactly 2 channels.
+    assert_eq!(coordinator.channel_manager.list_channels().len(), 2);
+
+    send_interceptable_payment(&user_a, &user_b, &coordinator, 3_000, None)
+        .await
+        .unwrap();
+
+    // no additional just-in-time channel should be created.
+    assert_eq!(coordinator.channel_manager.list_channels().len(), 2);
+
+    send_interceptable_payment(&user_b, &user_a, &coordinator, 4_500, None)
+        .await
+        .unwrap();
+
+    // no additional just-in-time channel should be created.
+    assert_eq!(coordinator.channel_manager.list_channels().len(), 2);
+
+    send_interceptable_payment(&user_a, &user_b, &coordinator, 5_000, None)
+        .await
+        .unwrap();
+
+    // no additional just-in-time channel should be created.
+    assert_eq!(coordinator.channel_manager.list_channels().len(), 2);
+}

--- a/crates/ln-dlc-node/src/tests/mod.rs
+++ b/crates/ln-dlc-node/src/tests/mod.rs
@@ -40,7 +40,6 @@ use std::time::Duration;
 mod bitcoind;
 mod dlc;
 mod just_in_time_channel;
-mod just_in_time_channel_with_multiple_payments;
 mod lnd;
 mod multi_hop_payment;
 mod onboard_from_lnd;

--- a/crates/ln-dlc-node/src/tests/mod.rs
+++ b/crates/ln-dlc-node/src/tests/mod.rs
@@ -40,6 +40,7 @@ use std::time::Duration;
 mod bitcoind;
 mod dlc;
 mod just_in_time_channel;
+mod just_in_time_channel_with_multiple_payments;
 mod lnd;
 mod multi_hop_payment;
 mod onboard_from_lnd;
@@ -54,7 +55,7 @@ fn init_tracing() {
     TRACING_TEST_SUBSCRIBER.call_once(|| {
         tracing_subscriber::fmt()
             .with_env_filter(
-                "debug,hyper=warn,reqwest=warn,rustls=warn,bdk=info,ldk=debug,sled=info",
+                "debug,hyper=warn,reqwest=warn,rustls=warn,bdk=info,lightning=trace,sled=info",
             )
             .with_test_writer()
             .init()


### PR DESCRIPTION
fix: Forward payment on channel if existing

The current logic was flawed due to the following reasons.

1. The `requested_next_hop_scid` does not match the `short_channel_id`, is the fake scid generated by the coordinator. Also note, that this fake scid, is always different.
2. Matching on the `short_channel_id` is generally not ideal as the `short_channel_id` is only set after the channel has sufficient confirmations.

The fix matches on the `target_node_id` instead, assuming that we will currently only ever have exactly one channel with the user.

Eventually we should not use interceptable invoices once we have an open channel. However, I decided to stick with only interceptable invoices for now as mixing regular invoices with interceptable invoices seems to be failure prune upon the first invoice(s). e.g. Assume a second invoice is created before the first invoice has been paid.