### PR TITLE
Revert "chore: Added backtrace logging to debug tasks trying to acquire the bdk lock"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1666,7 +1666,6 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "autometrics",
- "backtrace",
  "bdk",
  "bip39",
  "bitcoin",

--- a/crates/ln-dlc-node/Cargo.toml
+++ b/crates/ln-dlc-node/Cargo.toml
@@ -9,7 +9,6 @@ description = "A common interface for using Lightning and DLC channels side-by-s
 [dependencies]
 anyhow = { version = "1", features = ["backtrace"] }
 autometrics = "0.4.1"
-backtrace = "0.3"
 bdk = { version = "0.27.0", default-features = false, features = ["key-value-db", "use-esplora-blocking"] }
 bip39 = { version = "2", features = ["rand_core"] }
 bitcoin = "0.29"

--- a/crates/ln-dlc-node/src/ldk_node_wallet.rs
+++ b/crates/ln-dlc-node/src/ldk_node_wallet.rs
@@ -70,9 +70,6 @@ where
     }
 
     fn bdk_lock(&self) -> MutexGuard<bdk::Wallet<D>> {
-        // TODO: Remove me: only added for debugging
-        let bt = backtrace::Backtrace::new();
-        tracing::debug!("{bt:?}");
         self.inner.lock().expect("mutex not to be poisoned")
     }
 


### PR DESCRIPTION
This reverts commit 3e826edb8bbf860e41baa5a0d678e1594b8070f7.