### PR TITLE
feat: Add connect and is connected endpoints

### DIFF
--- a/coordinator/src/admin.rs
+++ b/coordinator/src/admin.rs
@@ -175,3 +175,24 @@ pub async fn sign_message(
 
     Ok(Json(signature))
 }
+
+pub async fn connect_to_peer(
+    State(state): State<Arc<AppState>>,
+    target: Json<NodeInfo>,
+) -> Result<(), AppError> {
+    let target = target.0;
+    state.node.inner.connect(target).await.map_err(|err| {
+        AppError::InternalServerError(format!("Could not connect to {target}. Error: {err}"))
+    })?;
+    Ok(())
+}
+
+pub async fn is_connected(
+    State(state): State<Arc<AppState>>,
+    Path(target_pubkey): Path<String>,
+) -> Result<Json<bool>, AppError> {
+    let target = target_pubkey.parse().map_err(|err| {
+        AppError::BadRequest(format!("Invalid public key {target_pubkey}. Error: {err}"))
+    })?;
+    Ok(Json(state.node.is_connected(&target)))
+}

--- a/coordinator/src/routes.rs
+++ b/coordinator/src/routes.rs
@@ -26,7 +26,9 @@ use ln_dlc_node::node::NodeInfo;
 use orderbook_commons::OrderbookMsg;
 
 use crate::admin::close_channel;
+use crate::admin::connect_to_peer;
 use crate::admin::get_balance;
+use crate::admin::is_connected;
 use crate::admin::list_channels;
 use crate::admin::list_dlc_channels;
 use crate::admin::list_peers;
@@ -76,6 +78,8 @@ pub fn router(node: Node, pool: Pool<ConnectionManager<PgConnection>>) -> Router
         .route("/api/admin/peers", get(list_peers))
         .route("/api/admin/dlc_channels", get(list_dlc_channels))
         .route("/api/admin/sign/:msg", get(sign_message))
+        .route("/api/admin/connect", post(connect_to_peer))
+        .route("/api/admin/is_connected/:target_pubkey", get(is_connected))
         .with_state(app_state)
 }
 


### PR DESCRIPTION
If the coordinator restarts it does not attempt to reconnect to previously connected peers. This is a quick fix to add an admin endpoint to connect to any given peer.

### Tested with maker and taker.

1. Open channel from taker to maker.
```
curl -v -X POST -H "Content-Type: application/json" -d '{"target": { "pubkey": "025c578b8e05cd203e2a486388ed4de4e480456923192a0f288ef96c863940ce6b", "address": "127.0.0.1:19045"}, "local_balance": 300000 }' http://localhost:8000/api/admin/channels
```
2. Check if peer is connected
```
# will list all connected peers.
curl -X GET http://localhost:8000/api/admin/peers

# returns true if given peer is connected or false otherwise.
curl -X GET http://localhost:8000/api/admin/is_connected/025c578b8e05cd203e2a486388ed4de4e480456923192a0f288ef96c863940ce6b
```
3. Stop the maker
4. Verify that coordinator is not connected to maker
```
# will return an empty list
curl -X GET http://localhost:8000/api/admin/peers

# returns false
curl -X GET http://localhost:8000/api/admin/is_connected/025c578b8e05cd203e2a486388ed4de4e480456923192a0f288ef96c863940ce6b
```
5. Start maker again. At this point the maker and coordinator remain disconnected as neither tries to reconnect to a peer they have a channel with. This should be fixed for public channels.
6. Connect coordinator to maker
```
curl -X POST -H "Content-Type: application/json" -d '{"pubkey": "025c578b8e05cd203e2a486388ed4de4e480456923192a0f288ef96c863940ce6b", "address": "127.0.0.1:19045"}' http://localhost:8000/api/admin/connect
```
7. Verify that maker and coordinator are connected (see step 4)

resolves #479 