### PR TITLE
feat: Enable anchor outputs

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -11,6 +11,8 @@ rustflags = [
   "-Wunused-import-braces",
   "-Wunused-qualifications",
   "-Wclippy::unwrap_used",
+  # Enable LDK anchor outputs
+  "--cfg=anchors",
 ]
 
 [target.'cfg(feature = "cargo-clippy")']
@@ -24,6 +26,8 @@ rustflags = [
   "-Wunused-import-braces",
   "-Wunused-qualifications",
   "-Wclippy::unwrap_used",
+  # Enable LDK anchor outputs
+  "--cfg=anchors",
 ]
 
 [target.armv7-unknown-linux-musleabihf]

--- a/crates/ln-dlc-node/src/dlc_custom_signer.rs
+++ b/crates/ln-dlc-node/src/dlc_custom_signer.rs
@@ -277,6 +277,21 @@ impl CustomKeysManager {
     pub fn get_node_secret_key(&self) -> SecretKey {
         self.keys_manager.get_node_secret_key()
     }
+
+    #[cfg(anchors)]
+    pub fn sign_anchor_channel_close(
+        &self,
+        anchor_descriptor: lightning::util::events::AnchorDescriptor,
+        anchor_tx: &mut Transaction,
+    ) -> Result<(secp256k1_zkp::PublicKey, secp256k1_zkp::ecdsa::Signature), ()> {
+        let signer = self.keys_manager.derive_channel_signer(
+            anchor_descriptor.channel_value_satoshis,
+            anchor_descriptor.channel_keys_id,
+        );
+        let funding_pubkey = signer.pubkeys().funding_pubkey;
+        let funding_sig = signer.sign_holder_anchor_input(anchor_tx, 0, self.wallet.secp())?;
+        Ok((funding_pubkey, funding_sig))
+    }
 }
 
 impl CustomKeysManager {

--- a/crates/ln-dlc-node/src/dlc_custom_signer.rs
+++ b/crates/ln-dlc-node/src/dlc_custom_signer.rs
@@ -182,6 +182,23 @@ impl EcdsaChannelSigner for CustomSigner {
         self.in_memory_signer_lock()
             .sign_channel_announcement_with_funding_key(msg, secp_ctx)
     }
+
+    // LDK hides this behind the `anchors` feature flag, so we should too for consistency
+    #[cfg(anchors)]
+    fn sign_holder_htlc_transaction(
+        &self,
+        htlc_tx: &Transaction,
+        input: usize,
+        htlc_descriptor: &lightning::util::events::HTLCDescriptor,
+        secp_ctx: &Secp256k1<bitcoin::secp256k1::All>,
+    ) -> Result<secp256k1_zkp::ecdsa::Signature, ()> {
+        self.in_memory_signer_lock().sign_holder_htlc_transaction(
+            htlc_tx,
+            input,
+            htlc_descriptor,
+            secp_ctx,
+        )
+    }
 }
 
 impl ChannelSigner for CustomSigner {

--- a/crates/ln-dlc-node/src/ln/event_handler.rs
+++ b/crates/ln-dlc-node/src/ln/event_handler.rs
@@ -664,6 +664,27 @@ where
                     (intercept_id, expected_outbound_amount_msat),
                 );
             }
+            #[cfg(anchors)]
+            Event::BumpTransaction(bump_event) => {
+                tracing::info!(?bump_event, "Received BumpTransaction event");
+                match bump_event {
+                    lightning::util::events::BumpTransactionEvent::ChannelClose {
+                        package_target_feerate_sat_per_1000_weight,
+                        commitment_tx,
+                        commitment_tx_fee_satoshis,
+                        anchor_descriptor,
+                        pending_htlcs,
+                    } => {
+                        todo!("Handle BumpTransaction event");
+                    }
+                    lightning::util::events::BumpTransactionEvent::HTLCResolution {
+                        target_feerate_sat_per_1000_weight,
+                        htlc_descriptors,
+                    } => {
+                        todo!("Handle BumpTransaction event");
+                    }
+                }
+            }
         };
 
         Ok(())

--- a/crates/ln-dlc-node/src/ln/event_handler.rs
+++ b/crates/ln-dlc-node/src/ln/event_handler.rs
@@ -675,7 +675,67 @@ where
                         anchor_descriptor,
                         pending_htlcs,
                     } => {
-                        todo!("Handle BumpTransaction event");
+                        let bg_estimated_fee = self
+                            .fee_rate_estimator
+                            .get_est_sat_per_1000_weight(ConfirmationTarget::Background);
+
+                        if bg_estimated_fee > package_target_feerate_sat_per_1000_weight {
+                            tracing::info!("Bumping transaction for channel close");
+
+                            let value = commitment_tx_fee_satoshis;
+
+                            // TODO: set see for miner
+                            // let fee_for_miner = self
+                            //     .wallet
+                            //     .inner()
+                            //     .get_est_sat_per_1000_weight(ConfirmationTarget::Background);
+
+                            // let script_p2wpkh = self
+                            //     .wallet
+                            //     .inner()
+                            //     .get_last_unused_address()
+                            //     .expect("can't acquire the lock")
+                            //     .script_pubkey();
+
+                            // let mut anchor_tx = bitcoin::Transaction {
+                            //     version: 2,
+                            //     lock_time: bitcoin::PackedLockTime::ZERO,
+                            //     input: vec![bitcoin::TxIn {
+                            //         previous_output: anchor_descriptor.outpoint,
+                            //         ..Default::default()
+                            //     }],
+                            //     output: vec![bitcoin::TxOut {
+                            //         value: value - fee_for_miner,
+                            //         script_pubkey: script_p2wpkh,
+                            //     }],
+                            // };
+
+                            // self.wallet.inner().lock().bu
+
+                            let psbt = self
+                                .wallet
+                                .inner()
+                                .create_bumped_anchor_transaction_psbt(
+                                    anchor_descriptor.outpoint,
+                                    ConfirmationTarget::Normal,
+                                )
+                                .await
+                                .unwrap();
+                            let mut anchor_tx = psbt.unsigned_tx;
+
+                            let (funding_pubkey, funding_sig) = self
+                                .keys_manager
+                                .sign_anchor_channel_close(anchor_descriptor, &mut anchor_tx)
+                                .expect("this API to not implement any errors");
+                            anchor_tx.input[0].witness =
+                                lightning::ln::chan_utils::build_anchor_input_witness(
+                                    &funding_pubkey,
+                                    &funding_sig,
+                                );
+
+                            self.wallet.inner().broadcast_transaction(&anchor_tx);
+                            self.wallet.inner().broadcast_transaction(&commitment_tx);
+                        }
                     }
                     lightning::util::events::BumpTransactionEvent::HTLCResolution {
                         target_feerate_sat_per_1000_weight,

--- a/crates/ln-dlc-node/src/ln_dlc_wallet.rs
+++ b/crates/ln-dlc-node/src/ln_dlc_wallet.rs
@@ -90,6 +90,10 @@ impl LnDlcWallet {
         self.seed.get_seed_phrase()
     }
 
+    pub(crate) fn secp(&self) -> &Secp256k1<All> {
+        &self.secp
+    }
+
     // TODO: Better to keep this private and expose the necessary APIs instead.
     pub fn inner(&self) -> Arc<ldk_node_wallet::Wallet<sled::Tree>> {
         self.ln_wallet.clone()


### PR DESCRIPTION
Anchor outputs are hidden by LDK behind a config flag.

We keep it consistent across all our targets to avoid unnecessary recompilation
for clippy.