### PR TITLE
Center email request prompt

### DIFF
--- a/mobile/lib/features/welcome/welcome_screen.dart
+++ b/mobile/lib/features/welcome/welcome_screen.dart
@@ -46,10 +46,11 @@ class _WelcomeScreenState extends State<WelcomeScreen> {
                 Column(
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: const <Widget>[
-                    Text(
+                    Center(
+                        child: Text(
                       "As we are in closed beta, there may be bugs. To assist with any issues, please provide your email.",
                       style: TextStyle(fontSize: 16, color: Colors.black54),
-                    )
+                    ))
                   ],
                 ),
                 const SizedBox(height: 20),


### PR DESCRIPTION
Previously, this text was right aligned, which looks weird.

Before this change:
![image](https://github.com/get10101/10101/assets/6688948/fa4ab8ae-7236-4f12-b37e-a612f45257de)


After this change:
![image](https://github.com/get10101/10101/assets/6688948/9bbed03a-28f6-442e-81b5-1dfd4b4762ff)

Left alignment could also make sense though.