### PR TITLE
Add dev API to the app to remove position from DB

### DIFF
--- a/mobile/lib/common/app_bar_wrapper.dart
+++ b/mobile/lib/common/app_bar_wrapper.dart
@@ -1,4 +1,6 @@
+import 'package:f_logs/f_logs.dart';
 import 'package:flutter/material.dart';
+import 'package:get_10101/features/trade/dev_mode_screen.dart';
 import 'package:get_10101/features/trade/settings_screen.dart';
 import 'package:get_10101/features/trade/trade_screen.dart';
 import 'package:get_10101/features/wallet/scanner_screen.dart';
@@ -16,20 +18,18 @@ class AppBarWrapper extends StatelessWidget {
     final currentRoute = GoRouter.of(context).location;
 
     var actionButtons = <Widget>[];
-    Widget? leadingButton;
+    Widget? settingsButton;
 
     if (currentRoute == WalletScreen.route) {
-      actionButtons = [
-        IconButton(
-          icon: const Icon(Icons.qr_code_scanner),
-          tooltip: 'Scanner',
-          onPressed: () {
-            context.go(ScannerScreen.route);
-          },
-        )
-      ];
+      actionButtons.add(IconButton(
+        icon: const Icon(Icons.qr_code_scanner),
+        tooltip: 'Scanner',
+        onPressed: () {
+          context.go(ScannerScreen.route);
+        },
+      ));
 
-      leadingButton = IconButton(
+      settingsButton = IconButton(
         icon: const Icon(Icons.settings),
         tooltip: 'Settings',
         onPressed: () {
@@ -39,20 +39,30 @@ class AppBarWrapper extends StatelessWidget {
     }
 
     if (currentRoute == TradeScreen.route) {
-      leadingButton = IconButton(
+      settingsButton = IconButton(
         icon: const Icon(Icons.settings),
         tooltip: 'Settings',
         onPressed: () {
           context.go(TradeSettingsScreen.route);
         },
       );
+
+      actionButtons.add(IconButton(
+        icon: const Icon(Icons.developer_mode),
+        tooltip: 'Developers',
+        onPressed: () {
+          context.go(TradeDevModeScreen.route);
+        },
+      ));
     }
+
+    FLog.info(text: 'Action buttons $actionButtons');
 
     return AppBar(
       elevation: 0,
       backgroundColor: Colors.transparent,
       iconTheme: const IconThemeData(color: Colors.black),
-      leading: leadingButton,
+      leading: settingsButton,
       actions: actionButtons,
     );
   }

--- a/mobile/lib/common/dev_mode/dev_mode_screen.dart
+++ b/mobile/lib/common/dev_mode/dev_mode_screen.dart
@@ -1,0 +1,136 @@
+import 'package:f_logs/model/flog/flog.dart';
+import 'package:flutter/material.dart';
+import 'package:get_10101/ffi.dart' as rust;
+import 'package:go_router/go_router.dart';
+
+class DevModeScreen extends StatefulWidget {
+  const DevModeScreen({required this.fromRoute, super.key});
+
+  final String fromRoute;
+
+  @override
+  State<DevModeScreen> createState() => _DevModeScreenState();
+}
+
+class _DevModeScreenState extends State<DevModeScreen> {
+  @override
+  void initState() {
+    super.initState();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text("Developers")),
+      body: ListView(
+          children: ListTile.divideTiles(context: context, tiles: [
+        InkWell(
+          child: ListTile(
+            title: Row(children: [
+              RichText(
+                text: const TextSpan(
+                    text: 'Close position',
+                    style: TextStyle(
+                        fontWeight: FontWeight.w600,
+                        fontSize: 18,
+                        color: Colors.black,
+                        fontFamily: "Arial")),
+                textAlign: TextAlign.right,
+              )
+            ]),
+            trailing: const Icon(Icons.arrow_forward_ios),
+            onTap: () {
+              GoRouter.of(context).go('${widget.fromRoute}/${DevClosePositionScreen.subRouteName}');
+            },
+          ),
+        ),
+      ]).toList()),
+    );
+  }
+}
+
+class DevClosePositionScreen extends StatefulWidget {
+  static const subRouteName = "close_position";
+
+  const DevClosePositionScreen({super.key});
+
+  @override
+  State<DevClosePositionScreen> createState() => _DevClosePositionScreenState();
+}
+
+class _DevClosePositionScreenState extends State<DevClosePositionScreen> {
+  bool isLoading = false;
+
+  @override
+  void initState() {
+    super.initState();
+  }
+
+  Future<void> closePosition() async {
+    setState(() {
+      isLoading = true;
+    });
+
+    try {
+      await Future.delayed(const Duration(seconds: 1));
+      await rust.api.closePosition();
+    } catch (error) {
+      FLog.error(text: "Failed to close position: $error");
+      ScaffoldMessenger.of(context)
+          .showSnackBar(const SnackBar(content: Text('Could not close position')));
+      return;
+    } finally {
+      setState(() {
+        isLoading = false;
+      });
+    }
+
+    if (context.mounted) {
+      ScaffoldMessenger.of(context).showSnackBar(const SnackBar(content: Text('Position closed')));
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+        appBar: AppBar(title: const Text("Close position")),
+        body: SafeArea(
+          child: Padding(
+            padding: const EdgeInsets.all(20.0),
+            child: Column(children: [
+              Center(
+                child: RichText(
+                    text: const TextSpan(
+                        style: TextStyle(color: Colors.black, fontSize: 18),
+                        children: [
+                      TextSpan(
+                          text:
+                              "If you proceed, the app will assume that there is no underlying open DLC and delete the currently open position from the database.\n\n"),
+                      TextSpan(
+                          text: "This operation is irreversible.",
+                          style: TextStyle(fontWeight: FontWeight.bold)),
+                    ])),
+              ),
+              Column(children: [
+                Padding(
+                  padding: const EdgeInsets.all(32.0),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.stretch,
+                    mainAxisAlignment: MainAxisAlignment.end,
+                    children: [
+                      ElevatedButton.icon(
+                          onPressed: isLoading ? null : closePosition,
+                          label: isLoading ? const Text('') : const Text("Proceed"),
+                          icon: isLoading
+                              ? const SizedBox(
+                                  width: 20, height: 20, child: CircularProgressIndicator())
+                              : const SizedBox.shrink()),
+                    ],
+                  ),
+                ),
+              ])
+            ]),
+          ),
+        ));
+  }
+}

--- a/mobile/lib/features/trade/dev_mode_screen.dart
+++ b/mobile/lib/features/trade/dev_mode_screen.dart
@@ -1,0 +1,15 @@
+import 'package:flutter/material.dart';
+import 'package:get_10101/features/trade/trade_screen.dart';
+import 'package:get_10101/common/dev_mode/dev_mode_screen.dart';
+
+class TradeDevModeScreen extends StatelessWidget {
+  static const route = "${TradeScreen.route}/$subRouteName";
+  static const subRouteName = "dev_mode";
+
+  const TradeDevModeScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const DevModeScreen(fromRoute: route);
+  }
+}

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -6,11 +6,13 @@ import 'package:flutter_rust_bridge/flutter_rust_bridge.dart';
 import 'package:get_10101/bridge_generated/bridge_definitions.dart' as bridge;
 import 'package:get_10101/common/application/channel_constraints_service.dart';
 import 'package:get_10101/common/application/event_service.dart';
+import 'package:get_10101/common/dev_mode/dev_mode_screen.dart';
 import 'package:get_10101/features/trade/application/candlestick_service.dart';
 import 'package:get_10101/features/trade/application/order_service.dart';
 import 'package:get_10101/features/trade/application/position_service.dart';
 import 'package:get_10101/features/trade/application/trade_values_service.dart';
 import 'package:get_10101/features/trade/candlestick_change_notifier.dart';
+import 'package:get_10101/features/trade/dev_mode_screen.dart';
 import 'package:get_10101/features/trade/domain/position.dart';
 import 'package:get_10101/features/trade/order_change_notifier.dart';
 import 'package:get_10101/features/trade/position_change_notifier.dart';
@@ -166,7 +168,21 @@ class _TenTenOneAppState extends State<TenTenOneApp> {
                     parentNavigatorKey: _rootNavigatorKey,
                     builder: (BuildContext context, GoRouterState state) {
                       return const TradeSettingsScreen();
-                    })
+                    }),
+                GoRoute(
+                    path: TradeDevModeScreen.subRouteName,
+                    parentNavigatorKey: _rootNavigatorKey,
+                    builder: (BuildContext context, GoRouterState state) {
+                      return const TradeDevModeScreen();
+                    },
+                    routes: <RouteBase>[
+                      GoRoute(
+                          path: DevClosePositionScreen.subRouteName,
+                          parentNavigatorKey: _rootNavigatorKey,
+                          builder: (BuildContext context, GoRouterState state) {
+                            return const DevClosePositionScreen();
+                          })
+                    ]),
               ],
             ),
           ],

--- a/mobile/native/src/api.rs
+++ b/mobile/native/src/api.rs
@@ -278,3 +278,12 @@ pub fn decode_invoice(invoice: String) -> Result<LightningInvoice> {
 pub fn get_node_id() -> SyncReturn<String> {
     SyncReturn(ln_dlc::get_node_info().pubkey.to_string())
 }
+
+/// Manually close the position.
+///
+/// The motivation to call this is to fix an incorrect trading state in the app, which might be
+/// preventing the user from trading. Only use this if you know what you are doing.
+#[tokio::main(flavor = "current_thread")]
+pub async fn close_position() -> Result<()> {
+    position::handler::close_position().await
+}

--- a/mobile/native/src/api.rs
+++ b/mobile/native/src/api.rs
@@ -285,5 +285,5 @@ pub fn get_node_id() -> SyncReturn<String> {
 /// preventing the user from trading. Only use this if you know what you are doing.
 #[tokio::main(flavor = "current_thread")]
 pub async fn close_position() -> Result<()> {
-    position::handler::close_position().await
+    position::handler::close_position(true).await
 }

--- a/mobile/native/src/ln_dlc/node.rs
+++ b/mobile/native/src/ln_dlc/node.rs
@@ -227,7 +227,7 @@ impl Node {
                         tracing::warn!("Could not find a filling position in the database. Maybe because the coordinator closed an expired position. Error: {e:#}");
 
                         tokio::spawn(async {
-                            match position::handler::close_position().await {
+                            match position::handler::close_position(false).await {
                                 Ok(_) => tracing::info!("Successfully closed expired position."),
                                 Err(e) => tracing::error!("Critical Error! We have a DLC but were unable to set the order to filled. Error: {e:?}")
                             }

--- a/mobile/native/src/trade/position/handler.rs
+++ b/mobile/native/src/trade/position/handler.rs
@@ -172,7 +172,6 @@ pub async fn close_position() -> Result<()> {
     let positions = get_positions()
         .await?
         .into_iter()
-        .filter(|p| p.position_state == PositionState::Open)
         .map(Position::from)
         .collect::<Vec<Position>>();
 

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -1,7 +1,7 @@
 name: get_10101
 description: 10101 combines the power of a self-custodial on-chain and off-chain wallet with the vast world of trading.
 publish_to: none
-version: 1.0.12
+version: 0.0.2
 environment:
   sdk: ">=2.17.5 <3.0.0"
 dependencies:


### PR DESCRIPTION
This is motivated by getting my app stuck after succeeding in closing a DLC, but failing to update `Position` and `Order`.

At the moment the developer tools aren't guarded by anything because I'm not sure what the logic should be there. But we could reuse the page for other similar functionalities.


https://user-images.githubusercontent.com/9418575/234835390-1e783a4a-2020-4b71-9f4b-9ff555aa0d70.mp4

The GIF shows the error path because I didn't bother trying to re-create the state that would allow you to succeed when calling it.

