### PR TITLE
Keep coordinator connected to public channel peers

### DIFF
--- a/coordinator/src/bin/coordinator.rs
+++ b/coordinator/src/bin/coordinator.rs
@@ -3,6 +3,7 @@ use anyhow::Result;
 use coordinator::cli::Opts;
 use coordinator::db;
 use coordinator::logger;
+use coordinator::node::connection;
 use coordinator::node::Node;
 use coordinator::node::TradeAction;
 use coordinator::position::models::Position;
@@ -210,6 +211,11 @@ async fn main() -> Result<()> {
                 }
             }
         }
+    });
+
+    tokio::spawn({
+        let node = node.clone();
+        connection::keep_public_channel_peers_connected(node.inner)
     });
 
     let app = router(node, pool);

--- a/coordinator/src/node.rs
+++ b/coordinator/src/node.rs
@@ -37,6 +37,8 @@ use trade::cfd::BTCUSD_MAX_PRICE;
 use trade::ContractSymbol;
 use trade::Direction;
 
+pub mod connection;
+
 /// The leverage used by the coordinator for all trades.
 const COORDINATOR_LEVERAGE: f32 = 1.0;
 

--- a/coordinator/src/node/connection.rs
+++ b/coordinator/src/node/connection.rs
@@ -1,0 +1,100 @@
+use lightning::ln::msgs::NetAddress;
+use ln_dlc_node::node::Node;
+use ln_dlc_node::node::NodeInfo;
+use ln_dlc_node::node::PaymentMap;
+use rand::seq::SliceRandom;
+use rand::thread_rng;
+use std::net::IpAddr;
+use std::net::SocketAddr;
+use std::sync::Arc;
+use std::time::Duration;
+
+const CONNECTION_CHECK_INTERVAL: Duration = Duration::from_secs(30);
+
+pub async fn keep_public_channel_peers_connected(node: Arc<Node<PaymentMap>>) {
+    loop {
+        reconnect_to_disconnected_public_channel_peers(node.clone());
+
+        tokio::time::sleep(CONNECTION_CHECK_INTERVAL).await;
+    }
+}
+
+fn reconnect_to_disconnected_public_channel_peers(node: Arc<Node<PaymentMap>>) {
+    let connected_peers = node.peer_manager.get_peer_node_ids();
+
+    let channels = node.channel_manager.list_channels();
+    let peers_with_public_channel = channels
+        .iter()
+        .filter_map(|c| c.is_public.then_some(c.counterparty.node_id));
+
+    for peer in peers_with_public_channel.filter(|peer| !connected_peers.contains(peer)) {
+        let addresses = match node
+            .network_graph
+            .read_only()
+            .get_addresses(&peer)
+            .map(|v| {
+                v.into_iter()
+                    .filter_map(net_address_to_socket_addr)
+                    .collect::<Vec<_>>()
+            }) {
+            None => {
+                tracing::warn!(%peer, "Cannot reconnect to unknown public node");
+                continue;
+            }
+            Some(addresses) if addresses.is_empty() => {
+                tracing::warn!(%peer, "Cannot reconnect to public node without known addresses");
+                continue;
+            }
+            Some(addresses) => addresses,
+        };
+
+        tokio::spawn({
+            let node = node.clone();
+            let mut addresses = addresses.clone();
+            async move {
+                tracing::debug!(%peer, "Establishing connection with public channel peer");
+
+                // We shuffle the addresses so as to not always retry
+                addresses.shuffle(&mut thread_rng());
+
+                for address in addresses {
+                    let node_info = NodeInfo {
+                        pubkey: peer,
+                        address,
+                    };
+
+                    match node.connect(node_info).await {
+                        Ok(connection_closed_future) => {
+                            connection_closed_future.await;
+                            tracing::debug!(
+                                %peer,
+                                "Connection lost with public channel peer"
+                            );
+
+                            // We return from the future and not just break out of the loop. This is
+                            // intentional, as we want to have one task per peer at a time
+                            return;
+                        }
+                        Err(e) => {
+                            tracing::trace!(%peer, %address, "Failed to connect to public channel peer: {e:#}")
+                        }
+                    };
+                }
+
+                tracing::warn!(%peer, "Failed to connect to public channel peer on all addresses");
+            }
+        });
+    }
+}
+
+fn net_address_to_socket_addr(net_address: NetAddress) -> Option<SocketAddr> {
+    match net_address {
+        NetAddress::IPv4 { addr, port } => Some(SocketAddr::new(IpAddr::from(addr), port)),
+        NetAddress::IPv6 { addr, port } => Some(SocketAddr::new(IpAddr::from(addr), port)),
+        // TODO: If we want to be able to connect to peers using Tor, we will have to use a Tor
+        // proxy
+        NetAddress::OnionV2(_) => None,
+        NetAddress::OnionV3 { .. } => None,
+        NetAddress::Hostname { .. } => None,
+    }
+}

--- a/crates/ln-dlc-node/src/node/mod.rs
+++ b/crates/ln-dlc-node/src/node/mod.rs
@@ -12,6 +12,7 @@ use crate::util;
 use crate::ChainMonitor;
 use crate::FakeChannelPaymentRequests;
 use crate::InvoicePayer;
+use crate::NetworkGraph;
 use crate::PeerManager;
 use anyhow::anyhow;
 use anyhow::ensure;
@@ -89,6 +90,7 @@ pub struct Node<P> {
     pub channel_manager: Arc<ChannelManager>,
     chain_monitor: Arc<ChainMonitor>,
     keys_manager: Arc<CustomKeysManager>,
+    pub network_graph: Arc<NetworkGraph>,
     _background_processor: BackgroundProcessor,
     _connection_manager_handle: RemoteHandle<()>,
     _broadcast_node_announcement_handle: RemoteHandle<()>,
@@ -341,7 +343,7 @@ where
                 runtime_handle,
                 channel_manager.clone(),
                 ln_dlc_wallet.clone(),
-                network_graph,
+                network_graph.clone(),
                 keys_manager.clone(),
                 payment_persister.clone(),
                 fake_channel_payments.clone(),
@@ -486,6 +488,7 @@ where
             _connection_manager_handle: connection_manager_handle,
             _broadcast_node_announcement_handle: broadcast_node_announcement_handle,
             _pending_dlc_actions_handle: pending_dlc_actions_handle,
+            network_graph,
         })
     }
 }


### PR DESCRIPTION
Fixes #490.
Fixes #492.

We want to stay connected to our public channel peers so that our channels can be usable and payments can be routed through them at all times.

This approach should work for all public channel peers who are listening on clearnet. If we want to reconnect to any peers who use Tor, we will need to use a Tor proxy (see this [sample repo](https://github.com/TonyGiorgio/ldk-sample-tor)).

---

This work is untested. I propose to test this in production (!) and see if we can keep these connections alive. Alternatively we might be able to quickly set up something locally. But I think there is almost no risk in testing this in production anyway.