### PR TITLE
Do not establish connection to app when opening channel

### DIFF
--- a/mobile/lib/features/wallet/share_invoice_screen.dart
+++ b/mobile/lib/features/wallet/share_invoice_screen.dart
@@ -222,7 +222,7 @@ class _ShareInvoiceScreenState extends State<ShareInvoiceScreen> {
     var coordinator = 'http://$coordinatorHost:$coordinatorPort';
 
     final requestBody = {
-      'target': {'pubkey': rust.api.getNodeId(), 'address': rust.api.getNodeAddress()},
+      'target': {'pubkey': rust.api.getNodeId()},
       'local_balance': 200000,
       'remote_balance': 100000,
       'is_public': false

--- a/mobile/native/src/api.rs
+++ b/mobile/native/src/api.rs
@@ -285,7 +285,3 @@ pub fn decode_invoice(invoice: String) -> Result<LightningInvoice> {
 pub fn get_node_id() -> SyncReturn<String> {
     SyncReturn(ln_dlc::get_node_info().pubkey.to_string())
 }
-
-pub fn get_node_address() -> SyncReturn<String> {
-    SyncReturn(ln_dlc::get_node_info().address.to_string())
-}


### PR DESCRIPTION
Because:

- The app is already keeping a connection with the coordinator alive.
- Establishing a connection from the coordinator to the app is really hard.