### PR TITLE
Feat/trading form validation

### DIFF
--- a/coordinator/src/node.rs
+++ b/coordinator/src/node.rs
@@ -109,7 +109,7 @@ impl Node {
         let contract_input = ContractInput {
             offer_collateral: margin_coordinator,
             accept_collateral: margin_trader,
-            fee_rate: 2,
+            fee_rate: 4,
             contract_infos: vec![ContractInputInfo {
                 contract_descriptor,
                 oracles: OracleInput {

--- a/mobile/lib/common/amount_text_input_form_field.dart
+++ b/mobile/lib/common/amount_text_input_form_field.dart
@@ -10,13 +10,16 @@ class AmountInputField extends StatelessWidget {
       required this.label,
       required this.hint,
       required this.onChanged,
-      required this.value});
+      required this.value,
+      this.validator});
 
   final Amount value;
   final TextEditingController controller;
   final String label;
   final String hint;
   final Function(String) onChanged;
+
+  final String? Function(String?)? validator;
 
   @override
   Widget build(BuildContext context) {
@@ -46,6 +49,13 @@ class AmountInputField extends StatelessWidget {
       ),
       inputFormatters: <TextInputFormatter>[FilteringTextInputFormatter.digitsOnly],
       onChanged: (value) => onChanged(value),
+      validator: (value) {
+        if (validator != null) {
+          return validator!(value);
+        }
+
+        return null;
+      },
     );
   }
 }

--- a/mobile/lib/common/modal_bottom_sheet_info.dart
+++ b/mobile/lib/common/modal_bottom_sheet_info.dart
@@ -1,0 +1,51 @@
+import 'package:flutter/material.dart';
+
+class ModalBottomSheetInfo extends StatelessWidget {
+  final String infoText;
+  final String buttonText;
+  final EdgeInsets padding;
+
+  const ModalBottomSheetInfo(
+      {super.key,
+      required this.infoText,
+      required this.buttonText,
+      this.padding = const EdgeInsets.all(8.0)});
+
+  @override
+  Widget build(BuildContext context) {
+    // TODO: implement build
+    return IconButton(
+        onPressed: () {
+          showModalBottomSheet<void>(
+            shape: const RoundedRectangleBorder(
+              borderRadius: BorderRadius.vertical(
+                top: Radius.circular(20),
+              ),
+            ),
+            clipBehavior: Clip.antiAliasWithSaveLayer,
+            useRootNavigator: true,
+            context: context,
+            builder: (BuildContext context) {
+              return Container(
+                height: 300,
+                padding: const EdgeInsets.all(20.0),
+                child: Column(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  children: [
+                    // TODO: Add link to FAQ
+                    Text(infoText),
+                    ElevatedButton(onPressed: () => Navigator.pop(context), child: Text(buttonText))
+                  ],
+                ),
+              );
+            },
+          );
+        },
+        padding: padding,
+        constraints: const BoxConstraints(),
+        icon: Icon(
+          Icons.info,
+          color: Colors.blue.shade400,
+        ));
+  }
+}

--- a/mobile/lib/features/trade/application/trade_values_service.dart
+++ b/mobile/lib/features/trade/application/trade_values_service.dart
@@ -24,4 +24,21 @@ class TradeValuesService {
     return rust.api.calculateLiquidationPrice(
         price: price, leverage: leverage.leverage, direction: direction.toApi());
   }
+
+  int getFeeReserve() {
+    // TODO: Fetch from backend
+    // This hardcoded value corresponds to the fee-rate of 4 sats per vbyte. We should relate this value to that fee-rate in the backend.
+    return 1666;
+  }
+
+  int getChannelReserve() {
+    // TODO: Fetch from backend
+    // This is the minimum value that has to remain in the channel. It is defined in rust-lightning and we should fetch this value from the corresponding constant in the backend.
+    return 1000;
+  }
+
+  int getMinTradeMargin() {
+    // This value is an arbitrary number; we only allow trades with a minimum of 1000 sats margin.
+    return 1000;
+  }
 }

--- a/mobile/lib/features/trade/application/trade_values_service.dart
+++ b/mobile/lib/features/trade/application/trade_values_service.dart
@@ -41,4 +41,9 @@ class TradeValuesService {
     // This value is an arbitrary number; we only allow trades with a minimum of 1000 sats margin.
     return 1000;
   }
+
+  int getLightningChannelCapacity() {
+    // This value is what we agree on as channel capacity cap for the beta
+    return 200000;
+  }
 }

--- a/mobile/lib/features/trade/domain/trade_values.dart
+++ b/mobile/lib/features/trade/domain/trade_values.dart
@@ -29,14 +29,14 @@ class TradeValues {
       required this.tradeValuesService});
 
   factory TradeValues.create(
-      {required double quantity,
+      {required Amount margin,
       required Leverage leverage,
       required double price,
       required double fundingRate,
       required Direction direction,
       required TradeValuesService tradeValuesService}) {
-    Amount margin =
-        tradeValuesService.calculateMargin(price: price, quantity: quantity, leverage: leverage);
+    double quantity =
+        tradeValuesService.calculateQuantity(price: price, margin: margin, leverage: leverage);
     double liquidationPrice = tradeValuesService.calculateLiquidationPrice(
         price: price, leverage: leverage, direction: direction);
 
@@ -67,7 +67,7 @@ class TradeValues {
 
   updatePrice(double price) {
     this.price = price;
-    _recalculateMargin();
+    _recalculateQuantity();
     _recalculateLiquidationPrice();
   }
 

--- a/mobile/lib/features/trade/trade_bottom_sheet.dart
+++ b/mobile/lib/features/trade/trade_bottom_sheet.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:get_10101/common/modal_bottom_sheet_info.dart';
 import 'package:get_10101/features/trade/domain/direction.dart';
 import 'package:get_10101/features/trade/trade_bottom_sheet_tab.dart';
 import 'package:get_10101/features/trade/trade_tabs.dart';
@@ -66,48 +67,17 @@ class TradeBottomSheet extends StatelessWidget {
         ],
         selectedIndex: direction == Direction.long ? 0 : 1,
         topRightWidget: Row(
-          children: [
-            const Text(
+          children: const [
+            Text(
               "Market Order",
               style: TextStyle(color: Colors.grey),
             ),
-            IconButton(
-                onPressed: () {
-                  showModalBottomSheet<void>(
-                    shape: const RoundedRectangleBorder(
-                      borderRadius: BorderRadius.vertical(
-                        top: Radius.circular(20),
-                      ),
-                    ),
-                    clipBehavior: Clip.antiAliasWithSaveLayer,
-                    useRootNavigator: true,
-                    context: context,
-                    builder: (BuildContext context) {
-                      return Container(
-                        height: 300,
-                        padding: const EdgeInsets.all(20.0),
-                        child: Column(
-                          mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                          children: [
-                            // TODO: Add link to FAQ
-                            const Text(
-                                "For the beta phase only market orders are enabled in the 10101 app.\n\n"
-                                "Market orders are executed at the best market price. \n\nPlease note that the displayed "
-                                "price is the best market price at the time but due to fast market "
-                                "movements the market price for order fulfillment can be slightly different."),
-                            ElevatedButton(
-                                onPressed: () => Navigator.pop(context),
-                                child: const Text("Back to order..."))
-                          ],
-                        ),
-                      );
-                    },
-                  );
-                },
-                icon: Icon(
-                  Icons.info,
-                  color: Theme.of(context).colorScheme.primary,
-                ))
+            ModalBottomSheetInfo(
+                infoText: "While in beta only market orders are enabled in the 10101 app.\n\n"
+                    "Market orders are executed at the best market price. \n\nPlease note that the displayed "
+                    "price is the best market price at the time but due to fast market "
+                    "movements the market price for order fulfillment can be slightly different.",
+                buttonText: "Back to order...")
           ],
         ),
       ),

--- a/mobile/lib/features/trade/trade_bottom_sheet_tab.dart
+++ b/mobile/lib/features/trade/trade_bottom_sheet_tab.dart
@@ -1,3 +1,5 @@
+import 'dart:math';
+
 import 'package:flutter/material.dart';
 import 'package:get_10101/common/amount_text.dart';
 import 'package:get_10101/common/amount_text_input_form_field.dart';
@@ -14,11 +16,39 @@ import 'package:get_10101/features/wallet/domain/wallet_info.dart';
 import 'package:get_10101/features/wallet/wallet_change_notifier.dart';
 import 'package:provider/provider.dart';
 
-class TradeBottomSheetTab extends StatelessWidget {
+class TradeBottomSheetTab extends StatefulWidget {
   final Direction direction;
   final Key buttonKey;
 
   const TradeBottomSheetTab({required this.direction, super.key, required this.buttonKey});
+
+  @override
+  State<TradeBottomSheetTab> createState() => _TradeBottomSheetTabState();
+}
+
+class _TradeBottomSheetTabState extends State<TradeBottomSheetTab> {
+  late final TradeValuesChangeNotifier provider;
+
+  TextEditingController marginController = TextEditingController();
+  TextEditingController quantityController = TextEditingController();
+  TextEditingController priceController = TextEditingController();
+
+  final _formKey = GlobalKey<FormState>();
+
+  @override
+  void initState() {
+    provider = context.read<TradeValuesChangeNotifier>();
+    super.initState();
+  }
+
+  @override
+  void dispose() {
+    marginController.dispose();
+    quantityController.dispose();
+    priceController.dispose();
+
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -26,142 +56,177 @@ class TradeBottomSheetTab extends StatelessWidget {
 
     WalletInfo walletInfo = context.watch<WalletChangeNotifier>().walletInfo;
 
-    String label = direction == Direction.long ? "Buy" : "Sell";
-    Color color = direction == Direction.long ? tradeTheme.buy : tradeTheme.sell;
+    String label = widget.direction == Direction.long ? "Buy" : "Sell";
+    Color color = widget.direction == Direction.long ? tradeTheme.buy : tradeTheme.sell;
 
-    TradeValuesChangeNotifier provider = context.read<TradeValuesChangeNotifier>();
+    int minMargin = provider.minMargin;
+    int usableBalance = max(walletInfo.balances.lightning.sats - provider.reserve, 0);
+    int maxMargin = usableBalance;
 
-    TextEditingController marginController =
-        TextEditingController(text: provider.fromDirection(direction).margin.toString());
-    TextEditingController quantityController =
-        TextEditingController(text: provider.fromDirection(direction).quantity.toString());
-    TextEditingController priceController =
-        TextEditingController(text: provider.fromDirection(direction).price.toString());
-
-    return Column(
-      mainAxisAlignment: MainAxisAlignment.spaceBetween,
-      crossAxisAlignment: CrossAxisAlignment.center,
-      mainAxisSize: MainAxisSize.min,
-      children: [
-        Wrap(
-          runSpacing: 15,
-          children: [
-            Padding(
-              padding: const EdgeInsets.only(bottom: 10),
-              child: Row(
+    return Form(
+      key: _formKey,
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        crossAxisAlignment: CrossAxisAlignment.center,
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Wrap(
+            runSpacing: 15,
+            children: [
+              Padding(
+                padding: const EdgeInsets.only(bottom: 10),
+                child: Row(
+                  children: [
+                    const Flexible(child: Text("Usable Balance:")),
+                    const SizedBox(width: 5),
+                    Flexible(child: AmountText(amount: Amount(usableBalance)))
+                  ],
+                ),
+              ),
+              Selector<TradeValuesChangeNotifier, double>(
+                  selector: (_, provider) => provider.fromDirection(widget.direction).price,
+                  builder: (context, price, child) {
+                    return DoubleTextInputFormField(
+                      value: price,
+                      controller: priceController,
+                      enabled: false,
+                      label: "Market Price",
+                    );
+                  }),
+              Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  const Flexible(child: Text("Available Balance:")),
-                  const SizedBox(width: 5),
-                  Flexible(child: AmountText(amount: walletInfo.balances.lightning))
+                  Flexible(
+                    child: Selector<TradeValuesChangeNotifier, double>(
+                      selector: (_, provider) => provider.fromDirection(widget.direction).quantity,
+                      builder: (context, quantity, child) {
+                        return DoubleTextInputFormField(
+                          value: quantity,
+                          hint: "e.g. 100 USD",
+                          label: "Quantity (USD)",
+                          controller: quantityController,
+                          onChanged: (value) {
+                            if (value.isEmpty) {
+                              return;
+                            }
+
+                            try {
+                              double quantity = double.parse(value);
+                              context
+                                  .read<TradeValuesChangeNotifier>()
+                                  .updateQuantity(widget.direction, quantity);
+                            } on Exception {
+                              context
+                                  .read<TradeValuesChangeNotifier>()
+                                  .updateQuantity(widget.direction, 0);
+                            }
+                          },
+                        );
+                      },
+                    ),
+                  ),
+                  const SizedBox(
+                    width: 10,
+                  ),
+                  Flexible(
+                    child: Selector<TradeValuesChangeNotifier, Amount>(
+                      selector: (_, provider) => provider.fromDirection(widget.direction).margin,
+                      builder: (context, margin, child) {
+                        return AmountInputField(
+                          value: margin,
+                          hint: "e.g. 2000 sats",
+                          label: "Margin (sats)",
+                          controller: marginController,
+                          onChanged: (value) {
+                            if (value.isEmpty) {
+                              return;
+                            }
+
+                            try {
+                              Amount margin = Amount.parse(value);
+                              context
+                                  .read<TradeValuesChangeNotifier>()
+                                  .updateMargin(widget.direction, margin);
+                              _formKey.currentState!.validate();
+                            } on Exception {
+                              context
+                                  .read<TradeValuesChangeNotifier>()
+                                  .updateMargin(widget.direction, Amount.zero());
+                              _formKey.currentState!.validate();
+                            }
+                          },
+                          validator: (value) {
+                            if (value == null) {
+                              return "Enter margin";
+                            }
+
+                            try {
+                              int margin = int.parse(value);
+
+                              if (usableBalance < margin) {
+                                return "Insufficient balance";
+                              }
+
+                              if (margin > maxMargin) {
+                                return "Max margin is $maxMargin";
+                              }
+                              if (margin < minMargin) {
+                                return "Min margin is $minMargin";
+                              }
+                            } on Exception {
+                              return "Enter a number";
+                            }
+
+                            return null;
+                          },
+                        );
+                      },
+                    ),
+                  ),
                 ],
               ),
-            ),
-            DoubleTextInputFormField(
-              controller: priceController,
-              enabled: false,
-              label: "Market Price",
-            ),
-            Row(
-              children: [
-                Flexible(
-                  child: Selector<TradeValuesChangeNotifier, double>(
-                    selector: (_, provider) => provider.fromDirection(direction).quantity,
-                    builder: (context, quantity, child) {
-                      return DoubleTextInputFormField(
-                        value: quantity,
-                        hint: "e.g. 100 USD",
-                        label: "Quantity (USD)",
-                        controller: quantityController,
-                        onChanged: (value) {
-                          if (value.isEmpty) {
-                            return;
-                          }
-
-                          try {
-                            double quantity = double.parse(value);
-                            context
-                                .read<TradeValuesChangeNotifier>()
-                                .updateQuantity(direction, quantity);
-                          } on Exception {
-                            context.read<TradeValuesChangeNotifier>().updateQuantity(direction, 0);
-                          }
-                        },
-                      );
-                    },
-                  ),
-                ),
-                const SizedBox(
-                  width: 10,
-                ),
-                Flexible(
-                  child: Selector<TradeValuesChangeNotifier, Amount>(
-                    selector: (_, provider) => provider.fromDirection(direction).margin,
-                    builder: (context, margin, child) {
-                      return AmountInputField(
-                        value: margin,
-                        hint: "e.g. 2000 sats",
-                        label: "Margin (sats)",
-                        controller: marginController,
-                        onChanged: (value) {
-                          if (value.isEmpty) {
-                            return;
-                          }
-
-                          try {
-                            Amount margin = Amount.parse(value);
-                            context
-                                .read<TradeValuesChangeNotifier>()
-                                .updateMargin(direction, margin);
-                          } on Exception {
-                            context
-                                .read<TradeValuesChangeNotifier>()
-                                .updateMargin(direction, Amount.zero());
-                          }
-                        },
-                      );
-                    },
-                  ),
-                ),
-              ],
-            ),
-            LeverageSlider(
-                initialValue: context
-                    .read<TradeValuesChangeNotifier>()
-                    .fromDirection(direction)
-                    .leverage
-                    .leverage,
-                onLeverageChanged: (value) {
-                  context
+              LeverageSlider(
+                  initialValue: context
                       .read<TradeValuesChangeNotifier>()
-                      .updateLeverage(direction, Leverage(value));
-                }),
-            Row(
-              children: [
-                const Flexible(child: Text("Liquidation Price:")),
-                const SizedBox(width: 5),
-                Selector<TradeValuesChangeNotifier, double>(
-                    selector: (_, provider) => provider.fromDirection(direction).liquidationPrice,
-                    builder: (context, liquidationPrice, child) {
-                      return Flexible(child: FiatText(amount: liquidationPrice));
-                    }),
-              ],
-            )
-          ],
-        ),
-        Column(
-          crossAxisAlignment: CrossAxisAlignment.stretch,
-          children: [
-            ElevatedButton(
-                key: buttonKey,
-                onPressed: () {
-                  tradeBottomSheetConfirmation(context: context, direction: direction);
-                },
-                style: ElevatedButton.styleFrom(
-                    backgroundColor: color, minimumSize: const Size.fromHeight(50)),
-                child: Text(label)),
-          ],
-        )
-      ],
+                      .fromDirection(widget.direction)
+                      .leverage
+                      .leverage,
+                  onLeverageChanged: (value) {
+                    context
+                        .read<TradeValuesChangeNotifier>()
+                        .updateLeverage(widget.direction, Leverage(value));
+                  }),
+              Row(
+                children: [
+                  const Flexible(child: Text("Liquidation Price:")),
+                  const SizedBox(width: 5),
+                  Selector<TradeValuesChangeNotifier, double>(
+                      selector: (_, provider) =>
+                          provider.fromDirection(widget.direction).liquidationPrice,
+                      builder: (context, liquidationPrice, child) {
+                        return Flexible(child: FiatText(amount: liquidationPrice));
+                      }),
+                ],
+              )
+            ],
+          ),
+          Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              ElevatedButton(
+                  key: widget.buttonKey,
+                  onPressed: () {
+                    if (_formKey.currentState!.validate()) {
+                      tradeBottomSheetConfirmation(context: context, direction: widget.direction);
+                    }
+                  },
+                  style: ElevatedButton.styleFrom(
+                      backgroundColor: color, minimumSize: const Size.fromHeight(50)),
+                  child: Text(label)),
+            ],
+          )
+        ],
+      ),
     );
   }
 }

--- a/mobile/lib/features/trade/trade_bottom_sheet_tab.dart
+++ b/mobile/lib/features/trade/trade_bottom_sheet_tab.dart
@@ -6,6 +6,7 @@ import 'package:get_10101/common/amount_text_input_form_field.dart';
 import 'package:get_10101/common/domain/model.dart';
 import 'package:get_10101/common/double_text_input_form_field.dart';
 import 'package:get_10101/common/fiat_text.dart';
+import 'package:get_10101/common/modal_bottom_sheet_info.dart';
 import 'package:get_10101/features/trade/domain/direction.dart';
 import 'package:get_10101/features/trade/domain/leverage.dart';
 import 'package:get_10101/features/trade/leverage_slider.dart';
@@ -79,7 +80,19 @@ class _TradeBottomSheetTabState extends State<TradeBottomSheetTab> {
                   children: [
                     const Flexible(child: Text("Usable Balance:")),
                     const SizedBox(width: 5),
-                    Flexible(child: AmountText(amount: Amount(usableBalance)))
+                    Flexible(child: AmountText(amount: Amount(usableBalance))),
+                    const SizedBox(
+                      width: 5,
+                    ),
+                    ModalBottomSheetInfo(
+                      infoText:
+                          "Your usable balance of $usableBalance sats takes a fixed reserve of ${provider.reserve} sats into account. "
+                          "\n${provider.channelReserve} is the minimum amount that has to stay in the Lightning channel. "
+                          "\n${provider.feeReserve} is reserved for fees per trade that is needed for publishing on-chain transactions in a worst case scenario. This is needed for the self-custodial setup"
+                          "\n\nWe are working on optimizing the reserve and it might be subject to change after the beta.",
+                      buttonText: "Back to order...",
+                      padding: const EdgeInsets.symmetric(horizontal: 8.0),
+                    )
                   ],
                 ),
               ),

--- a/mobile/lib/features/trade/trade_bottom_sheet_tab.dart
+++ b/mobile/lib/features/trade/trade_bottom_sheet_tab.dart
@@ -147,12 +147,10 @@ class _TradeBottomSheetTabState extends State<TradeBottomSheetTab> {
                               context
                                   .read<TradeValuesChangeNotifier>()
                                   .updateMargin(widget.direction, margin);
-                              _formKey.currentState!.validate();
                             } on Exception {
                               context
                                   .read<TradeValuesChangeNotifier>()
                                   .updateMargin(widget.direction, Amount.zero());
-                              _formKey.currentState!.validate();
                             }
                           },
                           validator: (value) {

--- a/mobile/lib/features/trade/trade_bottom_sheet_tab.dart
+++ b/mobile/lib/features/trade/trade_bottom_sheet_tab.dart
@@ -36,6 +36,8 @@ class _TradeBottomSheetTabState extends State<TradeBottomSheetTab> {
 
   final _formKey = GlobalKey<FormState>();
 
+  bool showCapacityInfo = false;
+
   @override
   void initState() {
     provider = context.read<TradeValuesChangeNotifier>();
@@ -174,6 +176,19 @@ class _TradeBottomSheetTabState extends State<TradeBottomSheetTab> {
                             try {
                               int margin = int.parse(value);
 
+                              // This condition has to stay as the first thing to check, so we reset showing the info
+                              if (margin > provider.availableTradingCapacity(widget.direction)) {
+                                setState(() {
+                                  showCapacityInfo = true;
+                                });
+
+                                return "Insufficient capacity";
+                              } else if (showCapacityInfo) {
+                                setState(() {
+                                  showCapacityInfo = false;
+                                });
+                              }
+
                               if (usableBalance < margin) {
                                 return "Insufficient balance";
                               }
@@ -194,6 +209,14 @@ class _TradeBottomSheetTabState extends State<TradeBottomSheetTab> {
                       },
                     ),
                   ),
+                  if (showCapacityInfo)
+                    ModalBottomSheetInfo(
+                        infoText:
+                            "While in beta channel capacity is limited to ${provider.capacity} sats. "
+                            "In order to trade with higher margin you have to reduce your balance"
+                            "\n\nYour current usable balance is $usableBalance."
+                            "Please send ${usableBalance - (provider.capacity / 2)} out of your wallet to free up capacity.",
+                        buttonText: "Back to order...")
                 ],
               ),
               LeverageSlider(

--- a/mobile/lib/features/trade/trade_value_change_notifier.dart
+++ b/mobile/lib/features/trade/trade_value_change_notifier.dart
@@ -74,9 +74,20 @@ class TradeValuesChangeNotifier extends ChangeNotifier implements Subscriber {
 
   // Orderbook price updates both directions
   void updatePrice(Price price) {
-    _buyTradeValues.updatePrice(price.ask);
-    _sellTradeValues.updatePrice(price.bid);
-    notifyListeners();
+    bool update = false;
+
+    if (price.ask != _buyTradeValues.price) {
+      _buyTradeValues.updatePrice(price.ask);
+      update = true;
+    }
+    if (price.bid != _sellTradeValues.price) {
+      _sellTradeValues.updatePrice(price.bid);
+      update = true;
+    }
+
+    if (update) {
+      notifyListeners();
+    }
   }
 
   TradeValues fromDirection(Direction direction) =>

--- a/mobile/lib/features/trade/trade_value_change_notifier.dart
+++ b/mobile/lib/features/trade/trade_value_change_notifier.dart
@@ -17,9 +17,17 @@ class TradeValuesChangeNotifier extends ChangeNotifier implements Subscriber {
   late final TradeValues _buyTradeValues;
   late final TradeValues _sellTradeValues;
 
+  late final int _feeReserve;
+  late final int _channelReserve;
+  late final int _minimumTradeMargin;
+
   TradeValuesChangeNotifier(this.tradeValuesService) {
     _buyTradeValues = _initOrder(Direction.long);
     _sellTradeValues = _initOrder(Direction.short);
+
+    _feeReserve = tradeValuesService.getFeeReserve();
+    _channelReserve = tradeValuesService.getChannelReserve();
+    _minimumTradeMargin = tradeValuesService.getMinTradeMargin();
   }
 
   TradeValues _initOrder(Direction direction) {
@@ -45,6 +53,9 @@ class TradeValuesChangeNotifier extends ChangeNotifier implements Subscriber {
             tradeValuesService: tradeValuesService);
     }
   }
+
+  int get minMargin => _minimumTradeMargin;
+  int get reserve => _feeReserve + _channelReserve;
 
   void updateQuantity(Direction direction, double quantity) {
     fromDirection(direction).updateQuantity(quantity);

--- a/mobile/lib/features/trade/trade_value_change_notifier.dart
+++ b/mobile/lib/features/trade/trade_value_change_notifier.dart
@@ -56,6 +56,8 @@ class TradeValuesChangeNotifier extends ChangeNotifier implements Subscriber {
 
   int get minMargin => _minimumTradeMargin;
   int get reserve => _feeReserve + _channelReserve;
+  int get channelReserve => _channelReserve;
+  int get feeReserve => _feeReserve;
 
   void updateQuantity(Direction direction, double quantity) {
     fromDirection(direction).updateQuantity(quantity);

--- a/mobile/lib/features/trade/trade_value_change_notifier.dart
+++ b/mobile/lib/features/trade/trade_value_change_notifier.dart
@@ -33,22 +33,22 @@ class TradeValuesChangeNotifier extends ChangeNotifier implements Subscriber {
   }
 
   TradeValues _initOrder(Direction direction) {
-    double defaultQuantity = 100;
-    double defaultLeverage = 2;
+    Amount defaultMargin = Amount(tradeValuesService.getMinTradeMargin());
+    Leverage defaultLeverage = Leverage(2);
 
     switch (direction) {
       case Direction.long:
         return TradeValues.create(
-            quantity: defaultQuantity,
-            leverage: Leverage(defaultLeverage),
+            margin: defaultMargin,
+            leverage: defaultLeverage,
             price: dummyAskPrice,
             fundingRate: fundingRateBuy,
             direction: direction,
             tradeValuesService: tradeValuesService);
       case Direction.short:
         return TradeValues.create(
-            quantity: defaultQuantity,
-            leverage: Leverage(defaultLeverage),
+            margin: defaultMargin,
+            leverage: defaultLeverage,
             price: dummyBidPrice,
             fundingRate: fundingRateSell,
             direction: direction,


### PR DESCRIPTION
resolves https://github.com/get10101/10101/issues/131

Please read this:

We keep seeing an exception thrown by flutter in the logs.

TLDR: 
I would just ignore the exception thrown by Flutter. Nothing actually breaks in the UI, but Flutter keeps complaining. The user should never see this, and I don't think it's a big deal...

---

Long story:

After making the `TradeBottomSheetTab` stateful we keep seeing this exception in the logs (when modifying the `margin`; we also see it when modifying the `quantity`, but slightly different because it is always triggered by the other text field):

```
══╡ EXCEPTION CAUGHT BY FOUNDATION LIBRARY ╞════════════════════════════════════════════════════════
The following assertion was thrown while dispatching notifications for TextEditingController:
setState() or markNeedsBuild() called during build.
This Form widget cannot be marked as needing to build because the framework is already in the
process of building widgets. A widget can be marked as needing to be built during the build phase
only if one of its ancestors is currently building. This exception is allowed because the framework
builds parent widgets before children, which means a dirty descendant will always be built.
Otherwise, the framework might not visit this widget during this build phase.
The widget on which setState() or markNeedsBuild() was called was:
  Form-[LabeledGlobalKey<FormState>#3fa9e]
The widget which was currently being built when the offending call was made was:
  DoubleTextInputFormField

When the exception was thrown, this was the stack:

...
```
When using `TextEdigintController`s and a `Form` it is recommended to have a `Stateful` widget.

Part of the problem comes from the complexity of having two text fields that update each other - sounds easy, but is actually quite complex. But even without editing both fields we can run into the exception of triggering multiple builds. 

I added `print` statements to see how often certain code pathes (onChange, and build) are triggered and they are triggered too often - but I just don't understand how. In many cases I did not even interact with the UI and somehow it triggered a rebuild. I am not sure what in our setup triggers this, but something is and I don't have the time to look into this now.