### PR TITLE
Add coordinator load test via `ln-dlc-node`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -891,7 +891,7 @@ dependencies = [
 [[package]]
 name = "dlc"
 version = "0.4.0"
-source = "git+https://github.com/get10101/rust-dlc?rev=124534f#124534ff77b63065ba5826826276826f0d4a7434"
+source = "git+https://github.com/get10101/rust-dlc?rev=a207cff#a207cff4061b3b1322e45fc2a690da1bf891306f"
 dependencies = [
  "autometrics",
  "bitcoin",
@@ -904,7 +904,7 @@ dependencies = [
 [[package]]
 name = "dlc-manager"
 version = "0.4.0"
-source = "git+https://github.com/get10101/rust-dlc?rev=124534f#124534ff77b63065ba5826826276826f0d4a7434"
+source = "git+https://github.com/get10101/rust-dlc?rev=a207cff#a207cff4061b3b1322e45fc2a690da1bf891306f"
 dependencies = [
  "async-trait",
  "autometrics",
@@ -921,7 +921,7 @@ dependencies = [
 [[package]]
 name = "dlc-messages"
 version = "0.4.0"
-source = "git+https://github.com/get10101/rust-dlc?rev=124534f#124534ff77b63065ba5826826276826f0d4a7434"
+source = "git+https://github.com/get10101/rust-dlc?rev=a207cff#a207cff4061b3b1322e45fc2a690da1bf891306f"
 dependencies = [
  "bitcoin",
  "dlc",
@@ -933,7 +933,7 @@ dependencies = [
 [[package]]
 name = "dlc-sled-storage-provider"
 version = "0.1.0"
-source = "git+https://github.com/get10101/rust-dlc?rev=124534f#124534ff77b63065ba5826826276826f0d4a7434"
+source = "git+https://github.com/get10101/rust-dlc?rev=a207cff#a207cff4061b3b1322e45fc2a690da1bf891306f"
 dependencies = [
  "bitcoin",
  "dlc-manager",
@@ -946,7 +946,7 @@ dependencies = [
 [[package]]
 name = "dlc-trie"
 version = "0.4.0"
-source = "git+https://github.com/get10101/rust-dlc?rev=124534f#124534ff77b63065ba5826826276826f0d4a7434"
+source = "git+https://github.com/get10101/rust-dlc?rev=a207cff#a207cff4061b3b1322e45fc2a690da1bf891306f"
 dependencies = [
  "bitcoin",
  "dlc",
@@ -2268,7 +2268,7 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 [[package]]
 name = "p2pd-oracle-client"
 version = "0.1.0"
-source = "git+https://github.com/get10101/rust-dlc?rev=124534f#124534ff77b63065ba5826826276826f0d4a7434"
+source = "git+https://github.com/get10101/rust-dlc?rev=a207cff#a207cff4061b3b1322e45fc2a690da1bf891306f"
 dependencies = [
  "chrono",
  "dlc-manager",
@@ -3060,7 +3060,7 @@ dependencies = [
 [[package]]
 name = "simple-wallet"
 version = "0.1.0"
-source = "git+https://github.com/get10101/rust-dlc?rev=124534f#124534ff77b63065ba5826826276826f0d4a7434"
+source = "git+https://github.com/get10101/rust-dlc?rev=a207cff#a207cff4061b3b1322e45fc2a690da1bf891306f"
 dependencies = [
  "bitcoin",
  "dlc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1710,6 +1710,7 @@ dependencies = [
  "tracing-log",
  "tracing-subscriber",
  "ureq",
+ "uuid",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,13 +3,13 @@ members = ["coordinator", "maker", "mobile/native", "crates/*"]
 resolver = "2"
 
 [patch.crates-io]
-dlc-manager = { git = "https://github.com/get10101/rust-dlc", rev = "124534f" }
-dlc-messages = { git = "https://github.com/get10101/rust-dlc", rev = "124534f" }
-dlc = { git = "https://github.com/get10101/rust-dlc", rev = "124534f" }
-dlc-sled-storage-provider = { git = "https://github.com/get10101/rust-dlc", rev = "124534f" }
-p2pd-oracle-client = { git = "https://github.com/get10101/rust-dlc", rev = "124534f" }
-dlc-trie = { git = "https://github.com/get10101/rust-dlc", rev = "124534f" }
-simple-wallet = { git = "https://github.com/get10101/rust-dlc", rev = "124534f" }
+dlc-manager = { git = "https://github.com/get10101/rust-dlc", rev = "a207cff" }
+dlc-messages = { git = "https://github.com/get10101/rust-dlc", rev = "a207cff" }
+dlc = { git = "https://github.com/get10101/rust-dlc", rev = "a207cff" }
+dlc-sled-storage-provider = { git = "https://github.com/get10101/rust-dlc", rev = "a207cff" }
+p2pd-oracle-client = { git = "https://github.com/get10101/rust-dlc", rev = "a207cff" }
+dlc-trie = { git = "https://github.com/get10101/rust-dlc", rev = "a207cff" }
+simple-wallet = { git = "https://github.com/get10101/rust-dlc", rev = "a207cff" }
 lightning = { git = "https://github.com/get10101/rust-lightning/", rev = "29703c9e" }
 lightning-background-processor = { git = "https://github.com/get10101/rust-lightning/", rev = "29703c9e" }
 lightning-transaction-sync = { git = "https://github.com/get10101/rust-lightning/", rev = "29703c9e" }

--- a/crates/ln-dlc-node/Cargo.toml
+++ b/crates/ln-dlc-node/Cargo.toml
@@ -47,4 +47,9 @@ ureq = "2.5.0"
 clap = { version = "4", features = ["derive"] }
 local-ip-address = "0.5.1"
 rust_decimal = "1"
+time = { version = "0.3", features = ["serde"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+uuid = { version = "1.3.0", features = ["v4", "serde"] }
+
+[features]
+load_tests = []

--- a/crates/ln-dlc-node/examples/fund.rs
+++ b/crates/ln-dlc-node/examples/fund.rs
@@ -1,4 +1,3 @@
-extern crate ln_dlc_node;
 use anyhow::bail;
 use anyhow::Context;
 use anyhow::Result;

--- a/crates/ln-dlc-node/src/tests/dlc/create.rs
+++ b/crates/ln-dlc-node/src/tests/dlc/create.rs
@@ -73,7 +73,7 @@ pub async fn create_dlc_channel(
     app.propose_dlc_channel(channel_details.clone(), contract_input)
         .await?;
 
-    // Processs the app's offer to close the channel
+    // Process the app's offer to open the channel
     tokio::time::sleep(Duration::from_secs(2)).await;
     coordinator.process_incoming_messages()?;
 

--- a/crates/ln-dlc-node/src/tests/load.rs
+++ b/crates/ln-dlc-node/src/tests/load.rs
@@ -1,0 +1,208 @@
+use crate::ln::app_config;
+use crate::node::Node;
+use crate::node::NodeInfo;
+use crate::node::PaymentMap;
+use crate::tests::init_tracing;
+use crate::tests::wait_until;
+use anyhow::Result;
+use coordinator::Coordinator;
+use coordinator::Direction;
+use dlc_manager::subchannel::SubChannelState;
+use dlc_manager::Storage;
+use std::borrow::Borrow;
+use std::sync::Arc;
+use std::time::Duration;
+
+mod coordinator;
+
+const ESPLORA_ORIGIN_PUBLIC_REGTEST: &str = "http://35.189.57.114:3000";
+
+#[tokio::test]
+async fn single_app_many_positions_load() {
+    init_tracing();
+
+    let coordinator = Coordinator::new_public_regtest();
+    let app = Arc::new(
+        Node::start_test(
+            "app",
+            app_config(),
+            ESPLORA_ORIGIN_PUBLIC_REGTEST.to_string(),
+        )
+        .unwrap(),
+    );
+
+    tokio::spawn({
+        let app = app.clone();
+        let coordinator_info = coordinator.info();
+        async move { keep_connected(app, coordinator_info).await }
+    });
+
+    tokio::time::sleep(Duration::from_secs(5)).await;
+
+    // Operating the bitcoin node remotely is too much of a hassle. Just prepare the environment
+    // before running this test
+    coordinator
+        .open_channel(&app, 200_000, 100_000)
+        .await
+        .unwrap();
+
+    for n in 1..100 {
+        tracing::info!(%n, "Starting iteration");
+
+        open_position(&coordinator, &app).await.unwrap();
+        close_position(&coordinator, &app).await.unwrap();
+
+        tracing::info!(%n, "Finished iteration");
+    }
+}
+
+async fn open_position(coordinator: &Coordinator, app: &Node<PaymentMap>) -> Result<()> {
+    tracing::info!("Opening position");
+
+    loop {
+        tracing::info!("Sending open pre-proposal");
+
+        if coordinator.post_trade(app, Direction::Long).await.is_ok() {
+            break;
+        }
+
+        tokio::time::sleep(Duration::from_millis(500)).await;
+    }
+
+    tracing::info!("Open pre-proposal delivered");
+
+    let channel_id = wait_until(Duration::from_secs(60), || async {
+        tracing::info!("Waiting for DLC channel proposal");
+
+        app.process_incoming_messages()?;
+
+        let dlc_channel = app
+            .dlc_manager
+            .get_store()
+            .get_sub_channels()?
+            .first()
+            .cloned();
+
+        Ok(match dlc_channel {
+            Some(dlc_channel) if matches!(dlc_channel.state, SubChannelState::Offered(_)) => {
+                Some(dlc_channel.channel_id)
+            }
+            _ => None,
+        })
+    })
+    .await?;
+
+    app.accept_dlc_channel_offer(&channel_id)?;
+
+    wait_until(Duration::from_secs(60), || async {
+        tracing::info!("Waiting for Signed state");
+
+        app.process_incoming_messages()?;
+
+        let dlc_channel = app
+            .dlc_manager
+            .get_store()
+            .get_sub_channels()?
+            .into_iter()
+            .find(|sc| sc.channel_id == channel_id)
+            .unwrap();
+
+        Ok(matches!(dlc_channel.state, SubChannelState::Signed(_)).then_some(()))
+    })
+    .await?;
+
+    tracing::info!("Position open");
+
+    Ok(())
+}
+
+async fn close_position(coordinator: &Coordinator, app: &Node<PaymentMap>) -> Result<()> {
+    tracing::info!("Closing position");
+
+    loop {
+        tracing::info!("Sending close pre-proposal");
+
+        if coordinator.post_trade(app, Direction::Short).await.is_ok() {
+            break;
+        }
+
+        tokio::time::sleep(Duration::from_millis(500)).await;
+    }
+
+    tracing::info!("Close pre-proposal delivered");
+
+    let channel_id = wait_until(Duration::from_secs(60), || async {
+        tracing::info!("Waiting for DLC channel close proposal");
+
+        // Process confirm message and send finalize message
+        app.process_incoming_messages()?;
+
+        let dlc_channel = app
+            .dlc_manager
+            .get_store()
+            .get_sub_channels()?
+            .first()
+            .cloned();
+
+        Ok(match dlc_channel {
+            Some(dlc_channel) if matches!(dlc_channel.state, SubChannelState::CloseOffered(_)) => {
+                Some(dlc_channel.channel_id)
+            }
+            _ => None,
+        })
+    })
+    .await?;
+
+    app.accept_dlc_channel_collaborative_settlement(&channel_id)
+        .unwrap();
+
+    wait_until(Duration::from_secs(60), || async {
+        tracing::info!("Waiting for OffChainClosed state");
+
+        // Process confirm message and send finalize message
+        app.process_incoming_messages()?;
+
+        let dlc_channel = app
+            .dlc_manager
+            .get_store()
+            .get_sub_channels()?
+            .into_iter()
+            .find(|sc| sc.channel_id == channel_id)
+            .unwrap();
+
+        Ok(matches!(dlc_channel.state, SubChannelState::OffChainClosed).then_some(()))
+    })
+    .await?;
+
+    tracing::info!("Position closed");
+
+    Ok(())
+}
+
+async fn keep_connected(node: impl Borrow<Node<PaymentMap>>, peer: NodeInfo) {
+    let reconnect_interval = Duration::from_secs(1);
+    loop {
+        let connection_closed_future = match node.borrow().connect(peer).await {
+            Ok(fut) => fut,
+            Err(e) => {
+                tracing::warn!(
+                    %peer,
+                    ?reconnect_interval,
+                    "Connection failed: {e:#}; reconnecting"
+                );
+
+                tokio::time::sleep(reconnect_interval).await;
+                continue;
+            }
+        };
+
+        connection_closed_future.await;
+        tracing::debug!(
+            %peer,
+            ?reconnect_interval,
+            "Connection lost; reconnecting"
+        );
+
+        tokio::time::sleep(reconnect_interval).await;
+    }
+}

--- a/crates/ln-dlc-node/src/tests/load/coordinator.rs
+++ b/crates/ln-dlc-node/src/tests/load/coordinator.rs
@@ -1,0 +1,204 @@
+use crate::node::Node;
+use crate::node::NodeInfo;
+use crate::node::PaymentMap;
+use anyhow::bail;
+use anyhow::Result;
+use bitcoin::secp256k1::PublicKey;
+use bitcoin::XOnlyPublicKey;
+use reqwest::Response;
+use rust_decimal::prelude::FromPrimitive;
+use rust_decimal::Decimal;
+use serde::Serialize;
+use std::net::SocketAddr;
+use std::time::Duration;
+use time::ext::NumericalDuration;
+use time::OffsetDateTime;
+use uuid::Uuid;
+
+/// A 10101 test coordinator.
+pub struct Coordinator {
+    http_endpoint: SocketAddr,
+    pubkey: PublicKey,
+    p2p_address: SocketAddr,
+}
+
+#[derive(Serialize)]
+pub enum Direction {
+    Long,
+    Short,
+}
+
+impl Coordinator {
+    pub fn new(http_endpoint: &str, pubkey: &str, p2p_address: &str) -> Result<Self> {
+        Ok(Coordinator {
+            http_endpoint: http_endpoint.parse()?,
+            pubkey: pubkey.parse()?,
+            p2p_address: p2p_address.parse()?,
+        })
+    }
+
+    pub fn new_public_regtest() -> Self {
+        const HTTP_ENDPOINT: &str = "35.189.57.114:80";
+        const PK: &str = "03507b924dae6595cfb78492489978127c5f1e3877848564de2015cd6d41375802";
+        const P2P_ADDRESS: &str = "35.189.57.114:9045";
+
+        Self::new(HTTP_ENDPOINT, PK, P2P_ADDRESS).expect("correct coordinator parameters")
+    }
+
+    pub fn info(&self) -> NodeInfo {
+        NodeInfo {
+            pubkey: self.pubkey,
+            address: self.p2p_address,
+        }
+    }
+
+    /// Instruct the 10101 coordinator node to open a private channel with the app node.
+    ///
+    /// Assumes that the app node is already connected to the coordinator.
+    pub async fn open_channel(
+        &self,
+        app: &Node<PaymentMap>,
+        coordinator_balance: u64,
+        app_balance: u64,
+    ) -> Result<()> {
+        #[derive(Serialize)]
+        struct OpenChannelRequest {
+            target: TargetInfo,
+            local_balance: u64,
+            remote_balance: u64,
+            is_public: bool,
+        }
+
+        #[derive(Serialize)]
+        struct TargetInfo {
+            pubkey: PublicKey,
+        }
+
+        tracing::info!(
+            coordinator = ?self.info(),
+            app = ?app.info,
+            %coordinator_balance,
+            %app_balance,
+            "Opening channel between coordinator and target node",
+        );
+
+        self.post(
+            "api/channels",
+            &OpenChannelRequest {
+                target: TargetInfo {
+                    pubkey: app.info.pubkey,
+                },
+                local_balance: coordinator_balance,
+                remote_balance: app_balance,
+                is_public: false,
+            },
+        )
+        .await?;
+
+        tokio::time::timeout(Duration::from_secs(60), async {
+            loop {
+                if app.list_channels().iter().any(|channel| {
+                    channel.is_channel_ready && channel.counterparty.node_id == self.info().pubkey
+                }) {
+                    break;
+                }
+
+                tracing::debug!("Waiting for channel to be usable");
+                tokio::time::sleep(Duration::from_millis(500)).await;
+            }
+
+            anyhow::Ok(())
+        })
+        .await??;
+
+        tracing::info!(
+            coordinator = ?self.info(),
+            app = ?app.info,
+            "Channel open between coordinator and app",
+        );
+
+        Ok(())
+    }
+
+    pub async fn post_trade(&self, app: &Node<PaymentMap>, direction: Direction) -> Result<()> {
+        #[derive(Serialize)]
+        pub struct TradeParams {
+            pub pubkey: PublicKey,
+            pub contract_symbol: String,
+            pub leverage: f32,
+            pub quantity: f32,
+            pub direction: Direction,
+            pub filled_with: FilledWith,
+        }
+
+        #[derive(Serialize)]
+        pub struct FilledWith {
+            pub order_id: Uuid,
+            pub expiry_timestamp: OffsetDateTime,
+            pub oracle_pk: XOnlyPublicKey,
+            pub matches: Vec<Match>,
+        }
+
+        #[derive(Serialize)]
+        pub struct Match {
+            pub order_id: Uuid,
+            pub quantity: Decimal,
+            pub pubkey: PublicKey,
+            pub execution_price: Decimal,
+        }
+
+        let order_id = Uuid::new_v4();
+        let expiry_timestamp = OffsetDateTime::now_utc() + 1.days();
+        let quantity = 20.0;
+
+        let trade_params = TradeParams {
+            pubkey: app.info.pubkey,
+            contract_symbol: "BtcUsd".to_string(),
+            leverage: 2.0,
+            quantity,
+            direction,
+            filled_with: FilledWith {
+                order_id,
+                expiry_timestamp,
+                oracle_pk: app.oracle_pk(),
+                matches: vec![Match {
+                    order_id: Uuid::new_v4(),
+                    quantity: Decimal::from_f32(quantity).unwrap(),
+                    pubkey: self.info().pubkey, // should be the maker's one, but there is no maker
+                    execution_price: Decimal::from(30_000),
+                }],
+            },
+        };
+
+        self.post("api/trade", &trade_params).await?;
+
+        tracing::info!("Sent trade request to coordinator successfully");
+
+        Ok(())
+    }
+
+    async fn post<B>(&self, path: &str, json: &B) -> Result<Response>
+    where
+        B: Serialize,
+    {
+        let client = reqwest::Client::new();
+        let response = client
+            .post(format!("http://{}/{path}", self.http_endpoint))
+            .json(json)
+            .send()
+            .await?;
+
+        if !response.status().is_success() {
+            let response_text = match response.text().await {
+                Ok(text) => text,
+                Err(err) => {
+                    format!("could not decode response {err:#}")
+                }
+            };
+
+            bail!(response_text)
+        }
+
+        Ok(response)
+    }
+}

--- a/crates/ln-dlc-node/src/tests/mod.rs
+++ b/crates/ln-dlc-node/src/tests/mod.rs
@@ -45,6 +45,9 @@ mod multi_hop_payment;
 mod onboard_from_lnd;
 mod single_hop_payment;
 
+#[cfg(feature = "load_tests")]
+mod load;
+
 const ESPLORA_ORIGIN: &str = "http://localhost:3000";
 const FAUCET_ORIGIN: &str = "http://localhost:8080";
 
@@ -63,14 +66,14 @@ fn init_tracing() {
 
 impl Node<PaymentMap> {
     fn start_test_app(name: &str) -> Result<Self> {
-        Self::start_test(name, app_config())
+        Self::start_test(name, app_config(), ESPLORA_ORIGIN.to_string())
     }
 
     fn start_test_coordinator(name: &str) -> Result<Self> {
-        Self::start_test(name, coordinator_config())
+        Self::start_test(name, coordinator_config(), ESPLORA_ORIGIN.to_string())
     }
 
-    fn start_test(name: &str, user_config: UserConfig) -> Result<Self> {
+    fn start_test(name: &str, user_config: UserConfig, esplora_origin: String) -> Result<Self> {
         let data_dir = random_tmp_dir().join(name);
 
         let seed = Bip39Seed::new().expect("A valid bip39 seed");
@@ -91,7 +94,7 @@ impl Node<PaymentMap> {
             address,
             address,
             vec![util::build_net_address(address.ip(), address.port())],
-            ESPLORA_ORIGIN.to_string(),
+            esplora_origin,
             seed,
             ephemeral_randomness,
             user_config,


### PR DESCRIPTION
The motivation to add this test is to check that a hosted coordinator is able to trade repeatedly with an app. In this case we simply
simulate the app rather than using the `mobile/native` crate.

Notably, we have to interact with the coordinator's HTTP API. To do so we have to pretend like we got a match from the orderbook. We could involve the orderbook too, but it isn't strictly necessary at this stage.

The test in its current state is much slower than it needs to be. We should work towards replacing the hard-coded sleeps with calls to `wait_until`, wherever possible.

We've added a `load_tests` flag because we probably should refrain from running this type of test as frequently as the rest of the
`ln-dlc-node` tests. Currently it relies on the public regtest `coordinator` being up an running, and sufficiently funded. Eventually
we might want to run this kind of test, for example, before every release.