### PR TITLE
Build `rust-lightning` with `backtrace` flag

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -4,6 +4,8 @@
 rustflags = [
   "--cfg",
   "tokio_unstable",
+  "--cfg",
+  "backtrace",
   "-Wclippy::disallowed_methods",
   "-Wclippy::dbg_macro",
   "-Wclippy::print_stderr",
@@ -17,6 +19,8 @@ rustflags = [
 rustflags = [
   "--cfg",
   "tokio_unstable",
+  "--cfg",
+  "backtrace",
   "-Wclippy::disallowed_methods",
   "-Wclippy::dbg_macro",
   "-Wclippy::print_stderr",

--- a/crates/ln-dlc-node/src/node/payment_persister.rs
+++ b/crates/ln-dlc-node/src/node/payment_persister.rs
@@ -59,7 +59,7 @@ impl PaymentPersister for PaymentMap {
     ) -> Result<()> {
         let mut payments = self.lock();
         match payments.get_mut(payment_hash) {
-            Some(mut payment) => {
+            Some(payment) => {
                 payment.status = htlc_status;
 
                 if let amt_msat @ MillisatAmount(Some(_)) = amt_msat {

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.70"
+channel = "nightly"
 components = ["clippy", "rustfmt"]


### PR DESCRIPTION
We are temporarily activating this by default to investigate a deadlock.

We have to use a `nightly` toolchain to be able to use this flag.