### PR TITLE
fix: fetch coordinator host from config

### DIFF
--- a/justfile
+++ b/justfile
@@ -7,7 +7,6 @@ maker_log_file := "$PWD/data/maker/regtest.log"
 # public regtest constants
 public_regtest_coordinator := "03507b924dae6595cfb78492489978127c5f1e3877848564de2015cd6d41375802@35.189.57.114:9045"
 public_regtest_esplora := "http://35.189.57.114:3000"
-public_coordinator_host:= "35.189.57.114"
 public_coordinator_http_port := "80"
 
 default: gen
@@ -66,7 +65,7 @@ run-regtest args="":
     #!/usr/bin/env bash
     cd mobile && flutter run {{args}} --dart-define="COMMIT=$(git rev-parse HEAD)" --dart-define="BRANCH=$(git rev-parse --abbrev-ref HEAD)" \
     --dart-define="ESPLORA_ENDPOINT={{public_regtest_esplora}}" --dart-define="COORDINATOR_P2P_ENDPOINT={{public_regtest_coordinator}}" \
-    --dart-define="COORDINATOR_HOST={{public_coordinator_host}}" --dart-define="COORDINATOR_PORT_HTTP={{public_coordinator_http_port}}"
+    --dart-define="COORDINATOR_PORT_HTTP={{public_coordinator_http_port}}"
 
 fund:
     cargo run --example fund

--- a/mobile/lib/features/wallet/share_invoice_screen.dart
+++ b/mobile/lib/features/wallet/share_invoice_screen.dart
@@ -85,7 +85,7 @@ class _ShareInvoiceScreenState extends State<ShareInvoiceScreen> {
 
                         final router = GoRouter.of(context);
                         try {
-                          await openCoordinatorChannel();
+                          await openCoordinatorChannel(config.host);
                           // Pop both create invoice screen and share invoice screen
                           router.pop();
                           router.pop();
@@ -215,9 +215,7 @@ class _ShareInvoiceScreenState extends State<ShareInvoiceScreen> {
   // Open channel directly between coordinator and app.
   //
   // Just for regtest.
-  Future<void> openCoordinatorChannel() async {
-    String coordinatorHost =
-        const String.fromEnvironment('COORDINATOR_HOST', defaultValue: '127.0.0.1');
+  Future<void> openCoordinatorChannel(String coordinatorHost) async {
     int coordinatorPort = const int.fromEnvironment("COORDINATOR_PORT_HTTP", defaultValue: 8000);
     var coordinator = 'http://$coordinatorHost:$coordinatorPort';
 


### PR DESCRIPTION
The host can be correctly fetched from the config. It implies the host either from the `coordinator_p2p_endpoint` or if not set the `coordinator_host`.

This fix is only needed as the `build-ipa` target was incorrect. We could have alternatively also only added the `coordinator_host` argument, but I think its cleaner to not touch the environment variables outside of the environment file and fetch the configs only from the config service.