### PR TITLE
Run command with local flavor and configurable IP addr

### DIFF
--- a/justfile
+++ b/justfile
@@ -78,6 +78,13 @@ run-regtest args="":
     --dart-define="ESPLORA_ENDPOINT={{public_regtest_esplora}}" --dart-define="COORDINATOR_P2P_ENDPOINT={{public_regtest_coordinator}}" \
     --dart-define="COORDINATOR_PORT_HTTP={{public_coordinator_http_port}}"
 
+run-local-android args="":
+    #!/usr/bin/env bash
+    $LOCAL_IP=(curl -sS ifconfig.co)
+    cd mobile && flutter run {{args}} --dart-define="COMMIT=$(git rev-parse HEAD)" --dart-define="BRANCH=$(git rev-parse --abbrev-ref HEAD)" \
+    --dart-define="ESPLORA_ENDPOINT=http://${LOCAL_IP}:3000" --dart-define="COORDINATOR_P2P_ENDPOINT=02dd6abec97f9a748bf76ad502b004ce05d1b2d1f43a9e76bd7d85e767ffb022c9@${LOCAL_IP}:9045" \
+    --dart-define="COORDINATOR_PORT_HTTP=8000" --flavor local
+
 fund:
     cargo run --example fund
 

--- a/mobile/android/app/build.gradle
+++ b/mobile/android/app/build.gradle
@@ -59,6 +59,14 @@ android {
         }
     }
 
+    productFlavors {
+        local {
+            dimension "default"
+            resValue "string", "app_name", "10101 (local)"
+            applicationIdSuffix ".local"
+        }
+    }
+
     buildTypes {
         release {
             // TODO: Add your own signing config for the release build.


### PR DESCRIPTION
A simple way to run the app on the phone but connect to a local (any) coordinator via IP.

---

This command makes it easy to quickly change to another machine that runs the setup, assuming the default ports and the checked in coordinator seed.

I am not sure if we want to do anything with this, but it made me think about our configuration in general.

At least for the (local) regtest setup the only thing that usually changes is the host machine's IP, maybe we can simplify the configuration to extract the IP and only set that instead of all the other parameters.

---

Note: I only configured the `local` flavor for Android - if we want to keep this command we could consider adding a flavor iOS as well.