### PR TITLE
Process incoming DLC messages on a dedicated thread

### DIFF
--- a/coordinator/src/bin/coordinator.rs
+++ b/coordinator/src/bin/coordinator.rs
@@ -97,7 +97,8 @@ async fn main() -> Result<()> {
     let node = Node::new(node, pool.clone());
     node.update_settings(settings.as_node_settings()).await;
 
-    tokio::task::spawn_blocking({
+    // spawn a dedicated thread as this might be CPU-heavy
+    std::thread::spawn({
         let node = node.clone();
         move || loop {
             node.process_incoming_dlc_messages();

--- a/coordinator/src/bin/coordinator.rs
+++ b/coordinator/src/bin/coordinator.rs
@@ -28,7 +28,7 @@ use time::OffsetDateTime;
 use tracing::metadata::LevelFilter;
 use trade::bitmex_client::BitmexClient;
 
-const PROCESS_INCOMING_DLC_MESSAGES_INTERVAL: Duration = Duration::from_secs(5);
+const PROCESS_INCOMING_DLC_MESSAGES_INTERVAL: Duration = Duration::from_secs(2);
 const POSITION_SYNC_INTERVAL: Duration = Duration::from_secs(300);
 const CONNECTION_CHECK_INTERVAL: Duration = Duration::from_secs(30);
 

--- a/mobile/native/src/ln_dlc/mod.rs
+++ b/mobile/native/src/ln_dlc/mod.rs
@@ -43,7 +43,7 @@ use tokio::runtime::Runtime;
 mod node;
 
 static NODE: Storage<Arc<Node>> = Storage::new();
-const PROCESS_INCOMING_MESSAGES_INTERVAL: Duration = Duration::from_secs(5);
+const PROCESS_INCOMING_MESSAGES_INTERVAL: Duration = Duration::from_secs(2);
 const UPDATE_WALLET_HISTORY_INTERVAL: Duration = Duration::from_secs(5);
 const CHECK_OPEN_ORDERS_INTERVAL: Duration = Duration::from_secs(60);
 

--- a/mobile/native/src/ln_dlc/mod.rs
+++ b/mobile/native/src/ln_dlc/mod.rs
@@ -151,7 +151,8 @@ pub fn run(data_dir: String, seed_dir: String) -> Result<()> {
             async move { node.keep_connected(config::get_coordinator_info()).await }
         });
 
-        runtime.spawn_blocking({
+        // spawn a dedicated thread as this might be CPU-heavy
+        std::thread::spawn({
             let node = node.clone();
             move || loop {
                 node.process_incoming_dlc_messages();


### PR DESCRIPTION
Also reduce the wait time to 2s, as we're not going to starve the runtime.