### PR TITLE
Run `ln-dlc-node` tests sequentially on CI

### DIFF
--- a/.github/workflows/tests-ln-dlc-node.yml
+++ b/.github/workflows/tests-ln-dlc-node.yml
@@ -48,7 +48,7 @@ jobs:
         run: |
           curl -d '{"address":"bcrt1qylgu6ffkp3p0m8tw8kp4tt2dmdh755f4r5dq7s", "amount":"0.1"}' -H "Content-Type: application/json" -X POST http://localhost:3000/faucet
       - name: Run slow tests
-        run: cargo test -p ln-dlc-node -j 1 -- --ignored --nocapture --test-threads=2
+        run: cargo test -p ln-dlc-node -- --ignored --nocapture --test-threads=1
 
   tests-ln-dlc-node:
     runs-on: ubuntu-latest


### PR DESCRIPTION
I think we can remove the `-j 1` flag, because I introduced it to achieve the same thing and it clearly wasn't working.

We must go down to `--test-threads=1` if we want to ensure that no two tests are run in parallel. Running tests in parallel at all seems to pretty consistently cause either test failures or non-terminating tests. Perhaps this change might fix
https://github.com/get10101/10101/issues/355.

---

This change will obviously slow down CI, but I don't have any better ideas at this stage.