### PR TITLE
Encourage user not to close the app while order is being processed

### DIFF
--- a/mobile/lib/features/trade/application/order_service.dart
+++ b/mobile/lib/features/trade/application/order_service.dart
@@ -5,8 +5,8 @@ import 'package:get_10101/features/trade/domain/leverage.dart';
 import 'package:get_10101/features/trade/domain/order.dart';
 
 class OrderService {
-  Future<void> submitMarketOrder(Leverage leverage, double quantity, ContractSymbol contractSymbol,
-      Direction direction) async {
+  Future<String> submitMarketOrder(Leverage leverage, double quantity,
+      ContractSymbol contractSymbol, Direction direction) async {
     rust.NewOrder order = rust.NewOrder(
         leverage: leverage.leverage,
         quantity: quantity,
@@ -14,7 +14,7 @@ class OrderService {
         direction: direction.toApi(),
         orderType: const rust.OrderType.market());
 
-    await rust.api.submitOrder(order: order);
+    return await rust.api.submitOrder(order: order);
   }
 
   Future<List<Order>> fetchOrders() async {

--- a/mobile/lib/features/trade/order_submission_status_dialog.dart
+++ b/mobile/lib/features/trade/order_submission_status_dialog.dart
@@ -1,0 +1,88 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+
+enum OrderSubmissionStatusDialogType {
+  pendingSubmit,
+  successfulSubmit,
+  filled,
+  failedFill,
+  failedSubmit
+}
+
+class OrderSubmissionStatusDialog extends StatelessWidget {
+  final String title;
+  final OrderSubmissionStatusDialogType type;
+  final Widget content;
+  final String buttonText;
+  final EdgeInsets insetPadding;
+  final String navigateToRoute;
+
+  const OrderSubmissionStatusDialog(
+      {super.key,
+      required this.title,
+      required this.type,
+      required this.content,
+      this.buttonText = "Close",
+      this.insetPadding = const EdgeInsets.all(50),
+      this.navigateToRoute = ""});
+
+  @override
+  Widget build(BuildContext context) {
+    bool isPending = type == OrderSubmissionStatusDialogType.successfulSubmit ||
+        type == OrderSubmissionStatusDialogType.pendingSubmit;
+
+    Widget closeButton = ElevatedButton(
+        onPressed: () {
+          GoRouter.of(context).pop();
+
+          if (navigateToRoute.isNotEmpty) {
+            GoRouter.of(context).go(navigateToRoute);
+          }
+        },
+        child: Text(buttonText));
+
+    AlertDialog dialog = AlertDialog(
+      icon: (() {
+        switch (type) {
+          case OrderSubmissionStatusDialogType.pendingSubmit:
+          case OrderSubmissionStatusDialogType.successfulSubmit:
+            return const Center(
+                child: SizedBox(width: 20, height: 20, child: CircularProgressIndicator()));
+          case OrderSubmissionStatusDialogType.failedFill:
+          case OrderSubmissionStatusDialogType.failedSubmit:
+            return const Icon(
+              Icons.cancel,
+              color: Colors.red,
+            );
+          case OrderSubmissionStatusDialogType.filled:
+            return const Icon(
+              Icons.check_circle,
+              color: Colors.green,
+            );
+        }
+      })(),
+      title: Text("$title ${(() {
+        switch (type) {
+          case OrderSubmissionStatusDialogType.pendingSubmit:
+          case OrderSubmissionStatusDialogType.successfulSubmit:
+            return "Pending";
+          case OrderSubmissionStatusDialogType.filled:
+            return "Success";
+          case OrderSubmissionStatusDialogType.failedSubmit:
+          case OrderSubmissionStatusDialogType.failedFill:
+            return "Failure";
+        }
+      })()}"),
+      content: content,
+      actions: isPending ? null : [closeButton],
+      insetPadding: insetPadding,
+    );
+
+    // If pending, prevent use of back button
+    if (isPending) {
+      return WillPopScope(child: dialog, onWillPop: () async => false);
+    } else {
+      return dialog;
+    }
+  }
+}

--- a/mobile/lib/features/trade/submit_order_change_notifier.dart
+++ b/mobile/lib/features/trade/submit_order_change_notifier.dart
@@ -1,16 +1,22 @@
+import 'dart:developer';
 import 'package:f_logs/model/flog/flog.dart';
 import 'package:flutter/material.dart';
+import 'package:get_10101/common/application/event_service.dart';
 import 'package:get_10101/common/domain/model.dart';
 import 'package:get_10101/features/trade/application/order_service.dart';
 import 'package:get_10101/features/trade/application/trade_values_service.dart';
 import 'package:get_10101/features/trade/domain/contract_symbol.dart';
 import 'package:get_10101/features/trade/domain/position.dart';
+import 'domain/order.dart';
 import 'domain/trade_values.dart';
+import 'package:get_10101/bridge_generated/bridge_definitions.dart' as bridge;
 
 enum PendingOrderState {
   submitting,
   submittedSuccessfully,
   submissionFailed,
+  orderFilled,
+  orderFailed,
 }
 
 enum PositionAction {
@@ -23,11 +29,12 @@ class PendingOrder {
   PendingOrderState state = PendingOrderState.submitting;
   String? pendingOrderError;
   final PositionAction positionAction;
+  String? id;
 
   PendingOrder(this._tradeValues, this.positionAction);
 }
 
-class SubmitOrderChangeNotifier extends ChangeNotifier {
+class SubmitOrderChangeNotifier extends ChangeNotifier implements Subscriber {
   final OrderService orderService;
   PendingOrder? _pendingOrder;
 
@@ -40,7 +47,7 @@ class SubmitOrderChangeNotifier extends ChangeNotifier {
     notifyListeners();
 
     try {
-      await orderService.submitMarketOrder(
+      _pendingOrder!.id = await orderService.submitMarketOrder(
           tradeValues.leverage, tradeValues.quantity, ContractSymbol.btcusd, tradeValues.direction);
       _pendingOrder!.state = PendingOrderState.submittedSuccessfully;
     } catch (exception) {
@@ -50,6 +57,33 @@ class SubmitOrderChangeNotifier extends ChangeNotifier {
 
     // notify listeners about the status change of the pending order after submission
     notifyListeners();
+  }
+
+  // TODO: This is not optimal, because we map the Order in the change notifier. We can do this, but it would be better to do this on the service level.
+  @override
+  void notify(bridge.Event event) {
+    log("Receiving this in the submit order change notifier: ${event.toString()}");
+
+    if (event is bridge.Event_OrderUpdateNotification) {
+      Order order = Order.fromApi(event.field0);
+
+      if (_pendingOrder?.id == order.id) {
+        switch (order.state) {
+          case OrderState.open:
+            return;
+          case OrderState.filled:
+            _pendingOrder!.state = PendingOrderState.orderFilled;
+            break;
+          case OrderState.failed:
+            _pendingOrder!.state = PendingOrderState.orderFailed;
+            break;
+        }
+
+        notifyListeners();
+      }
+    } else {
+      log("Received unexpected event: ${event.toString()}");
+    }
   }
 
   Future<void> closePosition(Position position) async {

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -201,7 +201,8 @@ class _TenTenOneAppState extends State<TenTenOneApp> {
         context.read<PositionChangeNotifier>(),
         context.read<WalletChangeNotifier>(),
         context.read<CandlestickChangeNotifier>(),
-        context.read<TradeValuesChangeNotifier>());
+        context.read<TradeValuesChangeNotifier>(),
+        context.read<SubmitOrderChangeNotifier>());
   }
 
   @override
@@ -232,7 +233,8 @@ class _TenTenOneAppState extends State<TenTenOneApp> {
       PositionChangeNotifier positionChangeNotifier,
       WalletChangeNotifier walletChangeNotifier,
       CandlestickChangeNotifier candlestickChangeNotifier,
-      TradeValuesChangeNotifier tradeValuesChangeNotifier) async {
+      TradeValuesChangeNotifier tradeValuesChangeNotifier,
+      SubmitOrderChangeNotifier submitOrderChangeNotifier) async {
     try {
       setupRustLogging();
 
@@ -241,6 +243,9 @@ class _TenTenOneAppState extends State<TenTenOneApp> {
       final EventService eventService = EventService.create();
       eventService.subscribe(
           orderChangeNotifier, bridge.Event.orderUpdateNotification(Order.apiDummy()));
+
+      eventService.subscribe(
+          submitOrderChangeNotifier, bridge.Event.orderUpdateNotification(Order.apiDummy()));
 
       eventService.subscribe(
           positionChangeNotifier, bridge.Event.positionUpdateNotification(Position.apiDummy()));

--- a/mobile/native/src/api.rs
+++ b/mobile/native/src/api.rs
@@ -139,9 +139,10 @@ pub fn calculate_pnl(
 }
 
 #[tokio::main(flavor = "current_thread")]
-pub async fn submit_order(order: NewOrder) -> Result<()> {
-    order::handler::submit_order(order.into()).await?;
-    Ok(())
+pub async fn submit_order(order: NewOrder) -> Result<String> {
+    order::handler::submit_order(order.into())
+        .await
+        .map(|id| id.to_string())
 }
 
 #[tokio::main(flavor = "current_thread")]

--- a/mobile/native/src/trade/order/handler.rs
+++ b/mobile/native/src/trade/order/handler.rs
@@ -20,7 +20,7 @@ use uuid::Uuid;
 
 const ORDER_OUTDATED_AFTER: Duration = Duration::minutes(5);
 
-pub async fn submit_order(order: Order) -> Result<()> {
+pub async fn submit_order(order: Order) -> Result<Uuid> {
     let url = format!("http://{}", config::get_http_endpoint());
     let orderbook_client = OrderbookClient::new(Url::parse(&url)?);
 
@@ -44,7 +44,7 @@ pub async fn submit_order(order: Order) -> Result<()> {
     update_order_state_in_db_and_ui(order.id, OrderState::Open)?;
     update_position_after_order_submitted(&order)?;
 
-    Ok(())
+    Ok(order.id)
 }
 
 /// Update order to state [`OrderState::Filling`].


### PR DESCRIPTION
Share is shown after it is filled, fixing #714.

While order is filling (hard to see but that's a loading spinner on top):
![image](https://github.com/get10101/10101/assets/6688948/a6de9ddf-71a4-4fd1-bd53-5695155f6bd2)

Once order has been filled successfully:
![image](https://github.com/get10101/10101/assets/6688948/5b7e3897-6785-4dd2-aeeb-97fc69eceb9c)
