### PR TITLE
chore: Increase ln-dlc-node test timeout for bors

### DIFF
--- a/.github/workflows/tests-ln-dlc-node.yml
+++ b/.github/workflows/tests-ln-dlc-node.yml
@@ -31,7 +31,7 @@ jobs:
 
   run-tests-ln-dlc-node:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 40
     needs: changes
     if: ${{ needs.changes.outputs.ln-dlc-node == 'true' }}
     steps:


### PR DESCRIPTION
We often fail in the middle of the test run, causing bors to retry.
Since this timeout is arbitrary, we might as well increase it a bit to reduce
the failure rate.