### PR TITLE
feat: Delay payment for the user to open 10101

### DIFF
--- a/crates/ln-dlc-node/src/ln/mod.rs
+++ b/crates/ln-dlc-node/src/ln/mod.rs
@@ -22,3 +22,10 @@ pub(crate) use logger::TracingLogger;
 ///
 /// This constant only applies to the coordinator.
 pub(crate) const JUST_IN_TIME_CHANNEL_OUTBOUND_LIQUIDITY_SAT: u64 = 200_000;
+
+/// When handling the [`Event::HTLCIntercepted`], the user might not be online right away. This
+/// could be because she is funding the wallet through another wallet. In order to give the user
+/// some time to open 10101 again we wait for a bit to see if we can establish a connection.
+///
+/// This constant specifies the amount of time (in seconds) we are willing to delay a payment.
+pub(crate) const HTLC_INTERCEPTED_CONNECTION_TIMEOUT: u64 = 30;

--- a/crates/ln-dlc-node/src/node/mod.rs
+++ b/crates/ln-dlc-node/src/node/mod.rs
@@ -346,6 +346,7 @@ where
                 payment_persister.clone(),
                 fake_channel_payments.clone(),
                 Arc::new(Mutex::new(HashMap::new())),
+                peer_manager.clone(),
             )
         };
 

--- a/crates/ln-dlc-node/src/tests/just_in_time_channel/mod.rs
+++ b/crates/ln-dlc-node/src/tests/just_in_time_channel/mod.rs
@@ -1,2 +1,11 @@
 mod create;
 mod multiple_payments;
+mod offline_receiver;
+
+#[derive(PartialEq)]
+pub enum TestPath {
+    // funding through an always on lightning node
+    OnlineFunding,
+    // funding through a mobile lightning node (on the same phone)
+    MobileFunding,
+}

--- a/crates/ln-dlc-node/src/tests/just_in_time_channel/multiple_payments.rs
+++ b/crates/ln-dlc-node/src/tests/just_in_time_channel/multiple_payments.rs
@@ -2,6 +2,7 @@ use crate::ln::JUST_IN_TIME_CHANNEL_OUTBOUND_LIQUIDITY_SAT;
 use crate::node::Node;
 use crate::tests::init_tracing;
 use crate::tests::just_in_time_channel::create::send_interceptable_payment;
+use crate::tests::just_in_time_channel::TestPath;
 use crate::tests::min_outbound_liquidity_channel_creator;
 use bitcoin::Amount;
 
@@ -36,6 +37,7 @@ async fn just_in_time_channel_with_multiple_payments() {
 
     // this creates the just in time channel between the coordinator and user_b
     send_interceptable_payment(
+        TestPath::OnlineFunding,
         &user_a,
         &user_b,
         &coordinator,
@@ -48,23 +50,44 @@ async fn just_in_time_channel_with_multiple_payments() {
     // after creating the just-in-time channel. The coordinator should have exactly 2 channels.
     assert_eq!(coordinator.channel_manager.list_channels().len(), 2);
 
-    send_interceptable_payment(&user_a, &user_b, &coordinator, 3_000, None)
-        .await
-        .unwrap();
+    send_interceptable_payment(
+        TestPath::OnlineFunding,
+        &user_a,
+        &user_b,
+        &coordinator,
+        3_000,
+        None,
+    )
+    .await
+    .unwrap();
 
     // no additional just-in-time channel should be created.
     assert_eq!(coordinator.channel_manager.list_channels().len(), 2);
 
-    send_interceptable_payment(&user_b, &user_a, &coordinator, 4_500, None)
-        .await
-        .unwrap();
+    send_interceptable_payment(
+        TestPath::OnlineFunding,
+        &user_b,
+        &user_a,
+        &coordinator,
+        4_500,
+        None,
+    )
+    .await
+    .unwrap();
 
     // no additional just-in-time channel should be created.
     assert_eq!(coordinator.channel_manager.list_channels().len(), 2);
 
-    send_interceptable_payment(&user_a, &user_b, &coordinator, 5_000, None)
-        .await
-        .unwrap();
+    send_interceptable_payment(
+        TestPath::OnlineFunding,
+        &user_a,
+        &user_b,
+        &coordinator,
+        5_000,
+        None,
+    )
+    .await
+    .unwrap();
 
     // no additional just-in-time channel should be created.
     assert_eq!(coordinator.channel_manager.list_channels().len(), 2);

--- a/crates/ln-dlc-node/src/tests/just_in_time_channel/offline_receiver.rs
+++ b/crates/ln-dlc-node/src/tests/just_in_time_channel/offline_receiver.rs
@@ -1,0 +1,49 @@
+use crate::ln::JUST_IN_TIME_CHANNEL_OUTBOUND_LIQUIDITY_SAT;
+use crate::node::Node;
+use crate::tests::init_tracing;
+use crate::tests::just_in_time_channel::create::send_interceptable_payment;
+use crate::tests::just_in_time_channel::TestPath;
+use crate::tests::min_outbound_liquidity_channel_creator;
+use bitcoin::Amount;
+
+#[tokio::test]
+#[ignore]
+async fn offline_receiver() {
+    init_tracing();
+
+    // Arrange
+
+    let payer = Node::start_test_app("payer").await.unwrap();
+    let coordinator = Node::start_test_coordinator("coordinator").await.unwrap();
+    let payee = Node::start_test_app("payee").await.unwrap();
+
+    payer.connect(coordinator.info).await.unwrap();
+
+    coordinator.fund(Amount::from_sat(1_000_000)).await.unwrap();
+
+    let payer_outbound_liquidity_sat = 25_000;
+    let coordinator_outbound_liquidity_sat =
+        min_outbound_liquidity_channel_creator(&payer, payer_outbound_liquidity_sat);
+
+    coordinator
+        .open_channel(
+            &payer,
+            coordinator_outbound_liquidity_sat,
+            payer_outbound_liquidity_sat,
+        )
+        .await
+        .unwrap();
+
+    let invoice_amount = 1_000;
+
+    send_interceptable_payment(
+        TestPath::MobileFunding,
+        &payer,
+        &payee,
+        &coordinator,
+        invoice_amount,
+        Some(JUST_IN_TIME_CHANNEL_OUTBOUND_LIQUIDITY_SAT),
+    )
+    .await
+    .unwrap();
+}


### PR DESCRIPTION
In cases the user will onboard to 10101 using another mobile app. 10101 will be closed at the time the payment is sent. Without delaying payment processing before the user opens 10101 the payment will always fail.

This is a quick fix to solve that issue, by simply waiting for 10 seconds for the 10101 receiver to come online.

Eventually we should implement some logic that is keeping 10101 online in the background for some time to cater for that scenario more nicely.

Also note, that this fix assumes that the sending party will remain online while the payment is sent.

resolves #478