### PR TITLE
Do not log LN `peer_handler` ping and pong messages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1433,7 +1433,7 @@ dependencies = [
 [[package]]
 name = "lightning"
 version = "0.0.114"
-source = "git+https://github.com/get10101/rust-lightning/?rev=2a7dcfce#2a7dcfce9895eadc37bef28ddd164ac96fb7c1f1"
+source = "git+https://github.com/get10101/rust-lightning/?rev=be430fbc#be430fbc187af02c227c4cf4b200e4e63acd9fc4"
 dependencies = [
  "bitcoin",
 ]
@@ -1441,7 +1441,7 @@ dependencies = [
 [[package]]
 name = "lightning-background-processor"
 version = "0.0.114"
-source = "git+https://github.com/get10101/rust-lightning/?rev=2a7dcfce#2a7dcfce9895eadc37bef28ddd164ac96fb7c1f1"
+source = "git+https://github.com/get10101/rust-lightning/?rev=be430fbc#be430fbc187af02c227c4cf4b200e4e63acd9fc4"
 dependencies = [
  "bitcoin",
  "lightning",
@@ -1464,7 +1464,7 @@ dependencies = [
 [[package]]
 name = "lightning-net-tokio"
 version = "0.0.114"
-source = "git+https://github.com/get10101/rust-lightning/?rev=2a7dcfce#2a7dcfce9895eadc37bef28ddd164ac96fb7c1f1"
+source = "git+https://github.com/get10101/rust-lightning/?rev=be430fbc#be430fbc187af02c227c4cf4b200e4e63acd9fc4"
 dependencies = [
  "bitcoin",
  "lightning",
@@ -1474,7 +1474,7 @@ dependencies = [
 [[package]]
 name = "lightning-persister"
 version = "0.0.114"
-source = "git+https://github.com/get10101/rust-lightning/?rev=2a7dcfce#2a7dcfce9895eadc37bef28ddd164ac96fb7c1f1"
+source = "git+https://github.com/get10101/rust-lightning/?rev=be430fbc#be430fbc187af02c227c4cf4b200e4e63acd9fc4"
 dependencies = [
  "bitcoin",
  "libc",
@@ -1485,7 +1485,7 @@ dependencies = [
 [[package]]
 name = "lightning-rapid-gossip-sync"
 version = "0.0.114"
-source = "git+https://github.com/get10101/rust-lightning/?rev=2a7dcfce#2a7dcfce9895eadc37bef28ddd164ac96fb7c1f1"
+source = "git+https://github.com/get10101/rust-lightning/?rev=be430fbc#be430fbc187af02c227c4cf4b200e4e63acd9fc4"
 dependencies = [
  "bitcoin",
  "lightning",
@@ -1494,7 +1494,7 @@ dependencies = [
 [[package]]
 name = "lightning-transaction-sync"
 version = "0.0.114"
-source = "git+https://github.com/get10101/rust-lightning/?rev=2a7dcfce#2a7dcfce9895eadc37bef28ddd164ac96fb7c1f1"
+source = "git+https://github.com/get10101/rust-lightning/?rev=be430fbc#be430fbc187af02c227c4cf4b200e4e63acd9fc4"
 dependencies = [
  "bdk-macros",
  "bitcoin",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,10 +10,10 @@ dlc-sled-storage-provider = { git = "https://github.com/get10101/rust-dlc", rev 
 p2pd-oracle-client = { git = "https://github.com/get10101/rust-dlc", rev = "304e85d" }
 dlc-trie = { git = "https://github.com/get10101/rust-dlc", rev = "304e85d" }
 simple-wallet = { git = "https://github.com/get10101/rust-dlc", rev = "304e85d" }
-lightning = { git = "https://github.com/get10101/rust-lightning/", rev = "2a7dcfce" }
-lightning-background-processor = { git = "https://github.com/get10101/rust-lightning/", rev = "2a7dcfce" }
-lightning-transaction-sync = { git = "https://github.com/get10101/rust-lightning/", rev = "2a7dcfce" }
-lightning-net-tokio = { git = "https://github.com/get10101/rust-lightning/", rev = "2a7dcfce" }
-lightning-persister = { git = "https://github.com/get10101/rust-lightning/", rev = "2a7dcfce" }
+lightning = { git = "https://github.com/get10101/rust-lightning/", rev = "be430fbc" }
+lightning-background-processor = { git = "https://github.com/get10101/rust-lightning/", rev = "be430fbc" }
+lightning-transaction-sync = { git = "https://github.com/get10101/rust-lightning/", rev = "be430fbc" }
+lightning-net-tokio = { git = "https://github.com/get10101/rust-lightning/", rev = "be430fbc" }
+lightning-persister = { git = "https://github.com/get10101/rust-lightning/", rev = "be430fbc" }
 rust-bitcoin-coin-selection = { git = "https://github.com/p2pderivatives/rust-bitcoin-coin-selection" }
 bdk = { git = "https://github.com/get10101/bdk", rev = "83fbc0cb471f8c377442d70bd6d68cea25d2221d" }

--- a/coordinator/src/logger.rs
+++ b/coordinator/src/logger.rs
@@ -25,7 +25,7 @@ pub fn init_tracing(level: LevelFilter, json_format: bool) -> Result<()> {
         .add_directive("rustls=warn".parse()?)
         .add_directive("sled=warn".parse()?)
         .add_directive("bdk=warn".parse()?) // bdk is quite spamy on debug
-        .add_directive("lightning::ln::peer_handler=trace".parse()?)
+        .add_directive("lightning::ln::peer_handler=debug".parse()?)
         .add_directive("lightning::chain=info".parse()?);
 
     // Parse additional log directives from env variable

--- a/mobile/native/src/logger.rs
+++ b/mobile/native/src/logger.rs
@@ -28,6 +28,7 @@ pub fn log_base_directives(env: EnvFilter, level: LevelFilter) -> Result<EnvFilt
         // set to debug to show ldk logs (they're also in logs.txt)
         .add_directive("sled=warn".parse()?)
         .add_directive("bdk=warn".parse()?) // bdk is quite spamy on debug
+        .add_directive("lightning::ln::peer_handler=debug".parse()?)
         .add_directive("lightning::chain=info".parse()?);
     Ok(filter)
 }


### PR DESCRIPTION
We update our `rust-lightning` dependencies to be able to keep seeing peer disconnects (which have been promoted to debug).