### PR TITLE
Implement force-close of LN-DLC channel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -792,7 +792,7 @@ dependencies = [
 [[package]]
 name = "dlc"
 version = "0.4.0"
-source = "git+https://github.com/get10101/rust-dlc?rev=ce78c25#ce78c253a22173c7f38b979d2187161aadb42451"
+source = "git+https://github.com/get10101/rust-dlc?rev=a0d3f36#a0d3f36b76e84aee86534aff79bef8dc01f90143"
 dependencies = [
  "bitcoin",
  "miniscript 8.0.0",
@@ -804,7 +804,7 @@ dependencies = [
 [[package]]
 name = "dlc-manager"
 version = "0.4.0"
-source = "git+https://github.com/get10101/rust-dlc?rev=ce78c25#ce78c253a22173c7f38b979d2187161aadb42451"
+source = "git+https://github.com/get10101/rust-dlc?rev=a0d3f36#a0d3f36b76e84aee86534aff79bef8dc01f90143"
 dependencies = [
  "async-trait",
  "bitcoin",
@@ -820,7 +820,7 @@ dependencies = [
 [[package]]
 name = "dlc-messages"
 version = "0.4.0"
-source = "git+https://github.com/get10101/rust-dlc?rev=ce78c25#ce78c253a22173c7f38b979d2187161aadb42451"
+source = "git+https://github.com/get10101/rust-dlc?rev=a0d3f36#a0d3f36b76e84aee86534aff79bef8dc01f90143"
 dependencies = [
  "bitcoin",
  "dlc",
@@ -832,7 +832,7 @@ dependencies = [
 [[package]]
 name = "dlc-sled-storage-provider"
 version = "0.1.0"
-source = "git+https://github.com/get10101/rust-dlc?rev=ce78c25#ce78c253a22173c7f38b979d2187161aadb42451"
+source = "git+https://github.com/get10101/rust-dlc?rev=a0d3f36#a0d3f36b76e84aee86534aff79bef8dc01f90143"
 dependencies = [
  "bitcoin",
  "dlc-manager",
@@ -845,7 +845,7 @@ dependencies = [
 [[package]]
 name = "dlc-trie"
 version = "0.4.0"
-source = "git+https://github.com/get10101/rust-dlc?rev=ce78c25#ce78c253a22173c7f38b979d2187161aadb42451"
+source = "git+https://github.com/get10101/rust-dlc?rev=a0d3f36#a0d3f36b76e84aee86534aff79bef8dc01f90143"
 dependencies = [
  "bitcoin",
  "dlc",
@@ -1433,7 +1433,7 @@ dependencies = [
 [[package]]
 name = "lightning"
 version = "0.0.114"
-source = "git+https://github.com/get10101/rust-lightning/?rev=cb1c096e#cb1c096e74ace33f8ea87316ede9902ba66cada7"
+source = "git+https://github.com/get10101/rust-lightning/?rev=2a7dcfce#2a7dcfce9895eadc37bef28ddd164ac96fb7c1f1"
 dependencies = [
  "bitcoin",
 ]
@@ -1441,7 +1441,7 @@ dependencies = [
 [[package]]
 name = "lightning-background-processor"
 version = "0.0.114"
-source = "git+https://github.com/get10101/rust-lightning/?rev=cb1c096e#cb1c096e74ace33f8ea87316ede9902ba66cada7"
+source = "git+https://github.com/get10101/rust-lightning/?rev=2a7dcfce#2a7dcfce9895eadc37bef28ddd164ac96fb7c1f1"
 dependencies = [
  "bitcoin",
  "lightning",
@@ -1464,7 +1464,7 @@ dependencies = [
 [[package]]
 name = "lightning-net-tokio"
 version = "0.0.114"
-source = "git+https://github.com/get10101/rust-lightning/?rev=cb1c096e#cb1c096e74ace33f8ea87316ede9902ba66cada7"
+source = "git+https://github.com/get10101/rust-lightning/?rev=2a7dcfce#2a7dcfce9895eadc37bef28ddd164ac96fb7c1f1"
 dependencies = [
  "bitcoin",
  "lightning",
@@ -1474,7 +1474,7 @@ dependencies = [
 [[package]]
 name = "lightning-persister"
 version = "0.0.114"
-source = "git+https://github.com/get10101/rust-lightning/?rev=cb1c096e#cb1c096e74ace33f8ea87316ede9902ba66cada7"
+source = "git+https://github.com/get10101/rust-lightning/?rev=2a7dcfce#2a7dcfce9895eadc37bef28ddd164ac96fb7c1f1"
 dependencies = [
  "bitcoin",
  "libc",
@@ -1485,7 +1485,7 @@ dependencies = [
 [[package]]
 name = "lightning-rapid-gossip-sync"
 version = "0.0.114"
-source = "git+https://github.com/get10101/rust-lightning/?rev=cb1c096e#cb1c096e74ace33f8ea87316ede9902ba66cada7"
+source = "git+https://github.com/get10101/rust-lightning/?rev=2a7dcfce#2a7dcfce9895eadc37bef28ddd164ac96fb7c1f1"
 dependencies = [
  "bitcoin",
  "lightning",
@@ -1494,7 +1494,7 @@ dependencies = [
 [[package]]
 name = "lightning-transaction-sync"
 version = "0.0.114"
-source = "git+https://github.com/get10101/rust-lightning/?rev=cb1c096e#cb1c096e74ace33f8ea87316ede9902ba66cada7"
+source = "git+https://github.com/get10101/rust-lightning/?rev=2a7dcfce#2a7dcfce9895eadc37bef28ddd164ac96fb7c1f1"
 dependencies = [
  "bdk-macros",
  "bitcoin",
@@ -1971,7 +1971,7 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 [[package]]
 name = "p2pd-oracle-client"
 version = "0.1.0"
-source = "git+https://github.com/get10101/rust-dlc?rev=ce78c25#ce78c253a22173c7f38b979d2187161aadb42451"
+source = "git+https://github.com/get10101/rust-dlc?rev=a0d3f36#a0d3f36b76e84aee86534aff79bef8dc01f90143"
 dependencies = [
  "chrono",
  "dlc-manager",
@@ -2622,7 +2622,7 @@ dependencies = [
 [[package]]
 name = "simple-wallet"
 version = "0.1.0"
-source = "git+https://github.com/get10101/rust-dlc?rev=ce78c25#ce78c253a22173c7f38b979d2187161aadb42451"
+source = "git+https://github.com/get10101/rust-dlc?rev=a0d3f36#a0d3f36b76e84aee86534aff79bef8dc01f90143"
 dependencies = [
  "bitcoin",
  "dlc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,16 +3,16 @@ members = ["coordinator", "maker", "mobile/native", "crates/*"]
 resolver = "2"
 
 [patch.crates-io]
-dlc-manager = { git = "https://github.com/get10101/rust-dlc", rev = "ce78c25" }
-dlc-messages = { git = "https://github.com/get10101/rust-dlc", rev = "ce78c25" }
-dlc = { git = "https://github.com/get10101/rust-dlc", rev = "ce78c25" }
-dlc-sled-storage-provider = { git = "https://github.com/get10101/rust-dlc", rev = "ce78c25" }
-p2pd-oracle-client = { git = "https://github.com/get10101/rust-dlc", rev = "ce78c25" }
-dlc-trie = { git = "https://github.com/get10101/rust-dlc", rev = "ce78c25" }
-simple-wallet = { git = "https://github.com/get10101/rust-dlc", rev = "ce78c25" }
-lightning = { git = "https://github.com/get10101/rust-lightning/", rev = "cb1c096e" }
-lightning-background-processor = { git = "https://github.com/get10101/rust-lightning/", rev = "cb1c096e" }
-lightning-transaction-sync = { git = "https://github.com/get10101/rust-lightning/", rev = "cb1c096e" }
-lightning-net-tokio = { git = "https://github.com/get10101/rust-lightning/", rev = "cb1c096e" }
-lightning-persister = { git = "https://github.com/get10101/rust-lightning/", rev = "cb1c096e" }
+dlc-manager = { git = "https://github.com/get10101/rust-dlc", rev = "a0d3f36" }
+dlc-messages = { git = "https://github.com/get10101/rust-dlc", rev = "a0d3f36" }
+dlc = { git = "https://github.com/get10101/rust-dlc", rev = "a0d3f36" }
+dlc-sled-storage-provider = { git = "https://github.com/get10101/rust-dlc", rev = "a0d3f36" }
+p2pd-oracle-client = { git = "https://github.com/get10101/rust-dlc", rev = "a0d3f36" }
+dlc-trie = { git = "https://github.com/get10101/rust-dlc", rev = "a0d3f36" }
+simple-wallet = { git = "https://github.com/get10101/rust-dlc", rev = "a0d3f36" }
+lightning = { git = "https://github.com/get10101/rust-lightning/", rev = "2a7dcfce" }
+lightning-background-processor = { git = "https://github.com/get10101/rust-lightning/", rev = "2a7dcfce" }
+lightning-transaction-sync = { git = "https://github.com/get10101/rust-lightning/", rev = "2a7dcfce" }
+lightning-net-tokio = { git = "https://github.com/get10101/rust-lightning/", rev = "2a7dcfce" }
+lightning-persister = { git = "https://github.com/get10101/rust-lightning/", rev = "2a7dcfce" }
 rust-bitcoin-coin-selection = { git = "https://github.com/p2pderivatives/rust-bitcoin-coin-selection" }

--- a/coordinator/src/routes.rs
+++ b/coordinator/src/routes.rs
@@ -1,3 +1,14 @@
+use crate::admin::close_channel;
+use crate::admin::connect_to_peer;
+use crate::admin::delete_subchannel;
+use crate::admin::finalize_force_close_ln_dlc_channel;
+use crate::admin::get_balance;
+use crate::admin::is_connected;
+use crate::admin::list_channels;
+use crate::admin::list_dlc_channels;
+use crate::admin::list_on_chain_transactions;
+use crate::admin::list_peers;
+use crate::admin::sign_message;
 use crate::db::user;
 use crate::node::Node;
 use crate::orderbook::routes::delete_order;
@@ -27,18 +38,6 @@ use diesel::PgConnection;
 use ln_dlc_node::node::NodeInfo;
 use orderbook_commons::FakeScidResponse;
 use orderbook_commons::OrderbookMsg;
-use tokio::sync::RwLock;
-
-use crate::admin::close_channel;
-use crate::admin::connect_to_peer;
-use crate::admin::delete_subchannel;
-use crate::admin::get_balance;
-use crate::admin::is_connected;
-use crate::admin::list_channels;
-use crate::admin::list_dlc_channels;
-use crate::admin::list_on_chain_transactions;
-use crate::admin::list_peers;
-use crate::admin::sign_message;
 use serde::Deserialize;
 use std::collections::HashMap;
 use std::str::FromStr;
@@ -46,6 +45,7 @@ use std::sync::Arc;
 use tokio::sync::broadcast;
 use tokio::sync::mpsc;
 use tokio::sync::Mutex;
+use tokio::sync::RwLock;
 
 pub struct AppState {
     pub node: Node,
@@ -92,6 +92,10 @@ pub fn router(
         .route("/api/admin/channels", get(list_channels))
         .route("/api/channels", post(open_channel))
         .route("/api/admin/channels/:channel_id", delete(close_channel))
+        .route(
+            "/api/admin/channels/finalize_force_close/:channel_id",
+            delete(finalize_force_close_ln_dlc_channel),
+        )
         .route("/api/admin/peers", get(list_peers))
         .route("/api/admin/dlc_channels", get(list_dlc_channels))
         .route("/api/admin/transactions", get(list_on_chain_transactions))

--- a/crates/ln-dlc-node/src/ldk_node_wallet.rs
+++ b/crates/ln-dlc-node/src/ldk_node_wallet.rs
@@ -1,3 +1,4 @@
+use crate::ln::TracingLogger;
 use anyhow::bail;
 use anyhow::Context;
 use anyhow::Error;
@@ -21,6 +22,10 @@ use lightning::chain::chaininterface::BroadcasterInterface;
 use lightning::chain::chaininterface::ConfirmationTarget;
 use lightning::chain::chaininterface::FeeEstimator;
 use lightning::chain::chaininterface::FEERATE_FLOOR_SATS_PER_KW;
+use lightning::chain::transaction::OutPoint;
+use lightning::chain::Filter;
+use lightning::chain::WatchedOutput;
+use lightning_transaction_sync::EsploraSyncClient;
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
@@ -38,6 +43,7 @@ where
     // A cache storing the most recently retrieved fee rate estimations.
     fee_rate_cache: RwLock<HashMap<ConfirmationTarget, FeeRate>>,
     settings: RwLock<WalletSettings>,
+    esplora_sync_client: Arc<EsploraSyncClient<Arc<TracingLogger>>>,
     runtime_handle: tokio::runtime::Handle,
 }
 
@@ -66,6 +72,7 @@ where
         blockchain: EsploraBlockchain,
         wallet: bdk::Wallet<D>,
         runtime_handle: tokio::runtime::Handle,
+        esplora_sync_client: Arc<EsploraSyncClient<Arc<TracingLogger>>>,
     ) -> Self {
         let inner = Mutex::new(wallet);
         let fee_rate_cache = RwLock::new(HashMap::new());
@@ -77,6 +84,7 @@ where
             fee_rate_cache,
             runtime_handle,
             settings,
+            esplora_sync_client,
         }
     }
 
@@ -369,7 +377,11 @@ where
     D: BatchDatabase,
 {
     fn broadcast_transaction(&self, tx: &Transaction) {
-        tracing::info!(txid = %tx.txid(), raw_tx = %serialize_hex(&tx), "Broadcasting transaction");
+        let txid = tx.txid();
+
+        tracing::info!(%txid, raw_tx = %serialize_hex(&tx), "Broadcasting transaction");
+
+        let txos = tx.output.clone();
 
         tokio::task::block_in_place(move || {
             self.runtime_handle.block_on(async move {
@@ -378,5 +390,23 @@ where
                 }
             })
         });
+
+        // FIXME: We've added this to ensure that we watch the outputs of any commitment transaction
+        // we publish. This is incredibly hacky and probably doesn't scale, as we simply register
+        // _every_ transaction output we ever publish. Obviously not all these outputs will be
+        // spendable by us, so it might result in some weirdness, but it should be safe.
+        //
+        // Also, this doesn't cover the counterparty, which unfortunately is only able to find the
+        // commitment transaction on-chain after a restart.
+        for (i, output) in txos.into_iter().enumerate() {
+            self.esplora_sync_client.register_output(WatchedOutput {
+                block_hash: None,
+                outpoint: OutPoint {
+                    txid,
+                    index: i as u16,
+                },
+                script_pubkey: output.script_pubkey,
+            });
+        }
     }
 }

--- a/crates/ln-dlc-node/src/tests/dlc/collaborative_settlement.rs
+++ b/crates/ln-dlc-node/src/tests/dlc/collaborative_settlement.rs
@@ -38,7 +38,7 @@ async fn dlc_collaborative_settlement(
         coordinator_balance_channel_creation,
         app,
         app_balance_channel_creation,
-        channel_id,
+        channel_details,
     } = create_dlc_channel(app_dlc_collateral, coordinator_dlc_collateral).await?;
 
     // Act
@@ -49,7 +49,10 @@ async fn dlc_collaborative_settlement(
     let coordinator_settlement_amount = coordinator_dlc_collateral / 2;
     let coordinator_loss_amount = coordinator_dlc_collateral - coordinator_settlement_amount;
 
-    app.propose_dlc_channel_collaborative_settlement(&channel_id, coordinator_settlement_amount)?;
+    app.propose_dlc_channel_collaborative_settlement(
+        &channel_details.channel_id,
+        coordinator_settlement_amount,
+    )?;
 
     // Processs the app's offer to close the channel
     tokio::time::sleep(Duration::from_secs(2)).await;

--- a/crates/ln-dlc-node/src/tests/dlc/non_collaborative_settlement.rs
+++ b/crates/ln-dlc-node/src/tests/dlc/non_collaborative_settlement.rs
@@ -1,7 +1,84 @@
-// Related issue: https://github.com/get10101/10101/issues/51.
+use crate::tests::bitcoind::mine;
+use crate::tests::dlc::create::create_dlc_channel;
+use crate::tests::dlc::create::DlcChannelCreated;
+use crate::tests::init_tracing;
+
 #[tokio::test(flavor = "multi_thread", worker_threads = 10)]
 #[ignore]
-async fn given_dlc_channel_present_when_dlc_settled_non_collaboratively_then_sibling_channel_operational(
-) {
-    // todo
+async fn force_close_ln_dlc_channel() {
+    init_tracing();
+
+    // Arrange
+
+    let app_dlc_collateral = 50_000;
+    let coordinator_dlc_collateral = 25_000;
+
+    let DlcChannelCreated {
+        coordinator,
+        app,
+        channel_details,
+        ..
+    } = create_dlc_channel(app_dlc_collateral, coordinator_dlc_collateral)
+        .await
+        .unwrap();
+
+    coordinator.wallet().sync().await.unwrap();
+    app.wallet().sync().await.unwrap();
+
+    // Act
+
+    coordinator.force_close_channel(&channel_details).unwrap();
+
+    // Need 288 confirmations on the split transaction to be able to publish the glue and buffer
+    // transactions
+    mine(288).await.unwrap();
+
+    coordinator.wallet().sync().await.unwrap();
+    app.wallet().sync().await.unwrap();
+
+    let coordinator = std::sync::Arc::new(coordinator);
+    tokio::task::spawn_blocking({
+        let coordinator = coordinator.clone();
+        move || {
+            coordinator
+                .finalize_force_close_ln_dlc_channel(channel_details.channel_id)
+                .unwrap()
+        }
+    })
+    .await
+    .unwrap();
+
+    // Assert
+
+    coordinator.wallet().sync().await.unwrap();
+    app.wallet().sync().await.unwrap();
+
+    // Mining 288 blocks ensures that we get:
+    // - 144 required confirmations for the delayed output on the LN commitment transaction to be
+    // spendable.
+    // - 288 required confirmations for the CET to be published.
+    mine(288).await.unwrap();
+
+    coordinator.wallet().sync().await.unwrap();
+    app.wallet().sync().await.unwrap();
+
+    // Ensure publication of CET (otherwise we need to wait for the periodic task)
+    coordinator.dlc_manager.periodic_check().unwrap();
+
+    // Confirm CET
+    mine(1).await.unwrap();
+
+    coordinator.wallet().sync().await.unwrap();
+
+    let coordinator_on_chain_balance_after_force_close =
+        coordinator.get_on_chain_balance().await.unwrap().confirmed;
+
+    // TODO: The expected value is temporarily a magic number that we should replace with a
+    // calculated value based on the inputs to this test
+    let coordinator_on_chain_balance_after_force_close_expected = 248709;
+
+    assert_eq!(
+        coordinator_on_chain_balance_after_force_close,
+        coordinator_on_chain_balance_after_force_close_expected
+    );
 }

--- a/crates/ln-dlc-node/src/tests/mod.rs
+++ b/crates/ln-dlc-node/src/tests/mod.rs
@@ -53,7 +53,7 @@ fn init_tracing() {
     TRACING_TEST_SUBSCRIBER.call_once(|| {
         tracing_subscriber::fmt()
             .with_env_filter(
-                "debug,hyper=warn,reqwest=warn,rustls=warn,bdk=info,lightning=debug,sled=info,lightning::chain::channelmonitor=trace",
+                "debug,hyper=warn,reqwest=warn,rustls=warn,bdk=info,lightning=trace,sled=info,lightning::chain::channelmonitor=trace,lightning::ln::peer_handler=debug",
             )
             .with_test_writer()
             .init()


### PR DESCRIPTION
Fixes part of https://github.com/get10101/10101/issues/591.

This patch finally adds a `force_close_ln_dlc_channel` test, which verifies that the party effecting the force-close of the LN-DLC
channel can get their coins back if they:

- Manually call `force_close_channel`, publishing the split transaction.

- Wait for 288 confirmations on the split transaction.

- Manually call `finalize_force_close_ln_dlc_channel`, publishing the buffer, glue and commitment transactions.

- Wait for 144 confirmations on the commitment transaction, so that the delayed output on it becomes spendable.

- Wait for a further 144 confirmations, so that the CET can spend from the buffer transaction.

For the time being only the coordinator is able to force-close a channel by first using the DELETE /api/admin/channels/:channel_id
endpoint and later the new DELETE /api/admin/channels/finalize_force_close/:channel_id endpoint.

#### Limitations

- This work does not yet verify that the party who did not trigger the force-close gets all their coins back. Specifically we are aware that there is a bug with the `StaticPaymentOutput` on the commitment transaction not being spendable.

- The updates to the `rust-dlc` and `rust-lightning` dependencies represent very hacky changes that "just work".

- The `force_close_ln_dlc_channel` test should not assert on a magic number, as this is hard to understand and brittle.

---

- Relevant changes on `rust-dlc`: https://github.com/p2pderivatives/rust-dlc/commit/f4953a4aa54b298fe9da2ecff478c6794c3aee92.

- Relevant changes on `rust-lightning`: https://github.com/lightningdevkit/rust-lightning/compare/a97b1e0219ea73f0fcdc2a02ab77cf4bdaa2c5f7...get10101:rust-lightning:split-tx-experiment-114.