### PR TITLE
Fix: failed to close position got revoke commitment secret not matching their current pubkey

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -891,7 +891,7 @@ dependencies = [
 [[package]]
 name = "dlc"
 version = "0.4.0"
-source = "git+https://github.com/p2pderivatives/rust-dlc?rev=11c746f#11c746fc55d6a7a95f17bce61d4989a48454d581"
+source = "git+https://github.com/p2pderivatives/rust-dlc?rev=51c3c3fc4c9f468a0aa31f51a73f87149697be50#51c3c3fc4c9f468a0aa31f51a73f87149697be50"
 dependencies = [
  "bitcoin",
  "miniscript 8.0.0",
@@ -903,7 +903,7 @@ dependencies = [
 [[package]]
 name = "dlc-manager"
 version = "0.4.0"
-source = "git+https://github.com/p2pderivatives/rust-dlc?rev=11c746f#11c746fc55d6a7a95f17bce61d4989a48454d581"
+source = "git+https://github.com/p2pderivatives/rust-dlc?rev=51c3c3fc4c9f468a0aa31f51a73f87149697be50#51c3c3fc4c9f468a0aa31f51a73f87149697be50"
 dependencies = [
  "async-trait",
  "bitcoin",
@@ -919,11 +919,12 @@ dependencies = [
 [[package]]
 name = "dlc-messages"
 version = "0.4.0"
-source = "git+https://github.com/p2pderivatives/rust-dlc?rev=11c746f#11c746fc55d6a7a95f17bce61d4989a48454d581"
+source = "git+https://github.com/p2pderivatives/rust-dlc?rev=51c3c3fc4c9f468a0aa31f51a73f87149697be50#51c3c3fc4c9f468a0aa31f51a73f87149697be50"
 dependencies = [
  "bitcoin",
  "dlc",
  "lightning",
+ "log",
  "secp256k1-zkp",
  "serde",
 ]
@@ -931,7 +932,7 @@ dependencies = [
 [[package]]
 name = "dlc-sled-storage-provider"
 version = "0.1.0"
-source = "git+https://github.com/p2pderivatives/rust-dlc?rev=11c746f#11c746fc55d6a7a95f17bce61d4989a48454d581"
+source = "git+https://github.com/p2pderivatives/rust-dlc?rev=51c3c3fc4c9f468a0aa31f51a73f87149697be50#51c3c3fc4c9f468a0aa31f51a73f87149697be50"
 dependencies = [
  "bitcoin",
  "dlc-manager",
@@ -945,7 +946,7 @@ dependencies = [
 [[package]]
 name = "dlc-trie"
 version = "0.4.0"
-source = "git+https://github.com/p2pderivatives/rust-dlc?rev=11c746f#11c746fc55d6a7a95f17bce61d4989a48454d581"
+source = "git+https://github.com/p2pderivatives/rust-dlc?rev=51c3c3fc4c9f468a0aa31f51a73f87149697be50#51c3c3fc4c9f468a0aa31f51a73f87149697be50"
 dependencies = [
  "bitcoin",
  "dlc",
@@ -2285,7 +2286,7 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 [[package]]
 name = "p2pd-oracle-client"
 version = "0.1.0"
-source = "git+https://github.com/p2pderivatives/rust-dlc?rev=11c746f#11c746fc55d6a7a95f17bce61d4989a48454d581"
+source = "git+https://github.com/p2pderivatives/rust-dlc?rev=51c3c3fc4c9f468a0aa31f51a73f87149697be50#51c3c3fc4c9f468a0aa31f51a73f87149697be50"
 dependencies = [
  "chrono",
  "dlc-manager",
@@ -3100,7 +3101,7 @@ dependencies = [
 [[package]]
 name = "simple-wallet"
 version = "0.1.0"
-source = "git+https://github.com/p2pderivatives/rust-dlc?rev=11c746f#11c746fc55d6a7a95f17bce61d4989a48454d581"
+source = "git+https://github.com/p2pderivatives/rust-dlc?rev=51c3c3fc4c9f468a0aa31f51a73f87149697be50#51c3c3fc4c9f468a0aa31f51a73f87149697be50"
 dependencies = [
  "bitcoin",
  "dlc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,13 +4,13 @@ resolver = "2"
 
 [patch.crates-io]
 # We should usually track the `feature/ln-dlc-channels[-10101]` branch
-dlc-manager = { git = "https://github.com/p2pderivatives/rust-dlc", rev = "11c746f" }
-dlc-messages = { git = "https://github.com/p2pderivatives/rust-dlc", rev = "11c746f" }
-dlc = { git = "https://github.com/p2pderivatives/rust-dlc", rev = "11c746f" }
-dlc-sled-storage-provider = { git = "https://github.com/p2pderivatives/rust-dlc", rev = "11c746f" }
-p2pd-oracle-client = { git = "https://github.com/p2pderivatives/rust-dlc", rev = "11c746f" }
-dlc-trie = { git = "https://github.com/p2pderivatives/rust-dlc", rev = "11c746f" }
-simple-wallet = { git = "https://github.com/p2pderivatives/rust-dlc", rev = "11c746f" }
+dlc-manager = { git = "https://github.com/p2pderivatives/rust-dlc", rev = "51c3c3fc4c9f468a0aa31f51a73f87149697be50" }
+dlc-messages = { git = "https://github.com/p2pderivatives/rust-dlc", rev = "51c3c3fc4c9f468a0aa31f51a73f87149697be50" }
+dlc = { git = "https://github.com/p2pderivatives/rust-dlc", rev = "51c3c3fc4c9f468a0aa31f51a73f87149697be50" }
+dlc-sled-storage-provider = { git = "https://github.com/p2pderivatives/rust-dlc", rev = "51c3c3fc4c9f468a0aa31f51a73f87149697be50" }
+p2pd-oracle-client = { git = "https://github.com/p2pderivatives/rust-dlc", rev = "51c3c3fc4c9f468a0aa31f51a73f87149697be50" }
+dlc-trie = { git = "https://github.com/p2pderivatives/rust-dlc", rev = "51c3c3fc4c9f468a0aa31f51a73f87149697be50" }
+simple-wallet = { git = "https://github.com/p2pderivatives/rust-dlc", rev = "51c3c3fc4c9f468a0aa31f51a73f87149697be50" }
 
 # We should usually track the `split-tx-experiment[-10101]` branch
 lightning = { git = "https://github.com/p2pderivatives/rust-lightning/", rev = "a663e1fb" }

--- a/crates/ln-dlc-node/src/lib.rs
+++ b/crates/ln-dlc-node/src/lib.rs
@@ -8,7 +8,6 @@ use fee_rate_estimator::FeeRateEstimator;
 use lightning::chain::chainmonitor;
 use lightning::chain::Filter;
 use lightning::ln::channelmanager::InterceptId;
-use lightning::ln::peer_handler::IgnoringMessageHandler;
 use lightning::ln::PaymentPreimage;
 use lightning::ln::PaymentSecret;
 use lightning::routing::gossip;
@@ -64,7 +63,7 @@ pub type PeerManager = lightning::ln::peer_handler::PeerManager<
             Arc<TracingLogger>,
         >,
     >,
-    Arc<IgnoringMessageHandler>,
+    Arc<DlcMessageHandler>,
     Arc<TracingLogger>,
     Arc<DlcMessageHandler>,
     Arc<CustomKeysManager>,

--- a/crates/ln-dlc-node/src/tests/dlc/dlc_setup_with_reconnects.rs
+++ b/crates/ln-dlc-node/src/tests/dlc/dlc_setup_with_reconnects.rs
@@ -118,7 +118,7 @@ async fn reconnecting_during_dlc_channel_setup() {
     .await
     .unwrap();
 
-    // Wait for the `Accepted` message to
+    // Wait for the `Accepted` message to be processed
     tokio::time::sleep(Duration::from_secs(2)).await;
     // The app processes the repeated accept message from the coordinator and sends another confirm
     // message.
@@ -138,6 +138,93 @@ async fn reconnecting_during_dlc_channel_setup() {
         .list_channels()
         .iter()
         .any(|channel| channel.channel_id == channel_details.channel_id));
+
+    // Process the `Finalize` message from the Coordinator.
+    wait_until_dlc_channel_state(
+        Duration::from_secs(30),
+        &app,
+        coordinator.info.pubkey,
+        SubChannelStateName::Signed,
+    )
+    .await
+    .unwrap();
+
+    let coordinator_settlement_amount = 12_500;
+    app.propose_dlc_channel_collaborative_settlement(
+        channel_details.channel_id,
+        coordinator_settlement_amount,
+    )
+    .await
+    .unwrap();
+
+    // Process the app's `CloseOffer`
+    let sub_channel = wait_until_dlc_channel_state(
+        Duration::from_secs(30),
+        &coordinator,
+        app.info.pubkey,
+        SubChannelStateName::CloseOffered,
+    )
+    .await
+    .unwrap();
+
+    coordinator
+        .accept_dlc_channel_collaborative_settlement(&sub_channel.channel_id)
+        .unwrap();
+
+    // Process the coordinator's `CloseAccept` and send `CloseConfirm`
+    wait_until_dlc_channel_state(
+        Duration::from_secs(30),
+        &app,
+        coordinator.info.pubkey,
+        SubChannelStateName::CloseConfirmed,
+    )
+    .await
+    .unwrap();
+
+    // Wait for the `CloseConfirm` message to be delivered
+    tokio::time::sleep(Duration::from_secs(2)).await;
+
+    app.reconnect(coordinator_info).await.unwrap();
+
+    // Wait for the peers to reconnect and get the `ChannelReestablish` event. During the reconnect
+    // the coordinator will return from `CloseAccepted` to the `Signed` state.
+    tokio::time::sleep(Duration::from_secs(2)).await;
+
+    // The coordinator handles `ReCloseAccept` action. We need this so that the coordinator advances
+    // its state to `CloseAccepted` again, so that it can process the app's repeated
+    // `CloseConfirm` message
+    sub_channel_manager_periodic_check(
+        coordinator.sub_channel_manager.clone(),
+        &coordinator.dlc_message_handler,
+    )
+    .await
+    .unwrap();
+
+    // Wait for the `CloseAccepted` message to be processed
+    tokio::time::sleep(Duration::from_secs(2)).await;
+    // The app processes the repeated `CloseAccept` message from the coordinator and sends another
+    // `CloseConfirm` message.
+    app.process_incoming_messages().unwrap();
+
+    // Process the app's `CloseConfirm` and send `CloseFinalize`
+    wait_until_dlc_channel_state(
+        Duration::from_secs(30),
+        &coordinator,
+        app.info.pubkey,
+        SubChannelStateName::OffChainClosed,
+    )
+    .await
+    .unwrap();
+
+    // Process the coordinator's `CloseFinalize`
+    wait_until_dlc_channel_state(
+        Duration::from_secs(30),
+        &app,
+        coordinator.info.pubkey,
+        SubChannelStateName::OffChainClosed,
+    )
+    .await
+    .unwrap();
 }
 
 #[tokio::test(flavor = "multi_thread")]


### PR DESCRIPTION
Fixes a bug very similar to #792. But happening during processing an outdated `Confirm` and `CloseConfirm` message. However, the bug reported with #792 fails on processing `CloseFinalize` message.

By using the dlc message handler as onion message handler we can hook into the `peer_disconnected event` and clear and pending unprocessed received `Confirm` and `CloseConfirm` messages from the disconnected peer.

See also fix in `rust-dlc` https://github.com/p2pderivatives/rust-dlc/commit/51c3c3fc4c9f468a0aa31f51a73f87149697be50