### PR TITLE
fix: Copy rust library for iOS from the correct path

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -126,7 +126,7 @@ jobs:
         run: just gen
 
       - name: Build iOS Rust lib in release mode
-        run: just ios --release
+        run: just ios-release
 
       - name: Parse version from pubspec.yaml
         id: version

--- a/justfile
+++ b/justfile
@@ -55,10 +55,15 @@ android args="":
 android-release:
     cd mobile/native && cargo ndk -o ../android/app/src/main/jniLibs build --release
 
-# Build Rust library for iOS
-ios args="":
-    cd mobile/native && cargo lipo {{args}}
+# Build Rust library for iOS (debug mode)
+ios:
+    cd mobile/native && cargo lipo
     cp target/universal/debug/libnative.a mobile/ios/Runner
+
+# Build Rust library for iOS (release mode)
+ios-release:
+    cd mobile/native && cargo lipo --release
+    cp target/universal/release/libnative.a mobile/ios/Runner
 
 
 run args="":


### PR DESCRIPTION
Just specifying `--release` for cargo-lipo is not enough, we still need to
copy the library from the correct path 🙈