### PR TITLE
Set JIT funding rate to 0.5% and make it configurable from the coordinator

### DIFF
--- a/coordinator/src/bin/coordinator.rs
+++ b/coordinator/src/bin/coordinator.rs
@@ -81,6 +81,7 @@ async fn main() -> Result<()> {
             opts.electrum,
             seed,
             ephemeral_randomness,
+            opts.jit_fee_rate_basis_point * 100,
         )
         .await?,
     );

--- a/coordinator/src/cli.rs
+++ b/coordinator/src/cli.rs
@@ -42,6 +42,11 @@ pub struct Opts {
     /// The address to connect electrum to
     #[clap(long, default_value = "tcp://localhost:50000")]
     pub electrum: String,
+
+    /// Fee rate to be charged for opening just in time channels. Rate is in basis points, i.e.
+    /// 100 basis point=1% or 50=0.5%
+    #[clap(long, default_value = "50")]
+    pub jit_fee_rate_basis_point: u32,
 }
 
 #[derive(Debug, Clone, Copy, clap::ValueEnum)]

--- a/coordinator/src/routes.rs
+++ b/coordinator/src/routes.rs
@@ -117,8 +117,9 @@ pub async fn post_fake_scid(
         ))
     })?;
 
-    let (fscid, _) = app_state.node.inner.create_intercept_scid(target_node);
-    Ok(Json(fscid))
+    Ok(Json(
+        app_state.node.inner.create_intercept_scid(target_node).scid,
+    ))
 }
 
 pub async fn post_fake_scid_with_fee_hint(
@@ -132,7 +133,9 @@ pub async fn post_fake_scid_with_fee_hint(
         ))
     })?;
 
-    let (scid, fee_rate_millionth) = app_state.node.inner.create_intercept_scid(target_node);
+    let details = app_state.node.inner.create_intercept_scid(target_node);
+    let scid = details.scid;
+    let fee_rate_millionth = details.jit_routing_fee_millionth;
     Ok(Json(FakeScidResponse {
         scid,
         fee_rate_millionth,

--- a/coordinator/src/routes.rs
+++ b/coordinator/src/routes.rs
@@ -66,7 +66,7 @@ pub fn router(node: Node, pool: Pool<ConnectionManager<PgConnection>>) -> Router
         .route("/api/fake_scid/:target_node", post(post_fake_scid))
         .route(
             "/api/fake_scid/v2/:target_node",
-            post(post_fake_scid_with_fee_hint),
+            post(register_interceptable_invoice),
         )
         .route("/api/newaddress", get(get_new_address))
         .route("/api/node", get(get_node_info))
@@ -122,7 +122,7 @@ pub async fn post_fake_scid(
     ))
 }
 
-pub async fn post_fake_scid_with_fee_hint(
+pub async fn register_interceptable_invoice(
     target_node: Path<String>,
     State(app_state): State<Arc<AppState>>,
 ) -> Result<Json<FakeScidResponse>, AppError> {

--- a/crates/bdk-ldk/src/lib.rs
+++ b/crates/bdk-ldk/src/lib.rs
@@ -13,6 +13,7 @@ use bdk::database::BatchDatabase;
 use bdk::wallet::AddressIndex;
 use bdk::wallet::Wallet;
 use bdk::Balance;
+use bdk::FeeRate;
 use bdk::SignOptions;
 use bdk::SyncOptions;
 use std::cmp::min;
@@ -167,7 +168,11 @@ where
     ) -> Result<Transaction, Error> {
         let wallet = self.wallet_lock();
         let mut tx_builder = wallet.build_tx();
+
         let fee_rate = self.client.estimate_fee(target_blocks)?;
+        let sats_per_vbyte = fee_rate.as_sat_per_vb();
+        let sats_per_vbyte = min(MAX_SATS_PER_V_BYTE, sats_per_vbyte as u32);
+        let fee_rate = FeeRate::from_sat_per_vb(sats_per_vbyte as f32);
 
         tx_builder
             .add_recipient(output_script.clone(), value)

--- a/crates/bdk-ldk/src/lib.rs
+++ b/crates/bdk-ldk/src/lib.rs
@@ -359,19 +359,6 @@ where
         }
     }
 
-    pub fn estimate_fee(&self, confirmation_target: ConfirmationTarget) -> Result<u32, Error> {
-        let target_blocks = match confirmation_target {
-            ConfirmationTarget::Background => 6,
-            ConfirmationTarget::Normal => 3,
-            ConfirmationTarget::HighPriority => 1,
-        };
-
-        let estimate = self.client.estimate_fee(target_blocks).unwrap_or_default();
-        let sats_per_vbyte = estimate.as_sat_per_vb() as u32;
-
-        Ok(sats_per_vbyte)
-    }
-
     /// Unlike `broadcast_transaction`, this one allows the client to inspect the errors
     pub fn broadcast(&self, tx: &Transaction) -> Result<(), Error> {
         let tx_hex = serialize_hex(tx);

--- a/crates/ln-dlc-node/src/node/invoice.rs
+++ b/crates/ln-dlc-node/src/node/invoice.rs
@@ -1,6 +1,5 @@
 use crate::node::Node;
 use crate::node::PaymentPersister;
-use crate::node::LIQUIDITY_ROUTING_FEE_MILLIONTHS;
 use crate::MillisatAmount;
 use crate::PaymentFlow;
 use crate::PaymentInfo;
@@ -131,7 +130,7 @@ where
     /// This is mainly used for instant payments where the receiver does not have a lightning
     /// channel yet, e.g. Alice does not have a channel with Bob yet but wants to
     /// receive a LN payment. Clair pays to Bob who opens a channel to Alice and pays her.
-    pub fn create_intercept_scid(&self, target_node: PublicKey) -> (u64, u32) {
+    pub fn create_intercept_scid(&self, target_node: PublicKey) -> InterceptableScidDetails {
         let intercept_scid = self.channel_manager.get_intercept_scid();
         self.fake_channel_payments
             .lock()
@@ -139,8 +138,10 @@ where
             .insert(intercept_scid, target_node);
 
         tracing::info!(peer_id=%target_node, %intercept_scid, "Successfully created intercept scid for payment routing");
-
-        (intercept_scid, LIQUIDITY_ROUTING_FEE_MILLIONTHS)
+        InterceptableScidDetails {
+            scid: intercept_scid,
+            jit_routing_fee_millionth: self.jit_funding_rate_millionth,
+        }
     }
 
     pub fn send_payment(&self, invoice: &Invoice) -> Result<()> {
@@ -237,4 +238,9 @@ pub enum HTLCStatus {
     Pending,
     Succeeded,
     Failed,
+}
+
+pub struct InterceptableScidDetails {
+    pub scid: u64,
+    pub jit_routing_fee_millionth: u32,
 }

--- a/crates/ln-dlc-node/src/node/invoice.rs
+++ b/crates/ln-dlc-node/src/node/invoice.rs
@@ -65,6 +65,7 @@ where
         hop_before_me: PublicKey,
         invoice_expiry: u32,
         description: String,
+        proportional_fee_millionth: u32,
     ) -> Result<Invoice> {
         let amount_msat = amount_in_sats.map(|x| x * 1000);
         let (payment_hash, payment_secret) = self
@@ -93,7 +94,7 @@ where
                 // in the `ChannelConfig` for the private channel?
                 fees: RoutingFees {
                     base_msat: 1000,
-                    proportional_millionths: LIQUIDITY_ROUTING_FEE_MILLIONTHS,
+                    proportional_millionths: proportional_fee_millionth,
                 },
                 cltv_expiry_delta: MIN_CLTV_EXPIRY_DELTA,
                 htlc_minimum_msat: None,
@@ -130,7 +131,7 @@ where
     /// This is mainly used for instant payments where the receiver does not have a lightning
     /// channel yet, e.g. Alice does not have a channel with Bob yet but wants to
     /// receive a LN payment. Clair pays to Bob who opens a channel to Alice and pays her.
-    pub fn create_intercept_scid(&self, target_node: PublicKey) -> u64 {
+    pub fn create_intercept_scid(&self, target_node: PublicKey) -> (u64, u32) {
         let intercept_scid = self.channel_manager.get_intercept_scid();
         self.fake_channel_payments
             .lock()
@@ -139,7 +140,7 @@ where
 
         tracing::info!(peer_id=%target_node, %intercept_scid, "Successfully created intercept scid for payment routing");
 
-        intercept_scid
+        (intercept_scid, LIQUIDITY_ROUTING_FEE_MILLIONTHS)
     }
 
     pub fn send_payment(&self, invoice: &Invoice) -> Result<()> {

--- a/crates/ln-dlc-node/src/node/mod.rs
+++ b/crates/ln-dlc-node/src/node/mod.rs
@@ -116,6 +116,10 @@ pub struct Node<P> {
     pub(crate) alias: [u8; 32],
     #[cfg(test)]
     pub(crate) announcement_addresses: Vec<NetAddress>,
+
+    /// Liquidity-based routing fee in millionths of a routed amount. In
+    /// other words, 10000 is 1% and 5_000 is 0.5%
+    jit_funding_rate_millionth: u32,
 }
 
 #[derive(Debug, Clone, Copy, Deserialize, Serialize)]
@@ -126,7 +130,7 @@ pub struct NodeInfo {
 
 /// Liquidity-based routing fee in millionths of a routed amount. In
 /// other words, 10000 is 1% and 5_000 is 0.5%
-pub(crate) const LIQUIDITY_ROUTING_FEE_MILLIONTHS: u32 = 5_000;
+pub(crate) const DEFAULT_LIQUIDITY_ROUTING_FEE_MILLIONTHS: u32 = 5_000;
 
 impl<P> Node<P>
 where
@@ -161,6 +165,7 @@ where
             seed,
             ephemeral_randomness,
             user_config,
+            DEFAULT_LIQUIDITY_ROUTING_FEE_MILLIONTHS,
         )
         .await
     }
@@ -181,6 +186,7 @@ where
         electrs_origin: String,
         seed: Bip39Seed,
         ephemeral_randomness: [u8; 32],
+        jit_funding_rate_millionth: u32,
     ) -> Result<Self> {
         let mut user_config = coordinator_config();
 
@@ -202,6 +208,7 @@ where
             seed,
             ephemeral_randomness,
             user_config,
+            jit_funding_rate_millionth,
         )
         .await
     }
@@ -219,6 +226,7 @@ where
         seed: Bip39Seed,
         ephemeral_randomness: [u8; 32],
         ldk_user_config: UserConfig,
+        jit_funding_rate_millionth: u32,
     ) -> Result<Self> {
         let time_since_unix_epoch = SystemTime::now().duration_since(SystemTime::UNIX_EPOCH)?;
 
@@ -502,6 +510,7 @@ where
             announcement_addresses,
             #[cfg(test)]
             alias,
+            jit_funding_rate_millionth,
         })
     }
 }

--- a/crates/ln-dlc-node/src/node/mod.rs
+++ b/crates/ln-dlc-node/src/node/mod.rs
@@ -125,8 +125,8 @@ pub struct NodeInfo {
 }
 
 /// Liquidity-based routing fee in millionths of a routed amount. In
-/// other words, 10000 is 1%.
-pub(crate) const LIQUIDITY_ROUTING_FEE_MILLIONTHS: u32 = 20_000;
+/// other words, 10000 is 1% and 5_000 is 0.5%
+pub(crate) const LIQUIDITY_ROUTING_FEE_MILLIONTHS: u32 = 5_000;
 
 impl<P> Node<P>
 where

--- a/crates/ln-dlc-node/src/tests/just_in_time_channel/create.rs
+++ b/crates/ln-dlc-node/src/tests/just_in_time_channel/create.rs
@@ -8,7 +8,12 @@ use crate::tests::min_outbound_liquidity_channel_creator;
 use anyhow::Context;
 use anyhow::Result;
 use bitcoin::Amount;
+use rust_decimal::prelude::FromPrimitive;
+use rust_decimal::prelude::ToPrimitive;
 use rust_decimal::Decimal;
+use rust_decimal::RoundingStrategy;
+use std::ops::Div;
+use std::ops::Mul;
 use std::time::Duration;
 
 #[tokio::test]
@@ -95,11 +100,21 @@ pub(crate) async fn send_interceptable_payment(
 
     // Act
 
-    let intercept_scid = coordinator.create_intercept_scid(payee.info.pubkey);
+    let (intercept_scid, fee_millionth) = coordinator.create_intercept_scid(payee.info.pubkey);
 
     let flat_routing_fee = 1; // according to the default `ChannelConfig`
-    let liquidity_routing_fee =
-        (invoice_amount * LIQUIDITY_ROUTING_FEE_MILLIONTHS as u64) / 1_000_000;
+    let liquidity_rounding_fee = Decimal::from_u64(invoice_amount)
+        .unwrap()
+        .mul(Decimal::from_u32(LIQUIDITY_ROUTING_FEE_MILLIONTHS).unwrap())
+        .div(Decimal::from_u64(1_000_000).unwrap());
+    let liquidity_routing_fee_payer = liquidity_rounding_fee
+        .round_dp_with_strategy(0, RoundingStrategy::MidpointAwayFromZero)
+        .to_u64()
+        .unwrap();
+    let liquidity_routing_fee_receiver = liquidity_rounding_fee
+        .round_dp_with_strategy(0, RoundingStrategy::MidpointTowardZero)
+        .to_u64()
+        .unwrap();
 
     assert!(
         does_inbound_htlc_fit_as_percent_of_channel(
@@ -110,7 +125,7 @@ pub(crate) async fn send_interceptable_payment(
                 .first()
                 .expect("payer channel should be created.")
                 .channel_id,
-            invoice_amount + flat_routing_fee + liquidity_routing_fee
+            invoice_amount + flat_routing_fee + liquidity_routing_fee_receiver
         )
         .unwrap(),
         "Invoice amount larger than maximum inbound HTLC in payer-coordinator channel"
@@ -123,6 +138,7 @@ pub(crate) async fn send_interceptable_payment(
         coordinator.info.pubkey,
         invoice_expiry,
         "interceptable-invoice".to_string(),
+        fee_millionth,
     )?;
 
     payer.send_payment(&invoice)?;
@@ -157,14 +173,14 @@ pub(crate) async fn send_interceptable_payment(
 
     assert_eq!(
         payer_balance_before.available - payer_balance_after.available,
-        invoice_amount + flat_routing_fee + liquidity_routing_fee
+        invoice_amount + flat_routing_fee + liquidity_routing_fee_payer
     );
 
     assert_eq!(
         coordinator_balance_after.available - coordinator_balance_before.available,
         coordinator_just_in_time_channel_creation_outbound_liquidity.unwrap_or_default()
             + flat_routing_fee
-            + liquidity_routing_fee
+            + liquidity_routing_fee_receiver
     );
 
     assert_eq!(

--- a/crates/ln-dlc-node/src/tests/mod.rs
+++ b/crates/ln-dlc-node/src/tests/mod.rs
@@ -3,6 +3,7 @@ use crate::ln::coordinator_config;
 use crate::node::Node;
 use crate::node::NodeInfo;
 use crate::node::PaymentMap;
+use crate::node::DEFAULT_LIQUIDITY_ROUTING_FEE_MILLIONTHS;
 use crate::seed::Bip39Seed;
 use crate::util;
 use anyhow::Result;
@@ -63,14 +64,23 @@ fn init_tracing() {
 
 impl Node<PaymentMap> {
     async fn start_test_app(name: &str) -> Result<Self> {
-        Self::start_test(name, app_config()).await
+        Self::start_test(name, app_config(), DEFAULT_LIQUIDITY_ROUTING_FEE_MILLIONTHS).await
     }
 
     async fn start_test_coordinator(name: &str) -> Result<Self> {
-        Self::start_test(name, coordinator_config()).await
+        Self::start_test(
+            name,
+            coordinator_config(),
+            DEFAULT_LIQUIDITY_ROUTING_FEE_MILLIONTHS,
+        )
+        .await
     }
 
-    async fn start_test(name: &str, user_config: UserConfig) -> Result<Self> {
+    async fn start_test(
+        name: &str,
+        user_config: UserConfig,
+        jit_funding_rate_millionth: u32,
+    ) -> Result<Self> {
         let data_dir = random_tmp_dir().join(name);
 
         let seed = Bip39Seed::new().expect("A valid bip39 seed");
@@ -95,6 +105,7 @@ impl Node<PaymentMap> {
             seed,
             ephemeral_randomness,
             user_config,
+            jit_funding_rate_millionth,
         )
         .await?;
 

--- a/crates/ln-dlc-node/src/tests/onboard_from_lnd.rs
+++ b/crates/ln-dlc-node/src/tests/onboard_from_lnd.rs
@@ -38,7 +38,7 @@ async fn onboard_from_lnd() {
 
     let invoice_amount = 1000;
 
-    let fake_scid = coordinator.create_intercept_scid(payee.info.pubkey);
+    let (fake_scid, fee_millionth) = coordinator.create_intercept_scid(payee.info.pubkey);
     let invoice = payee
         .create_interceptable_invoice(
             Some(invoice_amount),
@@ -46,6 +46,7 @@ async fn onboard_from_lnd() {
             coordinator.info.pubkey,
             0,
             "".to_string(),
+            fee_millionth,
         )
         .unwrap();
 

--- a/crates/ln-dlc-node/src/tests/onboard_from_lnd.rs
+++ b/crates/ln-dlc-node/src/tests/onboard_from_lnd.rs
@@ -38,7 +38,9 @@ async fn onboard_from_lnd() {
 
     let invoice_amount = 1000;
 
-    let (fake_scid, fee_millionth) = coordinator.create_intercept_scid(payee.info.pubkey);
+    let intercepted_scid_details = coordinator.create_intercept_scid(payee.info.pubkey);
+    let fake_scid = intercepted_scid_details.scid;
+    let fee_millionth = intercepted_scid_details.jit_routing_fee_millionth;
     let invoice = payee
         .create_interceptable_invoice(
             Some(invoice_amount),

--- a/crates/orderbook-commons/src/lib.rs
+++ b/crates/orderbook-commons/src/lib.rs
@@ -197,6 +197,12 @@ impl FilledWith {
     }
 }
 
+#[derive(Serialize, Deserialize)]
+pub struct FakeScidResponse {
+    pub scid: u64,
+    pub fee_rate_millionth: u32,
+}
+
 #[cfg(test)]
 mod test {
     use crate::FilledWith;


### PR DESCRIPTION
So far we had it at 2% which was a hurdle for users. 
Pushing it down to 0.5% will be expensive for us in the long run, hence, this is just a temporarily solution until we go for point 2 in #577 . 