### PR TITLE
Use address caches in `LnDlcWallet`

### DIFF
--- a/coordinator/src/routes.rs
+++ b/coordinator/src/routes.rs
@@ -168,14 +168,9 @@ pub async fn register_interceptable_invoice(
 }
 
 #[autometrics]
-pub async fn get_new_address(
-    State(app_state): State<Arc<AppState>>,
-) -> Result<Json<String>, AppError> {
-    let address =
-        app_state.node.inner.get_new_address().map_err(|e| {
-            AppError::InternalServerError(format!("Failed to get new address: {e:#}"))
-        })?;
-    Ok(Json(address.to_string()))
+pub async fn get_new_address(State(app_state): State<Arc<AppState>>) -> Json<String> {
+    let address = app_state.node.inner.get_new_address();
+    Json(address.to_string())
 }
 
 #[autometrics]

--- a/crates/ln-dlc-node/src/dlc_custom_signer.rs
+++ b/crates/ln-dlc-node/src/dlc_custom_signer.rs
@@ -288,18 +288,12 @@ impl SignerProvider for CustomKeysManager {
     type Signer = CustomSigner;
 
     fn get_destination_script(&self) -> Script {
-        let address = self
-            .wallet
-            .get_last_unused_address()
-            .expect("Failed to retrieve new address from wallet.");
+        let address = self.wallet.last_unused_address();
         address.script_pubkey()
     }
 
     fn get_shutdown_scriptpubkey(&self) -> ShutdownScript {
-        let address = self
-            .wallet
-            .get_last_unused_address()
-            .expect("Failed to retrieve new address from wallet.");
+        let address = self.wallet.last_unused_address();
         match address.payload {
             bitcoin::util::address::Payload::WitnessProgram { version, program } => {
                 ShutdownScript::new_witness_program(version, &program)

--- a/crates/ln-dlc-node/src/ln_dlc_wallet.rs
+++ b/crates/ln-dlc-node/src/ln_dlc_wallet.rs
@@ -95,17 +95,17 @@ impl LnDlcWallet {
         }
     }
 
-    pub(crate) fn get_seed_phrase(&self) -> Vec<String> {
+    pub fn get_seed_phrase(&self) -> Vec<String> {
         self.seed.get_seed_phrase()
     }
 
     // TODO: Better to keep this private and expose the necessary APIs instead.
-    pub(crate) fn inner(&self) -> Arc<ldk_node_wallet::Wallet<sled::Tree>> {
+    pub fn inner(&self) -> Arc<ldk_node_wallet::Wallet<sled::Tree>> {
         self.ln_wallet.clone()
     }
 
     #[autometrics]
-    pub(crate) fn tip(&self) -> Result<(u32, BlockHash)> {
+    pub fn tip(&self) -> Result<(u32, BlockHash)> {
         let (height, header) = self.ln_wallet.tip()?;
         Ok((height, header))
     }
@@ -116,7 +116,7 @@ impl LnDlcWallet {
     /// This list won't be up-to-date unless the wallet has previously been synchronised with the
     /// blockchain.
     #[autometrics]
-    pub(crate) async fn on_chain_transactions(&self) -> Result<Vec<TransactionDetails>> {
+    pub async fn on_chain_transactions(&self) -> Result<Vec<TransactionDetails>> {
         let mut txs = self.ln_wallet.on_chain_transaction_list().await?;
 
         txs.sort_by(|a, b| {

--- a/crates/ln-dlc-node/src/ln_dlc_wallet.rs
+++ b/crates/ln-dlc-node/src/ln_dlc_wallet.rs
@@ -62,7 +62,6 @@ impl LnDlcWallet {
         let wallet = Arc::new(ldk_node_wallet::Wallet::new(
             blockchain,
             on_chain_wallet,
-            esplora_client,
             fee_rate_estimator,
         ));
 

--- a/crates/ln-dlc-node/src/node/mod.rs
+++ b/crates/ln-dlc-node/src/node/mod.rs
@@ -326,6 +326,14 @@ where
                                 }
                             }
 
+                            if let Err(e) = ln_dlc_wallet.update_last_unused_address_cache() {
+                                tracing::warn!("Failed to update last unused address cache: {e:#}");
+                            }
+
+                            if let Err(e) = ln_dlc_wallet.update_new_address_cache() {
+                                tracing::warn!("Failed to update new address cache: {e:#}");
+                            }
+
                             let interval = {
                                 let guard = settings.read().await;
                                 guard.on_chain_sync_interval

--- a/crates/ln-dlc-node/src/node/wallet.rs
+++ b/crates/ln-dlc-node/src/node/wallet.rs
@@ -30,10 +30,8 @@ where
         self.wallet.inner()
     }
 
-    pub fn get_new_address(&self) -> Result<Address> {
-        let address = self.wallet.inner().get_new_address()?;
-
-        Ok(address)
+    pub fn get_new_address(&self) -> Address {
+        self.wallet.new_address()
     }
 
     pub fn get_on_chain_balance(&self) -> Result<bdk::Balance> {

--- a/crates/ln-dlc-node/src/tests/mod.rs
+++ b/crates/ln-dlc-node/src/tests/mod.rs
@@ -114,7 +114,7 @@ impl Node<PaymentMap> {
         let starting_balance = self.get_confirmed_balance().await?;
         let expected_balance = starting_balance + amount.to_sat();
 
-        let address = self.wallet.get_last_unused_address()?;
+        let address = self.wallet.last_unused_address();
 
         fund_and_mine(address, amount).await?;
 

--- a/maker/src/routes.rs
+++ b/maker/src/routes.rs
@@ -65,10 +65,7 @@ pub struct Invoice {
 }
 
 pub async fn index(State(app_state): State<Arc<AppState>>) -> Result<Json<Index>, AppError> {
-    let address = app_state
-        .node
-        .get_new_address()
-        .map_err(|e| AppError::InternalServerError(format!("Failed to get new address: {e:#}")))?;
+    let address = app_state.node.get_new_address();
 
     let offchain = app_state.node.get_ldk_balance();
     let onchain = app_state
@@ -95,14 +92,10 @@ pub async fn index(State(app_state): State<Arc<AppState>>) -> Result<Json<Index>
     }))
 }
 
-pub async fn get_new_address(
-    State(app_state): State<Arc<AppState>>,
-) -> Result<Json<String>, AppError> {
-    let address = app_state
-        .node
-        .get_new_address()
-        .map_err(|e| AppError::InternalServerError(format!("Failed to get new address: {e:#}")))?;
-    Ok(Json(address.to_string()))
+pub async fn get_new_address(State(app_state): State<Arc<AppState>>) -> Json<String> {
+    let address = app_state.node.get_new_address();
+
+    Json(address.to_string())
 }
 
 #[derive(Serialize, Deserialize)]

--- a/mobile/native/src/api.rs
+++ b/mobile/native/src/api.rs
@@ -198,8 +198,8 @@ pub fn run(config: Config, app_dir: String, seed_dir: String) -> Result<()> {
     orderbook::subscribe(ln_dlc::get_node_key(), runtime)
 }
 
-pub fn get_new_address() -> Result<SyncReturn<String>> {
-    ln_dlc::get_new_address().map(SyncReturn)
+pub fn get_new_address() -> SyncReturn<String> {
+    SyncReturn(ln_dlc::get_new_address())
 }
 
 pub fn close_channel() -> Result<()> {

--- a/mobile/native/src/ln_dlc/mod.rs
+++ b/mobile/native/src/ln_dlc/mod.rs
@@ -355,9 +355,8 @@ async fn keep_wallet_balance_and_history_up_to_date(node: &Node) -> Result<()> {
     Ok(())
 }
 
-pub fn get_new_address() -> Result<String> {
-    let address = NODE.get().inner.get_new_address()?;
-    Ok(address.to_string())
+pub fn get_new_address() -> String {
+    NODE.get().inner.get_new_address().to_string()
 }
 
 pub fn close_channel(is_force_close: bool) -> Result<()> {


### PR DESCRIPTION
Fixes #776.

By caching these addresses we are preventing situations where getting an address from the wallet takes a long time because the on-chain sync is ongoing (and therefore has the mutex write lock).

The downside is that we can end up reusing addresses if these caches are accessed more than once during a sync.