### PR TITLE
Bump bdk to 0.27.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -215,9 +215,9 @@ checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
 
 [[package]]
 name = "bdk"
-version = "0.24.0"
+version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c50e3f08fbcd7eb34f11e066a1353986d583f1f87af70f7cd50bff9fce97c817"
+checksum = "51c878ac60a45c41523ff790df555ccb1fbfd634a667220104dcae3e64d7ed9f"
 dependencies = [
  "async-trait",
  "bdk-macros",
@@ -226,7 +226,7 @@ dependencies = [
  "getrandom",
  "js-sys",
  "log",
- "miniscript",
+ "miniscript 9.0.1",
  "rand",
  "serde",
  "serde_json",
@@ -828,7 +828,7 @@ version = "0.4.0"
 source = "git+https://github.com/get10101/rust-dlc?rev=c8bbafaab705425f6b6bf0acb2735330b74a4224#c8bbafaab705425f6b6bf0acb2735330b74a4224"
 dependencies = [
  "bitcoin",
- "miniscript",
+ "miniscript 8.0.0",
  "secp256k1-sys",
  "secp256k1-zkp",
  "serde",
@@ -1743,6 +1743,15 @@ name = "miniscript"
 version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f4975078076f0b7b914a3044ad7432d2a7fcec38edb855afdc672e24ca35b69"
+dependencies = [
+ "bitcoin",
+]
+
+[[package]]
+name = "miniscript"
+version = "9.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9601439f168c13bdc5bf84349c2e61c815be4a4dcebe8c4ff4af58f4e8a6d20"
 dependencies = [
  "bitcoin",
  "serde",

--- a/coordinator/Cargo.toml
+++ b/coordinator/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 anyhow = { version = "1", features = ["backtrace"] }
 atty = "0.2.14"
 axum = { version = "0.6.7", features = ["ws", "query"] }
-bdk = { version = "0.24.0", features = ["key-value-db"] }
+bdk = { version = "0.27.0", features = ["key-value-db"] }
 bitcoin = "0.29"
 clap = { version = "4", features = ["derive"] }
 coordinator-commons = { path = "../crates/coordinator-commons" }

--- a/crates/bdk-ldk/Cargo.toml
+++ b/crates/bdk-ldk/Cargo.toml
@@ -13,7 +13,7 @@ description = "Use your bdk wallet to implement ldk lightning functionality"
 
 [dependencies]
 anyhow = "1.0"
-bdk = "0.24"
+bdk = "0.27"
 lightning = { version = "0.0.113", features = ["max_level_trace"] }
 serde_json = "1.0.87"
 thiserror = "1"

--- a/crates/coordinator-commons/Cargo.toml
+++ b/crates/coordinator-commons/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1"
-bdk = { version = "0.24.0" }
+bdk = { version = "0.27.0" }
 orderbook-commons = { path = "../orderbook-commons" }
 rust_decimal = { version = "1", features = ["serde-with-float"] }
 rust_decimal_macros = "1.26"

--- a/crates/ln-dlc-node/Cargo.toml
+++ b/crates/ln-dlc-node/Cargo.toml
@@ -8,7 +8,7 @@ description = "A common interface for using Lightning and DLC channels side-by-s
 
 [dependencies]
 anyhow = { version = "1", features = ["backtrace"] }
-bdk = { version = "0.24.0", features = ["key-value-db"] }
+bdk = { version = "0.27.0", features = ["key-value-db"] }
 bdk-ldk = { path = "../bdk-ldk" }
 bip39 = { version = "2", features = ["rand_core"] }
 bitcoin = "0.29"

--- a/crates/trade/Cargo.toml
+++ b/crates/trade/Cargo.toml
@@ -8,7 +8,7 @@ description = "A common library for the shared model and functions for trading"
 
 [dependencies]
 anyhow = "1"
-bdk = { version = "0.24.0" }
+bdk = { version = "0.27.0" }
 reqwest = { version = "0.11", default-features = false, features = ["json"] }
 rust_decimal = { version = "1", features = ["serde-with-float"] }
 rust_decimal_macros = "1.26"

--- a/maker/Cargo.toml
+++ b/maker/Cargo.toml
@@ -8,7 +8,7 @@ anyhow = { version = "1", features = ["backtrace"] }
 async-stream = "0.3"
 atty = "0.2.14"
 axum = { version = "0.6.7", features = ["ws"] }
-bdk = { version = "0.24.0", features = ["key-value-db"] }
+bdk = { version = "0.27.0", features = ["key-value-db"] }
 bitcoin = "0.29"
 bitmex-stream = { path = "../crates/bitmex-stream" }
 clap = { version = "4", features = ["derive"] }

--- a/mobile/native/Cargo.toml
+++ b/mobile/native/Cargo.toml
@@ -9,7 +9,7 @@ crate-type = ["cdylib", "staticlib"]
 [dependencies]
 anyhow = "1"
 base64 = "0.21.0"
-bdk = { version = "0.24.0", features = ["key-value-db"] }
+bdk = { version = "0.27.0", features = ["key-value-db"] }
 coordinator-commons = { path = "../../crates/coordinator-commons" }
 diesel = { version = "2.0.0", features = ["sqlite", "r2d2", "extras"] }
 diesel_migrations = "2.0.0"


### PR DESCRIPTION
There's no blocking dependencies for bdk 0.28 either, but I would hold off with
that until we bump rust-lightning to 0.1.114 (e.g. to have matching
esplora-client versions).

a bit more context: this is done for the upcoming #545 