### PR TITLE
chore: Allow querying regtest metrics directly from IDE

### DIFF
--- a/coordinator/build.rs
+++ b/coordinator/build.rs
@@ -1,0 +1,14 @@
+// This file is used to generate the environment variables for the Rust analyzer
+// to make autometrics docstrings resolve the chosen Prometheus URL.
+
+fn main() {
+    // Uncomment the `premetheus_url` line with the desired URL
+    // Note: Reload Rust analyzer after changing the Prometheus URL to regenerate the links
+
+    // regtest URL
+    let prometheus_url = "http://testnet.itchysats.network:9090";
+
+    // local debugging
+    // let prometheus_url = "http://localhost:9090";
+    println!("cargo:rustc-env=PROMETHEUS_URL={prometheus_url}");
+}


### PR DESCRIPTION
build.rs allows us to specify which prometheus server we're using when analysing
functions in IDEs.