### PR TITLE
Use temporary version of `rust-dlc` to circumvent bug

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -825,7 +825,7 @@ dependencies = [
 [[package]]
 name = "dlc"
 version = "0.4.0"
-source = "git+https://github.com/get10101/rust-dlc?rev=87c3f8b69884dbdfa4e0404de0bb6ec5aea3ff79#87c3f8b69884dbdfa4e0404de0bb6ec5aea3ff79"
+source = "git+https://github.com/get10101/rust-dlc?rev=9a8b0aff6b55b4b0903944359421ab63522e833c#9a8b0aff6b55b4b0903944359421ab63522e833c"
 dependencies = [
  "bitcoin",
  "miniscript",
@@ -837,7 +837,7 @@ dependencies = [
 [[package]]
 name = "dlc-manager"
 version = "0.4.0"
-source = "git+https://github.com/get10101/rust-dlc?rev=87c3f8b69884dbdfa4e0404de0bb6ec5aea3ff79#87c3f8b69884dbdfa4e0404de0bb6ec5aea3ff79"
+source = "git+https://github.com/get10101/rust-dlc?rev=9a8b0aff6b55b4b0903944359421ab63522e833c#9a8b0aff6b55b4b0903944359421ab63522e833c"
 dependencies = [
  "async-trait",
  "bitcoin",
@@ -853,7 +853,7 @@ dependencies = [
 [[package]]
 name = "dlc-messages"
 version = "0.4.0"
-source = "git+https://github.com/get10101/rust-dlc?rev=87c3f8b69884dbdfa4e0404de0bb6ec5aea3ff79#87c3f8b69884dbdfa4e0404de0bb6ec5aea3ff79"
+source = "git+https://github.com/get10101/rust-dlc?rev=9a8b0aff6b55b4b0903944359421ab63522e833c#9a8b0aff6b55b4b0903944359421ab63522e833c"
 dependencies = [
  "bitcoin",
  "dlc",
@@ -865,7 +865,7 @@ dependencies = [
 [[package]]
 name = "dlc-sled-storage-provider"
 version = "0.1.0"
-source = "git+https://github.com/get10101/rust-dlc?rev=87c3f8b69884dbdfa4e0404de0bb6ec5aea3ff79#87c3f8b69884dbdfa4e0404de0bb6ec5aea3ff79"
+source = "git+https://github.com/get10101/rust-dlc?rev=9a8b0aff6b55b4b0903944359421ab63522e833c#9a8b0aff6b55b4b0903944359421ab63522e833c"
 dependencies = [
  "bitcoin",
  "dlc-manager",
@@ -878,7 +878,7 @@ dependencies = [
 [[package]]
 name = "dlc-trie"
 version = "0.4.0"
-source = "git+https://github.com/get10101/rust-dlc?rev=87c3f8b69884dbdfa4e0404de0bb6ec5aea3ff79#87c3f8b69884dbdfa4e0404de0bb6ec5aea3ff79"
+source = "git+https://github.com/get10101/rust-dlc?rev=9a8b0aff6b55b4b0903944359421ab63522e833c#9a8b0aff6b55b4b0903944359421ab63522e833c"
 dependencies = [
  "bitcoin",
  "dlc",
@@ -2007,7 +2007,7 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 [[package]]
 name = "p2pd-oracle-client"
 version = "0.1.0"
-source = "git+https://github.com/get10101/rust-dlc?rev=87c3f8b69884dbdfa4e0404de0bb6ec5aea3ff79#87c3f8b69884dbdfa4e0404de0bb6ec5aea3ff79"
+source = "git+https://github.com/get10101/rust-dlc?rev=9a8b0aff6b55b4b0903944359421ab63522e833c#9a8b0aff6b55b4b0903944359421ab63522e833c"
 dependencies = [
  "chrono",
  "dlc-manager",
@@ -2670,7 +2670,7 @@ dependencies = [
 [[package]]
 name = "simple-wallet"
 version = "0.1.0"
-source = "git+https://github.com/get10101/rust-dlc?rev=87c3f8b69884dbdfa4e0404de0bb6ec5aea3ff79#87c3f8b69884dbdfa4e0404de0bb6ec5aea3ff79"
+source = "git+https://github.com/get10101/rust-dlc?rev=9a8b0aff6b55b4b0903944359421ab63522e833c#9a8b0aff6b55b4b0903944359421ab63522e833c"
 dependencies = [
  "bitcoin",
  "dlc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,13 +3,13 @@ members = ["coordinator", "maker", "mobile/native", "crates/*"]
 resolver = "2"
 
 [patch.crates-io]
-dlc-manager = { git = "https://github.com/get10101/rust-dlc", rev = "87c3f8b69884dbdfa4e0404de0bb6ec5aea3ff79" }
-dlc-messages = { git = "https://github.com/get10101/rust-dlc", rev = "87c3f8b69884dbdfa4e0404de0bb6ec5aea3ff79" }
-dlc = { git = "https://github.com/get10101/rust-dlc", rev = "87c3f8b69884dbdfa4e0404de0bb6ec5aea3ff79" }
-dlc-sled-storage-provider = { git = "https://github.com/get10101/rust-dlc", rev = "87c3f8b69884dbdfa4e0404de0bb6ec5aea3ff79" }
-p2pd-oracle-client = { git = "https://github.com/get10101/rust-dlc", rev = "87c3f8b69884dbdfa4e0404de0bb6ec5aea3ff79" }
-dlc-trie = { git = "https://github.com/get10101/rust-dlc", rev = "87c3f8b69884dbdfa4e0404de0bb6ec5aea3ff79" }
-simple-wallet = { git = "https://github.com/get10101/rust-dlc", rev = "87c3f8b69884dbdfa4e0404de0bb6ec5aea3ff79" }
+dlc-manager = { git = "https://github.com/get10101/rust-dlc", rev = "9a8b0aff6b55b4b0903944359421ab63522e833c" }
+dlc-messages = { git = "https://github.com/get10101/rust-dlc", rev = "9a8b0aff6b55b4b0903944359421ab63522e833c" }
+dlc = { git = "https://github.com/get10101/rust-dlc", rev = "9a8b0aff6b55b4b0903944359421ab63522e833c" }
+dlc-sled-storage-provider = { git = "https://github.com/get10101/rust-dlc", rev = "9a8b0aff6b55b4b0903944359421ab63522e833c" }
+p2pd-oracle-client = { git = "https://github.com/get10101/rust-dlc", rev = "9a8b0aff6b55b4b0903944359421ab63522e833c" }
+dlc-trie = { git = "https://github.com/get10101/rust-dlc", rev = "9a8b0aff6b55b4b0903944359421ab63522e833c" }
+simple-wallet = { git = "https://github.com/get10101/rust-dlc", rev = "9a8b0aff6b55b4b0903944359421ab63522e833c" }
 lightning = { git = "https://github.com/p2pderivatives/rust-lightning/", rev = "6df5761cfc4a27c35ca26a547ff90f656d50d85f" }
 lightning-background-processor = { git = "https://github.com/p2pderivatives/rust-lightning/", rev = "6df5761cfc4a27c35ca26a547ff90f656d50d85f" }
 lightning-block-sync = { git = "https://github.com/p2pderivatives/rust-lightning/", rev = "6df5761cfc4a27c35ca26a547ff90f656d50d85f" }


### PR DESCRIPTION
This is an attempt at dealing with the consequences of https://github.com/get10101/10101/issues/480.

I don't think `rust-dlc#ln-dlc-channels` intends to be backwards-compatible at this stage, so this is not something that we want to upstream.

---

The idea here is to use this branch to start up the mainnet coordinator and close a few DLC channels that are outdated. We can use the logs to identify which ones are old, or simply close all of them.

This is not guaranteed to "fix" #480, but it's the leading theory.