### PR TITLE
chore: Turn off clippy on bors

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -2,6 +2,5 @@ status = [
   "formatting",
   "lint-commits",
   "lint-flutter",
-  "clippy",
   "tests-ln-dlc-node",
 ]


### PR DESCRIPTION
Bors started having trouble with our clippy job.
Turn it off as it's not essential (we run it on github anyway).

This quickfix will buy us more time until we'll move away from bors.

context:
https://github.com/get10101/10101/pull/626#issuecomment-1542742519 (and other today's PRs, where clippy passes locally but fails on `bors`.