### PR TITLE
fix(mobile): Only store email address in preferences after successful registration

### DIFF
--- a/mobile/lib/features/welcome/welcome_screen.dart
+++ b/mobile/lib/features/welcome/welcome_screen.dart
@@ -74,9 +74,9 @@ class _WelcomeScreenState extends State<WelcomeScreen> {
                   onPressed: () {
                     if (_formKey.currentState != null && _formKey.currentState!.validate()) {
                       _formKey.currentState?.save();
+                      api.registerBeta(email: _email);
                       Preferences.instance.setEmailAddress(_email);
                       FLog.info(text: "Successfully stored the email address $_email .");
-                      api.registerBeta(email: _email);
                       context.go(WalletScreen.route);
                     }
                   },


### PR DESCRIPTION
Don't store email address in preferences if we somehow could not register (e.g.
backend was not started properly).