### PR TITLE
chore: electrum is a url and not a socket

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1803,6 +1803,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "trade",
+ "url",
  "uuid",
 ]
 

--- a/mobile/macos/Podfile.lock
+++ b/mobile/macos/Podfile.lock
@@ -5,11 +5,15 @@ PODS:
     - FlutterMacOS
   - share_plus (0.0.1):
     - FlutterMacOS
+  - shared_preferences_foundation (0.0.1):
+    - Flutter
+    - FlutterMacOS
 
 DEPENDENCIES:
   - FlutterMacOS (from `Flutter/ephemeral`)
   - path_provider_foundation (from `Flutter/ephemeral/.symlinks/plugins/path_provider_foundation/macos`)
   - share_plus (from `Flutter/ephemeral/.symlinks/plugins/share_plus/macos`)
+  - shared_preferences_foundation (from `Flutter/ephemeral/.symlinks/plugins/shared_preferences_foundation/macos`)
 
 EXTERNAL SOURCES:
   FlutterMacOS:
@@ -18,11 +22,14 @@ EXTERNAL SOURCES:
     :path: Flutter/ephemeral/.symlinks/plugins/path_provider_foundation/macos
   share_plus:
     :path: Flutter/ephemeral/.symlinks/plugins/share_plus/macos
+  shared_preferences_foundation:
+    :path: Flutter/ephemeral/.symlinks/plugins/shared_preferences_foundation/macos
 
 SPEC CHECKSUMS:
   FlutterMacOS: 8f6f14fa908a6fb3fba0cd85dbd81ec4b251fb24
   path_provider_foundation: 37748e03f12783f9de2cb2c4eadfaa25fe6d4852
   share_plus: 76dd39142738f7a68dd57b05093b5e8193f220f7
+  shared_preferences_foundation: 986fc17f3d3251412d18b0265f9c64113a8c2472
 
 PODFILE CHECKSUM: 353c8bcc5d5b0994e508d035b5431cfe18c1dea7
 

--- a/mobile/native/Cargo.toml
+++ b/mobile/native/Cargo.toml
@@ -37,4 +37,5 @@ tokio = { version = "1.25.0", features = ["macros", "rt", "rt-multi-thread", "sy
 tracing = "0.1.37"
 tracing-subscriber = { version = "0.3", default-features = false, features = ["fmt", "env-filter", "time", "json"] }
 trade = { path = "../../crates/trade" }
+url = "2.3.1"
 uuid = { version = "1.3.0", features = ["v4", "fast-rng", "macro-diagnostics"] }

--- a/mobile/native/src/config/api.rs
+++ b/mobile/native/src/config/api.rs
@@ -1,6 +1,7 @@
 use crate::config::ConfigInternal;
 use bdk::bitcoin::Network;
 use flutter_rust_bridge::frb;
+use url::Url;
 
 #[frb]
 #[derive(Debug)]
@@ -17,9 +18,7 @@ impl From<Config> for ConfigInternal {
     fn from(config: Config) -> Self {
         Self {
             coordinator_pubkey: config.coordinator_pubkey.parse().expect("PK to be valid"),
-            electrs_endpoint: config
-                .electrs_endpoint
-                .parse()
+            electrs_endpoint: Url::parse(config.electrs_endpoint.as_str())
                 .expect("electrs endpoint to be valid"),
             http_endpoint: format!("{}:{}", config.host, config.http_port)
                 .parse()

--- a/mobile/native/src/config/mod.rs
+++ b/mobile/native/src/config/mod.rs
@@ -6,13 +6,14 @@ use bdk::bitcoin::secp256k1::PublicKey;
 use ln_dlc_node::node::NodeInfo;
 use state::Storage;
 use std::net::SocketAddr;
+use url::Url;
 
 static CONFIG: Storage<ConfigInternal> = Storage::new();
 
-#[derive(Clone, Copy)]
+#[derive(Clone)]
 struct ConfigInternal {
     coordinator_pubkey: PublicKey,
-    electrs_endpoint: SocketAddr,
+    electrs_endpoint: Url,
     http_endpoint: SocketAddr,
     p2p_endpoint: SocketAddr,
     network: bitcoin::Network,
@@ -30,8 +31,8 @@ pub fn get_coordinator_info() -> NodeInfo {
     }
 }
 
-pub fn get_electrs_endpoint() -> SocketAddr {
-    CONFIG.get().electrs_endpoint
+pub fn get_electrs_endpoint() -> Url {
+    CONFIG.get().electrs_endpoint.clone()
 }
 
 pub fn get_http_endpoint() -> SocketAddr {


### PR DESCRIPTION
this allows us to use domains and not just IPs.

This way we can pass in `ELECTRS_ENDPOINT=tcp://blockstream.info:110"`