### PR TITLE
chore: Remove direct channel open workaround for public regtest

### DIFF
--- a/mobile/lib/features/wallet/share_invoice_screen.dart
+++ b/mobile/lib/features/wallet/share_invoice_screen.dart
@@ -84,16 +84,8 @@ class _ShareInvoiceScreenState extends State<ShareInvoiceScreen> {
                         });
 
                         final router = GoRouter.of(context);
-                        const localCoordinatorPubkey =
-                            "02dd6abec97f9a748bf76ad502b004ce05d1b2d1f43a9e76bd7d85e767ffb022c9";
                         try {
-                          if (config.coordinatorPubkey == localCoordinatorPubkey) {
-                            await payInvoiceWithFaucet(widget.invoice);
-                          } else {
-                            // For remote coordinator, we open the channel
-                            // directly with the coordinator as it's less error-prone
-                            await openCoordinatorChannel(config.host);
-                          }
+                          await payInvoiceWithFaucet(widget.invoice);
                           // Pop both create invoice screen and share invoice screen
                           router.pop();
                           router.pop();


### PR DESCRIPTION
We used this to circumvent the random channel closures / no route errors on
regtest during 10101-test app testing.
Now that the testing is back on mainnet and we focus on stability of the app,
the underlying issues should be tackled properly and this workaround removed.