### PR TITLE
Persist payments in app's DB

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1774,6 +1774,7 @@ name = "native"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "base64 0.21.0",
  "bdk",
  "coordinator-commons",
  "diesel",
@@ -1784,6 +1785,7 @@ dependencies = [
  "hex",
  "itertools",
  "libsqlite3-sys",
+ "lightning",
  "lightning-invoice",
  "ln-dlc-node",
  "openssl",

--- a/coordinator/src/bin/coordinator.rs
+++ b/coordinator/src/bin/coordinator.rs
@@ -9,6 +9,7 @@ use coordinator::run_migration;
 use diesel::r2d2;
 use diesel::r2d2::ConnectionManager;
 use diesel::PgConnection;
+use ln_dlc_node::node::PaymentMap;
 use ln_dlc_node::seed::Bip39Seed;
 use rand::thread_rng;
 use rand::RngCore;
@@ -66,6 +67,7 @@ async fn main() -> Result<()> {
             "coordinator",
             network,
             data_dir.as_path(),
+            PaymentMap::default(),
             address,
             SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), address.port()),
             opts.p2p_announcement_addresses(),

--- a/coordinator/src/node.rs
+++ b/coordinator/src/node.rs
@@ -20,6 +20,7 @@ use dlc_messages::Message;
 use lightning::ln::channelmanager::ChannelDetails;
 use ln_dlc_node::node::sub_channel_message_as_str;
 use ln_dlc_node::node::DlcManager;
+use ln_dlc_node::node::PaymentMap;
 use ln_dlc_node::node::SubChannelManager;
 use ln_dlc_node::PeerManager;
 use rust_decimal::prelude::ToPrimitive;
@@ -39,7 +40,7 @@ use trade::Direction;
 const COORDINATOR_LEVERAGE: f64 = 1.0;
 
 pub struct Node {
-    pub inner: Arc<ln_dlc_node::node::Node>,
+    pub inner: Arc<ln_dlc_node::node::Node<PaymentMap>>,
     pub positions: Mutex<HashMap<String, Position>>,
 }
 

--- a/crates/ln-dlc-node/src/node/connection.rs
+++ b/crates/ln-dlc-node/src/node/connection.rs
@@ -11,7 +11,7 @@ use std::pin::Pin;
 use std::sync::Arc;
 use std::time::Duration;
 
-impl Node {
+impl<P> Node<P> {
     pub async fn connect(&self, peer: NodeInfo) -> Result<Pin<Box<impl Future<Output = ()>>>> {
         #[allow(clippy::async_yields_async)] // We want to poll this future in a loop elsewhere
         let connection_closed_future = tokio::time::timeout(Duration::from_secs(30), async {

--- a/crates/ln-dlc-node/src/node/dlc_channel.rs
+++ b/crates/ln-dlc-node/src/node/dlc_channel.rs
@@ -19,7 +19,7 @@ pub struct Dlc {
     pub accept_pk: PublicKey,
 }
 
-impl Node {
+impl<P> Node<P> {
     pub async fn propose_dlc_channel(
         &self,
         channel_details: &ChannelDetails,

--- a/crates/ln-dlc-node/src/node/ln_channel.rs
+++ b/crates/ln-dlc-node/src/node/ln_channel.rs
@@ -5,7 +5,7 @@ use anyhow::Context;
 use anyhow::Result;
 use lightning::ln::channelmanager::ChannelDetails;
 
-impl Node {
+impl<P> Node<P> {
     /// Initiates the open private channel protocol.
     ///
     /// Returns a temporary channel ID as a 32-byte long array.

--- a/crates/ln-dlc-node/src/node/oracle_client.rs
+++ b/crates/ln-dlc-node/src/node/oracle_client.rs
@@ -14,7 +14,7 @@ pub async fn build() -> Result<P2PDOracleClient> {
     .map_err(|e| anyhow!(e))
 }
 
-impl Node {
+impl<P> Node<P> {
     pub fn oracle_pk(&self) -> XOnlyPublicKey {
         self.oracle.get_public_key()
     }

--- a/crates/ln-dlc-node/src/node/payment_persister.rs
+++ b/crates/ln-dlc-node/src/node/payment_persister.rs
@@ -1,0 +1,109 @@
+use crate::HTLCStatus;
+use crate::MillisatAmount;
+use crate::PaymentFlow;
+use crate::PaymentInfo;
+use anyhow::Result;
+use lightning::ln::PaymentHash;
+use lightning::ln::PaymentPreimage;
+use lightning::ln::PaymentSecret;
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::sync::Mutex;
+use time::OffsetDateTime;
+
+/// Interface which defines what a persister of Lightning payments should be able to do.
+pub trait PaymentPersister {
+    /// Add a new payment.
+    fn insert(&self, payment_hash: PaymentHash, info: PaymentInfo) -> Result<()>;
+    /// Add a new payment or update an existing one.
+    fn merge(
+        &self,
+        payment_hash: &PaymentHash,
+        flow: PaymentFlow,
+        amt_msat: MillisatAmount,
+        htlc_status: HTLCStatus,
+        preimage: Option<PaymentPreimage>,
+        secret: Option<PaymentSecret>,
+    ) -> Result<()>;
+    /// Get a payment based on its payment hash.
+    ///
+    /// # Returns
+    ///
+    /// A tuple of the form `(PaymentHash, PaymentInfo)` if the payment hash was found in the
+    /// persister; `Ok(None)` if the payment hash was not found in the persister; an error if
+    /// accessing the persister failed.
+    fn get(&self, payment_hash: &PaymentHash) -> Result<Option<(PaymentHash, PaymentInfo)>>;
+    /// Get all payments stored in the persister.
+    fn all(&self) -> Result<Vec<(PaymentHash, PaymentInfo)>>;
+}
+
+#[derive(Default, Clone)]
+pub struct PaymentMap(Arc<Mutex<HashMap<PaymentHash, PaymentInfo>>>);
+
+impl PaymentPersister for PaymentMap {
+    fn insert(&self, payment_hash: PaymentHash, info: PaymentInfo) -> Result<()> {
+        self.0.lock().unwrap().insert(payment_hash, info);
+
+        Ok(())
+    }
+
+    fn merge(
+        &self,
+        payment_hash: &PaymentHash,
+        flow: PaymentFlow,
+        amt_msat: MillisatAmount,
+        htlc_status: HTLCStatus,
+        preimage: Option<PaymentPreimage>,
+        secret: Option<PaymentSecret>,
+    ) -> Result<()> {
+        let mut payments = self.0.lock().unwrap();
+        match payments.get_mut(payment_hash) {
+            Some(mut payment) => {
+                payment.status = htlc_status;
+
+                if let amt_msat @ MillisatAmount(Some(_)) = amt_msat {
+                    payment.amt_msat = amt_msat
+                }
+
+                if let Some(preimage) = preimage {
+                    payment.preimage = Some(preimage);
+                }
+
+                if let Some(secret) = secret {
+                    payment.secret = Some(secret);
+                }
+            }
+            None => {
+                payments.insert(
+                    *payment_hash,
+                    PaymentInfo {
+                        preimage,
+                        secret,
+                        status: htlc_status,
+                        amt_msat: MillisatAmount(None),
+                        flow,
+                        timestamp: OffsetDateTime::now_utc(),
+                    },
+                );
+            }
+        }
+
+        Ok(())
+    }
+
+    fn get(&self, payment_hash: &PaymentHash) -> Result<Option<(PaymentHash, PaymentInfo)>> {
+        let payments = self.0.lock().unwrap();
+        let info = payments.get(payment_hash);
+
+        let payment = info.map(|info| (*payment_hash, *info));
+
+        Ok(payment)
+    }
+
+    fn all(&self) -> Result<Vec<(PaymentHash, PaymentInfo)>> {
+        let payments = self.0.lock().unwrap();
+        let payments = payments.iter().map(|(a, b)| (*a, *b)).collect();
+
+        Ok(payments)
+    }
+}

--- a/crates/ln-dlc-node/src/tests/dlc/collaborative_settlement.rs
+++ b/crates/ln-dlc-node/src/tests/dlc/collaborative_settlement.rs
@@ -1,4 +1,5 @@
 use crate::node::Node;
+use crate::node::PaymentMap;
 use crate::tests::dlc::create::create_dlc_channel;
 use crate::tests::dlc::create::DlcChannelCreated;
 use crate::tests::dummy_contract_input;
@@ -30,7 +31,7 @@ async fn dlc_collaborative_settlement_test() {
 async fn dlc_collaborative_settlement(
     app_dlc_collateral: u64,
     coordinator_dlc_collateral: u64,
-) -> Result<(Node, Node)> {
+) -> Result<(Node<PaymentMap>, Node<PaymentMap>)> {
     // Arrange
 
     let DlcChannelCreated {

--- a/crates/ln-dlc-node/src/tests/dlc/create.rs
+++ b/crates/ln-dlc-node/src/tests/dlc/create.rs
@@ -1,4 +1,5 @@
 use crate::node::Node;
+use crate::node::PaymentMap;
 use crate::tests::dummy_contract_input;
 use crate::tests::init_tracing;
 use crate::tests::wait_until;
@@ -25,10 +26,10 @@ async fn given_lightning_channel_then_can_add_dlc_channel() {
 }
 
 pub struct DlcChannelCreated {
-    pub coordinator: Node,
+    pub coordinator: Node<PaymentMap>,
     /// Available balance for the coordinator after the LN channel was created. In sats.
     pub coordinator_balance_channel_creation: u64,
-    pub app: Node,
+    pub app: Node<PaymentMap>,
     /// Available balance for the app after the LN channel was created. In sats.
     pub app_balance_channel_creation: u64,
     pub channel_id: ChannelId,

--- a/crates/ln-dlc-node/src/tests/just_in_time_channel/create.rs
+++ b/crates/ln-dlc-node/src/tests/just_in_time_channel/create.rs
@@ -1,5 +1,6 @@
 use crate::ln::JUST_IN_TIME_CHANNEL_OUTBOUND_LIQUIDITY_SAT;
 use crate::node::Node;
+use crate::node::PaymentMap;
 use crate::node::LIQUIDITY_ROUTING_FEE_MILLIONTHS;
 use crate::tests::init_tracing;
 use crate::tests::min_outbound_liquidity_channel_creator;
@@ -74,9 +75,9 @@ async fn just_in_time_channel() {
 }
 
 pub(crate) async fn send_interceptable_payment(
-    payer: &Node,
-    payee: &Node,
-    coordinator: &Node,
+    payer: &Node<PaymentMap>,
+    payee: &Node<PaymentMap>,
+    coordinator: &Node<PaymentMap>,
     invoice_amount: u64,
     coordinator_just_in_time_channel_creation_outbound_liquidity: Option<u64>,
 ) -> Result<()> {
@@ -162,7 +163,7 @@ pub(crate) async fn send_interceptable_payment(
 /// `max_inbound_htlc_value_in_flight_percent_of_channel`
 /// configuration flag of the receiving end of the channel.
 fn does_inbound_htlc_fit_as_percent_of_channel(
-    receiving_node: &Node,
+    receiving_node: &Node<PaymentMap>,
     channel_id: &[u8; 32],
     htlc_amount_sat: u64,
 ) -> Result<bool> {

--- a/crates/ln-dlc-node/src/tests/lnd.rs
+++ b/crates/ln-dlc-node/src/tests/lnd.rs
@@ -1,4 +1,5 @@
 use crate::node::Node;
+use crate::node::PaymentMap;
 use crate::tests;
 use crate::tests::bitcoind;
 use anyhow::anyhow;
@@ -42,7 +43,11 @@ impl LndNode {
     /// 2. Open channel to the target node.
     /// 3. Wait for the channel to become usable on the target node. Note, this logic assumes that
     /// there is no other channel.
-    pub async fn open_channel(&self, target: &Node, amount: bitcoin::Amount) -> Result<()> {
+    pub async fn open_channel(
+        &self,
+        target: &Node<PaymentMap>,
+        amount: bitcoin::Amount,
+    ) -> Result<()> {
         let port = target.info.address.port();
         let ip_address = local_ip()?;
         let host = format!("{ip_address}:{port}");

--- a/maker/src/bin/maker.rs
+++ b/maker/src/bin/maker.rs
@@ -4,6 +4,7 @@ use diesel::r2d2;
 use diesel::r2d2::ConnectionManager;
 use diesel::PgConnection;
 use ln_dlc_node::node::Node;
+use ln_dlc_node::node::PaymentMap;
 use ln_dlc_node::seed::Bip39Seed;
 use maker::cli::Opts;
 use maker::logger;
@@ -61,6 +62,7 @@ async fn main() -> Result<()> {
             "maker",
             network,
             data_dir.as_path(),
+            PaymentMap::default(),
             address,
             SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), address.port()),
             opts.electrum,

--- a/maker/src/routes.rs
+++ b/maker/src/routes.rs
@@ -13,6 +13,7 @@ use diesel::r2d2::Pool;
 use diesel::PgConnection;
 use ln_dlc_node::node::Node;
 use ln_dlc_node::node::NodeInfo;
+use ln_dlc_node::node::PaymentMap;
 use ln_dlc_node::ChannelDetails;
 use serde::Deserialize;
 use serde::Serialize;
@@ -21,11 +22,11 @@ use std::str::FromStr;
 use std::sync::Arc;
 
 pub struct AppState {
-    pub node: Arc<Node>,
+    pub node: Arc<Node<PaymentMap>>,
     pub pool: Pool<ConnectionManager<PgConnection>>,
 }
 
-pub fn router(node: Arc<Node>, pool: Pool<ConnectionManager<PgConnection>>) -> Router {
+pub fn router(node: Arc<Node<PaymentMap>>, pool: Pool<ConnectionManager<PgConnection>>) -> Router {
     let app_state = Arc::new(AppState { node, pool });
 
     Router::new()

--- a/mobile/native/Cargo.toml
+++ b/mobile/native/Cargo.toml
@@ -8,6 +8,7 @@ crate-type = ["cdylib", "staticlib"]
 
 [dependencies]
 anyhow = "1"
+base64 = "0.21.0"
 bdk = { version = "0.24.0", features = ["key-value-db"] }
 coordinator-commons = { path = "../../crates/coordinator-commons" }
 diesel = { version = "2.0.0", features = ["sqlite", "r2d2", "extras"] }
@@ -18,6 +19,7 @@ futures = "0.3"
 hex = "0.4"
 itertools = "0.10"
 libsqlite3-sys = { version = "0.25.2", features = ["bundled"] }
+lightning = { version = "0.0.113" }
 lightning-invoice = { version = "0.21" }
 ln-dlc-node = { path = "../../crates/ln-dlc-node" }
 openssl = { version = "0.10.45", features = ["vendored"] }

--- a/mobile/native/migrations/2023-04-11-131120_payments/down.sql
+++ b/mobile/native/migrations/2023-04-11-131120_payments/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS payments;

--- a/mobile/native/migrations/2023-04-11-131120_payments/up.sql
+++ b/mobile/native/migrations/2023-04-11-131120_payments/up.sql
@@ -1,0 +1,11 @@
+CREATE TABLE IF NOT EXISTS payments (
+    id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+    payment_hash TEXT UNIQUE NOT NULL,
+    preimage TEXT,
+    secret TEXT,
+    htlc_status TEXT NOT NULL,
+    amount_msat BIGINT,
+    flow TEXT NOT NULL,
+    created_at BIGINT NOT NULL,
+    updated_at BIGINT NOT NULL
+)

--- a/mobile/native/src/schema.rs
+++ b/mobile/native/src/schema.rs
@@ -24,6 +24,20 @@ diesel::table! {
 }
 
 diesel::table! {
+    payments (id) {
+        id -> Integer,
+        payment_hash -> Text,
+        preimage -> Nullable<Text>,
+        secret -> Nullable<Text>,
+        htlc_status -> Text,
+        amount_msat -> Nullable<BigInt>,
+        flow -> Text,
+        created_at -> BigInt,
+        updated_at -> BigInt,
+    }
+}
+
+diesel::table! {
     positions (contract_symbol) {
         contract_symbol -> Text,
         leverage -> Double,
@@ -37,4 +51,4 @@ diesel::table! {
     }
 }
 
-diesel::allow_tables_to_appear_in_same_query!(last_login, orders, positions,);
+diesel::allow_tables_to_appear_in_same_query!(last_login, orders, payments, positions,);


### PR DESCRIPTION
The `PaymentPersister` trait is introduced so that different consumers of `ln-dlc-node` can bring their own implementations. Alternatively, we could start moving away from `ln-dlc-node` altogether, since most of the important code differs between consumers, but that's too much work at the moment.

The app brings an implementation based on its SQLite DB. The coordinator and the maker use `ln_dlc_node::PaymentMap`, so their behaviour shouldn't change w.r.t. the previous patch.

---

~Small caveat: doesn't quite work yet, as I can't see the payment history at all. But the code shouldn't change much after the fix~. This was fixed. The problem was that we were not updating the `amount_msat` correctly, so the payments were being ignored for display purposes.