### PR TITLE
Use on-chain address for shutdown and destination

### DIFF
--- a/crates/ln-dlc-node/src/ln/config.rs
+++ b/crates/ln-dlc-node/src/ln/config.rs
@@ -14,7 +14,8 @@ pub fn app_config() -> UserConfig {
             minimum_depth: 1,
             // There is no risk in the leaf channel to receive 100% of the channel capacity.
             max_inbound_htlc_value_in_flight_percent_of_channel: 100,
-            // the delay before the fund of a force closed channel can be claimed again
+            // We want the coordinator to recover force-close funds as soon as possible. We choose
+            // 144 because we can't go any lower according to LDK.
             our_to_self_delay: 144,
             ..Default::default()
         },
@@ -23,8 +24,9 @@ pub fn app_config() -> UserConfig {
             trust_own_funding_0conf: true,
             // Enforces that incoming channels will be private.
             force_announced_channel_preference: true,
-            // lnd's max to_self_delay is 2016, so we want to be compatible.
-            their_to_self_delay: 2016,
+            // We want app users to only have to wait ~24 hours in case of a force-close. We choose
+            // 144 because we can't go any lower according to LDK.
+            their_to_self_delay: 144,
             ..Default::default()
         },
         channel_config: ChannelConfig {
@@ -52,7 +54,8 @@ pub fn coordinator_config() -> UserConfig {
             minimum_depth: 1,
             // We set this 100% as the coordinator is online 24/7 and can take the risk.
             max_inbound_htlc_value_in_flight_percent_of_channel: 100,
-            // the delay before the fund of a force closed channel can be claimed again
+            // Our channel peers are allowed to get back their funds ~24 hours after a
+            // force-closure.
             our_to_self_delay: 144,
             ..Default::default()
         },
@@ -64,7 +67,7 @@ pub fn coordinator_config() -> UserConfig {
             // Enforces incoming channels to the coordinator to be public! We
             // only want to open private channels to our 10101 app.
             force_announced_channel_preference: true,
-            // lnd's max to_self_delay is 2016, so we want to be compatible.
+            // LND's max to_self_delay is 2016, so we want to be compatible.
             their_to_self_delay: 2016,
             ..Default::default()
         },

--- a/crates/ln-dlc-node/src/ln_dlc_wallet.rs
+++ b/crates/ln-dlc-node/src/ln_dlc_wallet.rs
@@ -104,6 +104,12 @@ impl LnDlcWallet {
 
         Ok(txs)
     }
+
+    pub fn get_last_unused_address(&self) -> Result<Address> {
+        let address = self.inner().get_last_unused_address()?;
+
+        Ok(address)
+    }
 }
 
 impl Blockchain for LnDlcWallet {

--- a/crates/ln-dlc-node/src/node/mod.rs
+++ b/crates/ln-dlc-node/src/node/mod.rs
@@ -313,11 +313,14 @@ where
         ));
 
         let keys_manager = {
-            Arc::new(CustomKeysManager::new(KeysManager::new(
-                &seed.lightning_seed(),
-                time_since_unix_epoch.as_secs(),
-                time_since_unix_epoch.subsec_nanos(),
-            )))
+            Arc::new(CustomKeysManager::new(
+                KeysManager::new(
+                    &seed.lightning_seed(),
+                    time_since_unix_epoch.as_secs(),
+                    time_since_unix_epoch.subsec_nanos(),
+                ),
+                ln_dlc_wallet.clone(),
+            ))
         };
 
         let channel_manager = channel_manager::build(

--- a/crates/ln-dlc-node/src/node/wallet.rs
+++ b/crates/ln-dlc-node/src/node/wallet.rs
@@ -70,16 +70,12 @@ where
         };
 
         let pending_close = claimable_channel_balances.iter().fold(0, |acc, balance| {
-            tracing::trace!("Pending on-chain balance from channel closure: {balance:?}");
+            tracing::debug!("Pending on-chain balance from channel closure: {balance:?}");
 
             use ::lightning::chain::channelmonitor::Balance::*;
             match balance {
                 ClaimableOnChannelClose {
                     claimable_amount_satoshis,
-                }
-                | ClaimableAwaitingConfirmations {
-                    claimable_amount_satoshis,
-                    ..
                 }
                 | ContentiousClaimable {
                     claimable_amount_satoshis,
@@ -96,6 +92,12 @@ where
                 | CounterpartyRevokedOutputClaimable {
                     claimable_amount_satoshis,
                 } => acc + claimable_amount_satoshis,
+                ClaimableAwaitingConfirmations { .. } => {
+                    // we can safely ignore this type of balance because we override the
+                    // `destination_script` for the channel closure so that it's owned by our
+                    // on-chain wallet
+                    acc
+                }
             }
         });
 

--- a/crates/ln-dlc-node/src/tests/bitcoind.rs
+++ b/crates/ln-dlc-node/src/tests/bitcoind.rs
@@ -21,16 +21,19 @@ pub async fn fund(address: String, amount: bitcoin::Amount) -> Result<Response> 
 }
 
 /// Instructs `bitcoind` to generate to address.
-pub async fn mine(n: u16) -> Result<()> {
+pub async fn mine(n_blocks: u16) -> Result<()> {
+    tracing::debug!(n_blocks, "Mining");
+
     let response =
         query(r#"{"jsonrpc": "1.0", "method": "getnewaddress", "params": []}"#.to_string()).await?;
     let response: BitcoindResponse = response.json().await.unwrap();
 
     query(format!(
         r#"{{"jsonrpc": "1.0", "method": "generatetoaddress", "params": [{}, "{}"]}}"#,
-        n, response.result
+        n_blocks, response.result
     ))
     .await?;
+
     // For the mined blocks to be picked up by the subsequent wallet
     // syncs
     tokio::time::sleep(Duration::from_secs(5)).await;

--- a/crates/ln-dlc-node/src/tests/just_in_time_channel/mod.rs
+++ b/crates/ln-dlc-node/src/tests/just_in_time_channel/mod.rs
@@ -10,9 +10,3 @@ pub enum TestPathFunding {
     // funding through a mobile lightning node (on the same phone)
     Mobile,
 }
-
-#[derive(PartialEq)]
-pub enum TestPathChannelClose {
-    Force,
-    Collaborative,
-}

--- a/crates/ln-dlc-node/src/tests/mod.rs
+++ b/crates/ln-dlc-node/src/tests/mod.rs
@@ -22,7 +22,6 @@ use dlc_manager::payout_curve::PayoutPoint;
 use dlc_manager::payout_curve::PolynomialPayoutCurvePiece;
 use dlc_manager::payout_curve::RoundingInterval;
 use dlc_manager::payout_curve::RoundingIntervals;
-use dlc_manager::Wallet;
 use futures::Future;
 use lightning::ln::channelmanager::ChannelDetails;
 use lightning::util::config::UserConfig;
@@ -118,7 +117,7 @@ impl Node<PaymentMap> {
         let starting_balance = self.get_confirmed_balance().await?;
         let expected_balance = starting_balance + amount.to_sat();
 
-        let address = self.wallet.get_new_address()?;
+        let address = self.wallet.get_last_unused_address()?;
 
         fund_and_mine(address, amount).await?;
 


### PR DESCRIPTION
#### Collaborative close of LN channel

Before, the collab close transaction paid to an address owned by LDK, which had to be confirmed and then spent to the on-chain wallet.

After overriding `get_shutdown_scriptpubkey`, the close transaction pays directly to the on-chain wallet. This means that there is no risk of losing funds as soon as the close transaction is on-chain if we remember the seed, whereas before we could lose funds whilst waiting for the "claim transaction".

#### Force-close of LN channel

The effect of overriding `get_destination_script` to point to an on-chain wallet address is less clear to me, because the commitment transaction must still be processed by LDK to produce a `SpendableOutputs` event with a `SpendableOutputDescriptor::DelayedPaymentOutput` which can then be spent to an on-chain wallet address (after waiting for the corresponding delay).

#### Other changes

The tests were fixed to pass after the new changes were introduced. At the same time we decided to refactor them with the goal of making them clearer and simpler. These two tests diverged enough that it made sense to remove the common helper function.

#### Caveat

The trait method implementations modified include a few `expect`s because the trait methods are defined as infallible. We copied the code from `ldk-node`, so at least that suggests that they are okay with these `expect`s.