### PR TITLE
Dynamically adjust esplora-related intervals in the coordinator

### DIFF
--- a/coordinator/src/bin/coordinator.rs
+++ b/coordinator/src/bin/coordinator.rs
@@ -69,6 +69,8 @@ async fn main() -> Result<()> {
     let seed_path = data_dir.join("seed");
     let seed = Bip39Seed::initialize(&seed_path)?;
 
+    let settings = Settings::new().await;
+
     let node = Arc::new(
         ln_dlc_node::node::Node::new_coordinator(
             "10101.finance",
@@ -81,6 +83,7 @@ async fn main() -> Result<()> {
             opts.esplora,
             seed,
             ephemeral_randomness,
+            settings.ln_dlc.clone(),
         )
         .await?,
     );
@@ -94,7 +97,6 @@ async fn main() -> Result<()> {
     let mut conn = pool.get()?;
     run_migration(&mut conn);
 
-    let settings = Settings::new().await;
     let node = Node::new(node, pool.clone());
     node.update_settings(settings.as_node_settings()).await;
 

--- a/coordinator/src/node.rs
+++ b/coordinator/src/node.rs
@@ -97,6 +97,7 @@ impl Node {
     }
 
     pub async fn update_settings(&self, settings: NodeSettings) {
+        tracing::info!(?settings, "Updating node settings");
         *self.settings.write().await = settings.clone();
 
         // Forward relevant settings down to the wallet

--- a/coordinator/src/routes.rs
+++ b/coordinator/src/routes.rs
@@ -336,5 +336,13 @@ async fn update_settings(
         .node
         .update_settings(updated_settings.as_node_settings())
         .await;
+
+    // Forward relevant settings down to the wallet
+    state
+        .node
+        .inner
+        .update_settings(updated_settings.ln_dlc)
+        .await;
+
     Ok(())
 }

--- a/coordinator/src/settings.rs
+++ b/coordinator/src/settings.rs
@@ -1,6 +1,7 @@
 use crate::node::NodeSettings;
 use anyhow::Context;
 use anyhow::Result;
+use ln_dlc_node::node::LnDlcNodeSettings;
 use serde::Deserialize;
 use serde::Serialize;
 use std::path::Path;
@@ -25,6 +26,8 @@ pub struct Settings {
     /// If set to `None`, no limit is enforced.
     //  In sats/kWU (weight unit)
     pub max_allowed_tx_fee_rate_when_opening_channel: Option<u32>,
+
+    pub ln_dlc: LnDlcNodeSettings,
 }
 
 impl Default for Settings {
@@ -36,6 +39,7 @@ impl Default for Settings {
             fallback_tx_fee_rate_normal: 2000,
             fallback_tx_fee_rate_high_priority: 5000,
             max_allowed_tx_fee_rate_when_opening_channel: None,
+            ln_dlc: LnDlcNodeSettings::default(),
         }
     }
 }

--- a/coordinator/src/settings.rs
+++ b/coordinator/src/settings.rs
@@ -56,7 +56,11 @@ impl Settings {
             Ok(settings) => settings,
             Err(e) => {
                 tracing::warn!("Unable to read {SETTINGS_FILE_PATH} file, using defaults: {e}");
-                Settings::default()
+                let new = Settings::default();
+                if let Err(e) = new.write_to_file().await {
+                    tracing::error!("Unable to write default settings to file: {e}");
+                }
+                new
             }
         }
     }

--- a/crates/ln-dlc-node/src/ldk_node_wallet.rs
+++ b/crates/ln-dlc-node/src/ldk_node_wallet.rs
@@ -47,7 +47,7 @@ where
     runtime_handle: tokio::runtime::Handle,
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct WalletSettings {
     pub fallback_tx_fee_rate_normal: u32,
     pub fallback_tx_fee_rate_high_priority: u32,
@@ -89,6 +89,7 @@ where
     }
 
     pub async fn update_settings(&self, settings: WalletSettings) {
+        tracing::info!(?settings, "Updating wallet settings");
         *self.settings.write().await = settings;
     }
 

--- a/crates/ln-dlc-node/src/tests/mod.rs
+++ b/crates/ln-dlc-node/src/tests/mod.rs
@@ -1,5 +1,6 @@
 use crate::ln::app_config;
 use crate::ln::coordinator_config;
+use crate::node::LnDlcNodeSettings;
 use crate::node::Node;
 use crate::node::NodeInfo;
 use crate::node::PaymentMap;
@@ -94,6 +95,7 @@ impl Node<PaymentMap> {
             seed,
             ephemeral_randomness,
             user_config,
+            LnDlcNodeSettings::default(),
         )
         .await?;
 

--- a/mobile/native/src/ln_dlc/mod.rs
+++ b/mobile/native/src/ln_dlc/mod.rs
@@ -22,6 +22,7 @@ use coordinator_commons::TradeParams;
 use itertools::chain;
 use itertools::Itertools;
 use lightning_invoice::Invoice;
+use ln_dlc_node::node::LnDlcNodeSettings;
 use ln_dlc_node::node::NodeInfo;
 use ln_dlc_node::seed::Bip39Seed;
 use orderbook_commons::FakeScidResponse;
@@ -64,6 +65,11 @@ pub fn get_node_key() -> SecretKey {
 
 pub fn get_node_info() -> NodeInfo {
     NODE.get().inner.info
+}
+
+pub async fn update_node_settings(settings: LnDlcNodeSettings) {
+    let node = NODE.get();
+    node.inner.update_settings(settings).await;
 }
 
 // TODO: should we also wrap the oracle as `NodeInfo`. It would fit the required attributes pubkey


### PR DESCRIPTION
Add more settings to our coordinator settings API, which is changeable at
runtime via a REST endpoint, and also stored in `coordinator-settings.toml`
file.

This also decouples the app and coordinator sync settings (although they remain
the same by default).