### PR TITLE
Add message that mentions `2%` fee when receiving funds

### DIFF
--- a/mobile/lib/features/wallet/create_invoice_screen.dart
+++ b/mobile/lib/features/wallet/create_invoice_screen.dart
@@ -124,8 +124,8 @@ class _CreateInvoiceScreenState extends State<CreateInvoiceScreen> {
                     ),
                     if (showValidationHint)
                       ModalBottomSheetInfo(
-                          infoText:
-                              "While in beta, channel capacity is limited to $channelCapacity sats; payments above this capacity might get rejected."
+                          infoText: "Receiving funds is subject to a 3% fee."
+                              "\n\nWhile in beta, channel capacity is limited to $channelCapacity sats; payments above this capacity might get rejected."
                               "\n\nYour current balance is $balance, so you can receive up to $maxAmount sats."
                               "\nIf you hold less than $minAmount or more than $usableChannelCapacity in your wallet you might not be able to trade."
                               "\n\nThe maximum is enforced initially to ensure users only trade with small stakes until the software has proven to be stable.",


### PR DESCRIPTION
Note:
Adding this 2% fee is already an experiment - we will have to closely evaluate (by getting into contact with users) if the fee is a blocker for some users.

@bonomat @klochowicz I this fee is an initial blocker for users we should definitely experiment to charge at a later point (e.g. when trading, or if the channel was not used for some time, ...). Please think through if we can derive the fee being a blocker or not from the data we have available. 
I think we should be able to correlate the app being opened by a users and the user sending funds. It would be great to also have stats on which users succeeded to get funds in and which users did not. 
