### PR TITLE
chore: Use brand colours on trading screen

### DIFF
--- a/mobile/lib/common/modal_bottom_sheet_info.dart
+++ b/mobile/lib/common/modal_bottom_sheet_info.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:get_10101/common/color.dart';
 
 class ModalBottomSheetInfo extends StatelessWidget {
   final String infoText;
@@ -45,7 +46,7 @@ class ModalBottomSheetInfo extends StatelessWidget {
         constraints: const BoxConstraints(),
         icon: Icon(
           Icons.info,
-          color: Colors.blue.shade400,
+          color: tenTenOnePurple.shade200,
         ));
   }
 }

--- a/mobile/lib/common/settings_screen.dart
+++ b/mobile/lib/common/settings_screen.dart
@@ -196,15 +196,18 @@ class _SettingsScreenState extends State<SettingsScreen> {
               });
             },
             child: const Text("Print logs")),
-        if (logs != null)
-          Expanded(
-              child: SingleChildScrollView(
-                  scrollDirection: Axis.vertical,
-                  child: Padding(
-                      padding: const EdgeInsets.all(16.0),
-                      child: SelectableText.rich(
-                        TextSpan(children: logs!.toList()),
-                      )))),
+        Expanded(
+            child: logs != null
+                ? SingleChildScrollView(
+                    scrollDirection: Axis.vertical,
+                    child: Padding(
+                        padding: const EdgeInsets.all(16.0),
+                        child: SelectableText.rich(
+                          TextSpan(children: logs!.toList()),
+                        )))
+                : Center(
+                    child: Image.asset('assets/10101_logo_icon.png', width: 150, height: 150),
+                  ))
       ])),
     );
   }

--- a/mobile/lib/features/trade/trade_screen.dart
+++ b/mobile/lib/features/trade/trade_screen.dart
@@ -131,6 +131,7 @@ class TradeScreen extends StatelessWidget {
           child: Column(
             children: [
               Row(
+                mainAxisAlignment: MainAxisAlignment.center,
                 children: [const ContractSymbolIcon(), Text(ContractSymbol.btcusd.label)],
               ),
               Column(

--- a/mobile/lib/features/trade/trade_screen.dart
+++ b/mobile/lib/features/trade/trade_screen.dart
@@ -90,8 +90,8 @@ class TradeScreen extends StatelessWidget {
                         padding: const EdgeInsets.only(top: 20, left: 10, right: 10, bottom: 5),
                         child: Text(
                             pendingOrder.close
-                                ? "Your Position will be removed automatically once your ${submitOrderChangeNotifier.pendingOrderValues?.direction.name} order has been filled!"
-                                : "Your Position will be shown automatically in the Positions tab once your ${submitOrderChangeNotifier.pendingOrderValues?.direction.name} order has been filled!",
+                                ? "Your Position will be removed automatically once your ${submitOrderChangeNotifier.pendingOrderValues?.direction.name} order has been filled."
+                                : "Your Position will be shown automatically in the Positions tab once your ${submitOrderChangeNotifier.pendingOrderValues?.direction.name} order has been filled.",
                             style: DefaultTextStyle.of(context).style.apply(fontSizeFactor: 1.0)),
                       )
                     ],

--- a/mobile/lib/features/trade/trade_theme.dart
+++ b/mobile/lib/features/trade/trade_theme.dart
@@ -27,8 +27,8 @@ class TradeTheme extends ThemeExtension<TradeTheme> {
       this.profit = Colors.green,
       this.loss = Colors.red,
       this.tabColor = tenTenOnePurple,
-      this.leveragePlusButtonColor = Colors.grey,
-      this.leverageMinusButtonColor = Colors.grey,
+      this.leveragePlusButtonColor = tenTenOnePurple,
+      this.leverageMinusButtonColor = tenTenOnePurple,
       this.leverageInactiveSliderTrackColor = Colors.grey,
       this.leverageInactiveTicksColor = Colors.grey});
 

--- a/mobile/lib/features/welcome/welcome_screen.dart
+++ b/mobile/lib/features/welcome/welcome_screen.dart
@@ -30,7 +30,7 @@ class _WelcomeScreenState extends State<WelcomeScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-        appBar: AppBar(title: const Text("Welcome to 10101 beta!")),
+        appBar: AppBar(title: const Text("Welcome to 10101 beta.")),
         body: SafeArea(
             child: Form(
           key: _formKey,


### PR DESCRIPTION
Continue roll-out of our brand colours for added consistency.

Note: Info button uses a lighter shade of the same colour.


<img width="402" alt="Screenshot 2023-05-04 at 4 41 28 pm" src="https://user-images.githubusercontent.com/8319440/236324540-90447188-4da3-4920-b62b-e0d1f1d9ac56.png">

