### PR TITLE
Time out `run-tests-ln-dlc-node` job after 30 minutes

### DIFF
--- a/.github/workflows/tests-ln-dlc-node.yml
+++ b/.github/workflows/tests-ln-dlc-node.yml
@@ -31,6 +31,7 @@ jobs:
 
   run-tests-ln-dlc-node:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     needs: changes
     if: ${{ needs.changes.outputs.ln-dlc-node == 'true' }}
     steps:


### PR DESCRIPTION
We have seen these tests hang for hours, which is wasteful and annoying as we don't get feedback fast enough unless we actively check the Actions tab.

Choosing 30 minutes as a timeout seems sensible as no successful run has ever gone over 15 minutes and most of them are much faster than that.

---

Related to #355.