### PR TITLE
chore: enable file sharing

### DIFF
--- a/mobile/ios/Runner/Info.plist
+++ b/mobile/ios/Runner/Info.plist
@@ -56,5 +56,7 @@
 		</dict>
 		<key>ITSAppUsesNonExemptEncryption</key>
 		<false/>
+		<key>UIFileSharingEnabled</key>
+		<true/>
 	</dict>
 </plist>


### PR DESCRIPTION
This should allow us to browse the 10101 application files on the phone using the iOS Files app.

This is helpful to 1) create a backup of your phones data and 2) to copy the the app directory for local debugging.

https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/iPhoneOSKeys.html#//apple_ref/doc/uid/TP40009252-SW20