### PR TITLE
chore: Change data directory on phone

### DIFF
--- a/mobile/ios/Podfile.lock
+++ b/mobile/ios/Podfile.lock
@@ -2,6 +2,8 @@ PODS:
   - Flutter (1.0.0)
   - flutter_native_splash (0.0.1):
     - Flutter
+  - package_info_plus (0.4.5):
+    - Flutter
   - path_provider_foundation (0.0.1):
     - Flutter
     - FlutterMacOS
@@ -14,6 +16,7 @@ PODS:
 DEPENDENCIES:
   - Flutter (from `Flutter`)
   - flutter_native_splash (from `.symlinks/plugins/flutter_native_splash/ios`)
+  - package_info_plus (from `.symlinks/plugins/package_info_plus/ios`)
   - path_provider_foundation (from `.symlinks/plugins/path_provider_foundation/ios`)
   - share_plus (from `.symlinks/plugins/share_plus/ios`)
   - shared_preferences_foundation (from `.symlinks/plugins/shared_preferences_foundation/ios`)
@@ -23,6 +26,8 @@ EXTERNAL SOURCES:
     :path: Flutter
   flutter_native_splash:
     :path: ".symlinks/plugins/flutter_native_splash/ios"
+  package_info_plus:
+    :path: ".symlinks/plugins/package_info_plus/ios"
   path_provider_foundation:
     :path: ".symlinks/plugins/path_provider_foundation/ios"
   share_plus:
@@ -33,6 +38,7 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   Flutter: f04841e97a9d0b0a8025694d0796dd46242b2854
   flutter_native_splash: 52501b97d1c0a5f898d687f1646226c1f93c56ef
+  package_info_plus: 6c92f08e1f853dc01228d6f553146438dafcd14e
   path_provider_foundation: 37748e03f12783f9de2cb2c4eadfaa25fe6d4852
   share_plus: 056a1e8ac890df3e33cb503afffaf1e9b4fbae68
   shared_preferences_foundation: 986fc17f3d3251412d18b0265f9c64113a8c2472

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -257,11 +257,19 @@ class _TenTenOneAppState extends State<TenTenOneApp> {
       eventService.subscribe(
           AnonSubscriber((event) => FLog.info(text: event.field0)), const bridge.Event.log(""));
 
-      final appSupportDir = await getApplicationSupportDirectory();
-      final appDocumentsDir = await getApplicationDocumentsDirectory();
-      FLog.info(text: "App data will be stored in: $appDocumentsDir");
-      FLog.info(text: "Seed data will be stored in: $appSupportDir");
-      await rust.api.run(config: config, appDir: appDocumentsDir.path, seedDir: appSupportDir.path);
+      final seedDir = (await getApplicationSupportDirectory()).path;
+      String appDir = (await getApplicationDocumentsDirectory()).path;
+
+      if (File('$seedDir/${config.network}/db').existsSync()) {
+        FLog.info(
+            text:
+                "App has already data in the seed dir. For compatibility reasons we will not switch to the new app dir.");
+        appDir = seedDir;
+      }
+
+      FLog.info(text: "App data will be stored in: $appDir");
+      FLog.info(text: "Seed data will be stored in: $seedDir");
+      await rust.api.run(config: config, appDir: appDir, seedDir: seedDir);
 
       await orderChangeNotifier.initialize();
       await positionChangeNotifier.initialize();

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -258,9 +258,10 @@ class _TenTenOneAppState extends State<TenTenOneApp> {
           AnonSubscriber((event) => FLog.info(text: event.field0)), const bridge.Event.log(""));
 
       final appSupportDir = await getApplicationSupportDirectory();
-      FLog.info(text: "App data will be stored in: $appSupportDir");
-
-      await rust.api.run(config: config, appDir: appSupportDir.path, seedDir: appSupportDir.path);
+      final appDocumentsDir = await getApplicationDocumentsDirectory();
+      FLog.info(text: "App data will be stored in: $appDocumentsDir");
+      FLog.info(text: "Seed data will be stored in: $appSupportDir");
+      await rust.api.run(config: config, appDir: appDocumentsDir.path, seedDir: appSupportDir.path);
 
       await orderChangeNotifier.initialize();
       await positionChangeNotifier.initialize();

--- a/mobile/native/src/ln_dlc/mod.rs
+++ b/mobile/native/src/ln_dlc/mod.rs
@@ -115,7 +115,7 @@ pub fn run(data_dir: String, seed_dir: String) -> Result<()> {
             listener.local_addr().expect("To get a free local address")
         };
 
-        let seed_path = data_dir.join("seed");
+        let seed_path = seed_dir.join("seed");
         let seed = Bip39Seed::initialize(&seed_path)?;
 
         let node = Arc::new(


### PR DESCRIPTION
On iOS the ApplicationSupportDirectory is never exposed to the user and can not be backed up. Contrary the ApplicationDocumentsDirectory is user generated data, that can be backed up. I think this still not perfect as we have both kinds of data, but being able to access the data dir on the phone has IMHO several benefits. Especially during the beta phase.

This however, will be a breaking change, as the data dir folder will change. If we want that, we should get this in before the first beta users get to test the app.


![Screenshot 2023-04-27 at 15 40 55](https://user-images.githubusercontent.com/382048/234880251-83f9dff5-aebe-4ee9-8753-ea2534f5a90d.png)

