### PR TITLE
chore: Close stale issues after defined period of inactivity

### DIFF
--- a/.github/workflows/close-stale-issues.yml
+++ b/.github/workflows/close-stale-issues.yml
@@ -1,0 +1,15 @@
+# See more config options: https://github.com/marketplace/actions/close-stale-issues
+name: "Close stale issues and PRs"
+on:
+  schedule:
+    - cron: "30 1 * * *"
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v8
+        with:
+          stale-issue-message: "This issue is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 5 days."
+          days-before-stale: 30
+          days-before-close: 5


### PR DESCRIPTION
Issues and PRs without activity will be marked as stale after 30 days, and
closed if the label has not been removed (or any other action happened, such as
comment etc.) after 5 more days.