### PR TITLE
fix: the called workflow needs access to our secrets

### DIFF
--- a/.github/workflows/deliverables-push-main.yml
+++ b/.github/workflows/deliverables-push-main.yml
@@ -19,3 +19,4 @@ jobs:
       packages: write
       contents: read
     uses: ./.github/workflows/ios.yml
+    secrets: inherit


### PR DESCRIPTION
Let's try this to fix our testflight pipeline

Taken from: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idsecretsinherit