### PR TITLE
Revert "fix: Announce node only on channel creation and startup"

### DIFF
--- a/crates/ln-dlc-node/src/ln/event_handler.rs
+++ b/crates/ln-dlc-node/src/ln/event_handler.rs
@@ -25,7 +25,6 @@ use lightning::chain::chaininterface::BroadcasterInterface;
 use lightning::chain::chaininterface::ConfirmationTarget;
 use lightning::chain::chaininterface::FeeEstimator;
 use lightning::ln::channelmanager::InterceptId;
-use lightning::ln::msgs::NetAddress;
 use lightning::routing::gossip::NodeId;
 use lightning::util::events::Event;
 use lightning::util::events::PaymentPurpose;
@@ -48,8 +47,6 @@ pub struct EventHandler<P> {
     fake_channel_payments: FakeChannelPaymentRequests,
     pending_intercepted_htlcs: PendingInterceptedHtlcs,
     peer_manager: Arc<PeerManager>,
-    alias: [u8; 32],
-    announcements: Vec<NetAddress>,
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -67,8 +64,6 @@ where
         fake_channel_payments: FakeChannelPaymentRequests,
         pending_intercepted_htlcs: PendingInterceptedHtlcs,
         peer_manager: Arc<PeerManager>,
-        alias: [u8; 32],
-        announcements: Vec<NetAddress>,
     ) -> Self {
         Self {
             runtime_handle,
@@ -80,8 +75,6 @@ where
             fake_channel_payments,
             pending_intercepted_htlcs,
             peer_manager,
-            alias,
-            announcements,
         }
     }
 
@@ -425,24 +418,6 @@ where
                     counterparty = %counterparty_node_id.to_string(),
                     "Channel ready"
                 );
-
-                tokio::spawn({
-                    let announcements = self.announcements.clone();
-                    let peer_manager = self.peer_manager.clone();
-                    let alias = self.alias;
-                    async move {
-                        tokio::time::sleep(Duration::from_secs(
-                            crate::ln::BROADCAST_NODE_ANNOUNCEMENT_DELAY,
-                        ))
-                        .await;
-                        tracing::debug!("Announcing node on {:?}", announcements);
-                        peer_manager.broadcast_node_announcement(
-                            [0; 3],
-                            alias,
-                            announcements.clone(),
-                        );
-                    }
-                });
 
                 let pending_intercepted_htlcs = self.pending_intercepted_htlcs_lock();
 

--- a/crates/ln-dlc-node/src/ln/mod.rs
+++ b/crates/ln-dlc-node/src/ln/mod.rs
@@ -29,6 +29,3 @@ pub(crate) const JUST_IN_TIME_CHANNEL_OUTBOUND_LIQUIDITY_SAT: u64 = 200_000;
 ///
 /// This constant specifies the amount of time (in seconds) we are willing to delay a payment.
 pub(crate) const HTLC_INTERCEPTED_CONNECTION_TIMEOUT: u64 = 30;
-
-/// The delay before sending the node announcement after the [`Event::ChannelReady`] event.
-pub(crate) const BROADCAST_NODE_ANNOUNCEMENT_DELAY: u64 = 10;

--- a/crates/ln-dlc-node/src/node/mod.rs
+++ b/crates/ln-dlc-node/src/node/mod.rs
@@ -115,7 +115,7 @@ pub struct Node<P> {
     #[cfg(test)]
     pub(crate) alias: [u8; 32],
     #[cfg(test)]
-    pub(crate) node_announcements: Vec<NetAddress>,
+    pub(crate) announcement_addresses: Vec<NetAddress>,
 }
 
 #[derive(Debug, Clone, Copy, Deserialize, Serialize)]
@@ -177,7 +177,7 @@ where
         payment_persister: P,
         announcement_address: SocketAddr,
         listen_address: SocketAddr,
-        announcements: Vec<NetAddress>,
+        announcement_addresses: Vec<NetAddress>,
         electrs_origin: String,
         seed: Bip39Seed,
         ephemeral_randomness: [u8; 32],
@@ -197,7 +197,7 @@ where
             payment_persister,
             announcement_address,
             listen_address,
-            announcements,
+            announcement_addresses,
             electrs_origin,
             seed,
             ephemeral_randomness,
@@ -214,7 +214,7 @@ where
         payment_persister: P,
         announcement_address: SocketAddr,
         listen_address: SocketAddr,
-        announcements: Vec<NetAddress>,
+        announcement_addresses: Vec<NetAddress>,
         electrs_origin: String,
         seed: Bip39Seed,
         ephemeral_randomness: [u8; 32],
@@ -428,12 +428,16 @@ where
 
         let alias = alias_as_bytes(alias)?;
         let broadcast_node_announcement_handle = {
-            let announcements = announcements.clone();
+            let announcement_addresses = announcement_addresses.clone();
             let peer_manager = peer_manager.clone();
             let (fut, remote_handle) = async move {
                 let mut interval = tokio::time::interval(BROADCAST_NODE_ANNOUNCEMENT_INTERVAL);
                 loop {
-                    broadcast_node_announcement(&peer_manager, alias, announcements.clone());
+                    broadcast_node_announcement(
+                        &peer_manager,
+                        alias,
+                        announcement_addresses.clone(),
+                    );
 
                     interval.tick().await;
                 }
@@ -494,7 +498,7 @@ where
             _pending_dlc_actions_handle: pending_dlc_actions_handle,
             network_graph,
             #[cfg(test)]
-            node_announcements: announcements,
+            announcement_addresses,
             #[cfg(test)]
             alias,
         })

--- a/crates/ln-dlc-node/src/node/mod.rs
+++ b/crates/ln-dlc-node/src/node/mod.rs
@@ -422,9 +422,6 @@ where
             let alias = alias_as_bytes(alias)?;
             let peer_manager = peer_manager.clone();
             let (fut, remote_handle) = async move {
-                // TODO: Check why we need to announce the node of the mobile app as otherwise the
-                // just-in-time channel creation will fail with a `unable to decode own hop data`
-                // error.
                 let mut interval = tokio::time::interval(BROADCAST_NODE_ANNOUNCEMENT_INTERVAL);
 
                 loop {

--- a/crates/ln-dlc-node/src/node/mod.rs
+++ b/crates/ln-dlc-node/src/node/mod.rs
@@ -77,8 +77,10 @@ pub use payment_persister::PaymentPersister;
 pub use sub_channel_manager::SubChannelManager;
 pub use wallet::PaymentDetails;
 
-// TODO: These intervals are quite arbitrary at the moment, come up with more sensible values
-const BROADCAST_NODE_ANNOUNCEMENT_INTERVAL: Duration = Duration::from_secs(60);
+/// The interval at which the [`lightning::ln::msgs::NodeAnnouncement`] is broadcast.
+///
+/// According to the LDK team, a value of up to 1 hour should be fine.
+const BROADCAST_NODE_ANNOUNCEMENT_INTERVAL: Duration = Duration::from_secs(600);
 
 /// An LN-DLC node.
 pub struct Node<P> {

--- a/crates/ln-dlc-node/src/node/peer_manager.rs
+++ b/crates/ln-dlc-node/src/node/peer_manager.rs
@@ -1,0 +1,27 @@
+use lightning::ln::msgs::NetAddress;
+
+use crate::node::Node;
+use crate::PeerManager;
+
+const NODE_COLOR: [u8; 3] = [0; 3];
+
+pub(crate) fn broadcast_node_announcement(
+    peer_manager: &PeerManager,
+    alias: [u8; 32],
+    inc_connection_addresses: Vec<NetAddress>,
+) {
+    tracing::debug!(?inc_connection_addresses, "Broadcasting node announcement");
+
+    peer_manager.broadcast_node_announcement(NODE_COLOR, alias, inc_connection_addresses)
+}
+
+impl<P> Node<P> {
+    #[cfg(test)]
+    pub(crate) fn broadcast_node_announcement(&self) {
+        broadcast_node_announcement(
+            &self.peer_manager,
+            self.alias,
+            self.node_announcements.clone(),
+        )
+    }
+}

--- a/crates/ln-dlc-node/src/node/peer_manager.rs
+++ b/crates/ln-dlc-node/src/node/peer_manager.rs
@@ -21,7 +21,7 @@ impl<P> Node<P> {
         broadcast_node_announcement(
             &self.peer_manager,
             self.alias,
-            self.node_announcements.clone(),
+            self.announcement_addresses.clone(),
         )
     }
 }

--- a/crates/ln-dlc-node/src/tests/lnd.rs
+++ b/crates/ln-dlc-node/src/tests/lnd.rs
@@ -99,10 +99,7 @@ impl LndNode {
 
         // todo: fetch channel status from lnd api instead of timeout.
         // wait for lnd to process the channel opening.
-        tokio::time::sleep(Duration::from_secs(
-            crate::ln::BROADCAST_NODE_ANNOUNCEMENT_DELAY + 5,
-        ))
-        .await;
+        tokio::time::sleep(Duration::from_secs(35)).await;
         Ok(())
     }
 

--- a/crates/ln-dlc-node/src/tests/onboard_from_lnd.rs
+++ b/crates/ln-dlc-node/src/tests/onboard_from_lnd.rs
@@ -30,6 +30,12 @@ async fn onboard_from_lnd() {
     coordinator.sync().unwrap();
     payee.sync().unwrap();
 
+    // The coordinator must send a `NodeAnnouncement` to LND before LND sends the payment, as
+    // otherwise we will encounter an error in the coordinator when processing the incoming HTLC:
+    // `Unable to decode our hop data` because of a `DecodeError::InvalidValue`.
+    coordinator.broadcast_node_announcement();
+    tokio::time::sleep(Duration::from_secs(2)).await;
+
     let invoice_amount = 1000;
 
     let fake_scid = coordinator.create_intercept_scid(payee.info.pubkey);


### PR DESCRIPTION
This reverts commit 53c0de1573c20067f147929e4f228fa2924919f6.

In an attempt to fix our connection issues, we reduced the node announcements to only when the `ChannelReady` event has been processed as a comment on the ldk-sample suggested that shouldn't be done in repeating task.

However, after asking the question on discord I got the answer that it should be fine to make node announcements in an interval. A more sensible delay of 600 instead of 60 seconds has been suggested, though. 

https://discord.com/channels/915026692102316113/978829624635195422/1100452596726116383

I am proposing to revert this change as it has not been properly tested and I am afraid we might run into regressions. 