### PR TITLE
chore: Use runner temp variable to execute tests on github actions

### DIFF
--- a/crates/ln-dlc-node/src/tests/mod.rs
+++ b/crates/ln-dlc-node/src/tests/mod.rs
@@ -240,7 +240,12 @@ fn min_outbound_liquidity_channel_creator(peer: &Node, peer_balance: u64) -> u64
 }
 
 fn random_tmp_dir() -> PathBuf {
-    let tmp = temp_dir();
+    let tmp = if let Ok(tmp) = std::env::var("RUNNER_TEMP") {
+        tracing::debug!("Running test on github actions - using temporary directory at {tmp}");
+        PathBuf::from(tmp)
+    } else {
+        temp_dir()
+    };
 
     let rand_string = thread_rng()
         .sample_iter(&Alphanumeric)


### PR DESCRIPTION
This is an attempt to fix stuck tests - #355 

We were able to reproduce the issue by deleting the local temp directory while the test were running. Hence we believe that the issue might be fixed if we are using the official temp directory provided by github actions.