### PR TITLE
Keep `rust-dlc` dependency up-to-date

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -825,7 +825,7 @@ dependencies = [
 [[package]]
 name = "dlc"
 version = "0.4.0"
-source = "git+https://github.com/get10101/rust-dlc?rev=884272e5b0a9490241fe702ccd65c0e0793fda1f#884272e5b0a9490241fe702ccd65c0e0793fda1f"
+source = "git+https://github.com/get10101/rust-dlc?rev=87c3f8b69884dbdfa4e0404de0bb6ec5aea3ff79#87c3f8b69884dbdfa4e0404de0bb6ec5aea3ff79"
 dependencies = [
  "bitcoin",
  "miniscript",
@@ -837,7 +837,7 @@ dependencies = [
 [[package]]
 name = "dlc-manager"
 version = "0.4.0"
-source = "git+https://github.com/get10101/rust-dlc?rev=884272e5b0a9490241fe702ccd65c0e0793fda1f#884272e5b0a9490241fe702ccd65c0e0793fda1f"
+source = "git+https://github.com/get10101/rust-dlc?rev=87c3f8b69884dbdfa4e0404de0bb6ec5aea3ff79#87c3f8b69884dbdfa4e0404de0bb6ec5aea3ff79"
 dependencies = [
  "async-trait",
  "bitcoin",
@@ -853,7 +853,7 @@ dependencies = [
 [[package]]
 name = "dlc-messages"
 version = "0.4.0"
-source = "git+https://github.com/get10101/rust-dlc?rev=884272e5b0a9490241fe702ccd65c0e0793fda1f#884272e5b0a9490241fe702ccd65c0e0793fda1f"
+source = "git+https://github.com/get10101/rust-dlc?rev=87c3f8b69884dbdfa4e0404de0bb6ec5aea3ff79#87c3f8b69884dbdfa4e0404de0bb6ec5aea3ff79"
 dependencies = [
  "bitcoin",
  "dlc",
@@ -865,7 +865,7 @@ dependencies = [
 [[package]]
 name = "dlc-sled-storage-provider"
 version = "0.1.0"
-source = "git+https://github.com/get10101/rust-dlc?rev=884272e5b0a9490241fe702ccd65c0e0793fda1f#884272e5b0a9490241fe702ccd65c0e0793fda1f"
+source = "git+https://github.com/get10101/rust-dlc?rev=87c3f8b69884dbdfa4e0404de0bb6ec5aea3ff79#87c3f8b69884dbdfa4e0404de0bb6ec5aea3ff79"
 dependencies = [
  "bitcoin",
  "dlc-manager",
@@ -878,7 +878,7 @@ dependencies = [
 [[package]]
 name = "dlc-trie"
 version = "0.4.0"
-source = "git+https://github.com/get10101/rust-dlc?rev=884272e5b0a9490241fe702ccd65c0e0793fda1f#884272e5b0a9490241fe702ccd65c0e0793fda1f"
+source = "git+https://github.com/get10101/rust-dlc?rev=87c3f8b69884dbdfa4e0404de0bb6ec5aea3ff79#87c3f8b69884dbdfa4e0404de0bb6ec5aea3ff79"
 dependencies = [
  "bitcoin",
  "dlc",
@@ -2007,7 +2007,7 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 [[package]]
 name = "p2pd-oracle-client"
 version = "0.1.0"
-source = "git+https://github.com/get10101/rust-dlc?rev=884272e5b0a9490241fe702ccd65c0e0793fda1f#884272e5b0a9490241fe702ccd65c0e0793fda1f"
+source = "git+https://github.com/get10101/rust-dlc?rev=87c3f8b69884dbdfa4e0404de0bb6ec5aea3ff79#87c3f8b69884dbdfa4e0404de0bb6ec5aea3ff79"
 dependencies = [
  "chrono",
  "dlc-manager",
@@ -2670,7 +2670,7 @@ dependencies = [
 [[package]]
 name = "simple-wallet"
 version = "0.1.0"
-source = "git+https://github.com/get10101/rust-dlc?rev=884272e5b0a9490241fe702ccd65c0e0793fda1f#884272e5b0a9490241fe702ccd65c0e0793fda1f"
+source = "git+https://github.com/get10101/rust-dlc?rev=87c3f8b69884dbdfa4e0404de0bb6ec5aea3ff79#87c3f8b69884dbdfa4e0404de0bb6ec5aea3ff79"
 dependencies = [
  "bitcoin",
  "dlc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,13 +3,13 @@ members = ["coordinator", "maker", "mobile/native", "crates/*"]
 resolver = "2"
 
 [patch.crates-io]
-dlc-manager = { git = "https://github.com/get10101/rust-dlc", rev = "884272e5b0a9490241fe702ccd65c0e0793fda1f" }
-dlc-messages = { git = "https://github.com/get10101/rust-dlc", rev = "884272e5b0a9490241fe702ccd65c0e0793fda1f" }
-dlc = { git = "https://github.com/get10101/rust-dlc", rev = "884272e5b0a9490241fe702ccd65c0e0793fda1f" }
-dlc-sled-storage-provider = { git = "https://github.com/get10101/rust-dlc", rev = "884272e5b0a9490241fe702ccd65c0e0793fda1f" }
-p2pd-oracle-client = { git = "https://github.com/get10101/rust-dlc", rev = "884272e5b0a9490241fe702ccd65c0e0793fda1f" }
-dlc-trie = { git = "https://github.com/get10101/rust-dlc", rev = "884272e5b0a9490241fe702ccd65c0e0793fda1f" }
-simple-wallet = { git = "https://github.com/get10101/rust-dlc", rev = "884272e5b0a9490241fe702ccd65c0e0793fda1f" }
+dlc-manager = { git = "https://github.com/get10101/rust-dlc", rev = "87c3f8b69884dbdfa4e0404de0bb6ec5aea3ff79" }
+dlc-messages = { git = "https://github.com/get10101/rust-dlc", rev = "87c3f8b69884dbdfa4e0404de0bb6ec5aea3ff79" }
+dlc = { git = "https://github.com/get10101/rust-dlc", rev = "87c3f8b69884dbdfa4e0404de0bb6ec5aea3ff79" }
+dlc-sled-storage-provider = { git = "https://github.com/get10101/rust-dlc", rev = "87c3f8b69884dbdfa4e0404de0bb6ec5aea3ff79" }
+p2pd-oracle-client = { git = "https://github.com/get10101/rust-dlc", rev = "87c3f8b69884dbdfa4e0404de0bb6ec5aea3ff79" }
+dlc-trie = { git = "https://github.com/get10101/rust-dlc", rev = "87c3f8b69884dbdfa4e0404de0bb6ec5aea3ff79" }
+simple-wallet = { git = "https://github.com/get10101/rust-dlc", rev = "87c3f8b69884dbdfa4e0404de0bb6ec5aea3ff79" }
 lightning = { git = "https://github.com/p2pderivatives/rust-lightning/", rev = "6df5761cfc4a27c35ca26a547ff90f656d50d85f" }
 lightning-background-processor = { git = "https://github.com/p2pderivatives/rust-lightning/", rev = "6df5761cfc4a27c35ca26a547ff90f656d50d85f" }
 lightning-block-sync = { git = "https://github.com/p2pderivatives/rust-lightning/", rev = "6df5761cfc4a27c35ca26a547ff90f656d50d85f" }


### PR DESCRIPTION
No notable functional changes other than ensuring that our fork of `rust-dlc` is as similar as possible to upstream.