### PR TITLE
Allow `just fund` to continue even if LND and coordinator are already connected

### DIFF
--- a/crates/ln-dlc-node/examples/fund.rs
+++ b/crates/ln-dlc-node/examples/fund.rs
@@ -178,7 +178,7 @@ async fn open_channel(node_info: &NodeInfo, amount: Amount, faucet: &str) -> Res
         node_info.address.to_string()
     };
     tracing::info!("Connecting lnd to {host}");
-    post_query(
+    let res = post_query(
         "lnd/v1/peers",
         format!(
             r#"{{"addr": {{ "pubkey": "{}", "host": "{host}" }}, "perm":false }}"]"#,
@@ -186,7 +186,9 @@ async fn open_channel(node_info: &NodeInfo, amount: Amount, faucet: &str) -> Res
         ),
         faucet,
     )
-    .await?;
+    .await;
+
+    tracing::debug!(?res, "Response after attempting to connect lnd to {host}");
 
     tokio::time::sleep(Duration::from_secs(5)).await;
 


### PR DESCRIPTION
It would be more correct to parse the error string to identify which errors can be ignored (such as the already-connected error), but at least this change makes `just fund` and `just fund-regtest` more usable.