### PR TITLE
feat(mobile): Decouple application data and seed locations

### DIFF
--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -260,7 +260,7 @@ class _TenTenOneAppState extends State<TenTenOneApp> {
       final appSupportDir = await getApplicationSupportDirectory();
       FLog.info(text: "App data will be stored in: $appSupportDir");
 
-      await rust.api.run(config: config, appDir: appSupportDir.path);
+      await rust.api.run(config: config, appDir: appSupportDir.path, seedDir: appSupportDir.path);
 
       await orderChangeNotifier.initialize();
       await positionChangeNotifier.initialize();

--- a/mobile/native/src/api.rs
+++ b/mobile/native/src/api.rs
@@ -171,7 +171,7 @@ pub fn subscribe(stream: StreamSink<event::api::Event>) {
     event::subscribe(FlutterSubscriber::new(stream))
 }
 
-pub fn run(config: Config, app_dir: String) -> Result<()> {
+pub fn run(config: Config, app_dir: String, seed_dir: String) -> Result<()> {
     std::panic::set_hook(
         #[allow(clippy::print_stderr)]
         Box::new(|info| {
@@ -186,7 +186,7 @@ pub fn run(config: Config, app_dir: String) -> Result<()> {
 
     config::set(config);
     db::init_db(&app_dir, get_network())?;
-    ln_dlc::run(app_dir)?;
+    ln_dlc::run(app_dir, seed_dir)?;
     orderbook::subscribe(ln_dlc::get_node_key()?)
 }
 


### PR DESCRIPTION
This allows for more flexibility, e.g. store app data in a different location
from the app seed.

This PR does not immediately use this feature, defaulting to the same directory.