### PR TITLE
Revert "chore: Pin rust version to latest stable"

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,0 @@
-[toolchain]
-channel = "1.70"
-components = ["clippy", "rustfmt"]


### PR DESCRIPTION
This reverts commit db8a7c2bdaabdb5c08ad1c1ed2c095d95f58b650.

The pin unfortunately overrides my default toolchain from `1.70-aarch64-apple-darwin` to the x86 version of rust, which results into a linking issue when trying to start the coordinator on my machine.

```
1.70-x86_64-apple-darwin (overridden by '/Users/holzeis/workspace/coblox/10101/rust-toolchain.toml')
```

I did not find an easy way to make rust to use the aarch64 version for the pin. Happy to close this PR if somebody can make that work on a M1 mac.

cc: @bonomat: I guess you are running into the same issue?
