### PR TITLE
feat: Add json logging option for coordinator and maker

### DIFF
--- a/coordinator/src/bin/coordinator.rs
+++ b/coordinator/src/bin/coordinator.rs
@@ -52,7 +52,7 @@ async fn main() -> Result<()> {
     let http_address = opts.http_address;
     let network = opts.network();
 
-    logger::init_tracing(LevelFilter::DEBUG, false)?;
+    logger::init_tracing(LevelFilter::DEBUG, opts.json)?;
 
     let mut ephemeral_randomness = [0; 32];
     thread_rng().fill_bytes(&mut ephemeral_randomness);

--- a/coordinator/src/cli.rs
+++ b/coordinator/src/cli.rs
@@ -28,6 +28,10 @@ pub struct Opts {
     #[clap(value_enum, default_value = "regtest")]
     pub network: Network,
 
+    /// If enabled logs will be in json format
+    #[clap(short, long)]
+    pub json: bool,
+
     /// The address where to find the database inclding username and password
     #[clap(
         long,

--- a/maker/src/bin/maker.rs
+++ b/maker/src/bin/maker.rs
@@ -40,7 +40,7 @@ async fn main() -> Result<()> {
     let http_address = opts.http_address;
     let network = opts.network();
 
-    logger::init_tracing(LevelFilter::DEBUG, false)?;
+    logger::init_tracing(LevelFilter::DEBUG, opts.json)?;
 
     let mut ephemeral_randomness = [0; 32];
     thread_rng().fill_bytes(&mut ephemeral_randomness);

--- a/maker/src/cli.rs
+++ b/maker/src/cli.rs
@@ -36,6 +36,10 @@ pub struct Opts {
     /// The address to connect electrum to
     #[clap(long, default_value = "tcp://localhost:50000")]
     pub electrum: String,
+
+    /// If enabled logs will be in json format
+    #[clap(short, long)]
+    pub json: bool,
 }
 
 #[derive(Debug, Clone, Copy, clap::ValueEnum)]


### PR DESCRIPTION
As usual, use `--json` to enable JSON output.

Turns out that we copied the functionality from ItchySats long time ago, we just
never exposed it.