### PR TITLE
Return early if there are no spendable outputs when handling `SpendableOutputs` event

### DIFF
--- a/crates/ln-dlc-node/src/ln/event_handler.rs
+++ b/crates/ln-dlc-node/src/ln/event_handler.rs
@@ -396,6 +396,10 @@ where
                     })
                     .collect::<Vec<_>>();
 
+                if ldk_outputs.is_empty() {
+                    return Ok(());
+                }
+
                 let destination_script = self.wallet.inner().get_last_unused_address()?;
                 let tx_feerate = self
                     .fee_rate_estimator


### PR DESCRIPTION
Otherwise we return an error that is subsequently logged.