### PR TITLE
Allow concurrent orders in maker

### DIFF
--- a/maker/src/bin/maker.rs
+++ b/maker/src/bin/maker.rs
@@ -20,13 +20,19 @@ async fn main() -> Result<()> {
     );
 
     let opts = Opts::read();
-    let network = opts.network();
 
     let node_pubkey =
         PublicKey::from_str("03f75f318471d32d39be3c86c622e2c51bd5731bf95f98aaa3ed5d6e1c0025927f")
             .expect("is a valid public key");
 
-    match trading::run(&opts.orderbook, node_pubkey, network).await {
+    match trading::run(
+        &opts.orderbook,
+        node_pubkey,
+        opts.network(),
+        opts.concurrent_orders,
+    )
+    .await
+    {
         Ok(_) => {
             tracing::error!("Maker stopped trading")
         }

--- a/maker/src/bin/maker.rs
+++ b/maker/src/bin/maker.rs
@@ -26,7 +26,7 @@ async fn main() -> Result<()> {
         PublicKey::from_str("03f75f318471d32d39be3c86c622e2c51bd5731bf95f98aaa3ed5d6e1c0025927f")
             .expect("is a valid public key");
 
-    match trading::run(opts.orderbook, node_pubkey, network).await {
+    match trading::run(&opts.orderbook, node_pubkey, network).await {
         Ok(_) => {
             tracing::error!("Maker stopped trading")
         }

--- a/maker/src/cli.rs
+++ b/maker/src/cli.rs
@@ -40,6 +40,10 @@ pub struct Opts {
     /// If enabled logs will be in json format
     #[clap(short, long)]
     pub json: bool,
+
+    /// Amount of concurrent orders (buy,sell) that maker will create at a time
+    #[clap(long, default_value = "5")]
+    pub concurrent_orders: usize,
 }
 
 #[derive(Debug, Clone, Copy, clap::ValueEnum)]

--- a/maker/src/trading/bitmex_client.rs
+++ b/maker/src/trading/bitmex_client.rs
@@ -12,6 +12,8 @@ use std::time::Duration;
 use time::OffsetDateTime;
 use trade::ContractSymbol;
 
+const BITMEX_RECONNECT_INTERVAL: Duration = Duration::from_secs(10);
+
 pub async fn bitmex(network: Network) -> impl Stream<Item = Result<Quote, Error>> + Unpin {
     let stream = stream! {
         loop {
@@ -34,9 +36,8 @@ pub async fn bitmex(network: Network) -> impl Stream<Item = Result<Quote, Error>
                 }
             }
 
-            let seconds = 10;
-            tracing::warn!("Disconnected from BitMEX. Reconnecting to BitMEX in {seconds}");
-            tokio::time::sleep(Duration::from_secs(seconds)).await;
+            tracing::warn!("Disconnected from BitMEX. Reconnecting to BitMEX in {seconds} seconds", seconds = BITMEX_RECONNECT_INTERVAL.as_secs());
+            tokio::time::sleep(BITMEX_RECONNECT_INTERVAL).await;
         }
     };
 

--- a/maker/src/trading/orderbook_client.rs
+++ b/maker/src/trading/orderbook_client.rs
@@ -19,7 +19,7 @@ impl OrderbookClient {
         }
     }
 
-    pub async fn post_new_order(&self, url: Url, order: NewOrder) -> Result<OrderResponse> {
+    pub async fn post_new_order(&self, url: &Url, order: NewOrder) -> Result<OrderResponse> {
         let url = url.join("/api/orderbook/orders")?;
 
         let response = self.client.post(url).json(&order).send().await?;
@@ -33,7 +33,7 @@ impl OrderbookClient {
         }
     }
 
-    pub async fn delete_order(&self, url: Url, order_id: Uuid) -> Result<()> {
+    pub async fn delete_order(&self, url: &Url, order_id: Uuid) -> Result<()> {
         let url = url.join(format!("/api/orderbook/orders/{order_id}").as_str())?;
 
         let response = self.client.delete(url).send().await?;


### PR DESCRIPTION
Maker creates multiple *same* orders based on the latest BitMEX quote.
Their amount is configurable.
When a new quote is received, all orders are updated.