### PR TITLE
fix: Stop using bdk fork that introduced 250ms delay

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -243,7 +243,8 @@ checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
 [[package]]
 name = "bdk"
 version = "0.27.1"
-source = "git+https://github.com/get10101/bdk?rev=83fbc0cb471f8c377442d70bd6d68cea25d2221d#83fbc0cb471f8c377442d70bd6d68cea25d2221d"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51c878ac60a45c41523ff790df555ccb1fbfd634a667220104dcae3e64d7ed9f"
 dependencies = [
  "async-trait",
  "bdk-macros",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,4 +16,3 @@ lightning-transaction-sync = { git = "https://github.com/get10101/rust-lightning
 lightning-net-tokio = { git = "https://github.com/get10101/rust-lightning/", rev = "2fbff163" }
 lightning-persister = { git = "https://github.com/get10101/rust-lightning/", rev = "2fbff163" }
 rust-bitcoin-coin-selection = { git = "https://github.com/p2pderivatives/rust-bitcoin-coin-selection" }
-bdk = { git = "https://github.com/get10101/bdk", rev = "83fbc0cb471f8c377442d70bd6d68cea25d2221d" }


### PR DESCRIPTION
Whilst an important quickfix at the time (it allowed us to resume testing on
mainnet), our fork introduced more side-effects than it fixed.

Some of the side-effects observed:
    - bdk wallet sync would take ~15s (instead of ~1-2s)
    - ln_collab_close` test was failing
    - lightning wallet sync took only 3ms to complete (instead ~1000ms normally)

Fixes #717 