### PR TITLE
fix: Properly print out errors converted into `thiserror`

### DIFF
--- a/crates/bdk-ldk/src/lib.rs
+++ b/crates/bdk-ldk/src/lib.rs
@@ -46,9 +46,9 @@ const MAX_SATS_PER_V_BYTE: u32 = 20;
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
-    #[error("BDK wallet error")]
+    #[error("BDK wallet error: {0}")]
     Bdk(#[from] bdk::Error),
-    #[error("Other")]
+    #[error("Other: {0}")]
     Other(#[from] anyhow::Error),
 }
 

--- a/mobile/native/src/db/models.rs
+++ b/mobile/native/src/db/models.rs
@@ -27,7 +27,7 @@ const SQLITE_DATETIME_FMT: &str = "[year]-[month]-[day] [hour]:[minute]:[second]
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
-    #[error("Invalid id when converting string to uuid")]
+    #[error("Invalid id when converting string to uuid: {0}")]
     InvalidId(#[from] uuid::Error),
     #[error("Limit order has to have a price")]
     MissingPriceForLimitOrder,


### PR DESCRIPTION
Override Display trait of newly constructed `thiserror` errors to print out the
underlying error by default.