### PR TITLE
chore: Add test for claiming funds of a closed channel

### DIFF
--- a/.github/workflows/tests-ln-dlc-node.yml
+++ b/.github/workflows/tests-ln-dlc-node.yml
@@ -48,7 +48,7 @@ jobs:
         run: |
           curl -d '{"address":"bcrt1qylgu6ffkp3p0m8tw8kp4tt2dmdh755f4r5dq7s", "amount":"0.1"}' -H "Content-Type: application/json" -X POST http://localhost:3000/faucet
       - name: Run slow tests
-        run: cargo test -p ln-dlc-node -j 1 -- --ignored --nocapture
+        run: cargo test -p ln-dlc-node -j 1 -- --ignored --nocapture --test-threads=2
 
   tests-ln-dlc-node:
     runs-on: ubuntu-latest

--- a/crates/bdk-ldk/src/lib.rs
+++ b/crates/bdk-ldk/src/lib.rs
@@ -421,7 +421,7 @@ where
     fn broadcast_transaction(&self, tx: &Transaction) {
         let tx_hex = serialize_hex(tx);
         let txid = tx.txid();
-        tracing::info!(%tx_hex, %txid, "Broadcasting transaction");
+        tracing::info!(%txid, %tx_hex, "Broadcasting transaction");
         if let Err(e) = self.client.broadcast(tx) {
             tracing::error!("Error broadcasting transaction: {e:#}");
         }

--- a/crates/ln-dlc-node/src/ln/config.rs
+++ b/crates/ln-dlc-node/src/ln/config.rs
@@ -14,6 +14,8 @@ pub fn app_config() -> UserConfig {
             minimum_depth: 1,
             // There is no risk in the leaf channel to receive 100% of the channel capacity.
             max_inbound_htlc_value_in_flight_percent_of_channel: 100,
+            // the delay before the fund of a force closed channel can be claimed again
+            our_to_self_delay: 144,
             ..Default::default()
         },
         channel_handshake_limits: ChannelHandshakeLimits {
@@ -50,6 +52,8 @@ pub fn coordinator_config() -> UserConfig {
             minimum_depth: 1,
             // We set this 100% as the coordinator is online 24/7 and can take the risk.
             max_inbound_htlc_value_in_flight_percent_of_channel: 100,
+            // the delay before the fund of a force closed channel can be claimed again
+            our_to_self_delay: 144,
             ..Default::default()
         },
         channel_handshake_limits: ChannelHandshakeLimits {

--- a/crates/ln-dlc-node/src/tests/just_in_time_channel/channel_close.rs
+++ b/crates/ln-dlc-node/src/tests/just_in_time_channel/channel_close.rs
@@ -1,0 +1,193 @@
+use crate::ln::JUST_IN_TIME_CHANNEL_OUTBOUND_LIQUIDITY_SAT;
+use crate::node::Node;
+use crate::node::PaymentMap;
+use crate::tests::bitcoind;
+use crate::tests::init_tracing;
+use crate::tests::just_in_time_channel::create::send_interceptable_payment;
+use crate::tests::just_in_time_channel::TestPathChannelClose;
+use crate::tests::just_in_time_channel::TestPathFunding;
+use crate::tests::min_outbound_liquidity_channel_creator;
+use anyhow::anyhow;
+use anyhow::Result;
+use bitcoin::Amount;
+use dlc_manager::subchannel::LNChannelManager;
+use std::time::Duration;
+
+#[tokio::test]
+#[ignore]
+async fn collab_close() {
+    init_tracing();
+
+    // Arrange
+
+    let payer = Node::start_test_app("payer").await.unwrap();
+    let coordinator = Node::start_test_coordinator("coordinator").await.unwrap();
+    let payee = Node::start_test_app("payee").await.unwrap();
+
+    payer.connect(coordinator.info).await.unwrap();
+    payee.connect(coordinator.info).await.unwrap();
+
+    coordinator.fund(Amount::from_sat(1_000_000)).await.unwrap();
+
+    let payer_outbound_liquidity_sat = 25_000;
+    let coordinator_outbound_liquidity_sat =
+        min_outbound_liquidity_channel_creator(&payer, payer_outbound_liquidity_sat);
+
+    coordinator
+        .open_channel(
+            &payer,
+            coordinator_outbound_liquidity_sat,
+            payer_outbound_liquidity_sat,
+        )
+        .await
+        .unwrap();
+
+    let invoice_amount = 1_000;
+
+    send_interceptable_payment(
+        TestPathFunding::Online,
+        &payer,
+        &payee,
+        &coordinator,
+        invoice_amount,
+        Some(JUST_IN_TIME_CHANNEL_OUTBOUND_LIQUIDITY_SAT),
+    )
+    .await
+    .unwrap();
+
+    close_channel(
+        TestPathChannelClose::Collaborative,
+        &payee,
+        &coordinator,
+        invoice_amount,
+    )
+    .await
+    .unwrap();
+}
+
+#[tokio::test]
+#[ignore]
+async fn force_close() {
+    init_tracing();
+
+    // Arrange
+
+    let payer = Node::start_test_app("payer").await.unwrap();
+    let coordinator = Node::start_test_coordinator("coordinator").await.unwrap();
+    let payee = Node::start_test_app("payee").await.unwrap();
+
+    payer.connect(coordinator.info).await.unwrap();
+    payee.connect(coordinator.info).await.unwrap();
+
+    coordinator.fund(Amount::from_sat(1_000_000)).await.unwrap();
+
+    let payer_outbound_liquidity_sat = 25_000;
+    let coordinator_outbound_liquidity_sat =
+        min_outbound_liquidity_channel_creator(&payer, payer_outbound_liquidity_sat);
+
+    coordinator
+        .open_channel(
+            &payer,
+            coordinator_outbound_liquidity_sat,
+            payer_outbound_liquidity_sat,
+        )
+        .await
+        .unwrap();
+
+    let invoice_amount = 1_000;
+
+    send_interceptable_payment(
+        TestPathFunding::Online,
+        &payer,
+        &payee,
+        &coordinator,
+        invoice_amount,
+        Some(JUST_IN_TIME_CHANNEL_OUTBOUND_LIQUIDITY_SAT),
+    )
+    .await
+    .unwrap();
+
+    close_channel(
+        TestPathChannelClose::Force,
+        &payee,
+        &coordinator,
+        invoice_amount,
+    )
+    .await
+    .unwrap();
+}
+
+async fn close_channel(
+    test_path: TestPathChannelClose,
+    payee: &Node<PaymentMap>,
+    coordinator: &Node<PaymentMap>,
+    lightning_balance: u64,
+) -> Result<()> {
+    let channel_id = payee
+        .channel_manager
+        .list_usable_channels()
+        .first()
+        .unwrap()
+        .channel_id;
+
+    assert_eq!(payee.get_on_chain_balance()?.confirmed, 0);
+    assert_eq!(payee.get_ldk_balance().available, lightning_balance);
+    assert_eq!(payee.get_ldk_balance().pending_close, 0);
+
+    match test_path {
+        TestPathChannelClose::Force => {
+            payee
+                .channel_manager
+                .force_close_channel(&channel_id, &coordinator.info.pubkey)
+                .map_err(|e| anyhow!("{e:?}"))?;
+        }
+        TestPathChannelClose::Collaborative => {
+            payee
+                .channel_manager
+                .close_channel(&channel_id, &coordinator.info.pubkey)
+                .map_err(|e| anyhow!("{e:?}"))?;
+
+            // wait for the collaboration closure to complete.
+            // todo: it would be nice if we could simply assert the channel close event.
+            tokio::time::sleep(Duration::from_secs(5)).await;
+        }
+    }
+
+    payee.sync()?;
+
+    assert_eq!(payee.get_on_chain_balance()?.confirmed, 0);
+    assert_eq!(payee.get_ldk_balance().available, 0);
+    assert_eq!(payee.get_ldk_balance().pending_close, lightning_balance);
+
+    // transaction fees for the on-chain transaction
+    let tx_fees = match test_path {
+        TestPathChannelClose::Force => {
+            // the delay we have to wait before the fund can be claimed on chain again.
+            bitcoind::mine(144).await?;
+            122
+        }
+        TestPathChannelClose::Collaborative => {
+            // mine six block after broadcasting the commit transaction.
+            bitcoind::mine(6).await?;
+            110
+        }
+    };
+
+    // this sync triggers the `[Event::SpendableOutputs]` broadcasting the transaction to claim
+    // the payees coins.
+    payee.sync()?;
+
+    // mine a single block to claim the spendable output after waiting for the force close delay.
+    bitcoind::mine(1).await?;
+    payee.sync()?;
+
+    assert_eq!(payee.get_ldk_balance().available, 0);
+    assert_eq!(payee.get_ldk_balance().pending_close, 0);
+    // the confirmed balance is greater 0. No exact match as the fee rates vary the result.
+    assert_eq!(
+        payee.get_on_chain_balance()?.confirmed,
+        lightning_balance - tx_fees
+    );
+
+    Ok(())
+}

--- a/crates/ln-dlc-node/src/tests/just_in_time_channel/create.rs
+++ b/crates/ln-dlc-node/src/tests/just_in_time_channel/create.rs
@@ -3,7 +3,7 @@ use crate::node::Node;
 use crate::node::PaymentMap;
 use crate::node::LIQUIDITY_ROUTING_FEE_MILLIONTHS;
 use crate::tests::init_tracing;
-use crate::tests::just_in_time_channel::TestPath;
+use crate::tests::just_in_time_channel::TestPathFunding;
 use crate::tests::min_outbound_liquidity_channel_creator;
 use anyhow::Context;
 use anyhow::Result;
@@ -66,7 +66,7 @@ async fn just_in_time_channel() {
     let invoice_amount = 1_000;
 
     send_interceptable_payment(
-        TestPath::OnlineFunding,
+        TestPathFunding::Online,
         &payer,
         &payee,
         &coordinator,
@@ -78,7 +78,7 @@ async fn just_in_time_channel() {
 }
 
 pub(crate) async fn send_interceptable_payment(
-    test_path: TestPath,
+    test_path: TestPathFunding,
     payer: &Node<PaymentMap>,
     payee: &Node<PaymentMap>,
     coordinator: &Node<PaymentMap>,
@@ -127,7 +127,7 @@ pub(crate) async fn send_interceptable_payment(
 
     payer.send_payment(&invoice)?;
 
-    if TestPath::MobileFunding == test_path {
+    if TestPathFunding::Mobile == test_path {
         // simulate the user switching from another app to 10101
 
         // Note, hopefully Breez, Phoenix or any other non-custodial wallet is able to run in the

--- a/crates/ln-dlc-node/src/tests/just_in_time_channel/mod.rs
+++ b/crates/ln-dlc-node/src/tests/just_in_time_channel/mod.rs
@@ -1,11 +1,18 @@
+mod channel_close;
 mod create;
 mod multiple_payments;
 mod offline_receiver;
 
 #[derive(PartialEq)]
-pub enum TestPath {
+pub enum TestPathFunding {
     // funding through an always on lightning node
-    OnlineFunding,
+    Online,
     // funding through a mobile lightning node (on the same phone)
-    MobileFunding,
+    Mobile,
+}
+
+#[derive(PartialEq)]
+pub enum TestPathChannelClose {
+    Force,
+    Collaborative,
 }

--- a/crates/ln-dlc-node/src/tests/just_in_time_channel/multiple_payments.rs
+++ b/crates/ln-dlc-node/src/tests/just_in_time_channel/multiple_payments.rs
@@ -2,7 +2,7 @@ use crate::ln::JUST_IN_TIME_CHANNEL_OUTBOUND_LIQUIDITY_SAT;
 use crate::node::Node;
 use crate::tests::init_tracing;
 use crate::tests::just_in_time_channel::create::send_interceptable_payment;
-use crate::tests::just_in_time_channel::TestPath;
+use crate::tests::just_in_time_channel::TestPathFunding;
 use crate::tests::min_outbound_liquidity_channel_creator;
 use bitcoin::Amount;
 
@@ -37,7 +37,7 @@ async fn just_in_time_channel_with_multiple_payments() {
 
     // this creates the just in time channel between the coordinator and user_b
     send_interceptable_payment(
-        TestPath::OnlineFunding,
+        TestPathFunding::Online,
         &user_a,
         &user_b,
         &coordinator,
@@ -51,7 +51,7 @@ async fn just_in_time_channel_with_multiple_payments() {
     assert_eq!(coordinator.channel_manager.list_channels().len(), 2);
 
     send_interceptable_payment(
-        TestPath::OnlineFunding,
+        TestPathFunding::Online,
         &user_a,
         &user_b,
         &coordinator,
@@ -65,7 +65,7 @@ async fn just_in_time_channel_with_multiple_payments() {
     assert_eq!(coordinator.channel_manager.list_channels().len(), 2);
 
     send_interceptable_payment(
-        TestPath::OnlineFunding,
+        TestPathFunding::Online,
         &user_b,
         &user_a,
         &coordinator,
@@ -79,7 +79,7 @@ async fn just_in_time_channel_with_multiple_payments() {
     assert_eq!(coordinator.channel_manager.list_channels().len(), 2);
 
     send_interceptable_payment(
-        TestPath::OnlineFunding,
+        TestPathFunding::Online,
         &user_a,
         &user_b,
         &coordinator,

--- a/crates/ln-dlc-node/src/tests/just_in_time_channel/offline_receiver.rs
+++ b/crates/ln-dlc-node/src/tests/just_in_time_channel/offline_receiver.rs
@@ -2,7 +2,7 @@ use crate::ln::JUST_IN_TIME_CHANNEL_OUTBOUND_LIQUIDITY_SAT;
 use crate::node::Node;
 use crate::tests::init_tracing;
 use crate::tests::just_in_time_channel::create::send_interceptable_payment;
-use crate::tests::just_in_time_channel::TestPath;
+use crate::tests::just_in_time_channel::TestPathFunding;
 use crate::tests::min_outbound_liquidity_channel_creator;
 use bitcoin::Amount;
 
@@ -37,7 +37,7 @@ async fn offline_receiver() {
     let invoice_amount = 1_000;
 
     send_interceptable_payment(
-        TestPath::MobileFunding,
+        TestPathFunding::Mobile,
         &payer,
         &payee,
         &coordinator,


### PR DESCRIPTION
Turns out the relevant configuration is `our_to_self_delay` and not `their_to_self_delay`. The later only specifies the amount of blocks we are at max willing to wait for claim funds after a force closed channel. `our_to_self_delay` is eventually the configuration we are using in case we are opening the channel. We used the default value of 144 blocks which is about 24 hours. I think this value is reasonable, but could be decreased even more for our just in time channels.

This PR pulls this config to 10101 and sets it to the default value of 144. So nothing changes here. I also added a test to ensure that force closing is actually working. Additionally I added a collaborative channel closure tests, which shows that the user has to wait for 6 blocks to receive the `[Event::SpendableOutput]` to broadcast the transaction to claim the on-chain funds. This will require the user to wait an additional block, before the funds are back to her wallet.

TIL: the app needs to be online after 
 - 144 blocks in case of a force closed channel
 - 6 blocks in case of a collaborative closed channel
to broadcast a transaction to be able to claim the funds. LDK does not do that automatically.