### PR TITLE
Actually assert on DLC channel state in tests

### DIFF
--- a/crates/ln-dlc-node/src/tests/dlc/collaborative_settlement.rs
+++ b/crates/ln-dlc-node/src/tests/dlc/collaborative_settlement.rs
@@ -96,10 +96,10 @@ async fn dlc_collaborative_settlement(
         .find(|sc| sc.channel_id == sub_channel.channel_id)
         .context("No DLC channel for coordinator")?;
 
-    matches!(
+    assert!(matches!(
         sub_channel_coordinator.state,
         SubChannelState::OffChainClosed
-    );
+    ));
 
     let sub_channel_app = app
         .dlc_manager
@@ -112,7 +112,10 @@ async fn dlc_collaborative_settlement(
     let app_balance_after = app.get_ldk_balance().available;
     let coordinator_balance_after = coordinator.get_ldk_balance().available;
 
-    matches!(sub_channel_app.state, SubChannelState::OffChainClosed);
+    assert!(matches!(
+        sub_channel_app.state,
+        SubChannelState::OffChainClosed
+    ));
 
     assert_eq!(
         app_balance_channel_creation + coordinator_loss_amount,
@@ -207,7 +210,10 @@ async fn open_dlc_channel_after_closing_dlc_channel() {
         .context("No DLC channel for coordinator")
         .unwrap();
 
-    matches!(sub_channel_coordinator.state, SubChannelState::Signed(_));
+    assert!(matches!(
+        sub_channel_coordinator.state,
+        SubChannelState::Signed(_)
+    ));
 
     let sub_channel_app = app
         .dlc_manager
@@ -219,5 +225,5 @@ async fn open_dlc_channel_after_closing_dlc_channel() {
         .context("No DLC channel for app")
         .unwrap();
 
-    matches!(sub_channel_app.state, SubChannelState::Signed(_));
+    assert!(matches!(sub_channel_app.state, SubChannelState::Signed(_)));
 }

--- a/crates/ln-dlc-node/src/tests/dlc/create.rs
+++ b/crates/ln-dlc-node/src/tests/dlc/create.rs
@@ -115,7 +115,10 @@ pub async fn create_dlc_channel(
         .find(|sc| sc.channel_id == sub_channel.channel_id)
         .context("No DLC channel for coordinator")?;
 
-    matches!(sub_channel_coordinator.state, SubChannelState::Signed(_));
+    assert!(matches!(
+        sub_channel_coordinator.state,
+        SubChannelState::Signed(_)
+    ));
 
     let sub_channel_app = app
         .dlc_manager
@@ -125,7 +128,7 @@ pub async fn create_dlc_channel(
         .find(|sc| sc.channel_id == sub_channel.channel_id)
         .context("No DLC channel for app")?;
 
-    matches!(sub_channel_app.state, SubChannelState::Signed(_));
+    assert!(matches!(sub_channel_app.state, SubChannelState::Signed(_)));
 
     Ok(DlcChannelCreated {
         coordinator,

--- a/crates/ln-dlc-node/src/tests/dlc/dlc_setup_with_reconnects.rs
+++ b/crates/ln-dlc-node/src/tests/dlc/dlc_setup_with_reconnects.rs
@@ -113,7 +113,10 @@ async fn reconnecting_during_dlc_channel_setup() {
         .find(|sc| sc.channel_id == sub_channel.channel_id)
         .unwrap();
 
-    matches!(sub_channel_coordinator.state, SubChannelState::Signed(_));
+    assert!(matches!(
+        sub_channel_coordinator.state,
+        SubChannelState::Signed(_)
+    ));
 
     let sub_channel_app = app
         .dlc_manager
@@ -124,5 +127,5 @@ async fn reconnecting_during_dlc_channel_setup() {
         .find(|sc| sc.channel_id == sub_channel.channel_id)
         .unwrap();
 
-    matches!(sub_channel_app.state, SubChannelState::Signed(_));
+    assert!(matches!(sub_channel_app.state, SubChannelState::Signed(_)));
 }


### PR DESCRIPTION
We somehow forgot to assert on the value returned by the `matches!` macro :facepalm: