### PR TITLE
Add support for autometrics in coordinator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ data/**
 
 # env file
 .env
+
+# prometheus data
+services/prometheus/data

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -61,9 +61,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.69"
+version = "1.0.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "224afbd727c3d6e4b90103ece64b8d1b67fbb1973b1046c2281eed3f3803f800"
+checksum = "9c7d0618f0e0b7e8ff11427422b64564d5fb0be1940354bfe2e0529b18a9d9b8"
 dependencies = [
  "backtrace",
 ]
@@ -132,6 +132,34 @@ name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
+name = "autometrics"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e06501aa216e24523c637bad8498c211e7a932ed4002ad0f62a2834fa5b3c400"
+dependencies = [
+ "autometrics-macros",
+ "const_format",
+ "metrics-exporter-prometheus",
+ "once_cell",
+ "opentelemetry-prometheus",
+ "opentelemetry_api",
+ "opentelemetry_sdk",
+ "prometheus",
+]
+
+[[package]]
+name = "autometrics-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2edb1335006ff621fe85b2c876f8e77ce31779fce866867b99a300891133aed9"
+dependencies = [
+ "percent-encoding",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "axum"
@@ -557,11 +585,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "const_format"
+version = "0.2.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7309d9b4d3d2c0641e018d449232f2e28f1b22933c137f157d3dbc14228b8c0e"
+dependencies = [
+ "const_format_proc_macros",
+]
+
+[[package]]
+name = "const_format_proc_macros"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d897f47bf7270cf70d370f8f98c1abb6d2d4cf60a6845d30e05bfb90c6568650"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
+]
+
+[[package]]
 name = "coordinator"
 version = "0.1.0"
 dependencies = [
  "anyhow",
  "atty",
+ "autometrics",
  "axum",
  "bdk",
  "bitcoin",
@@ -774,6 +823,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d8b5680b5c2cc52f50acb2457d9b3a3b58adcca785db13a0e3655626f601de6"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "dashmap"
+version = "5.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "907076dfda823b0b36d2a1bb5f90c96660a5bbcd7729e10727f07858f22c4edc"
+dependencies = [
+ "cfg-if",
+ "hashbrown 0.12.3",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core 0.9.7",
 ]
 
 [[package]]
@@ -1604,6 +1666,7 @@ name = "ln-dlc-node"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "autometrics",
  "bdk",
  "bip39",
  "bitcoin",
@@ -1687,6 +1750,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "mach2"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d0d1830bcd151a6fc4aea1369af235b36c1528fe976b8ff678683c9995eade8"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "maker"
 version = "0.1.0"
 dependencies = [
@@ -1748,6 +1820,57 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "metrics"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa8ebbd1a9e57bbab77b9facae7f5136aea44c356943bf9a198f647da64285d6"
+dependencies = [
+ "ahash 0.8.3",
+ "metrics-macros",
+ "portable-atomic",
+]
+
+[[package]]
+name = "metrics-exporter-prometheus"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a4964177ddfdab1e3a2b37aec7cf320e14169abb0ed73999f558136409178d5"
+dependencies = [
+ "base64 0.21.0",
+ "indexmap",
+ "metrics",
+ "metrics-util",
+ "quanta",
+ "thiserror",
+]
+
+[[package]]
+name = "metrics-macros"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddece26afd34c31585c74a4db0630c376df271c285d682d1e55012197830b6df"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.15",
+]
+
+[[package]]
+name = "metrics-util"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "111cb375987443c3de8d503580b536f77dc8416d32db62d9456db5d93bd7ac47"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "hashbrown 0.13.2",
+ "metrics",
+ "num_cpus",
+ "quanta",
+ "sketches-ddsketch",
 ]
 
 [[package]]
@@ -2028,6 +2151,63 @@ dependencies = [
 ]
 
 [[package]]
+name = "opentelemetry"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69d6c3d7288a106c0a363e4b0e8d308058d56902adefb16f4936f417ffef086e"
+dependencies = [
+ "opentelemetry_api",
+ "opentelemetry_sdk",
+]
+
+[[package]]
+name = "opentelemetry-prometheus"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06c3d833835a53cf91331d2cfb27e9121f5a95261f31f08a1f79ab31688b8da8"
+dependencies = [
+ "opentelemetry",
+ "prometheus",
+ "protobuf",
+]
+
+[[package]]
+name = "opentelemetry_api"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c24f96e21e7acc813c7a8394ee94978929db2bcc46cf6b5014fc612bf7760c22"
+dependencies = [
+ "fnv",
+ "futures-channel",
+ "futures-util",
+ "indexmap",
+ "js-sys",
+ "once_cell",
+ "pin-project-lite",
+ "thiserror",
+]
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ca41c4933371b61c2a2f214bf16931499af4ec90543604ec828f7a625c09113"
+dependencies = [
+ "async-trait",
+ "crossbeam-channel",
+ "dashmap",
+ "fnv",
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "once_cell",
+ "opentelemetry_api",
+ "percent-encoding",
+ "rand",
+ "thiserror",
+]
+
+[[package]]
 name = "orderbook-client"
 version = "0.1.0"
 dependencies = [
@@ -2180,6 +2360,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
 
 [[package]]
+name = "portable-atomic"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc59d1bcc64fc5d021d67521f818db868368028108d37f0e98d74e33f68297b5"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2237,6 +2423,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "prometheus"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "449811d15fbdf5ceb5c1144416066429cf82316e2ec8ce0c1f6f8a02e7bbcf8c"
+dependencies = [
+ "cfg-if",
+ "fnv",
+ "lazy_static",
+ "memchr",
+ "parking_lot 0.12.1",
+ "protobuf",
+ "thiserror",
+]
+
+[[package]]
 name = "prost"
 version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2269,6 +2470,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "protobuf"
+version = "2.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
+
+[[package]]
 name = "ptr_meta"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2286,6 +2493,22 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "quanta"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cc73c42f9314c4bdce450c77e6f09ecbddefbeddb1b5979ded332a3913ded33"
+dependencies = [
+ "crossbeam-utils",
+ "libc",
+ "mach2",
+ "once_cell",
+ "raw-cpuid",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+ "web-sys",
+ "winapi",
 ]
 
 [[package]]
@@ -2336,6 +2559,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
+]
+
+[[package]]
+name = "raw-cpuid"
+version = "10.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c297679cb867470fa8c9f67dbba74a78d78e3e98d7cf2b08d6d71540f797332"
+dependencies = [
+ "bitflags",
 ]
 
 [[package]]
@@ -2516,9 +2748,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.11"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5583e89e108996506031660fe09baa5011b9dd0341b89029313006d1fb508d70"
+checksum = "4f3208ce4d8448b3f3e7d168a73f5e0c43a61e32930de3bceeccedb388b6bf06"
 
 [[package]]
 name = "ryu"
@@ -2769,6 +3001,12 @@ dependencies = [
  "rust-bitcoin-coin-selection",
  "secp256k1-zkp",
 ]
+
+[[package]]
+name = "sketches-ddsketch"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68a406c1882ed7f29cd5e248c9848a80e7cb6ae0fea82346d2746f2f941c07e1"
 
 [[package]]
 name = "slab"
@@ -3350,6 +3588,12 @@ name = "unicode-width"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
 
 [[package]]
 name = "untrusted"

--- a/coordinator/Cargo.toml
+++ b/coordinator/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 [dependencies]
 anyhow = { version = "1", features = ["backtrace"] }
 atty = "0.2.14"
+autometrics = { version = "0.4.1", features = ["prometheus-exporter"] }
 axum = { version = "0.6.7", features = ["ws", "query"] }
 bdk = { version = "0.27.0", default-features = false, features = ["key-value-db", "async-interface", "use-esplora-async"] }
 bitcoin = "0.29"

--- a/coordinator/src/admin.rs
+++ b/coordinator/src/admin.rs
@@ -1,6 +1,7 @@
 use crate::routes::AppState;
 use crate::AppError;
 use anyhow::Context;
+use autometrics::autometrics;
 use axum::extract::Path;
 use axum::extract::Query;
 use axum::extract::State;
@@ -27,6 +28,7 @@ pub struct Balance {
     onchain: u64,
 }
 
+#[autometrics]
 pub async fn get_balance(State(state): State<Arc<AppState>>) -> Result<Json<Balance>, AppError> {
     let offchain = state.node.inner.get_ldk_balance();
     let onchain = state
@@ -41,6 +43,7 @@ pub async fn get_balance(State(state): State<Arc<AppState>>) -> Result<Json<Bala
     }))
 }
 
+#[autometrics]
 pub async fn list_channels(State(state): State<Arc<AppState>>) -> Json<Vec<ChannelDetails>> {
     let channels = state
         .node
@@ -53,6 +56,7 @@ pub async fn list_channels(State(state): State<Arc<AppState>>) -> Json<Vec<Chann
     Json(channels)
 }
 
+#[autometrics]
 pub async fn list_dlc_channels(
     State(state): State<Arc<AppState>>,
 ) -> Result<Json<Vec<DlcChannelDetails>>, AppError> {
@@ -102,6 +106,7 @@ where
     }
 }
 
+#[autometrics]
 pub async fn send_payment(
     Path(invoice): Path<String>,
     State(state): State<Arc<AppState>>,
@@ -119,6 +124,7 @@ pub async fn send_payment(
 }
 
 #[instrument(skip_all, err(Debug))]
+#[autometrics]
 pub async fn close_channel(
     Path(channel_id): Path<String>,
     Query(params): Query<CloseChanelParams>,
@@ -151,6 +157,7 @@ pub async fn close_channel(
 }
 
 #[instrument(skip_all, err(Debug))]
+#[autometrics]
 pub async fn finalize_force_close_ln_dlc_channel(
     Path(channel_id): Path<String>,
     State(state): State<Arc<AppState>>,
@@ -181,6 +188,7 @@ pub async fn finalize_force_close_ln_dlc_channel(
     Ok(())
 }
 
+#[autometrics]
 pub async fn delete_subchannel(
     Path(channel_id): Path<String>,
     State(state): State<Arc<AppState>>,
@@ -218,6 +226,7 @@ pub async fn delete_subchannel(
     Ok(())
 }
 
+#[autometrics]
 pub async fn sign_message(
     Path(msg): Path<String>,
     State(state): State<Arc<AppState>>,
@@ -230,6 +239,7 @@ pub async fn sign_message(
     Ok(Json(signature))
 }
 
+#[autometrics]
 pub async fn connect_to_peer(
     State(state): State<Arc<AppState>>,
     target: Json<NodeInfo>,
@@ -241,6 +251,7 @@ pub async fn connect_to_peer(
     Ok(())
 }
 
+#[autometrics]
 pub async fn is_connected(
     State(state): State<Arc<AppState>>,
     Path(target_pubkey): Path<String>,

--- a/coordinator/src/bin/coordinator.rs
+++ b/coordinator/src/bin/coordinator.rs
@@ -210,6 +210,9 @@ async fn main() -> Result<()> {
 
     let app = router(node, pool, settings);
 
+    // Start the metrics exporter
+    let _exporter = autometrics::global_metrics_exporter();
+
     tracing::debug!("listening on http://{}", http_address);
     axum::Server::bind(&http_address)
         .serve(app.into_make_service())

--- a/crates/ln-dlc-node/Cargo.toml
+++ b/crates/ln-dlc-node/Cargo.toml
@@ -8,6 +8,7 @@ description = "A common interface for using Lightning and DLC channels side-by-s
 
 [dependencies]
 anyhow = { version = "1", features = ["backtrace"] }
+autometrics = "0.4.1"
 bdk = { version = "0.27.0", default-features = false, features = ["key-value-db", "async-interface", "use-esplora-async"] }
 bip39 = { version = "2", features = ["rand_core"] }
 bitcoin = "0.29"

--- a/crates/ln-dlc-node/src/ldk_node_wallet.rs
+++ b/crates/ln-dlc-node/src/ldk_node_wallet.rs
@@ -3,6 +3,7 @@ use anyhow::bail;
 use anyhow::Context;
 use anyhow::Error;
 use anyhow::Result;
+use autometrics::autometrics;
 use bdk::blockchain::Blockchain;
 use bdk::blockchain::EsploraBlockchain;
 use bdk::blockchain::GetHeight;
@@ -97,6 +98,7 @@ where
         self.settings.read().await.clone()
     }
 
+    #[autometrics]
     /// Update fee estimates and the internal BDK wallet database with
     /// the blockchain.
     pub async fn sync(&self) -> Result<()> {
@@ -129,6 +131,7 @@ where
         Ok(())
     }
 
+    #[autometrics]
     pub(crate) async fn update_fee_estimates(&self) -> Result<()> {
         let mut locked_fee_rate_cache = self.fee_rate_cache.write().await;
 

--- a/justfile
+++ b/justfile
@@ -293,4 +293,18 @@ build-apk-regtest:
 
 release-apk-regtest: gen android-release build-apk-regtest
 
+# Run prometheus for local debugging (needs it installed, e.g. `brew install prometheus`)
+prometheus:
+    #!/usr/bin/env bash
+    set -euxo pipefail
+    cd services/prometheus
+    prometheus
+
+# Reset gathered prometheus metrics
+wipe-prometheus:
+    #!/usr/bin/env bash
+    set -euxo pipefail
+    cd services/prometheus
+    rm -rf data
+
 # vim:expandtab:sw=4:ts=4

--- a/services/prometheus/prometheus.yml
+++ b/services/prometheus/prometheus.yml
@@ -1,0 +1,9 @@
+scrape_configs:
+  - job_name: "coordinator"
+    metrics_path: /metrics
+    static_configs:
+      # Coordinator endpoint
+      - targets: ["localhost:8000"]
+    # For a real deployment, you would want the scrape interval to be
+    # longer but for testing, you want the data to show up quickly
+    scrape_interval: 200ms


### PR DESCRIPTION
Add support for easily collecting prometheus metrics and sprinkle some
`#[autometrics]` into a few functions, e.g. routes, and wallet sync.

For more information, see: https://github.com/autometrics-dev/autometrics-rs

Prometheus metrics are exposed at `/metrics` endpoint.

Add a `just prometheus` command, which starts prometheus configured to gather
the metrics for local debugging
(prometheus needs to be installed locally, e.g. with `brew install prometheus`).

Note: Local debugging works best with `rust-analyzer`, as docstrings are
automatically decorated with links to prometheus queries related to the function.

Production config can pull these metrics into Grafana dashboards provided by autometrics.