### PR TITLE
fix: Reset lnd mission control on send payment

### DIFF
--- a/faucet/faucet.html
+++ b/faucet/faucet.html
@@ -109,8 +109,22 @@
         xhr.send();
       }
 
+      function clearMissionControl() {
+        const xhr = new XMLHttpRequest();
+        xhr.open('post', '/lnd/v2/router/mc/reset', false);
+        xhr.setRequestHeader('Content-Type', 'application/json');
+        xhr.send();
+        if (xhr.status === 200) {
+          console.log("Successfully cleared mission control.");
+        } else {
+          console.warn("Failed to clear mission control.")
+        }
+      }
+
       function sendPayment() {
         const encoded_invoice = document.getElementById("inputInvoice").value;
+
+        clearMissionControl();
 
         const xhr = new XMLHttpRequest();
         xhr.onload = function() {


### PR DESCRIPTION
lnd is keeping a heuristic for routing attempts based on past payment attempts. This information is kept in the mission control and seems to block any subsequent payment to a node that has previously failed. If it is the very first payment that fails I guess this heuristic is even heavier opinionated.

https://docs.lightning.engineering/lightning-network-tools/lnd/payments#mission-control

In order to bypass this mission control, this change simply resets the mission control on every payment. resolves #333 

----

Note, I also tried setting setting the maximum number of payment results held on disk by mission control (`routerrpc.maxmchistory`) to 0, but without success. Other than that I found no meaningful configuration to disable lnds mission control. see also https://github.com/lightningnetwork/lnd/blob/master/sample-lnd.conf