### PR TITLE
Do not block `tokio` runtime when syncing on-chain

### DIFF
--- a/crates/ln-dlc-node/src/ldk_node_wallet.rs
+++ b/crates/ln-dlc-node/src/ldk_node_wallet.rs
@@ -76,7 +76,7 @@ where
     }
 
     /// Update the internal BDK wallet database with the blockchain.
-    pub async fn sync(&self) -> Result<()> {
+    pub fn sync(&self) -> Result<()> {
         let wallet_lock = self.bdk_lock();
 
         let now = Instant::now();

--- a/crates/ln-dlc-node/src/tests/dlc/collaborative_settlement.rs
+++ b/crates/ln-dlc-node/src/tests/dlc/collaborative_settlement.rs
@@ -9,7 +9,7 @@ use anyhow::Result;
 use bitcoin::Amount;
 use std::time::Duration;
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 #[ignore]
 async fn dlc_collaborative_settlement_test() {
     init_tracing();
@@ -80,7 +80,7 @@ async fn dlc_collaborative_settlement_test() {
     );
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 #[ignore]
 async fn open_dlc_channel_after_closing_dlc_channel() {
     init_tracing();

--- a/crates/ln-dlc-node/src/tests/dlc/create.rs
+++ b/crates/ln-dlc-node/src/tests/dlc/create.rs
@@ -9,7 +9,7 @@ use anyhow::Result;
 use bitcoin::Amount;
 use std::time::Duration;
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 #[ignore]
 async fn given_lightning_channel_then_can_add_dlc_channel() {
     init_tracing();

--- a/crates/ln-dlc-node/src/tests/dlc/dlc_setup_with_reconnects.rs
+++ b/crates/ln-dlc-node/src/tests/dlc/dlc_setup_with_reconnects.rs
@@ -8,7 +8,7 @@ use anyhow::Context;
 use bitcoin::Amount;
 use std::time::Duration;
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 #[ignore]
 async fn reconnecting_during_dlc_channel_setup() {
     init_tracing();

--- a/crates/ln-dlc-node/src/tests/dlc/non_collaborative_settlement.rs
+++ b/crates/ln-dlc-node/src/tests/dlc/non_collaborative_settlement.rs
@@ -5,7 +5,7 @@ use crate::tests::dlc::create::create_dlc_channel;
 use crate::tests::init_tracing;
 use bitcoin::Amount;
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 #[ignore]
 async fn force_close_ln_dlc_channel() {
     init_tracing();
@@ -44,8 +44,8 @@ async fn force_close_ln_dlc_channel() {
     .await
     .unwrap();
 
-    coordinator.wallet().sync().unwrap();
-    app.wallet().sync().unwrap();
+    coordinator.sync_on_chain().await.unwrap();
+    app.sync_on_chain().await.unwrap();
 
     // Act
 
@@ -55,8 +55,8 @@ async fn force_close_ln_dlc_channel() {
     // transactions
     mine(288).await.unwrap();
 
-    coordinator.wallet().sync().unwrap();
-    app.wallet().sync().unwrap();
+    coordinator.sync_on_chain().await.unwrap();
+    app.sync_on_chain().await.unwrap();
 
     // Ensure publication of the glue and buffer transactions (otherwise we need to wait for the
     // periodic task)
@@ -69,8 +69,8 @@ async fn force_close_ln_dlc_channel() {
 
     // Assert
 
-    coordinator.wallet().sync().unwrap();
-    app.wallet().sync().unwrap();
+    coordinator.sync_on_chain().await.unwrap();
+    app.sync_on_chain().await.unwrap();
 
     // Mining 288 blocks ensures that we get:
     // - 144 required confirmations for the delayed output on the LN commitment transaction to be
@@ -78,8 +78,8 @@ async fn force_close_ln_dlc_channel() {
     // - 288 required confirmations for the CET to be published.
     mine(288).await.unwrap();
 
-    coordinator.wallet().sync().unwrap();
-    app.wallet().sync().unwrap();
+    coordinator.sync_on_chain().await.unwrap();
+    app.sync_on_chain().await.unwrap();
 
     // Ensure publication of CET (otherwise we need to wait for the periodic task)
     sub_channel_manager_periodic_check(
@@ -92,8 +92,8 @@ async fn force_close_ln_dlc_channel() {
     // Confirm CET
     mine(1).await.unwrap();
 
-    coordinator.wallet().sync().unwrap();
-    app.wallet().sync().unwrap();
+    coordinator.sync_on_chain().await.unwrap();
+    app.sync_on_chain().await.unwrap();
 
     let coordinator_on_chain_balance_after_force_close =
         coordinator.get_on_chain_balance().unwrap().confirmed;

--- a/crates/ln-dlc-node/src/tests/dlc/non_collaborative_settlement.rs
+++ b/crates/ln-dlc-node/src/tests/dlc/non_collaborative_settlement.rs
@@ -44,8 +44,8 @@ async fn force_close_ln_dlc_channel() {
     .await
     .unwrap();
 
-    coordinator.wallet().sync().await.unwrap();
-    app.wallet().sync().await.unwrap();
+    coordinator.wallet().sync().unwrap();
+    app.wallet().sync().unwrap();
 
     // Act
 
@@ -55,8 +55,8 @@ async fn force_close_ln_dlc_channel() {
     // transactions
     mine(288).await.unwrap();
 
-    coordinator.wallet().sync().await.unwrap();
-    app.wallet().sync().await.unwrap();
+    coordinator.wallet().sync().unwrap();
+    app.wallet().sync().unwrap();
 
     // Ensure publication of the glue and buffer transactions (otherwise we need to wait for the
     // periodic task)
@@ -69,8 +69,8 @@ async fn force_close_ln_dlc_channel() {
 
     // Assert
 
-    coordinator.wallet().sync().await.unwrap();
-    app.wallet().sync().await.unwrap();
+    coordinator.wallet().sync().unwrap();
+    app.wallet().sync().unwrap();
 
     // Mining 288 blocks ensures that we get:
     // - 144 required confirmations for the delayed output on the LN commitment transaction to be
@@ -78,8 +78,8 @@ async fn force_close_ln_dlc_channel() {
     // - 288 required confirmations for the CET to be published.
     mine(288).await.unwrap();
 
-    coordinator.wallet().sync().await.unwrap();
-    app.wallet().sync().await.unwrap();
+    coordinator.wallet().sync().unwrap();
+    app.wallet().sync().unwrap();
 
     // Ensure publication of CET (otherwise we need to wait for the periodic task)
     sub_channel_manager_periodic_check(
@@ -92,8 +92,8 @@ async fn force_close_ln_dlc_channel() {
     // Confirm CET
     mine(1).await.unwrap();
 
-    coordinator.wallet().sync().await.unwrap();
-    app.wallet().sync().await.unwrap();
+    coordinator.wallet().sync().unwrap();
+    app.wallet().sync().unwrap();
 
     let coordinator_on_chain_balance_after_force_close =
         coordinator.get_on_chain_balance().unwrap().confirmed;

--- a/crates/ln-dlc-node/src/tests/just_in_time_channel/channel_close.rs
+++ b/crates/ln-dlc-node/src/tests/just_in_time_channel/channel_close.rs
@@ -78,7 +78,7 @@ async fn ln_collab_close() {
 
     // Mine one block to confirm the close transaction
     bitcoind::mine(1).await.unwrap();
-    payee.wallet().sync().await.unwrap();
+    payee.wallet().sync().unwrap();
 
     // Assert
 
@@ -150,7 +150,7 @@ async fn ln_force_close() {
         .force_close_broadcasting_latest_txn(&channel_id, &coordinator.info.pubkey)
         .unwrap();
 
-    payee.wallet().sync().await.unwrap();
+    payee.wallet().sync().unwrap();
 
     assert_eq!(payee.get_on_chain_balance().unwrap().confirmed, 0);
     assert_eq!(payee.get_ldk_balance().available, 0);
@@ -170,12 +170,12 @@ async fn ln_force_close() {
     // Syncing the payee's wallet should now trigger a `SpendableOutputs` event
     // corresponding to their revocable output in the commitment transaction, which they
     // will subsequently spend in a new transaction paying to their on-chain wallet
-    payee.wallet().sync().await.unwrap();
+    payee.wallet().sync().unwrap();
 
     // Mine one more block to confirm the transaction spending the payee's revocable output
     // in the commitment transaction
     bitcoind::mine(1).await.unwrap();
-    payee.wallet().sync().await.unwrap();
+    payee.wallet().sync().unwrap();
 
     // Assert
 

--- a/crates/ln-dlc-node/src/tests/just_in_time_channel/channel_close.rs
+++ b/crates/ln-dlc-node/src/tests/just_in_time_channel/channel_close.rs
@@ -7,7 +7,7 @@ use crate::tests::min_outbound_liquidity_channel_creator;
 use bitcoin::Amount;
 use std::time::Duration;
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 #[ignore]
 async fn ln_collab_close() {
     init_tracing();
@@ -78,7 +78,7 @@ async fn ln_collab_close() {
 
     // Mine one block to confirm the close transaction
     bitcoind::mine(1).await.unwrap();
-    payee.wallet().sync().unwrap();
+    payee.sync_on_chain().await.unwrap();
 
     // Assert
 
@@ -92,7 +92,7 @@ async fn ln_collab_close() {
     );
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 #[ignore]
 async fn ln_force_close() {
     init_tracing();
@@ -150,7 +150,7 @@ async fn ln_force_close() {
         .force_close_broadcasting_latest_txn(&channel_id, &coordinator.info.pubkey)
         .unwrap();
 
-    payee.wallet().sync().unwrap();
+    payee.sync_on_chain().await.unwrap();
 
     assert_eq!(payee.get_on_chain_balance().unwrap().confirmed, 0);
     assert_eq!(payee.get_ldk_balance().available, 0);
@@ -170,12 +170,12 @@ async fn ln_force_close() {
     // Syncing the payee's wallet should now trigger a `SpendableOutputs` event
     // corresponding to their revocable output in the commitment transaction, which they
     // will subsequently spend in a new transaction paying to their on-chain wallet
-    payee.wallet().sync().unwrap();
+    payee.sync_on_chain().await.unwrap();
 
     // Mine one more block to confirm the transaction spending the payee's revocable output
     // in the commitment transaction
     bitcoind::mine(1).await.unwrap();
-    payee.wallet().sync().unwrap();
+    payee.sync_on_chain().await.unwrap();
 
     // Assert
 

--- a/crates/ln-dlc-node/src/tests/just_in_time_channel/create.rs
+++ b/crates/ln-dlc-node/src/tests/just_in_time_channel/create.rs
@@ -209,9 +209,9 @@ pub(crate) async fn send_interceptable_payment(
     invoice_amount: u64,
     coordinator_just_in_time_channel_creation_outbound_liquidity: Option<u64>,
 ) -> Result<()> {
-    payer.wallet().sync().await?;
-    coordinator.wallet().sync().await?;
-    payee.wallet().sync().await?;
+    payer.wallet().sync()?;
+    coordinator.wallet().sync()?;
+    payee.wallet().sync()?;
 
     let payer_balance_before = payer.get_ldk_balance();
     let coordinator_balance_before = coordinator.get_ldk_balance();
@@ -270,9 +270,9 @@ pub(crate) async fn send_interceptable_payment(
     // Assert
 
     // Sync LN wallet after payment is claimed to update the balances
-    payer.wallet().sync().await?;
-    coordinator.wallet().sync().await?;
-    payee.wallet().sync().await?;
+    payer.wallet().sync()?;
+    coordinator.wallet().sync()?;
+    payee.wallet().sync()?;
 
     let payer_balance_after = payer.get_ldk_balance();
     let coordinator_balance_after = coordinator.get_ldk_balance();

--- a/crates/ln-dlc-node/src/tests/just_in_time_channel/create.rs
+++ b/crates/ln-dlc-node/src/tests/just_in_time_channel/create.rs
@@ -17,7 +17,7 @@ use std::ops::Div;
 use std::ops::Mul;
 use std::time::Duration;
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 #[ignore]
 async fn open_jit_channel() {
     init_tracing();
@@ -59,7 +59,7 @@ async fn open_jit_channel() {
     .unwrap();
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 #[ignore]
 async fn fail_to_open_jit_channel_with_fee_rate_over_max() {
     init_tracing();
@@ -128,7 +128,7 @@ async fn fail_to_open_jit_channel_with_fee_rate_over_max() {
         .expect_err("payment should not succeed");
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 #[ignore]
 async fn open_jit_channel_with_disconnected_payee() {
     init_tracing();

--- a/crates/ln-dlc-node/src/tests/just_in_time_channel/multiple_payments.rs
+++ b/crates/ln-dlc-node/src/tests/just_in_time_channel/multiple_payments.rs
@@ -5,7 +5,7 @@ use crate::tests::just_in_time_channel::create::send_interceptable_payment;
 use crate::tests::min_outbound_liquidity_channel_creator;
 use bitcoin::Amount;
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 #[ignore]
 async fn just_in_time_channel_with_multiple_payments() {
     init_tracing();

--- a/crates/ln-dlc-node/src/tests/lnd.rs
+++ b/crates/ln-dlc-node/src/tests/lnd.rs
@@ -75,7 +75,7 @@ impl LndNode {
         .await?;
 
         bitcoind::mine(1).await?;
-        target.wallet().sync().unwrap();
+        target.sync_on_chain().await.unwrap();
 
         tokio::time::timeout(Duration::from_secs(60), async {
             loop {
@@ -83,7 +83,7 @@ impl LndNode {
                     break;
                 }
 
-                target.wallet().sync().unwrap();
+                target.sync_on_chain().await.unwrap();
 
                 tracing::debug!("Waiting for channel to be usable");
                 tokio::time::sleep(Duration::from_millis(500)).await;

--- a/crates/ln-dlc-node/src/tests/lnd.rs
+++ b/crates/ln-dlc-node/src/tests/lnd.rs
@@ -75,7 +75,7 @@ impl LndNode {
         .await?;
 
         bitcoind::mine(1).await?;
-        target.wallet().sync().await.unwrap();
+        target.wallet().sync().unwrap();
 
         tokio::time::timeout(Duration::from_secs(60), async {
             loop {
@@ -83,7 +83,7 @@ impl LndNode {
                     break;
                 }
 
-                target.wallet().sync().await.unwrap();
+                target.wallet().sync().unwrap();
 
                 tracing::debug!("Waiting for channel to be usable");
                 tokio::time::sleep(Duration::from_millis(500)).await;

--- a/crates/ln-dlc-node/src/tests/load.rs
+++ b/crates/ln-dlc-node/src/tests/load.rs
@@ -16,7 +16,7 @@ mod coordinator;
 
 const ESPLORA_ORIGIN_PUBLIC_REGTEST: &str = "http://35.189.57.114:3000";
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn single_app_many_positions_load() {
     init_tracing();
 

--- a/crates/ln-dlc-node/src/tests/mod.rs
+++ b/crates/ln-dlc-node/src/tests/mod.rs
@@ -129,7 +129,7 @@ impl Node<PaymentMap> {
         while self.get_confirmed_balance().await? < expected_balance {
             let interval = Duration::from_millis(200);
 
-            self.wallet().sync().await.unwrap();
+            self.wallet().sync().unwrap();
 
             tokio::time::sleep(interval).await;
             tracing::debug!(
@@ -187,8 +187,8 @@ impl Node<PaymentMap> {
                     // We need to sync both parties, even if
                     // `trust_own_funding_0conf` is true for the creator
                     // of the channel (`self`)
-                    self.wallet().sync().await.unwrap();
-                    peer.wallet().sync().await.unwrap();
+                    self.wallet().sync().unwrap();
+                    peer.wallet().sync().unwrap();
                 }
 
                 tracing::debug!(

--- a/crates/ln-dlc-node/src/tests/mod.rs
+++ b/crates/ln-dlc-node/src/tests/mod.rs
@@ -40,6 +40,7 @@ use std::net::TcpListener;
 use std::path::PathBuf;
 use std::sync::Once;
 use std::time::Duration;
+use tokio::task::block_in_place;
 
 mod bitcoind;
 mod dlc;
@@ -118,6 +119,17 @@ impl Node<PaymentMap> {
         Ok(node)
     }
 
+    /// Trigger on-chain wallet sync.
+    ///
+    /// We wrap the wallet sync with a `block_in_place` to avoid blocking the async task in
+    /// `tokio::test`s.
+    ///
+    /// Because we use `block_in_place`, we must configure the `tokio::test`s with `flavor =
+    /// "multi_thread"`.
+    async fn sync_on_chain(&self) -> Result<()> {
+        block_in_place(|| self.wallet().sync())
+    }
+
     async fn fund(&self, amount: Amount) -> Result<()> {
         let starting_balance = self.get_confirmed_balance().await?;
         let expected_balance = starting_balance + amount.to_sat();
@@ -129,7 +141,7 @@ impl Node<PaymentMap> {
         while self.get_confirmed_balance().await? < expected_balance {
             let interval = Duration::from_millis(200);
 
-            self.wallet().sync().unwrap();
+            self.sync_on_chain().await.unwrap();
 
             tokio::time::sleep(interval).await;
             tracing::debug!(
@@ -187,8 +199,8 @@ impl Node<PaymentMap> {
                     // We need to sync both parties, even if
                     // `trust_own_funding_0conf` is true for the creator
                     // of the channel (`self`)
-                    self.wallet().sync().unwrap();
-                    peer.wallet().sync().unwrap();
+                    self.sync_on_chain().await.unwrap();
+                    peer.sync_on_chain().await.unwrap();
                 }
 
                 tracing::debug!(

--- a/crates/ln-dlc-node/src/tests/multi_hop_payment.rs
+++ b/crates/ln-dlc-node/src/tests/multi_hop_payment.rs
@@ -3,7 +3,7 @@ use crate::tests::init_tracing;
 use crate::tests::min_outbound_liquidity_channel_creator;
 use bitcoin::Amount;
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 #[ignore]
 async fn multi_hop_payment() {
     init_tracing();
@@ -37,9 +37,9 @@ async fn multi_hop_payment() {
     let coordinator_balance_before = coordinator.get_ldk_balance();
     let payee_balance_before = payee.get_ldk_balance();
 
-    payer.wallet().sync().unwrap();
-    coordinator.wallet().sync().unwrap();
-    payee.wallet().sync().unwrap();
+    payer.sync_on_chain().await.unwrap();
+    coordinator.sync_on_chain().await.unwrap();
+    payee.sync_on_chain().await.unwrap();
 
     // Act
 
@@ -58,9 +58,9 @@ async fn multi_hop_payment() {
     // Assert
 
     // Sync LN wallet after payment is claimed to update the balances
-    payer.wallet().sync().unwrap();
-    coordinator.wallet().sync().unwrap();
-    payee.wallet().sync().unwrap();
+    payer.sync_on_chain().await.unwrap();
+    coordinator.sync_on_chain().await.unwrap();
+    payee.sync_on_chain().await.unwrap();
 
     let payer_balance_after = payer.get_ldk_balance();
     let coordinator_balance_after = coordinator.get_ldk_balance();

--- a/crates/ln-dlc-node/src/tests/multi_hop_payment.rs
+++ b/crates/ln-dlc-node/src/tests/multi_hop_payment.rs
@@ -37,9 +37,9 @@ async fn multi_hop_payment() {
     let coordinator_balance_before = coordinator.get_ldk_balance();
     let payee_balance_before = payee.get_ldk_balance();
 
-    payer.wallet().sync().await.unwrap();
-    coordinator.wallet().sync().await.unwrap();
-    payee.wallet().sync().await.unwrap();
+    payer.wallet().sync().unwrap();
+    coordinator.wallet().sync().unwrap();
+    payee.wallet().sync().unwrap();
 
     // Act
 
@@ -58,9 +58,9 @@ async fn multi_hop_payment() {
     // Assert
 
     // Sync LN wallet after payment is claimed to update the balances
-    payer.wallet().sync().await.unwrap();
-    coordinator.wallet().sync().await.unwrap();
-    payee.wallet().sync().await.unwrap();
+    payer.wallet().sync().unwrap();
+    coordinator.wallet().sync().unwrap();
+    payee.wallet().sync().unwrap();
 
     let payer_balance_after = payer.get_ldk_balance();
     let coordinator_balance_after = coordinator.get_ldk_balance();

--- a/crates/ln-dlc-node/src/tests/onboard_from_lnd.rs
+++ b/crates/ln-dlc-node/src/tests/onboard_from_lnd.rs
@@ -27,8 +27,8 @@ async fn onboard_from_lnd() {
 
     log_channel_id(&coordinator, 0, "lnd-coordinator");
 
-    coordinator.wallet().sync().await.unwrap();
-    payee.wallet().sync().await.unwrap();
+    coordinator.wallet().sync().unwrap();
+    payee.wallet().sync().unwrap();
 
     // The coordinator must send a `NodeAnnouncement` to LND before LND sends the payment, as
     // otherwise we will encounter an error in the coordinator when processing the incoming HTLC:
@@ -59,8 +59,8 @@ async fn onboard_from_lnd() {
     // For the payment to be claimed before the wallets sync
     tokio::time::sleep(Duration::from_secs(3)).await;
 
-    coordinator.wallet().sync().await.unwrap();
-    payee.wallet().sync().await.unwrap();
+    coordinator.wallet().sync().unwrap();
+    payee.wallet().sync().unwrap();
 
     // Assert
 

--- a/crates/ln-dlc-node/src/tests/onboard_from_lnd.rs
+++ b/crates/ln-dlc-node/src/tests/onboard_from_lnd.rs
@@ -5,7 +5,7 @@ use crate::tests::log_channel_id;
 use bitcoin::Amount;
 use std::time::Duration;
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 #[ignore]
 async fn onboard_from_lnd() {
     init_tracing();
@@ -27,8 +27,8 @@ async fn onboard_from_lnd() {
 
     log_channel_id(&coordinator, 0, "lnd-coordinator");
 
-    coordinator.wallet().sync().unwrap();
-    payee.wallet().sync().unwrap();
+    coordinator.sync_on_chain().await.unwrap();
+    payee.sync_on_chain().await.unwrap();
 
     // The coordinator must send a `NodeAnnouncement` to LND before LND sends the payment, as
     // otherwise we will encounter an error in the coordinator when processing the incoming HTLC:
@@ -59,8 +59,8 @@ async fn onboard_from_lnd() {
     // For the payment to be claimed before the wallets sync
     tokio::time::sleep(Duration::from_secs(3)).await;
 
-    coordinator.wallet().sync().unwrap();
-    payee.wallet().sync().unwrap();
+    coordinator.sync_on_chain().await.unwrap();
+    payee.sync_on_chain().await.unwrap();
 
     // Assert
 

--- a/crates/ln-dlc-node/src/tests/single_hop_payment.rs
+++ b/crates/ln-dlc-node/src/tests/single_hop_payment.rs
@@ -41,8 +41,8 @@ async fn single_hop_payment() {
     // Assert
 
     // Sync LN wallet after payment is claimed to update the balances
-    payer.wallet().sync().await.unwrap();
-    payee.wallet().sync().await.unwrap();
+    payer.wallet().sync().unwrap();
+    payee.wallet().sync().unwrap();
 
     let payer_balance_after = payer.get_ldk_balance();
     let payee_balance_after = payee.get_ldk_balance();

--- a/crates/ln-dlc-node/src/tests/single_hop_payment.rs
+++ b/crates/ln-dlc-node/src/tests/single_hop_payment.rs
@@ -2,7 +2,7 @@ use crate::node::Node;
 use crate::tests::init_tracing;
 use bitcoin::Amount;
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 #[ignore]
 async fn single_hop_payment() {
     init_tracing();
@@ -41,8 +41,8 @@ async fn single_hop_payment() {
     // Assert
 
     // Sync LN wallet after payment is claimed to update the balances
-    payer.wallet().sync().unwrap();
-    payee.wallet().sync().unwrap();
+    payer.sync_on_chain().await.unwrap();
+    payee.sync_on_chain().await.unwrap();
 
     let payer_balance_after = payer.get_ldk_balance();
     let payee_balance_after = payee.get_ldk_balance();

--- a/mobile/native/src/ln_dlc/mod.rs
+++ b/mobile/native/src/ln_dlc/mod.rs
@@ -52,7 +52,7 @@ pub async fn refresh_wallet_info() -> Result<()> {
     let node = NODE.get();
     let wallet = node.inner.wallet();
 
-    wallet.sync().await?;
+    spawn_blocking(move || wallet.sync()).await??;
     keep_wallet_balance_and_history_up_to_date(node).await?;
 
     Ok(())


### PR DESCRIPTION
One patch addresses production and the other addresses the tests.

~This could help with #807, but I'm not convinced. [edit]: Indeed it did not help, the same test still hangs on this very PR~.