### PR TITLE
Add .gitkeep to data/maker so that run-detached-maker works properly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,8 @@ mobile/ios/Runner/libnative.a
 
 # ignore data runtime data
 data/**
+# must be kept so that logfiles can be created in data/maker/
+!data/maker/.gitkeep
 !data/coordinator/regtest/seed
 
 # ignore CLion/Android Studio files

--- a/data/maker/.gitkeep
+++ b/data/maker/.gitkeep
@@ -1,0 +1,2 @@
+This is a placeholder file to keep data/maker in git so that data/maker is available for logs to be
+written into upon checkout.


### PR DESCRIPTION
When setting up the project for the first time in a while, the only issue I came across was that the `run-maker-detached` recipe would try to redirect its logs to `data/maker/regtest.log`, but `data/maker` did not exist. This PR adds a placeholder file .gitkeep to that directory to keep it around, as directories cannot be checked in to git empty.

cc @holzeis since we discussed this on element