### PR TITLE
Update `rust-dlc` and `rust-lightning` to prevent a panic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -792,7 +792,7 @@ dependencies = [
 [[package]]
 name = "dlc"
 version = "0.4.0"
-source = "git+https://github.com/get10101/rust-dlc?rev=304e85d#304e85dbfc5e955e54f2ad08da344e512816a3aa"
+source = "git+https://github.com/get10101/rust-dlc?rev=5cae456#5cae45695a316e0ea32e7d4c9965f135acebcc05"
 dependencies = [
  "bitcoin",
  "miniscript 8.0.0",
@@ -804,7 +804,7 @@ dependencies = [
 [[package]]
 name = "dlc-manager"
 version = "0.4.0"
-source = "git+https://github.com/get10101/rust-dlc?rev=304e85d#304e85dbfc5e955e54f2ad08da344e512816a3aa"
+source = "git+https://github.com/get10101/rust-dlc?rev=5cae456#5cae45695a316e0ea32e7d4c9965f135acebcc05"
 dependencies = [
  "async-trait",
  "bitcoin",
@@ -820,7 +820,7 @@ dependencies = [
 [[package]]
 name = "dlc-messages"
 version = "0.4.0"
-source = "git+https://github.com/get10101/rust-dlc?rev=304e85d#304e85dbfc5e955e54f2ad08da344e512816a3aa"
+source = "git+https://github.com/get10101/rust-dlc?rev=5cae456#5cae45695a316e0ea32e7d4c9965f135acebcc05"
 dependencies = [
  "bitcoin",
  "dlc",
@@ -832,7 +832,7 @@ dependencies = [
 [[package]]
 name = "dlc-sled-storage-provider"
 version = "0.1.0"
-source = "git+https://github.com/get10101/rust-dlc?rev=304e85d#304e85dbfc5e955e54f2ad08da344e512816a3aa"
+source = "git+https://github.com/get10101/rust-dlc?rev=5cae456#5cae45695a316e0ea32e7d4c9965f135acebcc05"
 dependencies = [
  "bitcoin",
  "dlc-manager",
@@ -845,7 +845,7 @@ dependencies = [
 [[package]]
 name = "dlc-trie"
 version = "0.4.0"
-source = "git+https://github.com/get10101/rust-dlc?rev=304e85d#304e85dbfc5e955e54f2ad08da344e512816a3aa"
+source = "git+https://github.com/get10101/rust-dlc?rev=5cae456#5cae45695a316e0ea32e7d4c9965f135acebcc05"
 dependencies = [
  "bitcoin",
  "dlc",
@@ -1433,7 +1433,7 @@ dependencies = [
 [[package]]
 name = "lightning"
 version = "0.0.114"
-source = "git+https://github.com/get10101/rust-lightning/?rev=be430fbc#be430fbc187af02c227c4cf4b200e4e63acd9fc4"
+source = "git+https://github.com/get10101/rust-lightning/?rev=0dd9bf93#0dd9bf93b2677cc53c2296a72bbd088afbc31ff7"
 dependencies = [
  "bitcoin",
 ]
@@ -1441,7 +1441,7 @@ dependencies = [
 [[package]]
 name = "lightning-background-processor"
 version = "0.0.114"
-source = "git+https://github.com/get10101/rust-lightning/?rev=be430fbc#be430fbc187af02c227c4cf4b200e4e63acd9fc4"
+source = "git+https://github.com/get10101/rust-lightning/?rev=0dd9bf93#0dd9bf93b2677cc53c2296a72bbd088afbc31ff7"
 dependencies = [
  "bitcoin",
  "lightning",
@@ -1464,7 +1464,7 @@ dependencies = [
 [[package]]
 name = "lightning-net-tokio"
 version = "0.0.114"
-source = "git+https://github.com/get10101/rust-lightning/?rev=be430fbc#be430fbc187af02c227c4cf4b200e4e63acd9fc4"
+source = "git+https://github.com/get10101/rust-lightning/?rev=0dd9bf93#0dd9bf93b2677cc53c2296a72bbd088afbc31ff7"
 dependencies = [
  "bitcoin",
  "lightning",
@@ -1474,7 +1474,7 @@ dependencies = [
 [[package]]
 name = "lightning-persister"
 version = "0.0.114"
-source = "git+https://github.com/get10101/rust-lightning/?rev=be430fbc#be430fbc187af02c227c4cf4b200e4e63acd9fc4"
+source = "git+https://github.com/get10101/rust-lightning/?rev=0dd9bf93#0dd9bf93b2677cc53c2296a72bbd088afbc31ff7"
 dependencies = [
  "bitcoin",
  "libc",
@@ -1485,7 +1485,7 @@ dependencies = [
 [[package]]
 name = "lightning-rapid-gossip-sync"
 version = "0.0.114"
-source = "git+https://github.com/get10101/rust-lightning/?rev=be430fbc#be430fbc187af02c227c4cf4b200e4e63acd9fc4"
+source = "git+https://github.com/get10101/rust-lightning/?rev=0dd9bf93#0dd9bf93b2677cc53c2296a72bbd088afbc31ff7"
 dependencies = [
  "bitcoin",
  "lightning",
@@ -1494,7 +1494,7 @@ dependencies = [
 [[package]]
 name = "lightning-transaction-sync"
 version = "0.0.114"
-source = "git+https://github.com/get10101/rust-lightning/?rev=be430fbc#be430fbc187af02c227c4cf4b200e4e63acd9fc4"
+source = "git+https://github.com/get10101/rust-lightning/?rev=0dd9bf93#0dd9bf93b2677cc53c2296a72bbd088afbc31ff7"
 dependencies = [
  "bdk-macros",
  "bitcoin",
@@ -1971,7 +1971,7 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 [[package]]
 name = "p2pd-oracle-client"
 version = "0.1.0"
-source = "git+https://github.com/get10101/rust-dlc?rev=304e85d#304e85dbfc5e955e54f2ad08da344e512816a3aa"
+source = "git+https://github.com/get10101/rust-dlc?rev=5cae456#5cae45695a316e0ea32e7d4c9965f135acebcc05"
 dependencies = [
  "chrono",
  "dlc-manager",
@@ -2622,7 +2622,7 @@ dependencies = [
 [[package]]
 name = "simple-wallet"
 version = "0.1.0"
-source = "git+https://github.com/get10101/rust-dlc?rev=304e85d#304e85dbfc5e955e54f2ad08da344e512816a3aa"
+source = "git+https://github.com/get10101/rust-dlc?rev=5cae456#5cae45695a316e0ea32e7d4c9965f135acebcc05"
 dependencies = [
  "bitcoin",
  "dlc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,17 +3,17 @@ members = ["coordinator", "maker", "mobile/native", "crates/*"]
 resolver = "2"
 
 [patch.crates-io]
-dlc-manager = { git = "https://github.com/get10101/rust-dlc", rev = "304e85d" }
-dlc-messages = { git = "https://github.com/get10101/rust-dlc", rev = "304e85d" }
-dlc = { git = "https://github.com/get10101/rust-dlc", rev = "304e85d" }
-dlc-sled-storage-provider = { git = "https://github.com/get10101/rust-dlc", rev = "304e85d" }
-p2pd-oracle-client = { git = "https://github.com/get10101/rust-dlc", rev = "304e85d" }
-dlc-trie = { git = "https://github.com/get10101/rust-dlc", rev = "304e85d" }
-simple-wallet = { git = "https://github.com/get10101/rust-dlc", rev = "304e85d" }
-lightning = { git = "https://github.com/get10101/rust-lightning/", rev = "be430fbc" }
-lightning-background-processor = { git = "https://github.com/get10101/rust-lightning/", rev = "be430fbc" }
-lightning-transaction-sync = { git = "https://github.com/get10101/rust-lightning/", rev = "be430fbc" }
-lightning-net-tokio = { git = "https://github.com/get10101/rust-lightning/", rev = "be430fbc" }
-lightning-persister = { git = "https://github.com/get10101/rust-lightning/", rev = "be430fbc" }
+dlc-manager = { git = "https://github.com/get10101/rust-dlc", rev = "5cae456" }
+dlc-messages = { git = "https://github.com/get10101/rust-dlc", rev = "5cae456" }
+dlc = { git = "https://github.com/get10101/rust-dlc", rev = "5cae456" }
+dlc-sled-storage-provider = { git = "https://github.com/get10101/rust-dlc", rev = "5cae456" }
+p2pd-oracle-client = { git = "https://github.com/get10101/rust-dlc", rev = "5cae456" }
+dlc-trie = { git = "https://github.com/get10101/rust-dlc", rev = "5cae456" }
+simple-wallet = { git = "https://github.com/get10101/rust-dlc", rev = "5cae456" }
+lightning = { git = "https://github.com/get10101/rust-lightning/", rev = "0dd9bf93" }
+lightning-background-processor = { git = "https://github.com/get10101/rust-lightning/", rev = "0dd9bf93" }
+lightning-transaction-sync = { git = "https://github.com/get10101/rust-lightning/", rev = "0dd9bf93" }
+lightning-net-tokio = { git = "https://github.com/get10101/rust-lightning/", rev = "0dd9bf93" }
+lightning-persister = { git = "https://github.com/get10101/rust-lightning/", rev = "0dd9bf93" }
 rust-bitcoin-coin-selection = { git = "https://github.com/p2pderivatives/rust-bitcoin-coin-selection" }
 bdk = { git = "https://github.com/get10101/bdk", rev = "83fbc0cb471f8c377442d70bd6d68cea25d2221d" }


### PR DESCRIPTION
There was a regression in our dependencies that effectively reverted https://github.com/get10101/10101/pull/626.

We encounter this panic sometimes at the moment, so this should help.