### PR TITLE
Revert channel lock patch on `rust-dlc` again

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -931,7 +931,7 @@ dependencies = [
 [[package]]
 name = "dlc"
 version = "0.4.0"
-source = "git+https://github.com/get10101/rust-dlc?rev=37a9265#37a9265913e1b2c34fe7c85ca595053f2b0a9533"
+source = "git+https://github.com/get10101/rust-dlc?rev=8fd4965#8fd49651f702c7a3d54c6fb462659db6872a954e"
 dependencies = [
  "autometrics 0.5.0",
  "bitcoin",
@@ -944,7 +944,7 @@ dependencies = [
 [[package]]
 name = "dlc-manager"
 version = "0.4.0"
-source = "git+https://github.com/get10101/rust-dlc?rev=37a9265#37a9265913e1b2c34fe7c85ca595053f2b0a9533"
+source = "git+https://github.com/get10101/rust-dlc?rev=8fd4965#8fd49651f702c7a3d54c6fb462659db6872a954e"
 dependencies = [
  "async-trait",
  "autometrics 0.5.0",
@@ -961,7 +961,7 @@ dependencies = [
 [[package]]
 name = "dlc-messages"
 version = "0.4.0"
-source = "git+https://github.com/get10101/rust-dlc?rev=37a9265#37a9265913e1b2c34fe7c85ca595053f2b0a9533"
+source = "git+https://github.com/get10101/rust-dlc?rev=8fd4965#8fd49651f702c7a3d54c6fb462659db6872a954e"
 dependencies = [
  "bitcoin",
  "dlc",
@@ -973,7 +973,7 @@ dependencies = [
 [[package]]
 name = "dlc-sled-storage-provider"
 version = "0.1.0"
-source = "git+https://github.com/get10101/rust-dlc?rev=37a9265#37a9265913e1b2c34fe7c85ca595053f2b0a9533"
+source = "git+https://github.com/get10101/rust-dlc?rev=8fd4965#8fd49651f702c7a3d54c6fb462659db6872a954e"
 dependencies = [
  "bitcoin",
  "dlc-manager",
@@ -986,7 +986,7 @@ dependencies = [
 [[package]]
 name = "dlc-trie"
 version = "0.4.0"
-source = "git+https://github.com/get10101/rust-dlc?rev=37a9265#37a9265913e1b2c34fe7c85ca595053f2b0a9533"
+source = "git+https://github.com/get10101/rust-dlc?rev=8fd4965#8fd49651f702c7a3d54c6fb462659db6872a954e"
 dependencies = [
  "bitcoin",
  "dlc",
@@ -1609,7 +1609,7 @@ dependencies = [
 [[package]]
 name = "lightning"
 version = "0.0.114"
-source = "git+https://github.com/get10101/rust-lightning/?rev=5de4468d#5de4468dafd785e8bfb288a3ec29719e4f87dd75"
+source = "git+https://github.com/get10101/rust-lightning/?rev=5aa1449c#5aa1449c63d084428c566587121940208bc7cb06"
 dependencies = [
  "bitcoin",
 ]
@@ -1617,7 +1617,7 @@ dependencies = [
 [[package]]
 name = "lightning-background-processor"
 version = "0.0.114"
-source = "git+https://github.com/get10101/rust-lightning/?rev=5de4468d#5de4468dafd785e8bfb288a3ec29719e4f87dd75"
+source = "git+https://github.com/get10101/rust-lightning/?rev=5aa1449c#5aa1449c63d084428c566587121940208bc7cb06"
 dependencies = [
  "bitcoin",
  "futures-util",
@@ -1641,7 +1641,7 @@ dependencies = [
 [[package]]
 name = "lightning-net-tokio"
 version = "0.0.114"
-source = "git+https://github.com/get10101/rust-lightning/?rev=5de4468d#5de4468dafd785e8bfb288a3ec29719e4f87dd75"
+source = "git+https://github.com/get10101/rust-lightning/?rev=5aa1449c#5aa1449c63d084428c566587121940208bc7cb06"
 dependencies = [
  "bitcoin",
  "lightning",
@@ -1651,7 +1651,7 @@ dependencies = [
 [[package]]
 name = "lightning-persister"
 version = "0.0.114"
-source = "git+https://github.com/get10101/rust-lightning/?rev=5de4468d#5de4468dafd785e8bfb288a3ec29719e4f87dd75"
+source = "git+https://github.com/get10101/rust-lightning/?rev=5aa1449c#5aa1449c63d084428c566587121940208bc7cb06"
 dependencies = [
  "bitcoin",
  "libc",
@@ -1662,7 +1662,7 @@ dependencies = [
 [[package]]
 name = "lightning-rapid-gossip-sync"
 version = "0.0.114"
-source = "git+https://github.com/get10101/rust-lightning/?rev=5de4468d#5de4468dafd785e8bfb288a3ec29719e4f87dd75"
+source = "git+https://github.com/get10101/rust-lightning/?rev=5aa1449c#5aa1449c63d084428c566587121940208bc7cb06"
 dependencies = [
  "bitcoin",
  "lightning",
@@ -1671,7 +1671,7 @@ dependencies = [
 [[package]]
 name = "lightning-transaction-sync"
 version = "0.0.114"
-source = "git+https://github.com/get10101/rust-lightning/?rev=5de4468d#5de4468dafd785e8bfb288a3ec29719e4f87dd75"
+source = "git+https://github.com/get10101/rust-lightning/?rev=5aa1449c#5aa1449c63d084428c566587121940208bc7cb06"
 dependencies = [
  "bdk-macros",
  "bitcoin",
@@ -2292,7 +2292,7 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 [[package]]
 name = "p2pd-oracle-client"
 version = "0.1.0"
-source = "git+https://github.com/get10101/rust-dlc?rev=37a9265#37a9265913e1b2c34fe7c85ca595053f2b0a9533"
+source = "git+https://github.com/get10101/rust-dlc?rev=8fd4965#8fd49651f702c7a3d54c6fb462659db6872a954e"
 dependencies = [
  "chrono",
  "dlc-manager",
@@ -3048,7 +3048,7 @@ dependencies = [
 [[package]]
 name = "simple-wallet"
 version = "0.1.0"
-source = "git+https://github.com/get10101/rust-dlc?rev=37a9265#37a9265913e1b2c34fe7c85ca595053f2b0a9533"
+source = "git+https://github.com/get10101/rust-dlc?rev=8fd4965#8fd49651f702c7a3d54c6fb462659db6872a954e"
 dependencies = [
  "bitcoin",
  "dlc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,16 +3,16 @@ members = ["coordinator", "maker", "mobile/native", "crates/*"]
 resolver = "2"
 
 [patch.crates-io]
-dlc-manager = { git = "https://github.com/get10101/rust-dlc", rev = "37a9265" }
-dlc-messages = { git = "https://github.com/get10101/rust-dlc", rev = "37a9265" }
-dlc = { git = "https://github.com/get10101/rust-dlc", rev = "37a9265" }
-dlc-sled-storage-provider = { git = "https://github.com/get10101/rust-dlc", rev = "37a9265" }
-p2pd-oracle-client = { git = "https://github.com/get10101/rust-dlc", rev = "37a9265" }
-dlc-trie = { git = "https://github.com/get10101/rust-dlc", rev = "37a9265" }
-simple-wallet = { git = "https://github.com/get10101/rust-dlc", rev = "37a9265" }
-lightning = { git = "https://github.com/get10101/rust-lightning/", rev = "5de4468d" }
-lightning-background-processor = { git = "https://github.com/get10101/rust-lightning/", rev = "5de4468d" }
-lightning-transaction-sync = { git = "https://github.com/get10101/rust-lightning/", rev = "5de4468d" }
-lightning-net-tokio = { git = "https://github.com/get10101/rust-lightning/", rev = "5de4468d" }
-lightning-persister = { git = "https://github.com/get10101/rust-lightning/", rev = "5de4468d" }
+dlc-manager = { git = "https://github.com/get10101/rust-dlc", rev = "8fd4965" }
+dlc-messages = { git = "https://github.com/get10101/rust-dlc", rev = "8fd4965" }
+dlc = { git = "https://github.com/get10101/rust-dlc", rev = "8fd4965" }
+dlc-sled-storage-provider = { git = "https://github.com/get10101/rust-dlc", rev = "8fd4965" }
+p2pd-oracle-client = { git = "https://github.com/get10101/rust-dlc", rev = "8fd4965" }
+dlc-trie = { git = "https://github.com/get10101/rust-dlc", rev = "8fd4965" }
+simple-wallet = { git = "https://github.com/get10101/rust-dlc", rev = "8fd4965" }
+lightning = { git = "https://github.com/get10101/rust-lightning/", rev = "5aa1449c" }
+lightning-background-processor = { git = "https://github.com/get10101/rust-lightning/", rev = "5aa1449c" }
+lightning-transaction-sync = { git = "https://github.com/get10101/rust-lightning/", rev = "5aa1449c" }
+lightning-net-tokio = { git = "https://github.com/get10101/rust-lightning/", rev = "5aa1449c" }
+lightning-persister = { git = "https://github.com/get10101/rust-lightning/", rev = "5aa1449c" }
 rust-bitcoin-coin-selection = { git = "https://github.com/p2pderivatives/rust-bitcoin-coin-selection" }

--- a/crates/ln-dlc-node/src/node/sub_channel_manager.rs
+++ b/crates/ln-dlc-node/src/node/sub_channel_manager.rs
@@ -1,4 +1,3 @@
-use crate::dlc_custom_signer::CustomSigner;
 use crate::fee_rate_estimator::FeeRateEstimator;
 use crate::ln_dlc_wallet::LnDlcWallet;
 use crate::node::channel_manager::ChannelManager;
@@ -20,7 +19,6 @@ pub type SubChannelManager = sub_channel_manager::SubChannelManager<
     Arc<SystemTimeProvider>,
     Arc<FeeRateEstimator>,
     Arc<DlcManager>,
-    CustomSigner,
 >;
 
 #[autometrics]


### PR DESCRIPTION
This update should only remove the functionality related to https://github.com/get10101/rust-dlc/commit/d7c1ec5 and https://github.com/get10101/rust-lightning/commit/cb1c096e.

This should ideally be a temporary revert. We at least want to verify that this helps with https://github.com/get10101/10101/issues/692.