### PR TITLE
Set background transaction priority to 24 blocks

### DIFF
--- a/crates/ln-dlc-node/src/fee_rate_estimator.rs
+++ b/crates/ln-dlc-node/src/fee_rate_estimator.rs
@@ -64,7 +64,7 @@ impl FeeRateEstimator {
 
         let mut locked_fee_rate_cache = self.cache_write_lock();
         for (target, n_blocks) in [
-            (ConfirmationTarget::Background, 12),
+            (ConfirmationTarget::Background, 24),
             (ConfirmationTarget::Normal, 6),
             (ConfirmationTarget::HighPriority, 3),
         ] {


### PR DESCRIPTION
Fixes #778.

As opposed to 12 blocks.

This is an attempt to reduce the likelihood that LDK force-closes one of our channels because it deems that the counterparty's updated fee rate is too low. By using 24 blocks as the confirmation target we indicate that very low fees should be acceptable.