### PR TITLE
fix(mobile): Re-add missing line of seed initialisation

### DIFF
--- a/mobile/native/src/ln_dlc/mod.rs
+++ b/mobile/native/src/ln_dlc/mod.rs
@@ -115,7 +115,8 @@ pub fn run(data_dir: String, seed_dir: String) -> Result<()> {
             listener.local_addr().expect("To get a free local address")
         };
 
-        let seed = Bip39Seed::initialize(&seed_dir)?;
+        let seed_path = data_dir.join("seed");
+        let seed = Bip39Seed::initialize(&seed_path)?;
 
         let node = Arc::new(
             ln_dlc_node::node::Node::new_app(


### PR DESCRIPTION
The line got deleted accidentally and caused a regression of not being able to
start the node.