### PR TITLE
Add background task to report deadlocks

### DIFF
--- a/crates/ln-dlc-node/src/node/mod.rs
+++ b/crates/ln-dlc-node/src/node/mod.rs
@@ -631,6 +631,25 @@ where
             address: announcement_address,
         };
 
+        // Create a background task which checks for deadlocks
+        tokio::spawn(async move {
+            loop {
+                let deadlocks = spawn_blocking(parking_lot::deadlock::check_deadlock)
+                    .await
+                    .expect("task to complete");
+
+                for (i, threads) in deadlocks.iter().enumerate() {
+                    tracing::error!(%i, "Deadlock detected");
+                    for t in threads {
+                        tracing::error!(thread_id = %t.thread_id());
+                        tracing::error!("{:#?}", t.backtrace());
+                    }
+                }
+
+                tokio::time::sleep(Duration::from_secs(10)).await;
+            }
+        });
+
         tracing::info!("Lightning node started with node ID {}", node_info);
 
         Ok(Self {


### PR DESCRIPTION
From the `parking_lot` documentation it looks like we need to add something like this to know what deadlocks have been detected.