### PR TITLE
Release version 1.0.19

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.19] - 2023-06-12
+
 - Fixed a deadlock bug, resulting in the coordinator getting stuck
 - Upgrade our fork to rust-lightning 114
 - Added force closing a dlc channel feature
@@ -31,7 +33,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Self-Custodial CFD Trading based on DLC and lightning
 
-[Unreleased]: https://github.com/get10101/10101/compare/1.0.18...HEAD
+[Unreleased]: https://github.com/get10101/10101/compare/1.0.19...HEAD
+[1.0.19]: https://github.com/get10101/10101/compare/1.0.18...1.0.19
 [1.0.18]: https://github.com/get10101/10101/compare/1.0.17...1.0.18
 [1.0.17]: https://github.com/get10101/10101/compare/1.0.16...1.0.17
 [1.0.16]: https://github.com/get10101/10101/compare/1.0.15...1.0.16

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -1,7 +1,7 @@
 name: get_10101
 description: 10101 combines the power of a self-custodial on-chain and off-chain wallet with the vast world of trading.
 publish_to: none
-version: 1.0.18
+version: 1.0.19
 environment:
   sdk: ">=2.17.5 <3.0.0"
 dependencies:


### PR DESCRIPTION
Hi @holzeis!
This PR was created in response to a manual trigger of the release workflow here: https://github.com/get10101/10101/actions/runs/5242436099.
I've bumped the versions in the manifest files in this commit: d983a8af8076410cc3b366329c3e2c7ae731e114.
Merging this PR will create a GitHub release!