### PR TITLE
Allow open-closing many DLC channels in a row

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -825,7 +825,7 @@ dependencies = [
 [[package]]
 name = "dlc"
 version = "0.4.0"
-source = "git+https://github.com/get10101/rust-dlc?rev=b4f8e3239f10a9a4ad51695364761ac366de475d#b4f8e3239f10a9a4ad51695364761ac366de475d"
+source = "git+https://github.com/get10101/rust-dlc?rev=884272e5b0a9490241fe702ccd65c0e0793fda1f#884272e5b0a9490241fe702ccd65c0e0793fda1f"
 dependencies = [
  "bitcoin",
  "miniscript",
@@ -837,7 +837,7 @@ dependencies = [
 [[package]]
 name = "dlc-manager"
 version = "0.4.0"
-source = "git+https://github.com/get10101/rust-dlc?rev=b4f8e3239f10a9a4ad51695364761ac366de475d#b4f8e3239f10a9a4ad51695364761ac366de475d"
+source = "git+https://github.com/get10101/rust-dlc?rev=884272e5b0a9490241fe702ccd65c0e0793fda1f#884272e5b0a9490241fe702ccd65c0e0793fda1f"
 dependencies = [
  "async-trait",
  "bitcoin",
@@ -853,7 +853,7 @@ dependencies = [
 [[package]]
 name = "dlc-messages"
 version = "0.4.0"
-source = "git+https://github.com/get10101/rust-dlc?rev=b4f8e3239f10a9a4ad51695364761ac366de475d#b4f8e3239f10a9a4ad51695364761ac366de475d"
+source = "git+https://github.com/get10101/rust-dlc?rev=884272e5b0a9490241fe702ccd65c0e0793fda1f#884272e5b0a9490241fe702ccd65c0e0793fda1f"
 dependencies = [
  "bitcoin",
  "dlc",
@@ -865,7 +865,7 @@ dependencies = [
 [[package]]
 name = "dlc-sled-storage-provider"
 version = "0.1.0"
-source = "git+https://github.com/get10101/rust-dlc?rev=b4f8e3239f10a9a4ad51695364761ac366de475d#b4f8e3239f10a9a4ad51695364761ac366de475d"
+source = "git+https://github.com/get10101/rust-dlc?rev=884272e5b0a9490241fe702ccd65c0e0793fda1f#884272e5b0a9490241fe702ccd65c0e0793fda1f"
 dependencies = [
  "bitcoin",
  "dlc-manager",
@@ -878,7 +878,7 @@ dependencies = [
 [[package]]
 name = "dlc-trie"
 version = "0.4.0"
-source = "git+https://github.com/get10101/rust-dlc?rev=b4f8e3239f10a9a4ad51695364761ac366de475d#b4f8e3239f10a9a4ad51695364761ac366de475d"
+source = "git+https://github.com/get10101/rust-dlc?rev=884272e5b0a9490241fe702ccd65c0e0793fda1f#884272e5b0a9490241fe702ccd65c0e0793fda1f"
 dependencies = [
  "bitcoin",
  "dlc",
@@ -2007,7 +2007,7 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 [[package]]
 name = "p2pd-oracle-client"
 version = "0.1.0"
-source = "git+https://github.com/get10101/rust-dlc?rev=b4f8e3239f10a9a4ad51695364761ac366de475d#b4f8e3239f10a9a4ad51695364761ac366de475d"
+source = "git+https://github.com/get10101/rust-dlc?rev=884272e5b0a9490241fe702ccd65c0e0793fda1f#884272e5b0a9490241fe702ccd65c0e0793fda1f"
 dependencies = [
  "chrono",
  "dlc-manager",
@@ -2670,7 +2670,7 @@ dependencies = [
 [[package]]
 name = "simple-wallet"
 version = "0.1.0"
-source = "git+https://github.com/get10101/rust-dlc?rev=b4f8e3239f10a9a4ad51695364761ac366de475d#b4f8e3239f10a9a4ad51695364761ac366de475d"
+source = "git+https://github.com/get10101/rust-dlc?rev=884272e5b0a9490241fe702ccd65c0e0793fda1f#884272e5b0a9490241fe702ccd65c0e0793fda1f"
 dependencies = [
  "bitcoin",
  "dlc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,13 +3,13 @@ members = ["coordinator", "maker", "mobile/native", "crates/*"]
 resolver = "2"
 
 [patch.crates-io]
-dlc-manager = { git = "https://github.com/get10101/rust-dlc", rev = "b4f8e3239f10a9a4ad51695364761ac366de475d" }
-dlc-messages = { git = "https://github.com/get10101/rust-dlc", rev = "b4f8e3239f10a9a4ad51695364761ac366de475d" }
-dlc = { git = "https://github.com/get10101/rust-dlc", rev = "b4f8e3239f10a9a4ad51695364761ac366de475d" }
-dlc-sled-storage-provider = { git = "https://github.com/get10101/rust-dlc", rev = "b4f8e3239f10a9a4ad51695364761ac366de475d" }
-p2pd-oracle-client = { git = "https://github.com/get10101/rust-dlc", rev = "b4f8e3239f10a9a4ad51695364761ac366de475d" }
-dlc-trie = { git = "https://github.com/get10101/rust-dlc", rev = "b4f8e3239f10a9a4ad51695364761ac366de475d" }
-simple-wallet = { git = "https://github.com/get10101/rust-dlc", rev = "b4f8e3239f10a9a4ad51695364761ac366de475d" }
+dlc-manager = { git = "https://github.com/get10101/rust-dlc", rev = "884272e5b0a9490241fe702ccd65c0e0793fda1f" }
+dlc-messages = { git = "https://github.com/get10101/rust-dlc", rev = "884272e5b0a9490241fe702ccd65c0e0793fda1f" }
+dlc = { git = "https://github.com/get10101/rust-dlc", rev = "884272e5b0a9490241fe702ccd65c0e0793fda1f" }
+dlc-sled-storage-provider = { git = "https://github.com/get10101/rust-dlc", rev = "884272e5b0a9490241fe702ccd65c0e0793fda1f" }
+p2pd-oracle-client = { git = "https://github.com/get10101/rust-dlc", rev = "884272e5b0a9490241fe702ccd65c0e0793fda1f" }
+dlc-trie = { git = "https://github.com/get10101/rust-dlc", rev = "884272e5b0a9490241fe702ccd65c0e0793fda1f" }
+simple-wallet = { git = "https://github.com/get10101/rust-dlc", rev = "884272e5b0a9490241fe702ccd65c0e0793fda1f" }
 lightning = { git = "https://github.com/p2pderivatives/rust-lightning/", rev = "6df5761cfc4a27c35ca26a547ff90f656d50d85f" }
 lightning-background-processor = { git = "https://github.com/p2pderivatives/rust-lightning/", rev = "6df5761cfc4a27c35ca26a547ff90f656d50d85f" }
 lightning-block-sync = { git = "https://github.com/p2pderivatives/rust-lightning/", rev = "6df5761cfc4a27c35ca26a547ff90f656d50d85f" }


### PR DESCRIPTION
Fixes #310.
Fixes #399.

There was a bug in `rust-dlc` where the `per_split_secret` key was not being computed consistently across the different message handlers.