### PR TITLE
chore: Export 10101 app logs with '*.log' extension

### DIFF
--- a/mobile/lib/common/settings_screen.dart
+++ b/mobile/lib/common/settings_screen.dart
@@ -164,8 +164,8 @@ class _SettingsScreenState extends State<SettingsScreen> {
               var logsAsString = await file.readAsString();
               final List<int> bytes = utf8.encode(logsAsString);
               final Directory tempDir = await getTemporaryDirectory();
-              String now = DateFormat('yyyy-MM-dd_HH:mm:ss').format(DateTime.now());
-              final String filePath = '${tempDir.path}/$now.logs';
+              String now = DateFormat('yyyy-MM-dd_HHmmss').format(DateTime.now());
+              final String filePath = '${tempDir.path}/$now.log';
               await File(filePath).writeAsBytes(bytes);
               final XFile logFile = XFile(filePath);
               Share.shareXFiles([logFile], text: 'Logs from $now');


### PR DESCRIPTION
"*.logs" is non-standard, making it harder to open it in IDE.

![image](https://user-images.githubusercontent.com/8319440/233197238-297feddb-2e79-45f7-9acc-e94a8f7aa65b.png)
