### PR TITLE
feat(mobile): Panic if backend cannot be initialised

### DIFF
--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -274,7 +274,7 @@ class _TenTenOneAppState extends State<TenTenOneApp> {
 
       FLog.info(text: "App data will be stored in: $appDir");
       FLog.info(text: "Seed data will be stored in: $seedDir");
-      await rust.api.run(config: config, appDir: appDir, seedDir: seedDir);
+      await rust.api.runInFlutter(config: config, appDir: appDir, seedDir: seedDir);
 
       await orderChangeNotifier.initialize();
       await positionChangeNotifier.initialize();

--- a/mobile/native/src/api.rs
+++ b/mobile/native/src/api.rs
@@ -170,6 +170,14 @@ pub fn subscribe(stream: StreamSink<event::api::Event>) {
     event::subscribe(FlutterSubscriber::new(stream))
 }
 
+/// Wrapper for Flutter purposes, it ensures we do not return a Result, which
+/// would have otherwise be converted into an exception.
+/// There is no recovery possible, and panicking is the only option ensuring
+/// that we will get an adequate crash report.
+pub fn run_in_flutter(config: Config, app_dir: String, seed_dir: String) {
+    run(config, app_dir, seed_dir).expect("Failed to start the backend");
+}
+
 pub fn run(config: Config, app_dir: String, seed_dir: String) -> Result<()> {
     std::panic::set_hook(
         #[allow(clippy::print_stderr)]


### PR DESCRIPTION
Use a dedicated wrapper that instead of using a Result (that gets converted to
an exception), panics, triggering a crash report with a backtrace.