### PR TITLE
chore: Configure electrs containers

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,7 +41,9 @@ services:
       - --network
       - regtest
       - --daemon-dir
-      - /config
+      - /home/user/.bitcoin
+      - --db-dir
+      - /home/user/db
       - --daemon-rpc-addr
       - 10.5.0.2:18443
       - --cookie
@@ -53,6 +55,9 @@ services:
       - --cors
       - "*"
       - --jsonrpc-import
+    volumes:
+      - bitcoin:/home/user/.bitcoin:ro
+      - electrs:/home/user/db
     depends_on:
       - bitcoin
     ports:
@@ -170,3 +175,4 @@ volumes:
   bitcoin:
   postgres:
   lnd:
+  electrs:


### PR DESCRIPTION
I noticed that we didn't configure electrs proper whilst fixing cloud-conf
electrs container.

Inspired by:
https://github.com/romanz/electrs/blob/master/doc/install.md#docker-based-installation-from-source

and the CLI help (`electrs --help`):

```
  --daemon-dir <daemon_dir>                    Data directory of Bitcoind (default: ~/.bitcoin/)
  --db-dir <db_dir>                            Directory to store index database (default: ./db/)
```

Note: We shouldn't need to write to bitcoin data, it's just for reading, so it's
mounted read-only.