### PR TITLE
Log LDK pings

### DIFF
--- a/coordinator/src/logger.rs
+++ b/coordinator/src/logger.rs
@@ -25,6 +25,7 @@ pub fn init_tracing(level: LevelFilter, json_format: bool) -> Result<()> {
         .add_directive("rustls=warn".parse()?)
         .add_directive("sled=warn".parse()?)
         .add_directive("bdk=warn".parse()?) // bdk is quite spamy on debug
+        .add_directive("lightning::ln::peer_handler=trace".parse()?)
         .add_directive("lightning::chain=info".parse()?);
 
     // Parse additional log directives from env variable


### PR DESCRIPTION
This is so that we can debug the effect of future code changes on the frequency of lost connections due to ping timeout.