### PR TITLE
fix: we don't match limit orders

### DIFF
--- a/coordinator/src/orderbook/routes.rs
+++ b/coordinator/src/orderbook/routes.rs
@@ -91,6 +91,7 @@ pub async fn post_order(
         // we only tell everyone about new limit orders
         let sender = state.tx_pricefeed.clone();
         update_pricefeed(OrderbookMsg::NewOrder(order.clone()), sender);
+        return Ok(Json(order));
     }
 
     let all_orders = orders::all_by_direction_and_type(


### PR DESCRIPTION
when posting limit orders we do not expect a match to happen. Hence, we can return early with an Ok.