### PR TITLE
chore: Turn off bors and run all tests directly on GitHub

### DIFF
--- a/.github/workflows/tests-ln-dlc-node.yml
+++ b/.github/workflows/tests-ln-dlc-node.yml
@@ -1,9 +1,11 @@
 name: Slow ln-dlc-node tests
 
 on:
+  pull_request:
   push:
     branches:
       - "staging"
+      - "main"
 
 env:
   CARGO_INCREMENTAL: 0

--- a/.github/workflows/tests-ln-dlc-node.yml
+++ b/.github/workflows/tests-ln-dlc-node.yml
@@ -33,7 +33,7 @@ jobs:
 
   run-tests-ln-dlc-node:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 45
     needs: changes
     if: ${{ needs.changes.outputs.ln-dlc-node == 'true' }}
     steps:

--- a/bors.toml
+++ b/bors.toml
@@ -1,7 +1,0 @@
-status = [
-  "formatting",
-  "lint-commits",
-  "lint-flutter",
-  "clippy",
-  "tests-ln-dlc-node",
-]


### PR DESCRIPTION
Bors stopped working reliably and became more of a hindrance than a helpful
companion as it once was.

R.I.P. bors.