### PR TITLE
chore: Pin rust version to latest stable

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.70"
+components = ["clippy", "rustfmt"]


### PR DESCRIPTION
Ensure all builds for contributors and releases are done with the same rustc
version.

This also allows us to better reuse rust-cache on CI (only change the compiler
version when we want/need, not immediately when it's released).