### PR TITLE
chore: Log LDK logs on TRACE

### DIFF
--- a/coordinator/src/logger.rs
+++ b/coordinator/src/logger.rs
@@ -25,8 +25,7 @@ pub fn init_tracing(level: LevelFilter, json_format: bool, tokio_console: bool) 
         .add_directive("rustls=warn".parse()?)
         .add_directive("sled=warn".parse()?)
         .add_directive("bdk=warn".parse()?) // bdk is quite spamy on debug
-        .add_directive("lightning::ln::peer_handler=debug".parse()?)
-        .add_directive("lightning::chain=info".parse()?)
+        .add_directive("lightning=trace".parse()?)
         .add_directive("ureq=info".parse()?);
 
     let mut filter = if tokio_console {

--- a/mobile/native/src/logger.rs
+++ b/mobile/native/src/logger.rs
@@ -28,8 +28,7 @@ pub fn log_base_directives(env: EnvFilter, level: LevelFilter) -> Result<EnvFilt
         // set to debug to show ldk logs (they're also in logs.txt)
         .add_directive("sled=warn".parse()?)
         .add_directive("bdk=warn".parse()?) // bdk is quite spamy on debug
-        .add_directive("lightning::ln::peer_handler=debug".parse()?)
-        .add_directive("lightning::chain=info".parse()?)
+        .add_directive("lightning=trace".parse()?)
         .add_directive("ureq=info".parse()?);
     Ok(filter)
 }


### PR DESCRIPTION
Logging with trace on the app might impact mobile storage; we hope to be able to
revert this change before the next TestFlight release.