### PR TITLE
Re-enable list-DLC-channels endpoint on coordinator

### DIFF
--- a/coordinator/src/admin.rs
+++ b/coordinator/src/admin.rs
@@ -135,7 +135,7 @@ pub async fn delete_subchannel(
     let length = std::cmp::min(byte_array.len(), fixed_length_array.len());
     fixed_length_array[..length].copy_from_slice(&byte_array[..length]);
 
-    tracing::debug!("Attempting to delete channel {channel_id}");
+    tracing::debug!(%channel_id, "Attempting to delete DLC channel");
 
     state
         .node
@@ -146,7 +146,11 @@ pub async fn delete_subchannel(
         .delete_subchannel(&fixed_length_array)
         .map_err(|error| {
             AppError::InternalServerError(format!("Unable to delete channel: {error:#}"))
-        })
+        })?;
+
+    tracing::info!(%channel_id, "Deleted DLC channel");
+
+    Ok(())
 }
 
 #[derive(Deserialize)]

--- a/coordinator/src/routes.rs
+++ b/coordinator/src/routes.rs
@@ -77,9 +77,10 @@ pub fn router(node: Node, pool: Pool<ConnectionManager<PgConnection>>) -> Router
         .route("/api/admin/channels", get(list_channels).post(open_channel))
         .route("/api/admin/channels/:channel_id", delete(close_channel))
         .route("/api/admin/peers", get(list_peers))
+        .route("/api/admin/dlc_channels", get(list_dlc_channels))
         .route(
             "/api/admin/dlc_channels/:channel_id",
-            get(list_dlc_channels).delete(delete_subchannel),
+            delete(delete_subchannel),
         )
         .route("/api/admin/sign/:msg", get(sign_message))
         .route("/api/admin/connect", post(connect_to_peer))


### PR DESCRIPTION
We cannot query the endpoint at the moment. The server automatically reports a 404.