### PR TITLE
feat: Share on Twitter

### DIFF
--- a/mobile/lib/features/trade/submit_order_change_notifier.dart
+++ b/mobile/lib/features/trade/submit_order_change_notifier.dart
@@ -13,13 +13,18 @@ enum PendingOrderState {
   submissionFailed,
 }
 
+enum PositionAction {
+  close,
+  open,
+}
+
 class PendingOrder {
   final TradeValues _tradeValues;
   PendingOrderState state = PendingOrderState.submitting;
   String? pendingOrderError;
-  final bool close;
+  final PositionAction positionAction;
 
-  PendingOrder(this._tradeValues, this.close);
+  PendingOrder(this._tradeValues, this.positionAction);
 }
 
 class SubmitOrderChangeNotifier extends ChangeNotifier {
@@ -28,8 +33,8 @@ class SubmitOrderChangeNotifier extends ChangeNotifier {
 
   SubmitOrderChangeNotifier(this.orderService);
 
-  submitPendingOrder(TradeValues tradeValues, bool close) async {
-    _pendingOrder = PendingOrder(tradeValues, close);
+  submitPendingOrder(TradeValues tradeValues, PositionAction positionAction) async {
+    _pendingOrder = PendingOrder(tradeValues, positionAction);
 
     // notify listeners about pending order in state "pending"
     notifyListeners();
@@ -59,7 +64,7 @@ class SubmitOrderChangeNotifier extends ChangeNotifier {
             fee: Amount.zero(),
             fundingRate: 0,
             tradeValuesService: TradeValuesService()),
-        true);
+        PositionAction.close);
   }
 
   PendingOrder? get pendingOrder => _pendingOrder;

--- a/mobile/lib/features/trade/trade_bottom_sheet_tab.dart
+++ b/mobile/lib/features/trade/trade_bottom_sheet_tab.dart
@@ -272,7 +272,8 @@ class _TradeBottomSheetTabState extends State<TradeBottomSheetTab> {
                           context: context,
                           direction: widget.direction,
                           onConfirmation: () {
-                            submitOrderChangeNotifier.submitPendingOrder(tradeValues, false);
+                            submitOrderChangeNotifier.submitPendingOrder(
+                                tradeValues, PositionAction.open);
 
                             // TODO: Explore if it would be easier / better handle the popups as routes
                             // Pop twice to navigate back to the trade screen.


### PR DESCRIPTION
Allow spreading the message of self-custodial message when order got submitted.

msg: (for closed we substitute with "closed):

>        Just opened a #selfcustodial position using #DLC with @get10101 🚀. The future of decentralised finance starts now! #TenTenOne #10101 #BTC

screenshot of button:
![image](https://github.com/get10101/10101/assets/8319440/acdae579-0430-40d9-baa7-6e3c451bb9d9)

resolves #599 