### PR TITLE
Rename `fake_scid` V2 endpoint

### DIFF
--- a/coordinator/src/routes.rs
+++ b/coordinator/src/routes.rs
@@ -65,7 +65,7 @@ pub fn router(node: Node, pool: Pool<ConnectionManager<PgConnection>>) -> Router
         .route("/", get(index))
         .route("/api/fake_scid/:target_node", post(post_fake_scid))
         .route(
-            "/api/fake_scid/v2/:target_node",
+            "/api/register_invoice/:target_node",
             post(register_interceptable_invoice),
         )
         .route("/api/newaddress", get(get_new_address))

--- a/mobile/native/src/ln_dlc/mod.rs
+++ b/mobile/native/src/ln_dlc/mod.rs
@@ -355,7 +355,7 @@ pub fn create_invoice(amount_sats: Option<u64>) -> Result<Invoice> {
         let client = reqwest::Client::new();
         let response = client
             .post(format!(
-                "http://{}/api/fake_scid/v2/{}",
+                "http://{}/api/register_invoice/{}",
                 config::get_http_endpoint(),
                 node.inner.info.pubkey
             )) // TODO: make host configurable


### PR DESCRIPTION
We forgot to rename this.