### PR TITLE
chore: Allow specifying interval for tokio metrics

### DIFF
--- a/coordinator/src/bin/coordinator.rs
+++ b/coordinator/src/bin/coordinator.rs
@@ -98,12 +98,11 @@ async fn main() -> Result<()> {
     let node = Node::new(node, pool.clone());
     node.update_settings(settings.as_node_settings()).await;
 
-    if opts.tokio_metrics {
+    // TODO: Pass the tokio metrics into Prometheus
+    if let Some(interval) = opts.tokio_metrics_interval_seconds {
         let handle = tokio::runtime::Handle::current();
         let runtime_monitor = tokio_metrics::RuntimeMonitor::new(&handle);
-        // TODO: Pass the tokio metrics into Prometheus
-        // print runtime metrics every 1s
-        let frequency = std::time::Duration::from_secs(1);
+        let frequency = Duration::from_secs(interval);
         tokio::spawn(async move {
             for metrics in runtime_monitor.intervals() {
                 tracing::debug!(?metrics, "tokio metrics");

--- a/coordinator/src/cli.rs
+++ b/coordinator/src/cli.rs
@@ -47,9 +47,9 @@ pub struct Opts {
     #[clap(long)]
     pub tokio_console: bool,
 
-    /// If enabled, tokio metrics will be enabled
+    /// If specified, metrics will be printed at the given interval
     #[clap(long)]
-    pub tokio_metrics: bool,
+    pub tokio_metrics_interval_seconds: Option<u64>,
 }
 
 #[derive(Debug, Clone, Copy, clap::ValueEnum)]


### PR DESCRIPTION
Instead of a boolean flag, turn the feature on when specifying print interval.

This prevents log spam and is more flexible.