### PR TITLE
fix: Change the default concurrency in BDK wallet

### DIFF
--- a/crates/ln-dlc-node/src/node/mod.rs
+++ b/crates/ln-dlc-node/src/node/mod.rs
@@ -154,7 +154,7 @@ impl Default for LnDlcNodeSettings {
             on_chain_sync_interval: Duration::from_secs(300),
             fee_rate_sync_interval: Duration::from_secs(20),
             bdk_client_stop_gap: 20,
-            bdk_client_concurrency: 1,
+            bdk_client_concurrency: 4,
         }
     }
 }


### PR DESCRIPTION
This should substantially reduce the wait time for initial and subsequent sync, improving the app experience.

We had 8 previously, but 4 is the default value in esplora client, so should be
safe to use.

Note: our coordinator can be configured independently now, without neededing to
release a new version.