### PR TITLE
feat: Restrict trading buttons to only one trade

### DIFF
--- a/mobile/lib/features/trade/trade_bottom_sheet_tab.dart
+++ b/mobile/lib/features/trade/trade_bottom_sheet_tab.dart
@@ -17,6 +17,7 @@ import 'package:get_10101/features/trade/trade_value_change_notifier.dart';
 import 'package:get_10101/features/trade/trade_theme.dart';
 import 'package:get_10101/features/wallet/domain/wallet_info.dart';
 import 'package:get_10101/features/wallet/wallet_change_notifier.dart';
+import 'package:get_10101/util/preferences.dart';
 import 'package:go_router/go_router.dart';
 import 'package:provider/provider.dart';
 
@@ -273,6 +274,8 @@ class _TradeBottomSheetTabState extends State<TradeBottomSheetTab> {
                           direction: widget.direction,
                           onConfirmation: () {
                             submitOrderChangeNotifier.submitPendingOrder(tradeValues, false);
+
+                            Preferences.instance.setOpenedPosition(true);
 
                             // TODO: Explore if it would be easier / better handle the popups as routes
                             // Pop twice to navigate back to the trade screen.

--- a/mobile/lib/features/trade/trade_screen.dart
+++ b/mobile/lib/features/trade/trade_screen.dart
@@ -19,15 +19,23 @@ import 'package:get_10101/features/trade/trade_bottom_sheet_confirmation.dart';
 import 'package:get_10101/features/trade/trade_tabs.dart';
 import 'package:get_10101/features/trade/trade_theme.dart';
 import 'package:get_10101/features/trade/trade_value_change_notifier.dart';
+import 'package:get_10101/util/preferences.dart';
 import 'package:go_router/go_router.dart';
 import 'package:provider/provider.dart';
 import 'package:get_10101/util/constants.dart';
 
-class TradeScreen extends StatelessWidget {
+class TradeScreen extends StatefulWidget {
   static const route = "/trade";
   static const label = "Trade";
 
   const TradeScreen({Key? key}) : super(key: key);
+
+  @override
+  State<TradeScreen> createState() => _TradeScreenState();
+}
+
+class _TradeScreenState extends State<TradeScreen> {
+  bool showBuySellButtons = false;
 
   @override
   Widget build(BuildContext context) {
@@ -124,6 +132,12 @@ class TradeScreen extends StatelessWidget {
     SizedBox listBottomScrollSpace = const SizedBox(
       height: 60,
     );
+
+    Preferences.instance.isOpenedPosition().then((value) {
+      if (showBuySellButtons != !value) {
+        setState(() => showBuySellButtons = !value);
+      }
+    });
 
     return Scaffold(
         body: Container(
@@ -283,12 +297,12 @@ class TradeScreen extends StatelessWidget {
                   child: FloatingActionButton.extended(
                     key: tradeScreenButtonBuy,
                     heroTag: "btnBuy",
-                    onPressed: () {
-                      tradeBottomSheet(context: context, direction: Direction.long);
-                    },
+                    onPressed: showBuySellButtons
+                        ? () => tradeBottomSheet(context: context, direction: Direction.long)
+                        : null,
                     label: const Text("Buy"),
                     shape: tradeButtonShape,
-                    backgroundColor: tradeTheme.buy,
+                    backgroundColor: showBuySellButtons ? tradeTheme.buy : Colors.grey,
                   )),
               const SizedBox(width: 20),
               SizedBox(
@@ -296,12 +310,12 @@ class TradeScreen extends StatelessWidget {
                   child: FloatingActionButton.extended(
                     key: tradeScreenButtonSell,
                     heroTag: "btnSell",
-                    onPressed: () {
-                      tradeBottomSheet(context: context, direction: Direction.short);
-                    },
+                    onPressed: showBuySellButtons
+                        ? () => tradeBottomSheet(context: context, direction: Direction.short)
+                        : null,
                     label: const Text("Sell"),
                     shape: tradeButtonShape,
-                    backgroundColor: tradeTheme.sell,
+                    backgroundColor: showBuySellButtons ? tradeTheme.sell : Colors.grey,
                   )),
             ],
           ),

--- a/mobile/lib/util/preferences.dart
+++ b/mobile/lib/util/preferences.dart
@@ -7,6 +7,17 @@ class Preferences {
 
   static const userSeedBackupConfirmed = "userSeedBackupConfirmed";
   static const emailAddress = "emailAddress";
+  static const openedPosition = "openedPosition";
+
+  setOpenedPosition(bool value) async {
+    SharedPreferences preferences = await SharedPreferences.getInstance();
+    preferences.setBool(openedPosition, value);
+  }
+
+  Future<bool> isOpenedPosition() async {
+    SharedPreferences preferences = await SharedPreferences.getInstance();
+    return preferences.getBool(openedPosition) ?? false;
+  }
 
   setUserSeedBackupConfirmed(bool value) async {
     SharedPreferences preferences = await SharedPreferences.getInstance();


### PR DESCRIPTION
This prevents the user from running into a bug, that happens when a second position is opened.

Revert that commit once https://github.com/get10101/10101/issues/399 is fixed.