### PR TITLE
Ignore testnet testflight for releases

### DIFF
--- a/.github/workflows/deliverables-push-main.yml
+++ b/.github/workflows/deliverables-push-main.yml
@@ -35,7 +35,7 @@ jobs:
 
   build_and_release_ios_app_for_latest_main:
     needs: changes
-    if: ${{ needs.changes.outputs.ios-app == 'true' }}
+    if: ${{ needs.changes.outputs.ios-app == 'true' }} && "!startsWith(github.event.head_commit.message, 'Release version')"
     permissions:
       packages: write
       contents: read


### PR DESCRIPTION
When triggering a release, we get a merge commit in main which will trigger the release to production and testnet. This can fail, because each build gets a unique number, and when building at the same time, they might get the same which makes one of the two fail. To overcome this we simply ignore certain commits with the message starting with