### PR TITLE
Prevent panic by updating `rust-dlc` and `rust-lightning`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -814,7 +814,7 @@ dependencies = [
 [[package]]
 name = "dlc"
 version = "0.4.0"
-source = "git+https://github.com/get10101/rust-dlc?rev=1cabe22839a8aa6b86cf23b7e48c3367e255ee30#1cabe22839a8aa6b86cf23b7e48c3367e255ee30"
+source = "git+https://github.com/get10101/rust-dlc?rev=e0a4ee17414eb89389ae78a31de151fbc7c39022#e0a4ee17414eb89389ae78a31de151fbc7c39022"
 dependencies = [
  "bitcoin",
  "miniscript 8.0.0",
@@ -826,7 +826,7 @@ dependencies = [
 [[package]]
 name = "dlc-manager"
 version = "0.4.0"
-source = "git+https://github.com/get10101/rust-dlc?rev=1cabe22839a8aa6b86cf23b7e48c3367e255ee30#1cabe22839a8aa6b86cf23b7e48c3367e255ee30"
+source = "git+https://github.com/get10101/rust-dlc?rev=e0a4ee17414eb89389ae78a31de151fbc7c39022#e0a4ee17414eb89389ae78a31de151fbc7c39022"
 dependencies = [
  "async-trait",
  "bitcoin",
@@ -842,7 +842,7 @@ dependencies = [
 [[package]]
 name = "dlc-messages"
 version = "0.4.0"
-source = "git+https://github.com/get10101/rust-dlc?rev=1cabe22839a8aa6b86cf23b7e48c3367e255ee30#1cabe22839a8aa6b86cf23b7e48c3367e255ee30"
+source = "git+https://github.com/get10101/rust-dlc?rev=e0a4ee17414eb89389ae78a31de151fbc7c39022#e0a4ee17414eb89389ae78a31de151fbc7c39022"
 dependencies = [
  "bitcoin",
  "dlc",
@@ -854,7 +854,7 @@ dependencies = [
 [[package]]
 name = "dlc-sled-storage-provider"
 version = "0.1.0"
-source = "git+https://github.com/get10101/rust-dlc?rev=1cabe22839a8aa6b86cf23b7e48c3367e255ee30#1cabe22839a8aa6b86cf23b7e48c3367e255ee30"
+source = "git+https://github.com/get10101/rust-dlc?rev=e0a4ee17414eb89389ae78a31de151fbc7c39022#e0a4ee17414eb89389ae78a31de151fbc7c39022"
 dependencies = [
  "bitcoin",
  "dlc-manager",
@@ -867,7 +867,7 @@ dependencies = [
 [[package]]
 name = "dlc-trie"
 version = "0.4.0"
-source = "git+https://github.com/get10101/rust-dlc?rev=1cabe22839a8aa6b86cf23b7e48c3367e255ee30#1cabe22839a8aa6b86cf23b7e48c3367e255ee30"
+source = "git+https://github.com/get10101/rust-dlc?rev=e0a4ee17414eb89389ae78a31de151fbc7c39022#e0a4ee17414eb89389ae78a31de151fbc7c39022"
 dependencies = [
  "bitcoin",
  "dlc",
@@ -1466,7 +1466,7 @@ dependencies = [
 [[package]]
 name = "lightning"
 version = "0.0.113"
-source = "git+https://github.com/get10101/rust-lightning/?rev=0516b51eb9987d5f215e4098c7fae9a48e90296a#0516b51eb9987d5f215e4098c7fae9a48e90296a"
+source = "git+https://github.com/get10101/rust-lightning/?rev=15d48d8243e05fbd198215c6a3a762d2bdc9f38b#15d48d8243e05fbd198215c6a3a762d2bdc9f38b"
 dependencies = [
  "bitcoin",
 ]
@@ -1474,7 +1474,7 @@ dependencies = [
 [[package]]
 name = "lightning-background-processor"
 version = "0.0.113"
-source = "git+https://github.com/get10101/rust-lightning/?rev=0516b51eb9987d5f215e4098c7fae9a48e90296a#0516b51eb9987d5f215e4098c7fae9a48e90296a"
+source = "git+https://github.com/get10101/rust-lightning/?rev=15d48d8243e05fbd198215c6a3a762d2bdc9f38b#15d48d8243e05fbd198215c6a3a762d2bdc9f38b"
 dependencies = [
  "bitcoin",
  "lightning",
@@ -1484,7 +1484,7 @@ dependencies = [
 [[package]]
 name = "lightning-block-sync"
 version = "0.0.113"
-source = "git+https://github.com/get10101/rust-lightning/?rev=0516b51eb9987d5f215e4098c7fae9a48e90296a#0516b51eb9987d5f215e4098c7fae9a48e90296a"
+source = "git+https://github.com/get10101/rust-lightning/?rev=15d48d8243e05fbd198215c6a3a762d2bdc9f38b#15d48d8243e05fbd198215c6a3a762d2bdc9f38b"
 dependencies = [
  "bitcoin",
  "chunked_transfer",
@@ -1510,7 +1510,7 @@ dependencies = [
 [[package]]
 name = "lightning-net-tokio"
 version = "0.0.113"
-source = "git+https://github.com/get10101/rust-lightning/?rev=0516b51eb9987d5f215e4098c7fae9a48e90296a#0516b51eb9987d5f215e4098c7fae9a48e90296a"
+source = "git+https://github.com/get10101/rust-lightning/?rev=15d48d8243e05fbd198215c6a3a762d2bdc9f38b#15d48d8243e05fbd198215c6a3a762d2bdc9f38b"
 dependencies = [
  "bitcoin",
  "lightning",
@@ -1520,7 +1520,7 @@ dependencies = [
 [[package]]
 name = "lightning-persister"
 version = "0.0.113"
-source = "git+https://github.com/get10101/rust-lightning/?rev=0516b51eb9987d5f215e4098c7fae9a48e90296a#0516b51eb9987d5f215e4098c7fae9a48e90296a"
+source = "git+https://github.com/get10101/rust-lightning/?rev=15d48d8243e05fbd198215c6a3a762d2bdc9f38b#15d48d8243e05fbd198215c6a3a762d2bdc9f38b"
 dependencies = [
  "bitcoin",
  "libc",
@@ -1531,7 +1531,7 @@ dependencies = [
 [[package]]
 name = "lightning-rapid-gossip-sync"
 version = "0.0.113"
-source = "git+https://github.com/get10101/rust-lightning/?rev=0516b51eb9987d5f215e4098c7fae9a48e90296a#0516b51eb9987d5f215e4098c7fae9a48e90296a"
+source = "git+https://github.com/get10101/rust-lightning/?rev=15d48d8243e05fbd198215c6a3a762d2bdc9f38b#15d48d8243e05fbd198215c6a3a762d2bdc9f38b"
 dependencies = [
  "bitcoin",
  "lightning",
@@ -2031,7 +2031,7 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 [[package]]
 name = "p2pd-oracle-client"
 version = "0.1.0"
-source = "git+https://github.com/get10101/rust-dlc?rev=1cabe22839a8aa6b86cf23b7e48c3367e255ee30#1cabe22839a8aa6b86cf23b7e48c3367e255ee30"
+source = "git+https://github.com/get10101/rust-dlc?rev=e0a4ee17414eb89389ae78a31de151fbc7c39022#e0a4ee17414eb89389ae78a31de151fbc7c39022"
 dependencies = [
  "chrono",
  "dlc-manager",
@@ -2695,7 +2695,7 @@ dependencies = [
 [[package]]
 name = "simple-wallet"
 version = "0.1.0"
-source = "git+https://github.com/get10101/rust-dlc?rev=1cabe22839a8aa6b86cf23b7e48c3367e255ee30#1cabe22839a8aa6b86cf23b7e48c3367e255ee30"
+source = "git+https://github.com/get10101/rust-dlc?rev=e0a4ee17414eb89389ae78a31de151fbc7c39022#e0a4ee17414eb89389ae78a31de151fbc7c39022"
 dependencies = [
  "bitcoin",
  "dlc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,16 +3,16 @@ members = ["coordinator", "maker", "mobile/native", "crates/*"]
 resolver = "2"
 
 [patch.crates-io]
-dlc-manager = { git = "https://github.com/get10101/rust-dlc", rev = "1cabe22839a8aa6b86cf23b7e48c3367e255ee30" }
-dlc-messages = { git = "https://github.com/get10101/rust-dlc", rev = "1cabe22839a8aa6b86cf23b7e48c3367e255ee30" }
-dlc = { git = "https://github.com/get10101/rust-dlc", rev = "1cabe22839a8aa6b86cf23b7e48c3367e255ee30" }
-dlc-sled-storage-provider = { git = "https://github.com/get10101/rust-dlc", rev = "1cabe22839a8aa6b86cf23b7e48c3367e255ee30" }
-p2pd-oracle-client = { git = "https://github.com/get10101/rust-dlc", rev = "1cabe22839a8aa6b86cf23b7e48c3367e255ee30" }
-dlc-trie = { git = "https://github.com/get10101/rust-dlc", rev = "1cabe22839a8aa6b86cf23b7e48c3367e255ee30" }
-simple-wallet = { git = "https://github.com/get10101/rust-dlc", rev = "1cabe22839a8aa6b86cf23b7e48c3367e255ee30" }
-lightning = { git = "https://github.com/get10101/rust-lightning/", rev = "0516b51eb9987d5f215e4098c7fae9a48e90296a" }
-lightning-background-processor = { git = "https://github.com/get10101/rust-lightning/", rev = "0516b51eb9987d5f215e4098c7fae9a48e90296a" }
-lightning-block-sync = { git = "https://github.com/get10101/rust-lightning/", rev = "0516b51eb9987d5f215e4098c7fae9a48e90296a" }
-lightning-net-tokio = { git = "https://github.com/get10101/rust-lightning/", rev = "0516b51eb9987d5f215e4098c7fae9a48e90296a" }
-lightning-persister = { git = "https://github.com/get10101/rust-lightning/", rev = "0516b51eb9987d5f215e4098c7fae9a48e90296a" }
-lightning-rapid-gossip-sync = { git = "https://github.com/get10101/rust-lightning/", rev = "0516b51eb9987d5f215e4098c7fae9a48e90296a" }
+dlc-manager = { git = "https://github.com/get10101/rust-dlc", rev = "e0a4ee17414eb89389ae78a31de151fbc7c39022" }
+dlc-messages = { git = "https://github.com/get10101/rust-dlc", rev = "e0a4ee17414eb89389ae78a31de151fbc7c39022" }
+dlc = { git = "https://github.com/get10101/rust-dlc", rev = "e0a4ee17414eb89389ae78a31de151fbc7c39022" }
+dlc-sled-storage-provider = { git = "https://github.com/get10101/rust-dlc", rev = "e0a4ee17414eb89389ae78a31de151fbc7c39022" }
+p2pd-oracle-client = { git = "https://github.com/get10101/rust-dlc", rev = "e0a4ee17414eb89389ae78a31de151fbc7c39022" }
+dlc-trie = { git = "https://github.com/get10101/rust-dlc", rev = "e0a4ee17414eb89389ae78a31de151fbc7c39022" }
+simple-wallet = { git = "https://github.com/get10101/rust-dlc", rev = "e0a4ee17414eb89389ae78a31de151fbc7c39022" }
+lightning = { git = "https://github.com/get10101/rust-lightning/", rev = "15d48d8243e05fbd198215c6a3a762d2bdc9f38b" }
+lightning-background-processor = { git = "https://github.com/get10101/rust-lightning/", rev = "15d48d8243e05fbd198215c6a3a762d2bdc9f38b" }
+lightning-block-sync = { git = "https://github.com/get10101/rust-lightning/", rev = "15d48d8243e05fbd198215c6a3a762d2bdc9f38b" }
+lightning-net-tokio = { git = "https://github.com/get10101/rust-lightning/", rev = "15d48d8243e05fbd198215c6a3a762d2bdc9f38b" }
+lightning-persister = { git = "https://github.com/get10101/rust-lightning/", rev = "15d48d8243e05fbd198215c6a3a762d2bdc9f38b" }
+lightning-rapid-gossip-sync = { git = "https://github.com/get10101/rust-lightning/", rev = "15d48d8243e05fbd198215c6a3a762d2bdc9f38b" }


### PR DESCRIPTION
See https://github.com/p2pderivatives/rust-lightning/commit/15d48d8243e05fbd198215c6a3a762d2bdc9f38b.