### PR TITLE
Change `sync` to use a multi-threaded runtime builder

### DIFF
--- a/crates/ln-dlc-node/src/node/mod.rs
+++ b/crates/ln-dlc-node/src/node/mod.rs
@@ -303,7 +303,7 @@ where
             let ln_dlc_wallet = ln_dlc_wallet.clone();
             let stop_sync = stop_sync.clone();
             move || {
-                tokio::runtime::Builder::new_current_thread()
+                tokio::runtime::Builder::new_multi_thread()
                     .enable_all()
                     .build()
                     .expect("to be able to create a runtime")
@@ -335,7 +335,7 @@ where
             let ln_dlc_wallet = ln_dlc_wallet.clone();
             let stop_sync = stop_sync.clone();
             move || {
-                tokio::runtime::Builder::new_current_thread()
+                tokio::runtime::Builder::new_multi_thread()
                     .enable_all()
                     .build()
                     .expect("to be able to create a runtime")


### PR DESCRIPTION
We copied the code that uses `new_current_thread` from LDK wallet. In my understanding we need this because `SledTree` does not implement `Send`, so we need a non-send thread.

However, the tokio documentation states that one should use `LocalSet` when using `new_current_thread` - which is not done in the code copied over from `ldk-node`.
 The tokio docs further state that one can use `new_multi_thread` when having the `rt-multi-thread` feature activated - which we have.

See docs: https://docs.rs/tokio/latest/tokio/runtime/struct.Builder.html#method.new_current_thread

Note: I am not 100% sure this will change any assumptions; this code is generally weird - we copied it without questioning it too much. 