### PR TITLE
Use `get_offered_sub_channels` after fix in `rust-dlc`

### DIFF
--- a/crates/ln-dlc-node/src/node/dlc_channel.rs
+++ b/crates/ln-dlc-node/src/node/dlc_channel.rs
@@ -116,11 +116,13 @@ impl Node {
     }
 
     pub fn get_dlc_channel_offer(&self, pubkey: &PublicKey) -> Result<Option<SubChannel>> {
-        let matcher = |dlc_channel: &&SubChannel| {
-            dlc_channel.counter_party == *pubkey
-                && matches!(&dlc_channel.state, SubChannelState::Offered(_))
-        };
-        let dlc_channel = self.get_dlc_channel(&matcher)?; // `get_offered_sub_channels` appears to have a bug
+        let dlc_channel = self
+            .dlc_manager
+            .get_store()
+            .get_offered_sub_channels()
+            .map_err(|e| anyhow!(e.to_string()))?
+            .into_iter()
+            .find(|dlc_channel| dlc_channel.counter_party == *pubkey);
 
         Ok(dlc_channel)
     }

--- a/crates/ln-dlc-node/src/tests/dlc/collaborative_settlement.rs
+++ b/crates/ln-dlc-node/src/tests/dlc/collaborative_settlement.rs
@@ -172,13 +172,12 @@ async fn open_dlc_channel_after_closing_dlc_channel() {
         let sub_channels = coordinator
             .dlc_manager
             .get_store()
-            .get_sub_channels() // `get_offered_sub_channels` appears to have a bug
+            .get_offered_sub_channels()
             .map_err(|e| anyhow!(e.to_string()))?;
 
-        let sub_channel = sub_channels.iter().find(|sub_channel| {
-            sub_channel.counter_party == app.info.pubkey
-                && matches!(&sub_channel.state, SubChannelState::Offered(_))
-        });
+        let sub_channel = sub_channels
+            .iter()
+            .find(|sub_channel| sub_channel.counter_party == app.info.pubkey);
 
         Ok(sub_channel.cloned())
     })

--- a/crates/ln-dlc-node/src/tests/dlc/create.rs
+++ b/crates/ln-dlc-node/src/tests/dlc/create.rs
@@ -83,13 +83,12 @@ pub async fn create_dlc_channel(
         let sub_channels = coordinator
             .dlc_manager
             .get_store()
-            .get_sub_channels() // `get_offered_sub_channels` appears to have a bug
+            .get_offered_sub_channels()
             .map_err(|e| anyhow!(e.to_string()))?;
 
-        let sub_channel = sub_channels.iter().find(|sub_channel| {
-            sub_channel.counter_party == app.info.pubkey
-                && matches!(&sub_channel.state, SubChannelState::Offered(_))
-        });
+        let sub_channel = sub_channels
+            .iter()
+            .find(|sub_channel| sub_channel.counter_party == app.info.pubkey);
 
         Ok(sub_channel.cloned())
     })


### PR DESCRIPTION
The bug mentioned in the diff was fixed a while ago. We are now on a version of `rust-dlc` where `get_offered_sub_channels` is safe to call.