### PR TITLE
fix: Add coordinator host to `just run-regtest`

### DIFF
--- a/justfile
+++ b/justfile
@@ -7,6 +7,7 @@ maker_log_file := "$PWD/data/maker/regtest.log"
 # public regtest constants
 public_regtest_coordinator := "03507b924dae6595cfb78492489978127c5f1e3877848564de2015cd6d41375802@35.189.57.114:9045"
 public_regtest_esplora := "http://35.189.57.114:3000"
+public_coordinator_host:= "35.189.57.114"
 public_coordinator_http_port := "80"
 
 default: gen
@@ -65,7 +66,7 @@ run-regtest args="":
     #!/usr/bin/env bash
     cd mobile && flutter run {{args}} --dart-define="COMMIT=$(git rev-parse HEAD)" --dart-define="BRANCH=$(git rev-parse --abbrev-ref HEAD)" \
     --dart-define="ESPLORA_ENDPOINT={{public_regtest_esplora}}" --dart-define="COORDINATOR_P2P_ENDPOINT={{public_regtest_coordinator}}" \
-    --dart-define="COORDINATOR_PORT_HTTP={{public_coordinator_http_port}}"
+    --dart-define="COORDINATOR_HOST={{public_coordinator_host}}" --dart-define="COORDINATOR_PORT_HTTP={{public_coordinator_http_port}}"
 
 fund:
     cargo run --example fund


### PR DESCRIPTION
Now that we open the channel directly to the coordinator, we started relying on
this variable to be set correctly at startup.