### PR TITLE
Spawn expensive blocking `rust-dlc` code on blocking threads

### DIFF
--- a/coordinator/src/node.rs
+++ b/coordinator/src/node.rs
@@ -233,7 +233,7 @@ impl Node {
 
         let channel_details = self.get_counterparty_channel(trade_params.pubkey)?;
         self.inner
-            .propose_dlc_channel(&channel_details, &contract_input)
+            .propose_dlc_channel(channel_details, contract_input)
             .await
             .context("Could not propose dlc channel")?;
         Ok(())
@@ -268,7 +268,8 @@ impl Node {
         );
 
         self.inner
-            .propose_dlc_channel_collaborative_settlement(&channel_id, accept_settlement_amount)?;
+            .propose_dlc_channel_collaborative_settlement(channel_id, accept_settlement_amount)
+            .await?;
 
         let mut connection = self.pool.get()?;
         db::trades::insert(

--- a/crates/ln-dlc-node/src/node/ln_channel.rs
+++ b/crates/ln-dlc-node/src/node/ln_channel.rs
@@ -5,7 +5,10 @@ use anyhow::Result;
 use bitcoin::secp256k1::PublicKey;
 use lightning::ln::channelmanager::ChannelDetails;
 
-impl<P> Node<P> {
+impl<P> Node<P>
+where
+    P: Send + Sync,
+{
     /// Initiates the open private channel protocol.
     ///
     /// Returns a temporary channel ID as a 32-byte long array.

--- a/crates/ln-dlc-node/src/node/mod.rs
+++ b/crates/ln-dlc-node/src/node/mod.rs
@@ -580,7 +580,14 @@ where
             let (fut, remote_handle) = {
                 async move {
                     loop {
-                        process_pending_dlc_actions(&sub_channel_manager, &dlc_message_handler);
+                        if let Err(e) = process_pending_dlc_actions(
+                            sub_channel_manager.clone(),
+                            &dlc_message_handler,
+                        )
+                        .await
+                        {
+                            tracing::error!("Failed to process pending DLC actions: {e:#}");
+                        };
 
                         tokio::time::sleep(Duration::from_secs(30)).await;
                     }

--- a/crates/ln-dlc-node/src/tests/dlc/collaborative_settlement.rs
+++ b/crates/ln-dlc-node/src/tests/dlc/collaborative_settlement.rs
@@ -50,9 +50,10 @@ async fn dlc_collaborative_settlement(
     let coordinator_loss_amount = coordinator_dlc_collateral - coordinator_settlement_amount;
 
     app.propose_dlc_channel_collaborative_settlement(
-        &channel_details.channel_id,
+        channel_details.channel_id,
         coordinator_settlement_amount,
-    )?;
+    )
+    .await?;
 
     // Processs the app's offer to close the channel
     tokio::time::sleep(Duration::from_secs(2)).await;
@@ -146,7 +147,8 @@ async fn open_dlc_channel_after_closing_dlc_channel() {
         .iter()
         .find(|c| c.counterparty.node_id == coordinator.info.pubkey)
         .context("No usable channels for app")
-        .unwrap();
+        .unwrap()
+        .clone();
 
     // Act
 
@@ -157,7 +159,7 @@ async fn open_dlc_channel_after_closing_dlc_channel() {
     let contract_input =
         dummy_contract_input(app_dlc_collateral, coordinator_dlc_collateral, oracle_pk);
 
-    app.propose_dlc_channel(channel_details, &contract_input)
+    app.propose_dlc_channel(channel_details, contract_input)
         .await
         .unwrap();
 

--- a/crates/ln-dlc-node/src/tests/dlc/create.rs
+++ b/crates/ln-dlc-node/src/tests/dlc/create.rs
@@ -70,7 +70,7 @@ pub async fn create_dlc_channel(
     let contract_input =
         dummy_contract_input(app_dlc_collateral, coordinator_dlc_collateral, oracle_pk);
 
-    app.propose_dlc_channel(&channel_details, &contract_input)
+    app.propose_dlc_channel(channel_details.clone(), contract_input)
         .await?;
 
     // Processs the app's offer to close the channel

--- a/crates/ln-dlc-node/src/tests/dlc/dlc_setup_with_reconnects.rs
+++ b/crates/ln-dlc-node/src/tests/dlc/dlc_setup_with_reconnects.rs
@@ -35,14 +35,15 @@ async fn reconnecting_during_dlc_channel_setup() {
         .iter()
         .find(|c| c.counterparty.node_id == coordinator.info.pubkey)
         .context("No usable channels for app")
-        .unwrap();
+        .unwrap()
+        .clone();
 
     // Act
 
     let oracle_pk = app.oracle_pk();
     let contract_input = dummy_contract_input(20_000, 20_000, oracle_pk);
 
-    app.propose_dlc_channel(channel_details, &contract_input)
+    app.propose_dlc_channel(channel_details.clone(), contract_input)
         .await
         .unwrap();
 
@@ -76,9 +77,11 @@ async fn reconnecting_during_dlc_channel_setup() {
 
     // Instruct coordinator to re-send the accept message
     process_pending_dlc_actions(
-        &coordinator.sub_channel_manager,
+        coordinator.sub_channel_manager.clone(),
         &coordinator.dlc_message_handler,
-    );
+    )
+    .await
+    .unwrap();
 
     // Process the coordinator's accept message _and_ send the confirm message
     tokio::time::sleep(Duration::from_secs(2)).await;

--- a/mobile/native/src/ln_dlc/mod.rs
+++ b/mobile/native/src/ln_dlc/mod.rs
@@ -154,14 +154,12 @@ pub fn run(data_dir: String, seed_dir: String) -> Result<()> {
             async move { node.keep_connected(config::get_coordinator_info()).await }
         });
 
-        runtime.spawn({
+        runtime.spawn_blocking({
             let node = node.clone();
-            async move {
-                loop {
-                    node.process_incoming_dlc_messages();
+            move || loop {
+                node.process_incoming_dlc_messages();
 
-                    tokio::time::sleep(PROCESS_INCOMING_MESSAGES_INTERVAL).await;
-                }
+                std::thread::sleep(PROCESS_INCOMING_MESSAGES_INTERVAL);
             }
         });
 


### PR DESCRIPTION
This is done to mitigate risks such as starving other async tasks and even deadlocks.