### PR TITLE
Add `--cfg tokio_unstable` to Clippy target

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -15,6 +15,8 @@ rustflags = [
 
 [target.'cfg(feature = "cargo-clippy")']
 rustflags = [
+  "--cfg",
+  "tokio_unstable",
   "-Wclippy::disallowed_methods",
   "-Wclippy::dbg_macro",
   "-Wclippy::print_stderr",


### PR DESCRIPTION
This ensures that we don't have to recompile from scratch every time we switch between `cargo build` and `cargo clippy`.