### PR TITLE
Prefer unused addresses to new ones (temporarily)

### DIFF
--- a/coordinator/src/routes.rs
+++ b/coordinator/src/routes.rs
@@ -79,7 +79,7 @@ pub fn router(
             "/api/register_invoice/:target_node",
             post(register_interceptable_invoice),
         )
-        .route("/api/newaddress", get(get_new_address))
+        .route("/api/newaddress", get(get_unused_address))
         .route("/api/node", get(get_node_info))
         .route("/api/invoice", get(get_invoice))
         .route("/api/orderbook/orders", get(get_orders).post(post_order))
@@ -168,9 +168,8 @@ pub async fn register_interceptable_invoice(
 }
 
 #[autometrics]
-pub async fn get_new_address(State(app_state): State<Arc<AppState>>) -> Json<String> {
-    let address = app_state.node.inner.get_new_address();
-    Json(address.to_string())
+pub async fn get_unused_address(State(app_state): State<Arc<AppState>>) -> Json<String> {
+    Json(app_state.node.inner.get_unused_address().to_string())
 }
 
 #[autometrics]

--- a/crates/ln-dlc-node/src/dlc_custom_signer.rs
+++ b/crates/ln-dlc-node/src/dlc_custom_signer.rs
@@ -288,12 +288,12 @@ impl SignerProvider for CustomKeysManager {
     type Signer = CustomSigner;
 
     fn get_destination_script(&self) -> Script {
-        let address = self.wallet.last_unused_address();
+        let address = self.wallet.unused_address();
         address.script_pubkey()
     }
 
     fn get_shutdown_scriptpubkey(&self) -> ShutdownScript {
-        let address = self.wallet.last_unused_address();
+        let address = self.wallet.unused_address();
         match address.payload {
             bitcoin::util::address::Payload::WitnessProgram { version, program } => {
                 ShutdownScript::new_witness_program(version, &program)

--- a/crates/ln-dlc-node/src/ldk_node_wallet.rs
+++ b/crates/ln-dlc-node/src/ldk_node_wallet.rs
@@ -126,11 +126,6 @@ where
     }
 
     #[autometrics]
-    pub(crate) fn get_new_address(&self) -> Result<bitcoin::Address, Error> {
-        Ok(self.bdk_lock().get_address(AddressIndex::New)?.address)
-    }
-
-    #[autometrics]
     pub(crate) fn get_last_unused_address(&self) -> Result<bitcoin::Address, Error> {
         Ok(self
             .bdk_lock()

--- a/crates/ln-dlc-node/src/node/mod.rs
+++ b/crates/ln-dlc-node/src/node/mod.rs
@@ -326,12 +326,8 @@ where
                                 }
                             }
 
-                            if let Err(e) = ln_dlc_wallet.update_last_unused_address_cache() {
-                                tracing::warn!("Failed to update last unused address cache: {e:#}");
-                            }
-
-                            if let Err(e) = ln_dlc_wallet.update_new_address_cache() {
-                                tracing::warn!("Failed to update new address cache: {e:#}");
+                            if let Err(e) = ln_dlc_wallet.update_address_cache() {
+                                tracing::warn!("Failed to update address cache: {e:#}");
                             }
 
                             let interval = {

--- a/crates/ln-dlc-node/src/node/wallet.rs
+++ b/crates/ln-dlc-node/src/node/wallet.rs
@@ -30,8 +30,8 @@ where
         self.wallet.inner()
     }
 
-    pub fn get_new_address(&self) -> Address {
-        self.wallet.new_address()
+    pub fn get_unused_address(&self) -> Address {
+        self.wallet.unused_address()
     }
 
     pub fn get_on_chain_balance(&self) -> Result<bdk::Balance> {

--- a/crates/ln-dlc-node/src/tests/mod.rs
+++ b/crates/ln-dlc-node/src/tests/mod.rs
@@ -114,7 +114,7 @@ impl Node<PaymentMap> {
         let starting_balance = self.get_confirmed_balance().await?;
         let expected_balance = starting_balance + amount.to_sat();
 
-        let address = self.wallet.last_unused_address();
+        let address = self.wallet.unused_address();
 
         fund_and_mine(address, amount).await?;
 

--- a/maker/src/routes.rs
+++ b/maker/src/routes.rs
@@ -31,7 +31,7 @@ pub fn router(node: Arc<Node<PaymentMap>>, pool: Pool<ConnectionManager<PgConnec
 
     Router::new()
         .route("/", get(index))
-        .route("/api/newaddress", get(get_new_address))
+        .route("/api/newaddress", get(get_unused_address))
         .route("/api/balance", get(get_balance))
         .route("/api/invoice", get(get_invoice))
         .route("/api/channels", get(list_channels).post(create_channel))
@@ -65,7 +65,7 @@ pub struct Invoice {
 }
 
 pub async fn index(State(app_state): State<Arc<AppState>>) -> Result<Json<Index>, AppError> {
-    let address = app_state.node.get_new_address();
+    let address = app_state.node.get_unused_address();
 
     let offchain = app_state.node.get_ldk_balance();
     let onchain = app_state
@@ -92,10 +92,8 @@ pub async fn index(State(app_state): State<Arc<AppState>>) -> Result<Json<Index>
     }))
 }
 
-pub async fn get_new_address(State(app_state): State<Arc<AppState>>) -> Json<String> {
-    let address = app_state.node.get_new_address();
-
-    Json(address.to_string())
+pub async fn get_unused_address(State(app_state): State<Arc<AppState>>) -> Json<String> {
+    Json(app_state.node.get_unused_address().to_string())
 }
 
 #[derive(Serialize, Deserialize)]

--- a/mobile/lib/features/wallet/application/wallet_service.dart
+++ b/mobile/lib/features/wallet/application/wallet_service.dart
@@ -47,7 +47,7 @@ class WalletService {
     await rust.api.sendPayment(invoice: invoice);
   }
 
-  String getNewAddress() {
-    return rust.api.getNewAddress();
+  String getUnusedAddress() {
+    return rust.api.getUnusedAddress();
   }
 }

--- a/mobile/native/src/api.rs
+++ b/mobile/native/src/api.rs
@@ -198,8 +198,8 @@ pub fn run(config: Config, app_dir: String, seed_dir: String) -> Result<()> {
     orderbook::subscribe(ln_dlc::get_node_key(), runtime)
 }
 
-pub fn get_new_address() -> SyncReturn<String> {
-    SyncReturn(ln_dlc::get_new_address())
+pub fn get_unused_address() -> SyncReturn<String> {
+    SyncReturn(ln_dlc::get_unused_address())
 }
 
 pub fn close_channel() -> Result<()> {

--- a/mobile/native/src/ln_dlc/mod.rs
+++ b/mobile/native/src/ln_dlc/mod.rs
@@ -355,8 +355,8 @@ async fn keep_wallet_balance_and_history_up_to_date(node: &Node) -> Result<()> {
     Ok(())
 }
 
-pub fn get_new_address() -> String {
-    NODE.get().inner.get_new_address().to_string()
+pub fn get_unused_address() -> String {
+    NODE.get().inner.get_unused_address().to_string()
 }
 
 pub fn close_channel(is_force_close: bool) -> Result<()> {


### PR DESCRIPTION
AFAIK generating a new address means that the on-chain wallet must look for that address on the blockchain. Thus, we must only generate a new address if we are sure that we are about to use it.

As such, it is a bad idea to generate new addresses periodically. This would quickly become untenable, as the on-chain sync would grow more and more expensive and slow without good reason.

At the same time, it is best to use new addresses as it ensures that we don't run into address reuse, which is a bad practice as it leads to much worse privacy on-chain. Unfortunately, due to current limitations of `bdk::Wallet` it is not possible to ask the wallet for a new  (or even an unused) address during the on-chain sync. For this reasons we decided to introduce an address cache.

Given all this, it's bad to keep a new-address cache so it has been removed.

Furthermore, given that calls to `get_address(AddressIndex::LastUnused)` already generate new addresses if necessary and that we've already accepted that we are okay with using (probably) unused addresses by introducing the address cache, we have decided to _only_ allow calls to get_address(AddressIndex::LastUnused). This simplifies the code and ensures that we can always rely on the only cache we want to maintain i.e. we never have to wait for the wallet to finish to get an address.

---

We can revisit this change once we upgrade to `bdk:1.0.0-alpha.1` and rewrite our wallet to only take a write lock for a short time to update the wallet database.