### PR TITLE
Patch to version where we skip unreadable contracts / sub-channels

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -792,7 +792,7 @@ dependencies = [
 [[package]]
 name = "dlc"
 version = "0.4.0"
-source = "git+https://github.com/get10101/rust-dlc?rev=a0d3f36#a0d3f36b76e84aee86534aff79bef8dc01f90143"
+source = "git+https://github.com/get10101/rust-dlc?rev=304e85d#304e85dbfc5e955e54f2ad08da344e512816a3aa"
 dependencies = [
  "bitcoin",
  "miniscript 8.0.0",
@@ -804,7 +804,7 @@ dependencies = [
 [[package]]
 name = "dlc-manager"
 version = "0.4.0"
-source = "git+https://github.com/get10101/rust-dlc?rev=a0d3f36#a0d3f36b76e84aee86534aff79bef8dc01f90143"
+source = "git+https://github.com/get10101/rust-dlc?rev=304e85d#304e85dbfc5e955e54f2ad08da344e512816a3aa"
 dependencies = [
  "async-trait",
  "bitcoin",
@@ -820,7 +820,7 @@ dependencies = [
 [[package]]
 name = "dlc-messages"
 version = "0.4.0"
-source = "git+https://github.com/get10101/rust-dlc?rev=a0d3f36#a0d3f36b76e84aee86534aff79bef8dc01f90143"
+source = "git+https://github.com/get10101/rust-dlc?rev=304e85d#304e85dbfc5e955e54f2ad08da344e512816a3aa"
 dependencies = [
  "bitcoin",
  "dlc",
@@ -832,7 +832,7 @@ dependencies = [
 [[package]]
 name = "dlc-sled-storage-provider"
 version = "0.1.0"
-source = "git+https://github.com/get10101/rust-dlc?rev=a0d3f36#a0d3f36b76e84aee86534aff79bef8dc01f90143"
+source = "git+https://github.com/get10101/rust-dlc?rev=304e85d#304e85dbfc5e955e54f2ad08da344e512816a3aa"
 dependencies = [
  "bitcoin",
  "dlc-manager",
@@ -845,7 +845,7 @@ dependencies = [
 [[package]]
 name = "dlc-trie"
 version = "0.4.0"
-source = "git+https://github.com/get10101/rust-dlc?rev=a0d3f36#a0d3f36b76e84aee86534aff79bef8dc01f90143"
+source = "git+https://github.com/get10101/rust-dlc?rev=304e85d#304e85dbfc5e955e54f2ad08da344e512816a3aa"
 dependencies = [
  "bitcoin",
  "dlc",
@@ -1971,7 +1971,7 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 [[package]]
 name = "p2pd-oracle-client"
 version = "0.1.0"
-source = "git+https://github.com/get10101/rust-dlc?rev=a0d3f36#a0d3f36b76e84aee86534aff79bef8dc01f90143"
+source = "git+https://github.com/get10101/rust-dlc?rev=304e85d#304e85dbfc5e955e54f2ad08da344e512816a3aa"
 dependencies = [
  "chrono",
  "dlc-manager",
@@ -2622,7 +2622,7 @@ dependencies = [
 [[package]]
 name = "simple-wallet"
 version = "0.1.0"
-source = "git+https://github.com/get10101/rust-dlc?rev=a0d3f36#a0d3f36b76e84aee86534aff79bef8dc01f90143"
+source = "git+https://github.com/get10101/rust-dlc?rev=304e85d#304e85dbfc5e955e54f2ad08da344e512816a3aa"
 dependencies = [
  "bitcoin",
  "dlc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,13 +3,13 @@ members = ["coordinator", "maker", "mobile/native", "crates/*"]
 resolver = "2"
 
 [patch.crates-io]
-dlc-manager = { git = "https://github.com/get10101/rust-dlc", rev = "a0d3f36" }
-dlc-messages = { git = "https://github.com/get10101/rust-dlc", rev = "a0d3f36" }
-dlc = { git = "https://github.com/get10101/rust-dlc", rev = "a0d3f36" }
-dlc-sled-storage-provider = { git = "https://github.com/get10101/rust-dlc", rev = "a0d3f36" }
-p2pd-oracle-client = { git = "https://github.com/get10101/rust-dlc", rev = "a0d3f36" }
-dlc-trie = { git = "https://github.com/get10101/rust-dlc", rev = "a0d3f36" }
-simple-wallet = { git = "https://github.com/get10101/rust-dlc", rev = "a0d3f36" }
+dlc-manager = { git = "https://github.com/get10101/rust-dlc", rev = "304e85d" }
+dlc-messages = { git = "https://github.com/get10101/rust-dlc", rev = "304e85d" }
+dlc = { git = "https://github.com/get10101/rust-dlc", rev = "304e85d" }
+dlc-sled-storage-provider = { git = "https://github.com/get10101/rust-dlc", rev = "304e85d" }
+p2pd-oracle-client = { git = "https://github.com/get10101/rust-dlc", rev = "304e85d" }
+dlc-trie = { git = "https://github.com/get10101/rust-dlc", rev = "304e85d" }
+simple-wallet = { git = "https://github.com/get10101/rust-dlc", rev = "304e85d" }
 lightning = { git = "https://github.com/get10101/rust-lightning/", rev = "2a7dcfce" }
 lightning-background-processor = { git = "https://github.com/get10101/rust-lightning/", rev = "2a7dcfce" }
 lightning-transaction-sync = { git = "https://github.com/get10101/rust-lightning/", rev = "2a7dcfce" }


### PR DESCRIPTION
We have to ensure that users that have an position that is currently `Open` delete this position.
The only way to achieve this is to reset the app, i.e. uninstall and reinstall. 

Otherwise, when a user triggers the position close, the coordinator will not know that it is a close (because the position is not loaded on the coordinator) - and it will result in the coordinator opening a new position with the app which results in weird state discrepancy between the two.