### PR TITLE
Do not wrongly unconfirm funding TX

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1472,7 +1472,7 @@ dependencies = [
 [[package]]
 name = "lightning"
 version = "0.0.113"
-source = "git+https://github.com/p2pderivatives/rust-lightning/?rev=dff302382d04700f23d79fb3275c1798d775fef6#dff302382d04700f23d79fb3275c1798d775fef6"
+source = "git+https://github.com/p2pderivatives/rust-lightning/?rev=91434931df734bb59307a30b847836b7752a1999#91434931df734bb59307a30b847836b7752a1999"
 dependencies = [
  "bitcoin",
 ]
@@ -1480,7 +1480,7 @@ dependencies = [
 [[package]]
 name = "lightning-background-processor"
 version = "0.0.113"
-source = "git+https://github.com/p2pderivatives/rust-lightning/?rev=dff302382d04700f23d79fb3275c1798d775fef6#dff302382d04700f23d79fb3275c1798d775fef6"
+source = "git+https://github.com/p2pderivatives/rust-lightning/?rev=91434931df734bb59307a30b847836b7752a1999#91434931df734bb59307a30b847836b7752a1999"
 dependencies = [
  "bitcoin",
  "lightning",
@@ -1490,7 +1490,7 @@ dependencies = [
 [[package]]
 name = "lightning-block-sync"
 version = "0.0.113"
-source = "git+https://github.com/p2pderivatives/rust-lightning/?rev=dff302382d04700f23d79fb3275c1798d775fef6#dff302382d04700f23d79fb3275c1798d775fef6"
+source = "git+https://github.com/p2pderivatives/rust-lightning/?rev=91434931df734bb59307a30b847836b7752a1999#91434931df734bb59307a30b847836b7752a1999"
 dependencies = [
  "bitcoin",
  "chunked_transfer",
@@ -1516,7 +1516,7 @@ dependencies = [
 [[package]]
 name = "lightning-net-tokio"
 version = "0.0.113"
-source = "git+https://github.com/p2pderivatives/rust-lightning/?rev=dff302382d04700f23d79fb3275c1798d775fef6#dff302382d04700f23d79fb3275c1798d775fef6"
+source = "git+https://github.com/p2pderivatives/rust-lightning/?rev=91434931df734bb59307a30b847836b7752a1999#91434931df734bb59307a30b847836b7752a1999"
 dependencies = [
  "bitcoin",
  "lightning",
@@ -1526,7 +1526,7 @@ dependencies = [
 [[package]]
 name = "lightning-persister"
 version = "0.0.113"
-source = "git+https://github.com/p2pderivatives/rust-lightning/?rev=dff302382d04700f23d79fb3275c1798d775fef6#dff302382d04700f23d79fb3275c1798d775fef6"
+source = "git+https://github.com/p2pderivatives/rust-lightning/?rev=91434931df734bb59307a30b847836b7752a1999#91434931df734bb59307a30b847836b7752a1999"
 dependencies = [
  "bitcoin",
  "libc",
@@ -1537,7 +1537,7 @@ dependencies = [
 [[package]]
 name = "lightning-rapid-gossip-sync"
 version = "0.0.113"
-source = "git+https://github.com/p2pderivatives/rust-lightning/?rev=dff302382d04700f23d79fb3275c1798d775fef6#dff302382d04700f23d79fb3275c1798d775fef6"
+source = "git+https://github.com/p2pderivatives/rust-lightning/?rev=91434931df734bb59307a30b847836b7752a1999#91434931df734bb59307a30b847836b7752a1999"
 dependencies = [
  "bitcoin",
  "lightning",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,9 +10,9 @@ dlc-sled-storage-provider = { git = "https://github.com/get10101/rust-dlc", rev 
 p2pd-oracle-client = { git = "https://github.com/get10101/rust-dlc", rev = "f1627dbec11ac2ed062c841bd70d243c62743e6f" }
 dlc-trie = { git = "https://github.com/get10101/rust-dlc", rev = "f1627dbec11ac2ed062c841bd70d243c62743e6f" }
 simple-wallet = { git = "https://github.com/get10101/rust-dlc", rev = "f1627dbec11ac2ed062c841bd70d243c62743e6f" }
-lightning = { git = "https://github.com/p2pderivatives/rust-lightning/", rev = "dff302382d04700f23d79fb3275c1798d775fef6" }
-lightning-background-processor = { git = "https://github.com/p2pderivatives/rust-lightning/", rev = "dff302382d04700f23d79fb3275c1798d775fef6" }
-lightning-block-sync = { git = "https://github.com/p2pderivatives/rust-lightning/", rev = "dff302382d04700f23d79fb3275c1798d775fef6" }
-lightning-net-tokio = { git = "https://github.com/p2pderivatives/rust-lightning/", rev = "dff302382d04700f23d79fb3275c1798d775fef6" }
-lightning-persister = { git = "https://github.com/p2pderivatives/rust-lightning/", rev = "dff302382d04700f23d79fb3275c1798d775fef6" }
-lightning-rapid-gossip-sync = { git = "https://github.com/p2pderivatives/rust-lightning/", rev = "dff302382d04700f23d79fb3275c1798d775fef6" }
+lightning = { git = "https://github.com/p2pderivatives/rust-lightning/", rev = "91434931df734bb59307a30b847836b7752a1999" }
+lightning-background-processor = { git = "https://github.com/p2pderivatives/rust-lightning/", rev = "91434931df734bb59307a30b847836b7752a1999" }
+lightning-block-sync = { git = "https://github.com/p2pderivatives/rust-lightning/", rev = "91434931df734bb59307a30b847836b7752a1999" }
+lightning-net-tokio = { git = "https://github.com/p2pderivatives/rust-lightning/", rev = "91434931df734bb59307a30b847836b7752a1999" }
+lightning-persister = { git = "https://github.com/p2pderivatives/rust-lightning/", rev = "91434931df734bb59307a30b847836b7752a1999" }
+lightning-rapid-gossip-sync = { git = "https://github.com/p2pderivatives/rust-lightning/", rev = "91434931df734bb59307a30b847836b7752a1999" }

--- a/crates/ln-dlc-node/src/tests/dlc/create.rs
+++ b/crates/ln-dlc-node/src/tests/dlc/create.rs
@@ -76,7 +76,6 @@ pub async fn create_dlc_channel(
         .await?;
 
     // Processs the app's offer to close the channel
-    // TODO: Spawn a task that does this work periodically
     tokio::time::sleep(Duration::from_secs(2)).await;
     coordinator.process_incoming_messages()?;
 


### PR DESCRIPTION
Fix https://github.com/get10101/10101/issues/461.

With the version of `rust-lightning` prior to [this patch](https://github.com/p2pderivatives/rust-lightning/commit/a33cc845bc05eb0bb3e9ba8f11789ba4ed44f5b1), after opening a DLC channel we could wrongly unconfirm the LN funding transaction if it had already been confirmed.

We would look for the glue transaction on-chain, not find it and then report back to the `ChannelManager` that the _funding_ transaction was unconfirmed. This led to force-closing the LN channel unnecessarily.