### PR TITLE
Fail outdated orders

### DIFF
--- a/mobile/native/src/db/custom_types.rs
+++ b/mobile/native/src/db/custom_types.rs
@@ -124,6 +124,7 @@ impl ToSql<Text, Sqlite> for FailureReason {
             FailureReason::ProposeDlcChannel => "ProposeDlcChannel",
             FailureReason::FailedToSetToFilling => "FailedToSetToFilling",
             FailureReason::OrderNotAcceptable => "OrderNotAcceptable",
+            FailureReason::TimedOut => "TimedOut",
         };
         out.set_value(text);
         Ok(IsNull::No)
@@ -142,6 +143,7 @@ impl FromSql<Text, Sqlite> for FailureReason {
             "ProposeDlcChannel" => Ok(FailureReason::ProposeDlcChannel),
             "FailedToSetToFilling" => Ok(FailureReason::FailedToSetToFilling),
             "OrderNotAcceptable" => Ok(FailureReason::OrderNotAcceptable),
+            "TimedOut" => Ok(FailureReason::TimedOut),
             _ => Err("Unrecognized enum variant".into()),
         };
     }

--- a/mobile/native/src/db/mod.rs
+++ b/mobile/native/src/db/mod.rs
@@ -162,6 +162,26 @@ pub fn get_filled_orders() -> Result<Vec<trade::order::Order>> {
     Ok(orders)
 }
 
+/// Returns an order of there is currently an order that is open
+pub fn maybe_get_open_order() -> Result<Option<trade::order::Order>> {
+    let mut db = connection()?;
+    let orders = Order::get_by_state(OrderState::Open, &mut db)?;
+
+    if orders.is_empty() {
+        return Ok(None);
+    }
+
+    if orders.len() > 1 {
+        bail!("More than one order is being open at the same time, this should not happen.")
+    }
+
+    let first = orders
+        .get(0)
+        .expect("at this point we know there is exactly one order");
+
+    Ok(Some(first.clone().try_into()?))
+}
+
 /// Returns an order of there is currently an order that is being filled
 pub fn maybe_get_order_in_filling() -> Result<Option<trade::order::Order>> {
     let mut db = connection()?;

--- a/mobile/native/src/db/models.rs
+++ b/mobile/native/src/db/models.rs
@@ -569,6 +569,7 @@ pub enum FailureReason {
     NoUsableChannel,
     ProposeDlcChannel,
     OrderNotAcceptable,
+    TimedOut,
 }
 
 impl From<FailureReason> for crate::trade::order::FailureReason {
@@ -587,6 +588,7 @@ impl From<FailureReason> for crate::trade::order::FailureReason {
             FailureReason::OrderNotAcceptable => {
                 crate::trade::order::FailureReason::OrderNotAcceptable
             }
+            FailureReason::TimedOut => crate::trade::order::FailureReason::TimedOut,
         }
     }
 }
@@ -607,6 +609,7 @@ impl From<crate::trade::order::FailureReason> for FailureReason {
             crate::trade::order::FailureReason::OrderNotAcceptable => {
                 FailureReason::OrderNotAcceptable
             }
+            crate::trade::order::FailureReason::TimedOut => FailureReason::TimedOut,
         }
     }
 }

--- a/mobile/native/src/trade/order/mod.rs
+++ b/mobile/native/src/trade/order/mod.rs
@@ -37,6 +37,7 @@ pub enum FailureReason {
     ProposeDlcChannel,
     /// MVP scope: Can only close the order, not reduce or extend
     OrderNotAcceptable,
+    TimedOut,
 }
 
 #[derive(Debug, Clone, Copy)]


### PR DESCRIPTION
fixes https://github.com/get10101/10101/issues/670 (likely, unless there is some other problem that I don't understand yet...)

If an order remains `Open` for more than `5` minutes we don't expect it to ever get matched. We have a task that runs one per minute to load the orders that are `Open` and determine if the order's creation timestamp is older than `5`minutes; if so we fail the order.