### PR TITLE
fix: Improve faucet invoice payment error handling

### DIFF
--- a/mobile/lib/features/wallet/share_invoice_screen.dart
+++ b/mobile/lib/features/wallet/share_invoice_screen.dart
@@ -204,9 +204,10 @@ class _ShareInvoiceScreenState extends State<ShareInvoiceScreen> {
       body: encodedData,
     );
 
-    if (response.statusCode != 200) {
+    if (response.statusCode != 200 || response.body.contains("payment_error")) {
       throw Exception("Payment failed: Received ${response.statusCode} ${response.body}");
+    } else {
+      FLog.info(text: "Paying invoice succeeded: ${response.body}");
     }
-    FLog.info(text: "Paying invoice succeeded: ${response.body}");
   }
 }


### PR DESCRIPTION
Faucet payment can fail in more ways than just faucet being unreachable.
Parse the response for `payment_error` phrase and count it as an error.
For simplicity, print the whole response in such cases.