### PR TITLE
chore: reset a failed position to open

### DIFF
--- a/mobile/native/src/trade/order/handler.rs
+++ b/mobile/native/src/trade/order/handler.rs
@@ -28,6 +28,9 @@ pub async fn submit_order(order: Order) -> Result<()> {
         let order_id = order.id.to_string();
         tracing::error!(order_id, "Failed to post new order. Error: {err:#}");
         update_order_state_in_db_and_ui(order.id, OrderState::Rejected)?;
+        if let Err(e) = position::handler::set_position_to_open() {
+            bail!("Could not reset position to open because of {e:#}");
+        }
         bail!("Could not post order to orderbook");
     }
 

--- a/mobile/native/src/trade/position/handler.rs
+++ b/mobile/native/src/trade/position/handler.rs
@@ -82,6 +82,19 @@ pub fn update_position_after_order_submitted(submitted_order: Order) -> Result<(
     Ok(())
 }
 
+/// Resets the position to open again
+///
+/// This should be called if a went in a dirty state, e.g. the position is currently in
+/// `PositionState::Closing` but we didn't find a match.
+pub fn set_position_to_open() -> Result<()> {
+    if let Some(position) = db::get_positions()?.first() {
+        db::update_position_state(position.contract_symbol, PositionState::Open)?;
+        event::publish(&EventInternal::PositionUpdateNotification(position.clone()));
+    }
+
+    Ok(())
+}
+
 /// Create a position after the creation of a DLC channel.
 pub fn update_position_after_dlc_creation(filled_order: Order, collateral: u64) -> Result<()> {
     ensure!(


### PR DESCRIPTION
in case we are closing a position but fail at matching, we need to set the position to open again so that we can try again later.

resolves #435 