### PR TITLE
More reliable `pay-invoice-with-10101-faucet` button

### DIFF
--- a/crates/ln-dlc-node/src/node/mod.rs
+++ b/crates/ln-dlc-node/src/node/mod.rs
@@ -92,7 +92,7 @@ const ON_CHAIN_SYNC_INTERVAL: Duration = Duration::from_secs(20);
 
 /// An LN-DLC node.
 pub struct Node<P> {
-    network: Network,
+    pub network: Network,
 
     pub(crate) wallet: Arc<LnDlcWallet>,
 

--- a/mobile/native/src/api.rs
+++ b/mobile/native/src/api.rs
@@ -285,3 +285,7 @@ pub fn decode_invoice(invoice: String) -> Result<LightningInvoice> {
 pub fn get_node_id() -> SyncReturn<String> {
     SyncReturn(ln_dlc::get_node_info().pubkey.to_string())
 }
+
+pub fn get_node_address() -> SyncReturn<String> {
+    SyncReturn(ln_dlc::get_node_info().address.to_string())
+}


### PR DESCRIPTION
Fixes #633.

This is to ensure that we have a more reliable way to open a channel between coordinator and app on regtest.

The user still clicks on the newly introduced `Pay the invoice with 10101 faucet` button, but under the hood we just open a channel directly and push 100k sats to the app. We could try to read what the user asked for when creating the invoice, but that's more involved and we just wanted a simple fix.