### PR TITLE
Do not spawn new OS thread just for updating fee estimates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1676,6 +1676,7 @@ dependencies = [
  "dlc-messages",
  "dlc-sled-storage-provider",
  "dlc-trie",
+ "esplora-client",
  "futures",
  "hex",
  "hkdf",

--- a/crates/ln-dlc-node/Cargo.toml
+++ b/crates/ln-dlc-node/Cargo.toml
@@ -17,6 +17,7 @@ dlc-manager = { version = "0.4.0", features = ["use-serde"] }
 dlc-messages = { version = "0.4.0" }
 dlc-sled-storage-provider = { version = "0.1.0", features = ["wallet"] }
 dlc-trie = { version = "0.4.0" }
+esplora-client = { version = "0.3", default-features = false }
 futures = "0.3"
 hex = "0.4"
 hkdf = "0.12"

--- a/crates/ln-dlc-node/src/fee_rate_estimator.rs
+++ b/crates/ln-dlc-node/src/fee_rate_estimator.rs
@@ -1,0 +1,116 @@
+use anyhow::Result;
+use autometrics::autometrics;
+use bdk::FeeRate;
+use lightning::chain::chaininterface::ConfirmationTarget;
+use lightning::chain::chaininterface::FeeEstimator;
+use lightning::chain::chaininterface::FEERATE_FLOOR_SATS_PER_KW;
+use std::collections::HashMap;
+use std::sync::RwLock;
+use std::sync::RwLockReadGuard;
+use std::sync::RwLockWriteGuard;
+
+pub struct FeeRateEstimator {
+    client: esplora_client::AsyncClient,
+    fee_rate_cache: RwLock<HashMap<ConfirmationTarget, FeeRate>>,
+    fallbacks: RwLock<FeeRateFallbacks>,
+}
+
+#[derive(Debug)]
+pub struct FeeRateFallbacks {
+    pub normal_priority: u32,
+    pub high_priority: u32,
+}
+
+impl Default for FeeRateFallbacks {
+    fn default() -> Self {
+        Self {
+            normal_priority: 2000,
+            high_priority: 5000,
+        }
+    }
+}
+
+impl FeeRateEstimator {
+    pub fn new(esplora_url: String) -> Self {
+        let client = esplora_client::AsyncClient::from_client(esplora_url, reqwest::Client::new());
+
+        let fee_rate_cache = RwLock::new(HashMap::default());
+        let fallbacks = RwLock::new(FeeRateFallbacks::default());
+
+        Self {
+            client,
+            fee_rate_cache,
+            fallbacks,
+        }
+    }
+
+    pub(crate) fn get(&self, target: ConfirmationTarget) -> FeeRate {
+        self.cache_read_lock()
+            .get(&target)
+            .copied()
+            .unwrap_or_else(|| {
+                let fee_rate = match target {
+                    ConfirmationTarget::Background => FEERATE_FLOOR_SATS_PER_KW,
+                    ConfirmationTarget::Normal => self.fallbacks_read_lock().normal_priority,
+                    ConfirmationTarget::HighPriority => self.fallbacks_read_lock().high_priority,
+                };
+                FeeRate::from_sat_per_kwu(fee_rate as f32)
+            })
+    }
+
+    #[autometrics]
+    pub(crate) async fn update(&self) -> Result<()> {
+        let estimates = self.client.get_fee_estimates().await?;
+
+        let mut locked_fee_rate_cache = self.cache_write_lock();
+        for (target, n_blocks) in [
+            (ConfirmationTarget::Background, 12),
+            (ConfirmationTarget::Normal, 6),
+            (ConfirmationTarget::HighPriority, 3),
+        ] {
+            let fee_rate = esplora_client::convert_fee_rate(n_blocks, estimates.clone())?;
+
+            let fee_rate = FeeRate::from_sat_per_vb(fee_rate);
+
+            locked_fee_rate_cache.insert(target, fee_rate);
+            tracing::trace!(
+                n_blocks_confirmation = %n_blocks,
+                sats_per_kwu = %fee_rate.fee_wu(1000),
+                "Updated fee rate estimate",
+            );
+        }
+        Ok(())
+    }
+
+    pub fn update_fallbacks(&self, fallbacks: FeeRateFallbacks) {
+        tracing::info!(?fallbacks, "Updating fee rate fallbacks");
+        *self.fallbacks_write_lock() = fallbacks;
+    }
+
+    fn fallbacks_read_lock(&self) -> RwLockReadGuard<FeeRateFallbacks> {
+        self.fallbacks.read().expect("RwLock to not be poisoned")
+    }
+
+    fn fallbacks_write_lock(&self) -> RwLockWriteGuard<FeeRateFallbacks> {
+        self.fallbacks.write().expect("RwLock to not be poisoned")
+    }
+
+    fn cache_read_lock(&self) -> RwLockReadGuard<HashMap<ConfirmationTarget, FeeRate>> {
+        self.fee_rate_cache
+            .read()
+            .expect("RwLock to not be poisoned")
+    }
+
+    fn cache_write_lock(&self) -> RwLockWriteGuard<HashMap<ConfirmationTarget, FeeRate>> {
+        self.fee_rate_cache
+            .write()
+            .expect("RwLock to not be poisoned")
+    }
+}
+
+impl FeeEstimator for FeeRateEstimator {
+    #[autometrics]
+    fn get_est_sat_per_1000_weight(&self, confirmation_target: ConfirmationTarget) -> u32 {
+        (self.get(confirmation_target).fee_wu(1000) as u32).max(FEERATE_FLOOR_SATS_PER_KW)
+    }
+}

--- a/crates/ln-dlc-node/src/ldk_node_wallet.rs
+++ b/crates/ln-dlc-node/src/ldk_node_wallet.rs
@@ -1,3 +1,4 @@
+use crate::fee_rate_estimator::FeeRateEstimator;
 use crate::ln::TracingLogger;
 use anyhow::bail;
 use anyhow::Context;
@@ -9,7 +10,6 @@ use bdk::blockchain::EsploraBlockchain;
 use bdk::blockchain::GetHeight;
 use bdk::database::BatchDatabase;
 use bdk::wallet::AddressIndex;
-use bdk::FeeRate;
 use bdk::SignOptions;
 use bdk::SyncOptions;
 use bdk::TransactionDetails;
@@ -21,13 +21,10 @@ use bitcoin::Transaction;
 use bitcoin::Txid;
 use lightning::chain::chaininterface::BroadcasterInterface;
 use lightning::chain::chaininterface::ConfirmationTarget;
-use lightning::chain::chaininterface::FeeEstimator;
-use lightning::chain::chaininterface::FEERATE_FLOOR_SATS_PER_KW;
 use lightning::chain::transaction::OutPoint;
 use lightning::chain::Filter;
 use lightning::chain::WatchedOutput;
 use lightning_transaction_sync::EsploraSyncClient;
-use std::collections::HashMap;
 use std::sync::Arc;
 use std::sync::Mutex;
 use std::sync::MutexGuard;
@@ -42,28 +39,15 @@ where
     pub(crate) blockchain: Arc<EsploraBlockchain>,
     // A BDK on-chain wallet.
     inner: Mutex<bdk::Wallet<D>>,
-    // A cache storing the most recently retrieved fee rate estimations.
-    fee_rate_cache: RwLock<HashMap<ConfirmationTarget, FeeRate>>,
     settings: RwLock<WalletSettings>,
     esplora_sync_client: Arc<EsploraSyncClient<Arc<TracingLogger>>>,
     runtime_handle: tokio::runtime::Handle,
+    fee_rate_estimator: Arc<FeeRateEstimator>,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct WalletSettings {
-    pub fallback_tx_fee_rate_normal: u32,
-    pub fallback_tx_fee_rate_high_priority: u32,
     pub max_allowed_tx_fee_rate_when_opening_channel: Option<u32>,
-}
-
-impl Default for WalletSettings {
-    fn default() -> Self {
-        Self {
-            fallback_tx_fee_rate_normal: 2000,
-            fallback_tx_fee_rate_high_priority: 5000,
-            max_allowed_tx_fee_rate_when_opening_channel: None,
-        }
-    }
 }
 
 impl<D> Wallet<D>
@@ -75,18 +59,18 @@ where
         wallet: bdk::Wallet<D>,
         runtime_handle: tokio::runtime::Handle,
         esplora_sync_client: Arc<EsploraSyncClient<Arc<TracingLogger>>>,
+        fee_rate_estimator: Arc<FeeRateEstimator>,
     ) -> Self {
         let inner = Mutex::new(wallet);
-        let fee_rate_cache = RwLock::new(HashMap::new());
         let settings = RwLock::new(WalletSettings::default());
 
         Self {
             blockchain: Arc::new(blockchain),
             inner,
-            fee_rate_cache,
             runtime_handle,
             settings,
             esplora_sync_client,
+            fee_rate_estimator,
         }
     }
 
@@ -104,12 +88,11 @@ where
     }
 
     #[autometrics]
-    /// Update fee estimates and the internal BDK wallet database with
-    /// the blockchain.
+    /// Update the internal BDK wallet database with the blockchain.
     pub async fn sync(&self) -> Result<()> {
         let wallet_lock = self.bdk_lock();
         match wallet_lock
-            .sync(&self.blockchain, SyncOptions { progress: None })
+            .sync(&self.blockchain, SyncOptions::default())
             .await
         {
             Err(bdk::Error::Esplora(e)) => match *e {
@@ -137,51 +120,16 @@ where
     }
 
     #[autometrics]
-    pub(crate) async fn update_fee_estimates(&self) -> Result<()> {
-        let mut locked_fee_rate_cache = self.fee_rate_cache.write().await;
-
-        let confirmation_targets = vec![
-            ConfirmationTarget::Background,
-            ConfirmationTarget::Normal,
-            ConfirmationTarget::HighPriority,
-        ];
-        for target in confirmation_targets {
-            let num_blocks = match target {
-                ConfirmationTarget::Background => 12,
-                ConfirmationTarget::Normal => 6,
-                ConfirmationTarget::HighPriority => 3,
-            };
-
-            let est_fee_rate = self.blockchain.estimate_fee(num_blocks).await;
-
-            match est_fee_rate {
-                Ok(rate) => {
-                    locked_fee_rate_cache.insert(target, rate);
-                    tracing::trace!(
-                        "Fee rate estimation updated: {} sats/kwu",
-                        rate.fee_wu(1000)
-                    );
-                }
-                Err(e) => {
-                    tracing::error!("Failed to update fee rate estimation: {}", e);
-                }
-            }
-        }
-        Ok(())
-    }
-
-    #[autometrics]
     pub(crate) async fn create_funding_transaction(
         &self,
         output_script: Script,
         value_sats: u64,
         confirmation_target: ConfirmationTarget,
     ) -> Result<Transaction, Error> {
-        let fee_rate = self.estimate_fee_rate(confirmation_target);
-
         let locked_wallet = self.bdk_lock();
         let mut tx_builder = locked_wallet.build_tx();
 
+        let fee_rate = self.fee_rate_estimator.get(confirmation_target);
         tx_builder
             .add_recipient(output_script, value_sats)
             .fee_rate(fee_rate)
@@ -242,8 +190,7 @@ where
         address: &bitcoin::Address,
         amount_msat_or_drain: Option<u64>,
     ) -> Result<Txid> {
-        let confirmation_target = ConfirmationTarget::Normal;
-        let fee_rate = self.estimate_fee_rate(confirmation_target);
+        let fee_rate = self.fee_rate_estimator.get(ConfirmationTarget::Normal);
 
         let tx = {
             let locked_wallet = self.bdk_lock();
@@ -308,31 +255,6 @@ where
     }
 
     #[autometrics]
-    fn estimate_fee_rate(&self, confirmation_target: ConfirmationTarget) -> FeeRate {
-        let (fee_rate_cache, settings) = tokio::task::block_in_place(move || {
-            self.runtime_handle.block_on(async move {
-                (
-                    self.fee_rate_cache.read().await.clone(),
-                    self.settings.read().await.clone(),
-                )
-            })
-        });
-
-        let fallback_sats_kwu = match confirmation_target {
-            ConfirmationTarget::Background => FEERATE_FLOOR_SATS_PER_KW,
-            ConfirmationTarget::Normal => settings.fallback_tx_fee_rate_normal,
-            ConfirmationTarget::HighPriority => settings.fallback_tx_fee_rate_high_priority,
-        };
-
-        // We'll fall back on this, if we really don't have any other information.
-        let fallback_rate = FeeRate::from_sat_per_kwu(fallback_sats_kwu as f32);
-
-        *fee_rate_cache
-            .get(&confirmation_target)
-            .unwrap_or(&fallback_rate)
-    }
-
-    #[autometrics]
     pub fn tip(&self) -> Result<(u32, BlockHash)> {
         let ret = tokio::task::block_in_place(move || {
             self.runtime_handle.block_on(async move {
@@ -358,16 +280,6 @@ where
     pub fn network(&self) -> Result<Network> {
         // TODO: Store network separately, so we don't have to lock mutex here.
         Ok(self.bdk_lock().network())
-    }
-}
-
-impl<D> FeeEstimator for Wallet<D>
-where
-    D: BatchDatabase,
-{
-    fn get_est_sat_per_1000_weight(&self, confirmation_target: ConfirmationTarget) -> u32 {
-        (self.estimate_fee_rate(confirmation_target).fee_wu(1000) as u32)
-            .max(FEERATE_FLOOR_SATS_PER_KW)
     }
 }
 

--- a/crates/ln-dlc-node/src/lib.rs
+++ b/crates/ln-dlc-node/src/lib.rs
@@ -4,6 +4,7 @@ use bitcoin::secp256k1::PublicKey;
 use dlc_custom_signer::CustomKeysManager;
 use dlc_custom_signer::CustomSigner;
 use dlc_messages::message_handler::MessageHandler as DlcMessageHandler;
+use fee_rate_estimator::FeeRateEstimator;
 use lightning::chain::chainmonitor;
 use lightning::chain::Filter;
 use lightning::ln::channelmanager::InterceptId;
@@ -25,6 +26,7 @@ use time::OffsetDateTime;
 
 mod disk;
 mod dlc_custom_signer;
+mod fee_rate_estimator;
 mod ldk_node_wallet;
 mod ln;
 mod ln_dlc_wallet;
@@ -37,6 +39,7 @@ pub mod seed;
 #[cfg(test)]
 mod tests;
 
+pub use fee_rate_estimator::FeeRateFallbacks;
 pub use ldk_node_wallet::WalletSettings;
 pub use ln::ChannelDetails;
 pub use ln::DlcChannelDetails;
@@ -46,7 +49,7 @@ type ChainMonitor = chainmonitor::ChainMonitor<
     CustomSigner,
     Arc<dyn Filter + Send + Sync>,
     Arc<LnDlcWallet>,
-    Arc<LnDlcWallet>,
+    Arc<FeeRateEstimator>,
     Arc<TracingLogger>,
     Arc<FilesystemPersister>,
 >;

--- a/crates/ln-dlc-node/src/ln_dlc_wallet.rs
+++ b/crates/ln-dlc-node/src/ln_dlc_wallet.rs
@@ -1,3 +1,4 @@
+use crate::fee_rate_estimator::FeeRateEstimator;
 use crate::ldk_node_wallet;
 use crate::seed::Bip39Seed;
 use crate::TracingLogger;
@@ -43,9 +44,11 @@ pub struct LnDlcWallet {
 }
 
 impl LnDlcWallet {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         esplora_client: Arc<EsploraSyncClient<Arc<TracingLogger>>>,
         on_chain_wallet: bdk::Wallet<bdk::sled::Tree>,
+        fee_rate_estimator: Arc<FeeRateEstimator>,
         storage: Arc<SledStorageProvider>,
         seed: Bip39Seed,
         runtime_handle: tokio::runtime::Handle,
@@ -61,6 +64,7 @@ impl LnDlcWallet {
             on_chain_wallet,
             runtime_handle.clone(),
             esplora_client,
+            fee_rate_estimator,
         ));
 
         Self {
@@ -301,17 +305,6 @@ impl BroadcasterInterface for LnDlcWallet {
     #[autometrics]
     fn broadcast_transaction(&self, tx: &Transaction) {
         self.ln_wallet.broadcast_transaction(tx)
-    }
-}
-
-impl lightning::chain::chaininterface::FeeEstimator for LnDlcWallet {
-    #[autometrics]
-    fn get_est_sat_per_1000_weight(
-        &self,
-        confirmation_target: lightning::chain::chaininterface::ConfirmationTarget,
-    ) -> u32 {
-        self.ln_wallet
-            .get_est_sat_per_1000_weight(confirmation_target)
     }
 }
 

--- a/crates/ln-dlc-node/src/node/channel_manager.rs
+++ b/crates/ln-dlc-node/src/node/channel_manager.rs
@@ -1,4 +1,5 @@
 use crate::dlc_custom_signer::CustomKeysManager;
+use crate::fee_rate_estimator::FeeRateEstimator;
 use crate::ln::TracingLogger;
 use crate::ln_dlc_wallet::LnDlcWallet;
 use crate::ChainMonitor;
@@ -22,7 +23,7 @@ pub type ChannelManager = lightning::ln::channelmanager::ChannelManager<
     Arc<CustomKeysManager>,
     Arc<CustomKeysManager>,
     Arc<CustomKeysManager>,
-    Arc<LnDlcWallet>,
+    Arc<FeeRateEstimator>,
     Arc<Router>,
     Arc<TracingLogger>,
 >;
@@ -32,6 +33,7 @@ pub(crate) fn build(
     ldk_data_dir: &str,
     keys_manager: Arc<CustomKeysManager>,
     ln_dlc_wallet: Arc<LnDlcWallet>,
+    fee_rate_estimator: Arc<FeeRateEstimator>,
     explora_client: Arc<EsploraSyncClient<Arc<TracingLogger>>>,
     logger: Arc<TracingLogger>,
     chain_monitor: Arc<ChainMonitor>,
@@ -54,7 +56,7 @@ pub(crate) fn build(
 
             let (height, block_hash) = ln_dlc_wallet.tip()?;
             return Ok(ChannelManager::new(
-                ln_dlc_wallet.clone(),
+                fee_rate_estimator,
                 chain_monitor.clone(),
                 ln_dlc_wallet,
                 router,
@@ -82,7 +84,7 @@ pub(crate) fn build(
         keys_manager.clone(),
         keys_manager.clone(),
         keys_manager,
-        ln_dlc_wallet.clone(),
+        fee_rate_estimator,
         chain_monitor.clone(),
         ln_dlc_wallet,
         router,

--- a/crates/ln-dlc-node/src/node/dlc_manager.rs
+++ b/crates/ln-dlc-node/src/node/dlc_manager.rs
@@ -1,3 +1,4 @@
+use crate::fee_rate_estimator::FeeRateEstimator;
 use crate::ln_dlc_wallet::LnDlcWallet;
 use anyhow::Context;
 use anyhow::Result;
@@ -16,7 +17,7 @@ pub type DlcManager = dlc_manager::manager::Manager<
     Arc<SledStorageProvider>,
     Arc<P2PDOracleClient>,
     Arc<SystemTimeProvider>,
-    Arc<LnDlcWallet>,
+    Arc<FeeRateEstimator>,
 >;
 
 pub fn build(
@@ -24,6 +25,7 @@ pub fn build(
     ln_dlc_wallet: Arc<LnDlcWallet>,
     storage: Arc<SledStorageProvider>,
     p2pdoracle: Arc<P2PDOracleClient>,
+    fee_rate_estimator: Arc<FeeRateEstimator>,
 ) -> Result<DlcManager> {
     let offers_path = data_dir.join("offers");
     fs::create_dir_all(offers_path)?;
@@ -33,11 +35,11 @@ pub fn build(
 
     DlcManager::new(
         ln_dlc_wallet.clone(),
-        ln_dlc_wallet.clone(),
+        ln_dlc_wallet,
         storage,
         oracles,
         Arc::new(SystemTimeProvider {}),
-        ln_dlc_wallet,
+        fee_rate_estimator,
     )
     .context("Failed to initialise DlcManager")
 }

--- a/crates/ln-dlc-node/src/node/sub_channel_manager.rs
+++ b/crates/ln-dlc-node/src/node/sub_channel_manager.rs
@@ -1,3 +1,4 @@
+use crate::fee_rate_estimator::FeeRateEstimator;
 use crate::ln_dlc_wallet::LnDlcWallet;
 use crate::node::channel_manager::ChannelManager;
 use crate::node::dlc_manager::DlcManager;
@@ -16,7 +17,7 @@ pub type SubChannelManager = sub_channel_manager::SubChannelManager<
     Arc<LnDlcWallet>,
     Arc<P2PDOracleClient>,
     Arc<SystemTimeProvider>,
-    Arc<LnDlcWallet>,
+    Arc<FeeRateEstimator>,
     Arc<DlcManager>,
 >;
 

--- a/crates/ln-dlc-node/src/tests/just_in_time_channel/create.rs
+++ b/crates/ln-dlc-node/src/tests/just_in_time_channel/create.rs
@@ -26,7 +26,6 @@ async fn just_in_time_channel_fails_if_fee_too_low() {
     init_tracing();
     let low_fee_limit = WalletSettings {
         max_allowed_tx_fee_rate_when_opening_channel: Some(CURRENT_FEE_RATE - 1),
-        ..WalletSettings::default()
     };
 
     create_just_in_time_channel(low_fee_limit, TestPath::ExpectFundingFailure)
@@ -41,7 +40,6 @@ async fn just_in_time_channel_works_with_correct_fee() {
     let high_fee_limit = WalletSettings {
         // We set our fee limit to above the current fee rate
         max_allowed_tx_fee_rate_when_opening_channel: Some(CURRENT_FEE_RATE + 10),
-        ..WalletSettings::default()
     };
 
     create_just_in_time_channel(high_fee_limit, TestPath::FundingAlwaysOnline)


### PR DESCRIPTION
It is sufficient to use an asynchronous task, as the work we're doing here is primarily IO-bound: requesting the latest fee rate from using the `esplora` client.