### PR TITLE
Add funding button on regtest

### DIFF
--- a/justfile
+++ b/justfile
@@ -64,7 +64,8 @@ run args="":
 run-regtest args="":
     #!/usr/bin/env bash
     cd mobile && flutter run {{args}} --dart-define="COMMIT=$(git rev-parse HEAD)" --dart-define="BRANCH=$(git rev-parse --abbrev-ref HEAD)" \
-    --dart-define="ESPLORA_ENDPOINT={{public_regtest_esplora}}" --dart-define="COORDINATOR_P2P_ENDPOINT={{public_regtest_coordinator}}" --dart-define="COORDINATOR_PORT_HTTP={{public_coordinator_http_port}}"
+    --dart-define="ESPLORA_ENDPOINT={{public_regtest_esplora}}" --dart-define="COORDINATOR_P2P_ENDPOINT={{public_regtest_coordinator}}" \
+    --dart-define="COORDINATOR_PORT_HTTP={{public_coordinator_http_port}}"
 
 fund:
     cargo run --example fund
@@ -241,7 +242,9 @@ wait-for-electrs-to-be-ready:
 
 build-ipa:
     #!/usr/bin/env bash
-    cd mobile && flutter build ipa --dart-define="ESPLORA_ENDPOINT=${ESPLORA_ENDPOINT}" --dart-define="COORDINATOR_P2P_ENDPOINT=${COORDINATOR_P2P_ENDPOINT}" --dart-define="COMMIT=$(git rev-parse HEAD)" --dart-define="BRANCH=$(git rev-parse --abbrev-ref HEAD)"
+    cd mobile && flutter build ipa --dart-define="ESPLORA_ENDPOINT=${ESPLORA_ENDPOINT}" \
+    --dart-define="COORDINATOR_P2P_ENDPOINT=${COORDINATOR_P2P_ENDPOINT}" --dart-define="COMMIT=$(git rev-parse HEAD)" \
+    --dart-define="BRANCH=$(git rev-parse --abbrev-ref HEAD)"
 
 publish-testflight:
     cd mobile && xcrun altool --upload-app --type ios --file ./build/ios/ipa/10101.ipa --apiKey ${ALTOOL_API_KEY} --apiIssuer ${ALTOOL_API_ISSUER}

--- a/justfile
+++ b/justfile
@@ -57,7 +57,8 @@ ios:
 
 run args="":
     #!/usr/bin/env bash
-    cd mobile && flutter run {{args}} --dart-define="COMMIT=$(git rev-parse HEAD)" --dart-define="BRANCH=$(git rev-parse --abbrev-ref HEAD)"
+    cd mobile && flutter run {{args}} --dart-define="COMMIT=$(git rev-parse HEAD)" --dart-define="BRANCH=$(git rev-parse --abbrev-ref HEAD)" \
+    --dart-define="REGTEST_FAUCET=http://localhost:8080"
 
 # Run against our public regtest server
 run-regtest args="":


### PR DESCRIPTION
- The button is not visible outside regtest.
- The button by default points to our remote faucet, and `just run` overrides it with local faucet.
- The request is done in Dart, I didn't want to pollute our library with non-production code.

https://github.com/get10101/10101/assets/8319440/bdec0603-ea9d-44a7-a93d-94839ca6f543


