### PR TITLE
Stabilise key dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -891,7 +891,7 @@ dependencies = [
 [[package]]
 name = "dlc"
 version = "0.4.0"
-source = "git+https://github.com/get10101/rust-dlc?rev=709a363#709a363a75104fa9b6e369b54750be14a3023820"
+source = "git+https://github.com/get10101/rust-dlc?rev=3b277dc#3b277dcd7d573eac615fe2cecf0325c45413bcb9"
 dependencies = [
  "bitcoin",
  "miniscript 8.0.0",
@@ -903,7 +903,7 @@ dependencies = [
 [[package]]
 name = "dlc-manager"
 version = "0.4.0"
-source = "git+https://github.com/get10101/rust-dlc?rev=709a363#709a363a75104fa9b6e369b54750be14a3023820"
+source = "git+https://github.com/get10101/rust-dlc?rev=3b277dc#3b277dcd7d573eac615fe2cecf0325c45413bcb9"
 dependencies = [
  "async-trait",
  "bitcoin",
@@ -919,7 +919,7 @@ dependencies = [
 [[package]]
 name = "dlc-messages"
 version = "0.4.0"
-source = "git+https://github.com/get10101/rust-dlc?rev=709a363#709a363a75104fa9b6e369b54750be14a3023820"
+source = "git+https://github.com/get10101/rust-dlc?rev=3b277dc#3b277dcd7d573eac615fe2cecf0325c45413bcb9"
 dependencies = [
  "bitcoin",
  "dlc",
@@ -931,11 +931,12 @@ dependencies = [
 [[package]]
 name = "dlc-sled-storage-provider"
 version = "0.1.0"
-source = "git+https://github.com/get10101/rust-dlc?rev=709a363#709a363a75104fa9b6e369b54750be14a3023820"
+source = "git+https://github.com/get10101/rust-dlc?rev=3b277dc#3b277dcd7d573eac615fe2cecf0325c45413bcb9"
 dependencies = [
  "bitcoin",
  "dlc-manager",
  "lightning",
+ "log",
  "secp256k1-zkp",
  "simple-wallet",
  "sled",
@@ -944,7 +945,7 @@ dependencies = [
 [[package]]
 name = "dlc-trie"
 version = "0.4.0"
-source = "git+https://github.com/get10101/rust-dlc?rev=709a363#709a363a75104fa9b6e369b54750be14a3023820"
+source = "git+https://github.com/get10101/rust-dlc?rev=3b277dc#3b277dcd7d573eac615fe2cecf0325c45413bcb9"
 dependencies = [
  "bitcoin",
  "dlc",
@@ -2265,7 +2266,7 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 [[package]]
 name = "p2pd-oracle-client"
 version = "0.1.0"
-source = "git+https://github.com/get10101/rust-dlc?rev=709a363#709a363a75104fa9b6e369b54750be14a3023820"
+source = "git+https://github.com/get10101/rust-dlc?rev=3b277dc#3b277dcd7d573eac615fe2cecf0325c45413bcb9"
 dependencies = [
  "chrono",
  "dlc-manager",
@@ -3057,7 +3058,7 @@ dependencies = [
 [[package]]
 name = "simple-wallet"
 version = "0.1.0"
-source = "git+https://github.com/get10101/rust-dlc?rev=709a363#709a363a75104fa9b6e369b54750be14a3023820"
+source = "git+https://github.com/get10101/rust-dlc?rev=3b277dc#3b277dcd7d573eac615fe2cecf0325c45413bcb9"
 dependencies = [
  "bitcoin",
  "dlc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -891,9 +891,8 @@ dependencies = [
 [[package]]
 name = "dlc"
 version = "0.4.0"
-source = "git+https://github.com/get10101/rust-dlc?rev=2322288#2322288bc4b528be2ef2faada772b34cdce5af08"
+source = "git+https://github.com/get10101/rust-dlc?rev=709a363#709a363a75104fa9b6e369b54750be14a3023820"
 dependencies = [
- "autometrics",
  "bitcoin",
  "miniscript 8.0.0",
  "secp256k1-sys",
@@ -904,10 +903,9 @@ dependencies = [
 [[package]]
 name = "dlc-manager"
 version = "0.4.0"
-source = "git+https://github.com/get10101/rust-dlc?rev=2322288#2322288bc4b528be2ef2faada772b34cdce5af08"
+source = "git+https://github.com/get10101/rust-dlc?rev=709a363#709a363a75104fa9b6e369b54750be14a3023820"
 dependencies = [
  "async-trait",
- "autometrics",
  "bitcoin",
  "dlc",
  "dlc-messages",
@@ -921,7 +919,7 @@ dependencies = [
 [[package]]
 name = "dlc-messages"
 version = "0.4.0"
-source = "git+https://github.com/get10101/rust-dlc?rev=2322288#2322288bc4b528be2ef2faada772b34cdce5af08"
+source = "git+https://github.com/get10101/rust-dlc?rev=709a363#709a363a75104fa9b6e369b54750be14a3023820"
 dependencies = [
  "bitcoin",
  "dlc",
@@ -933,7 +931,7 @@ dependencies = [
 [[package]]
 name = "dlc-sled-storage-provider"
 version = "0.1.0"
-source = "git+https://github.com/get10101/rust-dlc?rev=2322288#2322288bc4b528be2ef2faada772b34cdce5af08"
+source = "git+https://github.com/get10101/rust-dlc?rev=709a363#709a363a75104fa9b6e369b54750be14a3023820"
 dependencies = [
  "bitcoin",
  "dlc-manager",
@@ -946,7 +944,7 @@ dependencies = [
 [[package]]
 name = "dlc-trie"
 version = "0.4.0"
-source = "git+https://github.com/get10101/rust-dlc?rev=2322288#2322288bc4b528be2ef2faada772b34cdce5af08"
+source = "git+https://github.com/get10101/rust-dlc?rev=709a363#709a363a75104fa9b6e369b54750be14a3023820"
 dependencies = [
  "bitcoin",
  "dlc",
@@ -1581,16 +1579,15 @@ dependencies = [
 [[package]]
 name = "lightning"
 version = "0.0.114"
-source = "git+https://github.com/get10101/rust-lightning/?rev=939ebb43#939ebb43f4d179050d38854bdd1684e96773bcaf"
+source = "git+https://github.com/get10101/rust-lightning/?rev=c65cb1c5#c65cb1c565293772be882b7f3ad281775b6b8b29"
 dependencies = [
  "bitcoin",
- "parking_lot 0.12.1",
 ]
 
 [[package]]
 name = "lightning-background-processor"
 version = "0.0.114"
-source = "git+https://github.com/get10101/rust-lightning/?rev=939ebb43#939ebb43f4d179050d38854bdd1684e96773bcaf"
+source = "git+https://github.com/get10101/rust-lightning/?rev=c65cb1c5#c65cb1c565293772be882b7f3ad281775b6b8b29"
 dependencies = [
  "bitcoin",
  "futures-util",
@@ -1614,7 +1611,7 @@ dependencies = [
 [[package]]
 name = "lightning-net-tokio"
 version = "0.0.114"
-source = "git+https://github.com/get10101/rust-lightning/?rev=939ebb43#939ebb43f4d179050d38854bdd1684e96773bcaf"
+source = "git+https://github.com/get10101/rust-lightning/?rev=c65cb1c5#c65cb1c565293772be882b7f3ad281775b6b8b29"
 dependencies = [
  "bitcoin",
  "lightning",
@@ -1624,7 +1621,7 @@ dependencies = [
 [[package]]
 name = "lightning-persister"
 version = "0.0.114"
-source = "git+https://github.com/get10101/rust-lightning/?rev=939ebb43#939ebb43f4d179050d38854bdd1684e96773bcaf"
+source = "git+https://github.com/get10101/rust-lightning/?rev=c65cb1c5#c65cb1c565293772be882b7f3ad281775b6b8b29"
 dependencies = [
  "bitcoin",
  "libc",
@@ -1635,7 +1632,7 @@ dependencies = [
 [[package]]
 name = "lightning-rapid-gossip-sync"
 version = "0.0.114"
-source = "git+https://github.com/get10101/rust-lightning/?rev=939ebb43#939ebb43f4d179050d38854bdd1684e96773bcaf"
+source = "git+https://github.com/get10101/rust-lightning/?rev=c65cb1c5#c65cb1c565293772be882b7f3ad281775b6b8b29"
 dependencies = [
  "bitcoin",
  "lightning",
@@ -1644,7 +1641,7 @@ dependencies = [
 [[package]]
 name = "lightning-transaction-sync"
 version = "0.0.114"
-source = "git+https://github.com/get10101/rust-lightning/?rev=939ebb43#939ebb43f4d179050d38854bdd1684e96773bcaf"
+source = "git+https://github.com/get10101/rust-lightning/?rev=c65cb1c5#c65cb1c565293772be882b7f3ad281775b6b8b29"
 dependencies = [
  "bdk-macros",
  "bitcoin",
@@ -2268,7 +2265,7 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 [[package]]
 name = "p2pd-oracle-client"
 version = "0.1.0"
-source = "git+https://github.com/get10101/rust-dlc?rev=2322288#2322288bc4b528be2ef2faada772b34cdce5af08"
+source = "git+https://github.com/get10101/rust-dlc?rev=709a363#709a363a75104fa9b6e369b54750be14a3023820"
 dependencies = [
  "chrono",
  "dlc-manager",
@@ -3060,7 +3057,7 @@ dependencies = [
 [[package]]
 name = "simple-wallet"
 version = "0.1.0"
-source = "git+https://github.com/get10101/rust-dlc?rev=2322288#2322288bc4b528be2ef2faada772b34cdce5af08"
+source = "git+https://github.com/get10101/rust-dlc?rev=709a363#709a363a75104fa9b6e369b54750be14a3023820"
 dependencies = [
  "bitcoin",
  "dlc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,16 +3,16 @@ members = ["coordinator", "maker", "mobile/native", "crates/*"]
 resolver = "2"
 
 [patch.crates-io]
-dlc-manager = { git = "https://github.com/get10101/rust-dlc", rev = "2322288" }
-dlc-messages = { git = "https://github.com/get10101/rust-dlc", rev = "2322288" }
-dlc = { git = "https://github.com/get10101/rust-dlc", rev = "2322288" }
-dlc-sled-storage-provider = { git = "https://github.com/get10101/rust-dlc", rev = "2322288" }
-p2pd-oracle-client = { git = "https://github.com/get10101/rust-dlc", rev = "2322288" }
-dlc-trie = { git = "https://github.com/get10101/rust-dlc", rev = "2322288" }
-simple-wallet = { git = "https://github.com/get10101/rust-dlc", rev = "2322288" }
-lightning = { git = "https://github.com/get10101/rust-lightning/", rev = "939ebb43" }
-lightning-background-processor = { git = "https://github.com/get10101/rust-lightning/", rev = "939ebb43" }
-lightning-transaction-sync = { git = "https://github.com/get10101/rust-lightning/", rev = "939ebb43" }
-lightning-net-tokio = { git = "https://github.com/get10101/rust-lightning/", rev = "939ebb43" }
-lightning-persister = { git = "https://github.com/get10101/rust-lightning/", rev = "939ebb43" }
+dlc-manager = { git = "https://github.com/get10101/rust-dlc", rev = "709a363" }
+dlc-messages = { git = "https://github.com/get10101/rust-dlc", rev = "709a363" }
+dlc = { git = "https://github.com/get10101/rust-dlc", rev = "709a363" }
+dlc-sled-storage-provider = { git = "https://github.com/get10101/rust-dlc", rev = "709a363" }
+p2pd-oracle-client = { git = "https://github.com/get10101/rust-dlc", rev = "709a363" }
+dlc-trie = { git = "https://github.com/get10101/rust-dlc", rev = "709a363" }
+simple-wallet = { git = "https://github.com/get10101/rust-dlc", rev = "709a363" }
+lightning = { git = "https://github.com/get10101/rust-lightning/", rev = "c65cb1c5" }
+lightning-background-processor = { git = "https://github.com/get10101/rust-lightning/", rev = "c65cb1c5" }
+lightning-transaction-sync = { git = "https://github.com/get10101/rust-lightning/", rev = "c65cb1c5" }
+lightning-net-tokio = { git = "https://github.com/get10101/rust-lightning/", rev = "c65cb1c5" }
+lightning-persister = { git = "https://github.com/get10101/rust-lightning/", rev = "c65cb1c5" }
 rust-bitcoin-coin-selection = { git = "https://github.com/p2pderivatives/rust-bitcoin-coin-selection" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,13 +3,13 @@ members = ["coordinator", "maker", "mobile/native", "crates/*"]
 resolver = "2"
 
 [patch.crates-io]
-dlc-manager = { git = "https://github.com/get10101/rust-dlc", rev = "709a363" }
-dlc-messages = { git = "https://github.com/get10101/rust-dlc", rev = "709a363" }
-dlc = { git = "https://github.com/get10101/rust-dlc", rev = "709a363" }
-dlc-sled-storage-provider = { git = "https://github.com/get10101/rust-dlc", rev = "709a363" }
-p2pd-oracle-client = { git = "https://github.com/get10101/rust-dlc", rev = "709a363" }
-dlc-trie = { git = "https://github.com/get10101/rust-dlc", rev = "709a363" }
-simple-wallet = { git = "https://github.com/get10101/rust-dlc", rev = "709a363" }
+dlc-manager = { git = "https://github.com/get10101/rust-dlc", rev = "3b277dc" }
+dlc-messages = { git = "https://github.com/get10101/rust-dlc", rev = "3b277dc" }
+dlc = { git = "https://github.com/get10101/rust-dlc", rev = "3b277dc" }
+dlc-sled-storage-provider = { git = "https://github.com/get10101/rust-dlc", rev = "3b277dc" }
+p2pd-oracle-client = { git = "https://github.com/get10101/rust-dlc", rev = "3b277dc" }
+dlc-trie = { git = "https://github.com/get10101/rust-dlc", rev = "3b277dc" }
+simple-wallet = { git = "https://github.com/get10101/rust-dlc", rev = "3b277dc" }
 lightning = { git = "https://github.com/get10101/rust-lightning/", rev = "c65cb1c5" }
 lightning-background-processor = { git = "https://github.com/get10101/rust-lightning/", rev = "c65cb1c5" }
 lightning-transaction-sync = { git = "https://github.com/get10101/rust-lightning/", rev = "c65cb1c5" }

--- a/coordinator/src/admin.rs
+++ b/coordinator/src/admin.rs
@@ -8,7 +8,6 @@ use axum::extract::State;
 use axum::Json;
 use bdk::TransactionDetails;
 use bitcoin::secp256k1::PublicKey;
-use dlc_manager::Storage;
 use lightning_invoice::Invoice;
 use ln_dlc_node::node::NodeInfo;
 use ln_dlc_node::ChannelDetails;
@@ -156,76 +155,6 @@ pub async fn close_channel(
         .inner
         .close_channel(fixed_length_array, params.force.unwrap_or_default())
         .map_err(|e| AppError::InternalServerError(format!("{e:#}")))?;
-
-    Ok(())
-}
-
-#[instrument(skip_all, err(Debug))]
-#[autometrics]
-pub async fn finalize_force_close_ln_dlc_channel(
-    Path(channel_id): Path<String>,
-    State(state): State<Arc<AppState>>,
-) -> Result<(), AppError> {
-    let byte_array =
-        hex::decode(channel_id.clone()).map_err(|err| AppError::BadRequest(err.to_string()))?;
-
-    if byte_array.len() > 32 {
-        return Err(AppError::BadRequest(
-            "Provided channel id was invalid".to_string(),
-        ));
-    }
-    // Create a fixed-length byte array of size 8
-    let mut fixed_length_array = [0u8; 32];
-
-    // Copy the decoded bytes to the fixed-length array
-    let length = std::cmp::min(byte_array.len(), fixed_length_array.len());
-    fixed_length_array[..length].copy_from_slice(&byte_array[..length]);
-
-    tracing::info!(%channel_id, "Attempting to finalize channel force-close");
-
-    state
-        .node
-        .inner
-        .finalize_force_close_ln_dlc_channel(fixed_length_array)
-        .map_err(|e| AppError::InternalServerError(format!("{e:#}")))?;
-
-    Ok(())
-}
-
-#[autometrics]
-pub async fn delete_subchannel(
-    Path(channel_id): Path<String>,
-    State(state): State<Arc<AppState>>,
-) -> Result<(), AppError> {
-    let byte_array =
-        hex::decode(channel_id.clone()).map_err(|err| AppError::BadRequest(err.to_string()))?;
-
-    if byte_array.len() > 32 {
-        return Err(AppError::BadRequest(
-            "Provided channel id was invalid".to_string(),
-        ));
-    }
-    // Create a fixed-length byte array of size 8
-    let mut fixed_length_array = [0u8; 32];
-
-    // Copy the decoded bytes to the fixed-length array
-    let length = std::cmp::min(byte_array.len(), fixed_length_array.len());
-    fixed_length_array[..length].copy_from_slice(&byte_array[..length]);
-
-    tracing::debug!(%channel_id, "Attempting to delete DLC channel");
-
-    state
-        .node
-        .inner
-        .sub_channel_manager
-        .get_dlc_manager()
-        .get_store()
-        .delete_subchannel(&fixed_length_array)
-        .map_err(|error| {
-            AppError::InternalServerError(format!("Unable to delete channel: {error:#}"))
-        })?;
-
-    tracing::info!(%channel_id, "Deleted DLC channel");
 
     Ok(())
 }

--- a/coordinator/src/routes.rs
+++ b/coordinator/src/routes.rs
@@ -1,7 +1,5 @@
 use crate::admin::close_channel;
 use crate::admin::connect_to_peer;
-use crate::admin::delete_subchannel;
-use crate::admin::finalize_force_close_ln_dlc_channel;
 use crate::admin::get_balance;
 use crate::admin::is_connected;
 use crate::admin::list_channels;
@@ -96,18 +94,10 @@ pub fn router(
         .route("/api/admin/channels", get(list_channels))
         .route("/api/channels", post(open_channel))
         .route("/api/admin/channels/:channel_id", delete(close_channel))
-        .route(
-            "/api/admin/channels/finalize_force_close/:channel_id",
-            delete(finalize_force_close_ln_dlc_channel),
-        )
         .route("/api/admin/peers", get(list_peers))
         .route("/api/admin/send_payment/:invoice", post(send_payment))
         .route("/api/admin/dlc_channels", get(list_dlc_channels))
         .route("/api/admin/transactions", get(list_on_chain_transactions))
-        .route(
-            "/api/admin/dlc_channels/:channel_id",
-            delete(delete_subchannel),
-        )
         .route("/api/admin/sign/:msg", get(sign_message))
         .route("/api/admin/connect", post(connect_to_peer))
         .route("/api/admin/is_connected/:target_pubkey", get(is_connected))

--- a/crates/ln-dlc-node/src/node/ln_channel.rs
+++ b/crates/ln-dlc-node/src/node/ln_channel.rs
@@ -121,7 +121,7 @@ where
             );
 
             self.sub_channel_manager
-                .initiate_force_close_sub_channel(&channel_id)
+                .force_close_sub_channel(&channel_id)
                 .map_err(|e| anyhow!("Failed to initiate force-close: {e:#}"))?;
         } else {
             tracing::info!(channel_id = %hex::encode(channel_id), %peer, "Force-closing LN channel");
@@ -130,24 +130,6 @@ where
                 .force_close_broadcasting_latest_txn(&channel_id, &peer)
                 .map_err(|e| anyhow!("Could not force-close channel {channel_id_str}: {e:?}"))?;
         };
-
-        Ok(())
-    }
-
-    #[autometrics]
-    pub fn finalize_force_close_ln_dlc_channel(&self, channel_id: [u8; 32]) -> Result<()> {
-        let channel_id_str = hex::encode(channel_id);
-
-        tracing::info!(
-            channel_id = %channel_id_str,
-            "Finalizing force-closure of LN-DLC channel"
-        );
-
-        self.sub_channel_manager
-            .finalize_force_close_sub_channels(&channel_id)
-            .map_err(|e| {
-                anyhow!("Failed to finalize force-close of channel {channel_id_str}: {e:#}")
-            })?;
 
         Ok(())
     }

--- a/crates/ln-dlc-node/src/node/ln_channel.rs
+++ b/crates/ln-dlc-node/src/node/ln_channel.rs
@@ -90,7 +90,7 @@ where
 
         self.is_safe_to_close_ln_channel_collaboratively(&channel_id)
             .with_context(|| {
-                format!("Could not collaboratively close LN channel {channel_id_str}")
+                format!("Could not collaboratively close LN channel {channel_id_str}: must close DLC channel first")
             })?;
 
         self.channel_manager

--- a/crates/ln-dlc-node/src/node/sub_channel_manager.rs
+++ b/crates/ln-dlc-node/src/node/sub_channel_manager.rs
@@ -2,6 +2,7 @@ use crate::fee_rate_estimator::FeeRateEstimator;
 use crate::ln_dlc_wallet::LnDlcWallet;
 use crate::node::channel_manager::ChannelManager;
 use crate::node::dlc_manager::DlcManager;
+use crate::CustomSigner;
 use anyhow::Result;
 use autometrics::autometrics;
 use dlc_manager::sub_channel_manager;
@@ -19,6 +20,7 @@ pub type SubChannelManager = sub_channel_manager::SubChannelManager<
     Arc<SystemTimeProvider>,
     Arc<FeeRateEstimator>,
     Arc<DlcManager>,
+    CustomSigner,
 >;
 
 #[autometrics]

--- a/crates/ln-dlc-node/src/tests/dlc/non_collaborative_settlement.rs
+++ b/crates/ln-dlc-node/src/tests/dlc/non_collaborative_settlement.rs
@@ -1,5 +1,5 @@
-use tokio::task::spawn_blocking;
-
+use crate::node::dlc_channel::dlc_manager_periodic_check;
+use crate::node::dlc_channel::sub_channel_manager_periodic_check;
 use crate::tests::bitcoind::mine;
 use crate::tests::dlc::create::create_dlc_channel;
 use crate::tests::dlc::create::DlcChannelCreated;
@@ -38,15 +38,12 @@ async fn force_close_ln_dlc_channel() {
     coordinator.wallet().sync().await.unwrap();
     app.wallet().sync().await.unwrap();
 
-    let coordinator = std::sync::Arc::new(coordinator);
-    spawn_blocking({
-        let coordinator = coordinator.clone();
-        move || {
-            coordinator
-                .finalize_force_close_ln_dlc_channel(channel_details.channel_id)
-                .unwrap()
-        }
-    })
+    // Ensure publication of the glue and buffer transactions (otherwise we need to wait for the
+    // periodic task)
+    sub_channel_manager_periodic_check(
+        coordinator.sub_channel_manager.clone(),
+        &coordinator.dlc_message_handler,
+    )
     .await
     .unwrap();
 
@@ -65,23 +62,33 @@ async fn force_close_ln_dlc_channel() {
     app.wallet().sync().await.unwrap();
 
     // Ensure publication of CET (otherwise we need to wait for the periodic task)
-    coordinator.dlc_manager.periodic_check().unwrap();
+    dlc_manager_periodic_check(coordinator.dlc_manager.clone())
+        .await
+        .unwrap();
 
     // Confirm CET
     mine(1).await.unwrap();
 
     coordinator.wallet().sync().await.unwrap();
+    app.wallet().sync().await.unwrap();
 
     let coordinator_on_chain_balance_after_force_close =
         coordinator.get_on_chain_balance().unwrap().confirmed;
+    let app_on_chain_balance_after_force_close = app.get_on_chain_balance().unwrap().confirmed;
 
     // Given that we have dynamic transaction fees based on the state of the regtest mempool, it's
-    // less error-prone to choose a conservative lower bound on the funds we expect the coordinator
-    // to get after force-closing the LN-DLC channel
+    // less error-prone to choose a conservative lower bound on the expected funds after
+    // force-closing the LN-DLC channel
     let coordinator_on_chain_balance_after_force_close_expected_min = 245_000;
+    let app_on_chain_balance_after_force_close_expected_min = 45_000;
 
     assert!(
         coordinator_on_chain_balance_after_force_close
             >= coordinator_on_chain_balance_after_force_close_expected_min
+    );
+
+    assert!(
+        app_on_chain_balance_after_force_close
+            >= app_on_chain_balance_after_force_close_expected_min
     );
 }

--- a/crates/ln-dlc-node/src/tests/load.rs
+++ b/crates/ln-dlc-node/src/tests/load.rs
@@ -58,15 +58,22 @@ async fn single_app_many_positions_load() {
 async fn open_position(coordinator: &Coordinator, app: &Node<PaymentMap>) -> Result<()> {
     tracing::info!("Opening position");
 
-    loop {
-        tracing::info!("Sending open pre-proposal");
+    tokio::time::timeout(Duration::from_secs(30), async {
+        loop {
+            tracing::info!("Sending open pre-proposal");
 
-        if coordinator.post_trade(app, Direction::Long).await.is_ok() {
-            break;
+            match coordinator.post_trade(app, Direction::Long).await {
+                Ok(_) => break,
+                Err(e) => {
+                    tracing::debug!("Could not yet process open pre-proposal: {e:#}");
+                }
+            }
+
+            tokio::time::sleep(Duration::from_millis(500)).await;
         }
-
-        tokio::time::sleep(Duration::from_millis(500)).await;
-    }
+    })
+    .await
+    .unwrap();
 
     tracing::info!("Open pre-proposal delivered");
 
@@ -96,15 +103,22 @@ async fn open_position(coordinator: &Coordinator, app: &Node<PaymentMap>) -> Res
 async fn close_position(coordinator: &Coordinator, app: &Node<PaymentMap>) -> Result<()> {
     tracing::info!("Closing position");
 
-    loop {
-        tracing::info!("Sending close pre-proposal");
+    tokio::time::timeout(Duration::from_secs(30), async {
+        loop {
+            tracing::info!("Sending close pre-proposal");
 
-        if coordinator.post_trade(app, Direction::Short).await.is_ok() {
-            break;
+            match coordinator.post_trade(app, Direction::Short).await {
+                Ok(_) => break,
+                Err(e) => {
+                    tracing::debug!("Could not yet process close pre-proposal: {e:#}");
+                }
+            }
+
+            tokio::time::sleep(Duration::from_millis(500)).await;
         }
-
-        tokio::time::sleep(Duration::from_millis(500)).await;
-    }
+    })
+    .await
+    .unwrap();
 
     tracing::info!("Close pre-proposal delivered");
 

--- a/crates/ln-dlc-node/src/tests/load.rs
+++ b/crates/ln-dlc-node/src/tests/load.rs
@@ -3,12 +3,11 @@ use crate::node::Node;
 use crate::node::NodeInfo;
 use crate::node::PaymentMap;
 use crate::tests::init_tracing;
-use crate::tests::wait_until;
+use crate::tests::wait_until_dlc_channel_state;
+use crate::tests::SubChannelStateName;
 use anyhow::Result;
 use coordinator::Coordinator;
 use coordinator::Direction;
-use dlc_manager::subchannel::SubChannelState;
-use dlc_manager::Storage;
 use std::borrow::Borrow;
 use std::sync::Arc;
 use std::time::Duration;
@@ -71,44 +70,22 @@ async fn open_position(coordinator: &Coordinator, app: &Node<PaymentMap>) -> Res
 
     tracing::info!("Open pre-proposal delivered");
 
-    let channel_id = wait_until(Duration::from_secs(60), || async {
-        tracing::info!("Waiting for DLC channel proposal");
-
-        app.process_incoming_messages()?;
-
-        let dlc_channel = app
-            .dlc_manager
-            .get_store()
-            .get_sub_channels()?
-            .first()
-            .cloned();
-
-        Ok(match dlc_channel {
-            Some(dlc_channel) if matches!(dlc_channel.state, SubChannelState::Offered(_)) => {
-                Some(dlc_channel.channel_id)
-            }
-            _ => None,
-        })
-    })
+    let dlc_channel = wait_until_dlc_channel_state(
+        Duration::from_secs(60),
+        app,
+        coordinator.info().pubkey,
+        SubChannelStateName::Offered,
+    )
     .await?;
 
-    app.accept_dlc_channel_offer(&channel_id)?;
+    app.accept_dlc_channel_offer(&dlc_channel.channel_id)?;
 
-    wait_until(Duration::from_secs(60), || async {
-        tracing::info!("Waiting for Signed state");
-
-        app.process_incoming_messages()?;
-
-        let dlc_channel = app
-            .dlc_manager
-            .get_store()
-            .get_sub_channels()?
-            .into_iter()
-            .find(|sc| sc.channel_id == channel_id)
-            .unwrap();
-
-        Ok(matches!(dlc_channel.state, SubChannelState::Signed(_)).then_some(()))
-    })
+    wait_until_dlc_channel_state(
+        Duration::from_secs(60),
+        app,
+        coordinator.info().pubkey,
+        SubChannelStateName::Signed,
+    )
     .await?;
 
     tracing::info!("Position open");
@@ -131,47 +108,23 @@ async fn close_position(coordinator: &Coordinator, app: &Node<PaymentMap>) -> Re
 
     tracing::info!("Close pre-proposal delivered");
 
-    let channel_id = wait_until(Duration::from_secs(60), || async {
-        tracing::info!("Waiting for DLC channel close proposal");
-
-        // Process confirm message and send finalize message
-        app.process_incoming_messages()?;
-
-        let dlc_channel = app
-            .dlc_manager
-            .get_store()
-            .get_sub_channels()?
-            .first()
-            .cloned();
-
-        Ok(match dlc_channel {
-            Some(dlc_channel) if matches!(dlc_channel.state, SubChannelState::CloseOffered(_)) => {
-                Some(dlc_channel.channel_id)
-            }
-            _ => None,
-        })
-    })
+    let dlc_channel = wait_until_dlc_channel_state(
+        Duration::from_secs(60),
+        app,
+        coordinator.info().pubkey,
+        SubChannelStateName::CloseOffered,
+    )
     .await?;
 
-    app.accept_dlc_channel_collaborative_settlement(&channel_id)
+    app.accept_dlc_channel_collaborative_settlement(&dlc_channel.channel_id)
         .unwrap();
 
-    wait_until(Duration::from_secs(60), || async {
-        tracing::info!("Waiting for OffChainClosed state");
-
-        // Process confirm message and send finalize message
-        app.process_incoming_messages()?;
-
-        let dlc_channel = app
-            .dlc_manager
-            .get_store()
-            .get_sub_channels()?
-            .into_iter()
-            .find(|sc| sc.channel_id == channel_id)
-            .unwrap();
-
-        Ok(matches!(dlc_channel.state, SubChannelState::OffChainClosed).then_some(()))
-    })
+    wait_until_dlc_channel_state(
+        Duration::from_secs(60),
+        app,
+        coordinator.info().pubkey,
+        SubChannelStateName::OffChainClosed,
+    )
     .await?;
 
     tracing::info!("Position closed");

--- a/crates/ln-dlc-node/src/tests/mod.rs
+++ b/crates/ln-dlc-node/src/tests/mod.rs
@@ -7,6 +7,7 @@ use crate::node::PaymentMap;
 use crate::seed::Bip39Seed;
 use crate::util;
 use anyhow::Result;
+use bitcoin::secp256k1::PublicKey;
 use bitcoin::Address;
 use bitcoin::Amount;
 use bitcoin::Network;
@@ -22,6 +23,9 @@ use dlc_manager::payout_curve::PayoutPoint;
 use dlc_manager::payout_curve::PolynomialPayoutCurvePiece;
 use dlc_manager::payout_curve::RoundingInterval;
 use dlc_manager::payout_curve::RoundingIntervals;
+use dlc_manager::subchannel::SubChannel;
+use dlc_manager::subchannel::SubChannelState;
+use dlc_manager::Storage;
 use futures::Future;
 use lightning::ln::channelmanager::ChannelDetails;
 use lightning::util::config::UserConfig;
@@ -309,6 +313,69 @@ where
         }
     })
     .await?
+}
+
+async fn wait_until_dlc_channel_state(
+    timeout: Duration,
+    node: &Node<PaymentMap>,
+    counterparty_pk: PublicKey,
+    target_state: SubChannelStateName,
+) -> Result<SubChannel> {
+    wait_until(timeout, || async {
+        node.process_incoming_messages()?;
+
+        let dlc_channels = node.dlc_manager.get_store().get_sub_channels()?;
+
+        Ok(dlc_channels
+            .iter()
+            .find(|channel| {
+                let current_state = SubChannelStateName::from(&channel.state);
+
+                tracing::info!(target = ?target_state, current = ?current_state, "Waiting for DLC subchannel to reach state");
+
+                channel.counter_party == counterparty_pk && current_state == target_state
+            })
+            .cloned())
+    })
+    .await
+}
+
+#[derive(PartialEq, Debug)]
+enum SubChannelStateName {
+    Offered,
+    Accepted,
+    Confirmed,
+    Signed,
+    Closing,
+    OnChainClosed,
+    CounterOnChainClosed,
+    CloseOffered,
+    CloseAccepted,
+    CloseConfirmed,
+    OffChainClosed,
+    ClosedPunished,
+    Rejected,
+}
+
+impl From<&SubChannelState> for SubChannelStateName {
+    fn from(value: &SubChannelState) -> Self {
+        use SubChannelState::*;
+        match value {
+            Offered(_) => SubChannelStateName::Offered,
+            Accepted(_) => SubChannelStateName::Accepted,
+            Confirmed(_) => SubChannelStateName::Confirmed,
+            Signed(_) => SubChannelStateName::Signed,
+            Closing(_) => SubChannelStateName::Closing,
+            OnChainClosed => SubChannelStateName::OnChainClosed,
+            CounterOnChainClosed => SubChannelStateName::CounterOnChainClosed,
+            CloseOffered(_) => SubChannelStateName::CloseOffered,
+            CloseAccepted(_) => SubChannelStateName::CloseAccepted,
+            CloseConfirmed(_) => SubChannelStateName::CloseConfirmed,
+            OffChainClosed => SubChannelStateName::OffChainClosed,
+            ClosedPunished(_) => SubChannelStateName::ClosedPunished,
+            Rejected => SubChannelStateName::Rejected,
+        }
+    }
 }
 
 fn dummy_contract_input(


### PR DESCRIPTION
Fixes https://github.com/get10101/10101/issues/766 (they pass locally :D).
Fixes https://github.com/get10101/10101/issues/768.
Fixes https://github.com/get10101/10101/issues/664.
Fixes https://github.com/get10101/10101/issues/663 (we don't run into it and the app gets their money back [^1]).

The main motivation is to stay on top of the latest changes to `rust-lightning` and `rust-dlc`, whilst also definitively removing some of the things that we temporarily added during our latest bug hunt.

Some patches were also removed which might cause some controversy:

- https://github.com/get10101/rust-dlc/commit/ce78c25.
- https://github.com/get10101/rust-dlc/commit/cf3d1eb.
- https://github.com/get10101/rust-dlc/commit/304e85d.

In general reviewers are encouraged to take a look at the differences between these branches:

- For `rust-dlc` we are now using https://github.com/get10101/rust-dlc/commit/8fa3692 [^2] instead of https://github.com/get10101/rust-dlc/commit/2322288.

- For `rust-lightning` we are now using https://github.com/get10101/rust-lightning/commit/c65cb1c5 [^3] instead of https://github.com/get10101/rust-lightning/commit/939ebb43.

The differences are not so obvious because we diverged quite a bit. We still want to keep certain commits that haven't been upstreamed yet.

Other notable changes
---------------------

- Adapting to the new API to force-close the LN-DLC channel provided by `rust-dlc`. As such, we've modified some code around that and updated the `force_close_ln_dlc_channel` test accordingly.

- Introducing `wait_until_dlc_channel_state` to replace a lot of eager sleeps which led to slower and flakier tests.

- Enabling the configuration of the `dlc_manager_periodic_check_interval` and `sub_channel_manager_periodic_check_interval` viat the `LnDlcNodeSettings`. Originally this was added to be able to circumvent another issue, but the issue has now been fixed in
`rust-dlc`.

- Ensuring that we drop the `LnDlcNodeSettings` read lock as soon as possible so that we don't hold onto it during the sleeps of certain periodic tasks. This fixes a bug as in a previous version of this patch we were not able to update the settings in the tests, because there was always at least one read lock being held!

[^1]: The test can still be improved by making sure that the oracle unlocks a CET that pays to both parties. Atm we use an event whose attestation results in the coordinator getting the whole DLC output. This means that we are only verifying that the part of the LN channel that belongs to the app is returned.
[^2]: This branch is temporarily named `feature/ln-dlc-channels-114-tibo`.
[^3]: This branch is temporarily named `split-tx-experiment-114-tibo`.
