### PR TITLE
Attempt to fix deadlock by updating dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -792,7 +792,7 @@ dependencies = [
 [[package]]
 name = "dlc"
 version = "0.4.0"
-source = "git+https://github.com/get10101/rust-dlc?rev=5cae456#5cae45695a316e0ea32e7d4c9965f135acebcc05"
+source = "git+https://github.com/get10101/rust-dlc?rev=d605b64#d605b64c56e94e412317f03d94e959e77370db00"
 dependencies = [
  "bitcoin",
  "miniscript 8.0.0",
@@ -804,7 +804,7 @@ dependencies = [
 [[package]]
 name = "dlc-manager"
 version = "0.4.0"
-source = "git+https://github.com/get10101/rust-dlc?rev=5cae456#5cae45695a316e0ea32e7d4c9965f135acebcc05"
+source = "git+https://github.com/get10101/rust-dlc?rev=d605b64#d605b64c56e94e412317f03d94e959e77370db00"
 dependencies = [
  "async-trait",
  "bitcoin",
@@ -820,7 +820,7 @@ dependencies = [
 [[package]]
 name = "dlc-messages"
 version = "0.4.0"
-source = "git+https://github.com/get10101/rust-dlc?rev=5cae456#5cae45695a316e0ea32e7d4c9965f135acebcc05"
+source = "git+https://github.com/get10101/rust-dlc?rev=d605b64#d605b64c56e94e412317f03d94e959e77370db00"
 dependencies = [
  "bitcoin",
  "dlc",
@@ -832,7 +832,7 @@ dependencies = [
 [[package]]
 name = "dlc-sled-storage-provider"
 version = "0.1.0"
-source = "git+https://github.com/get10101/rust-dlc?rev=5cae456#5cae45695a316e0ea32e7d4c9965f135acebcc05"
+source = "git+https://github.com/get10101/rust-dlc?rev=d605b64#d605b64c56e94e412317f03d94e959e77370db00"
 dependencies = [
  "bitcoin",
  "dlc-manager",
@@ -845,7 +845,7 @@ dependencies = [
 [[package]]
 name = "dlc-trie"
 version = "0.4.0"
-source = "git+https://github.com/get10101/rust-dlc?rev=5cae456#5cae45695a316e0ea32e7d4c9965f135acebcc05"
+source = "git+https://github.com/get10101/rust-dlc?rev=d605b64#d605b64c56e94e412317f03d94e959e77370db00"
 dependencies = [
  "bitcoin",
  "dlc",
@@ -1433,7 +1433,7 @@ dependencies = [
 [[package]]
 name = "lightning"
 version = "0.0.114"
-source = "git+https://github.com/get10101/rust-lightning/?rev=0dd9bf93#0dd9bf93b2677cc53c2296a72bbd088afbc31ff7"
+source = "git+https://github.com/get10101/rust-lightning/?rev=2fbff163#2fbff163e6106a82523c8df87ac3c4fa6f34abbe"
 dependencies = [
  "bitcoin",
 ]
@@ -1441,7 +1441,7 @@ dependencies = [
 [[package]]
 name = "lightning-background-processor"
 version = "0.0.114"
-source = "git+https://github.com/get10101/rust-lightning/?rev=0dd9bf93#0dd9bf93b2677cc53c2296a72bbd088afbc31ff7"
+source = "git+https://github.com/get10101/rust-lightning/?rev=2fbff163#2fbff163e6106a82523c8df87ac3c4fa6f34abbe"
 dependencies = [
  "bitcoin",
  "lightning",
@@ -1464,7 +1464,7 @@ dependencies = [
 [[package]]
 name = "lightning-net-tokio"
 version = "0.0.114"
-source = "git+https://github.com/get10101/rust-lightning/?rev=0dd9bf93#0dd9bf93b2677cc53c2296a72bbd088afbc31ff7"
+source = "git+https://github.com/get10101/rust-lightning/?rev=2fbff163#2fbff163e6106a82523c8df87ac3c4fa6f34abbe"
 dependencies = [
  "bitcoin",
  "lightning",
@@ -1474,7 +1474,7 @@ dependencies = [
 [[package]]
 name = "lightning-persister"
 version = "0.0.114"
-source = "git+https://github.com/get10101/rust-lightning/?rev=0dd9bf93#0dd9bf93b2677cc53c2296a72bbd088afbc31ff7"
+source = "git+https://github.com/get10101/rust-lightning/?rev=2fbff163#2fbff163e6106a82523c8df87ac3c4fa6f34abbe"
 dependencies = [
  "bitcoin",
  "libc",
@@ -1485,7 +1485,7 @@ dependencies = [
 [[package]]
 name = "lightning-rapid-gossip-sync"
 version = "0.0.114"
-source = "git+https://github.com/get10101/rust-lightning/?rev=0dd9bf93#0dd9bf93b2677cc53c2296a72bbd088afbc31ff7"
+source = "git+https://github.com/get10101/rust-lightning/?rev=2fbff163#2fbff163e6106a82523c8df87ac3c4fa6f34abbe"
 dependencies = [
  "bitcoin",
  "lightning",
@@ -1494,7 +1494,7 @@ dependencies = [
 [[package]]
 name = "lightning-transaction-sync"
 version = "0.0.114"
-source = "git+https://github.com/get10101/rust-lightning/?rev=0dd9bf93#0dd9bf93b2677cc53c2296a72bbd088afbc31ff7"
+source = "git+https://github.com/get10101/rust-lightning/?rev=2fbff163#2fbff163e6106a82523c8df87ac3c4fa6f34abbe"
 dependencies = [
  "bdk-macros",
  "bitcoin",
@@ -1971,7 +1971,7 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 [[package]]
 name = "p2pd-oracle-client"
 version = "0.1.0"
-source = "git+https://github.com/get10101/rust-dlc?rev=5cae456#5cae45695a316e0ea32e7d4c9965f135acebcc05"
+source = "git+https://github.com/get10101/rust-dlc?rev=d605b64#d605b64c56e94e412317f03d94e959e77370db00"
 dependencies = [
  "chrono",
  "dlc-manager",
@@ -2622,7 +2622,7 @@ dependencies = [
 [[package]]
 name = "simple-wallet"
 version = "0.1.0"
-source = "git+https://github.com/get10101/rust-dlc?rev=5cae456#5cae45695a316e0ea32e7d4c9965f135acebcc05"
+source = "git+https://github.com/get10101/rust-dlc?rev=d605b64#d605b64c56e94e412317f03d94e959e77370db00"
 dependencies = [
  "bitcoin",
  "dlc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,17 +3,17 @@ members = ["coordinator", "maker", "mobile/native", "crates/*"]
 resolver = "2"
 
 [patch.crates-io]
-dlc-manager = { git = "https://github.com/get10101/rust-dlc", rev = "5cae456" }
-dlc-messages = { git = "https://github.com/get10101/rust-dlc", rev = "5cae456" }
-dlc = { git = "https://github.com/get10101/rust-dlc", rev = "5cae456" }
-dlc-sled-storage-provider = { git = "https://github.com/get10101/rust-dlc", rev = "5cae456" }
-p2pd-oracle-client = { git = "https://github.com/get10101/rust-dlc", rev = "5cae456" }
-dlc-trie = { git = "https://github.com/get10101/rust-dlc", rev = "5cae456" }
-simple-wallet = { git = "https://github.com/get10101/rust-dlc", rev = "5cae456" }
-lightning = { git = "https://github.com/get10101/rust-lightning/", rev = "0dd9bf93" }
-lightning-background-processor = { git = "https://github.com/get10101/rust-lightning/", rev = "0dd9bf93" }
-lightning-transaction-sync = { git = "https://github.com/get10101/rust-lightning/", rev = "0dd9bf93" }
-lightning-net-tokio = { git = "https://github.com/get10101/rust-lightning/", rev = "0dd9bf93" }
-lightning-persister = { git = "https://github.com/get10101/rust-lightning/", rev = "0dd9bf93" }
+dlc-manager = { git = "https://github.com/get10101/rust-dlc", rev = "d605b64" }
+dlc-messages = { git = "https://github.com/get10101/rust-dlc", rev = "d605b64" }
+dlc = { git = "https://github.com/get10101/rust-dlc", rev = "d605b64" }
+dlc-sled-storage-provider = { git = "https://github.com/get10101/rust-dlc", rev = "d605b64" }
+p2pd-oracle-client = { git = "https://github.com/get10101/rust-dlc", rev = "d605b64" }
+dlc-trie = { git = "https://github.com/get10101/rust-dlc", rev = "d605b64" }
+simple-wallet = { git = "https://github.com/get10101/rust-dlc", rev = "d605b64" }
+lightning = { git = "https://github.com/get10101/rust-lightning/", rev = "2fbff163" }
+lightning-background-processor = { git = "https://github.com/get10101/rust-lightning/", rev = "2fbff163" }
+lightning-transaction-sync = { git = "https://github.com/get10101/rust-lightning/", rev = "2fbff163" }
+lightning-net-tokio = { git = "https://github.com/get10101/rust-lightning/", rev = "2fbff163" }
+lightning-persister = { git = "https://github.com/get10101/rust-lightning/", rev = "2fbff163" }
 rust-bitcoin-coin-selection = { git = "https://github.com/p2pderivatives/rust-bitcoin-coin-selection" }
 bdk = { git = "https://github.com/get10101/bdk", rev = "83fbc0cb471f8c377442d70bd6d68cea25d2221d" }

--- a/crates/ln-dlc-node/src/node/sub_channel_manager.rs
+++ b/crates/ln-dlc-node/src/node/sub_channel_manager.rs
@@ -1,4 +1,3 @@
-use crate::dlc_custom_signer::CustomSigner;
 use crate::ln_dlc_wallet::LnDlcWallet;
 use crate::node::channel_manager::ChannelManager;
 use crate::node::dlc_manager::DlcManager;
@@ -18,7 +17,6 @@ pub type SubChannelManager = sub_channel_manager::SubChannelManager<
     Arc<SystemTimeProvider>,
     Arc<LnDlcWallet>,
     Arc<DlcManager>,
-    CustomSigner,
 >;
 
 pub(crate) fn build(


### PR DESCRIPTION
The update reverts a couple of patches in `rust-dlc` and `rust-lightning` which may have introduced a deadlock.

---

After this patch we will be building on top of `get10101/rust-dlc#fix/deadlock` and `get10101/rust-lightning#split-tx-experiment-114-without-lock`.