### PR TITLE
fix: Map network mainnet to bitcoin

### DIFF
--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -265,7 +265,8 @@ class _TenTenOneAppState extends State<TenTenOneApp> {
       final seedDir = (await getApplicationSupportDirectory()).path;
       String appDir = (await getApplicationDocumentsDirectory()).path;
 
-      if (File('$seedDir/${config.network}/db').existsSync()) {
+      final network = config.network == "mainnet" ? "bitcoin" : config.network;
+      if (File('$seedDir/$network/db').existsSync()) {
         FLog.info(
             text:
                 "App has already data in the seed dir. For compatibility reasons we will not switch to the new app dir.");


### PR DESCRIPTION
This is a critical fix as we would otherwise break existing installations. 1.0.17 is broken and must not be release to the users.

We are using mainnet as argument and map it eventually to bitcoin to be used as subdir for the data dir. We need this mapping on the frontend as well to check if the data dir has already been initialised as we would otherwise break a previous installation.