### PR TITLE
Process lightning events asynchronously

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1576,7 +1576,7 @@ dependencies = [
 [[package]]
 name = "lightning"
 version = "0.0.114"
-source = "git+https://github.com/get10101/rust-lightning/?rev=0dd9bf93#0dd9bf93b2677cc53c2296a72bbd088afbc31ff7"
+source = "git+https://github.com/get10101/rust-lightning/?rev=5de4468d#5de4468dafd785e8bfb288a3ec29719e4f87dd75"
 dependencies = [
  "bitcoin",
 ]
@@ -1584,9 +1584,10 @@ dependencies = [
 [[package]]
 name = "lightning-background-processor"
 version = "0.0.114"
-source = "git+https://github.com/get10101/rust-lightning/?rev=0dd9bf93#0dd9bf93b2677cc53c2296a72bbd088afbc31ff7"
+source = "git+https://github.com/get10101/rust-lightning/?rev=5de4468d#5de4468dafd785e8bfb288a3ec29719e4f87dd75"
 dependencies = [
  "bitcoin",
+ "futures-util",
  "lightning",
  "lightning-rapid-gossip-sync",
 ]
@@ -1607,7 +1608,7 @@ dependencies = [
 [[package]]
 name = "lightning-net-tokio"
 version = "0.0.114"
-source = "git+https://github.com/get10101/rust-lightning/?rev=0dd9bf93#0dd9bf93b2677cc53c2296a72bbd088afbc31ff7"
+source = "git+https://github.com/get10101/rust-lightning/?rev=5de4468d#5de4468dafd785e8bfb288a3ec29719e4f87dd75"
 dependencies = [
  "bitcoin",
  "lightning",
@@ -1617,7 +1618,7 @@ dependencies = [
 [[package]]
 name = "lightning-persister"
 version = "0.0.114"
-source = "git+https://github.com/get10101/rust-lightning/?rev=0dd9bf93#0dd9bf93b2677cc53c2296a72bbd088afbc31ff7"
+source = "git+https://github.com/get10101/rust-lightning/?rev=5de4468d#5de4468dafd785e8bfb288a3ec29719e4f87dd75"
 dependencies = [
  "bitcoin",
  "libc",
@@ -1628,7 +1629,7 @@ dependencies = [
 [[package]]
 name = "lightning-rapid-gossip-sync"
 version = "0.0.114"
-source = "git+https://github.com/get10101/rust-lightning/?rev=0dd9bf93#0dd9bf93b2677cc53c2296a72bbd088afbc31ff7"
+source = "git+https://github.com/get10101/rust-lightning/?rev=5de4468d#5de4468dafd785e8bfb288a3ec29719e4f87dd75"
 dependencies = [
  "bitcoin",
  "lightning",
@@ -1637,7 +1638,7 @@ dependencies = [
 [[package]]
 name = "lightning-transaction-sync"
 version = "0.0.114"
-source = "git+https://github.com/get10101/rust-lightning/?rev=0dd9bf93#0dd9bf93b2677cc53c2296a72bbd088afbc31ff7"
+source = "git+https://github.com/get10101/rust-lightning/?rev=5de4468d#5de4468dafd785e8bfb288a3ec29719e4f87dd75"
 dependencies = [
  "bdk-macros",
  "bitcoin",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,9 +10,9 @@ dlc-sled-storage-provider = { git = "https://github.com/get10101/rust-dlc", rev 
 p2pd-oracle-client = { git = "https://github.com/get10101/rust-dlc", rev = "428e870" }
 dlc-trie = { git = "https://github.com/get10101/rust-dlc", rev = "428e870" }
 simple-wallet = { git = "https://github.com/get10101/rust-dlc", rev = "428e870" }
-lightning = { git = "https://github.com/get10101/rust-lightning/", rev = "0dd9bf93" }
-lightning-background-processor = { git = "https://github.com/get10101/rust-lightning/", rev = "0dd9bf93" }
-lightning-transaction-sync = { git = "https://github.com/get10101/rust-lightning/", rev = "0dd9bf93" }
-lightning-net-tokio = { git = "https://github.com/get10101/rust-lightning/", rev = "0dd9bf93" }
-lightning-persister = { git = "https://github.com/get10101/rust-lightning/", rev = "0dd9bf93" }
+lightning = { git = "https://github.com/get10101/rust-lightning/", rev = "5de4468d" }
+lightning-background-processor = { git = "https://github.com/get10101/rust-lightning/", rev = "5de4468d" }
+lightning-transaction-sync = { git = "https://github.com/get10101/rust-lightning/", rev = "5de4468d" }
+lightning-net-tokio = { git = "https://github.com/get10101/rust-lightning/", rev = "5de4468d" }
+lightning-persister = { git = "https://github.com/get10101/rust-lightning/", rev = "5de4468d" }
 rust-bitcoin-coin-selection = { git = "https://github.com/p2pderivatives/rust-bitcoin-coin-selection" }

--- a/crates/ln-dlc-node/Cargo.toml
+++ b/crates/ln-dlc-node/Cargo.toml
@@ -22,7 +22,7 @@ futures = "0.3"
 hex = "0.4"
 hkdf = "0.12"
 lightning = { version = "0.0.114", features = ["max_level_trace"] }
-lightning-background-processor = { version = "0.0.114" }
+lightning-background-processor = { version = "0.0.114", features = ["futures"] }
 lightning-invoice = { version = "0.22" }
 lightning-net-tokio = { version = "0.0.114" }
 lightning-persister = { version = "0.0.114" }


### PR DESCRIPTION
I had to backport a few fixes that are only in version 0.0.115 of `rust-lightning`, hence the upgraded `rust-lightning` dependency.