### PR TITLE
feat: Improve UX over funding with remote faucet

### DIFF
--- a/mobile/lib/common/snack_bar.dart
+++ b/mobile/lib/common/snack_bar.dart
@@ -1,0 +1,9 @@
+import 'package:flutter/material.dart';
+
+/// Show a snackbar with the given message
+///
+/// Extracted as a separate function to ensure consistent style of error messages
+void showSnackBar(BuildContext context, String message) {
+  final snackBar = SnackBar(content: Text(message));
+  ScaffoldMessenger.of(context).showSnackBar(snackBar);
+}


### PR DESCRIPTION
- Add a Snackbar that displays an error if the invoice could not be paid.
- Interface only goes back to the main screen if the payment worked.
- Prevent any possibility of calling the request twice by disabling the button
  during a call.

This changeset also showcases how to disable a button from being able to invoke an action
repeatedly (useful when we want to prohibit this), bu using a simple boolean
flag that overwrites the `onPressed` handler.

This PR addresses the issues spotted by @holzeis and @luckysori during the previous review.