### PR TITLE
Refactor DLC tests

### DIFF
--- a/crates/ln-dlc-node/src/node/dlc_channel.rs
+++ b/crates/ln-dlc-node/src/node/dlc_channel.rs
@@ -29,6 +29,8 @@ where
         channel_details: ChannelDetails,
         contract_input: ContractInput,
     ) -> Result<()> {
+        tracing::info!(channel_id = %hex::encode(channel_details.channel_id), "Sending DLC channel offer");
+
         spawn_blocking({
             let oracle = self.oracle.clone();
             let sub_channel_manager = self.sub_channel_manager.clone();

--- a/crates/ln-dlc-node/src/tests/dlc/collaborative_settlement.rs
+++ b/crates/ln-dlc-node/src/tests/dlc/collaborative_settlement.rs
@@ -1,13 +1,12 @@
 use crate::node::Node;
 use crate::node::PaymentMap;
 use crate::tests::dlc::create::create_dlc_channel;
-use crate::tests::dlc::create::DlcChannelCreated;
-use crate::tests::dummy_contract_input;
 use crate::tests::init_tracing;
 use crate::tests::wait_until_dlc_channel_state;
 use crate::tests::SubChannelStateName;
 use anyhow::Context;
 use anyhow::Result;
+use bitcoin::Amount;
 use std::time::Duration;
 
 #[tokio::test]
@@ -15,84 +14,57 @@ use std::time::Duration;
 async fn dlc_collaborative_settlement_test() {
     init_tracing();
 
+    // Arrange
+
     let app_dlc_collateral = 50_000;
     let coordinator_dlc_collateral = 25_000;
 
-    dlc_collaborative_settlement(app_dlc_collateral, coordinator_dlc_collateral)
+    let app_ln_balance = app_dlc_collateral * 2;
+    let coordinator_ln_balance = coordinator_dlc_collateral * 2;
+
+    let fund_amount = (app_ln_balance + coordinator_ln_balance) * 2;
+
+    let app = Node::start_test_app("app").unwrap();
+    let coordinator = Node::start_test_coordinator("coordinator").unwrap();
+
+    app.connect(coordinator.info).await.unwrap();
+
+    coordinator
+        .fund(Amount::from_sat(fund_amount))
         .await
         .unwrap();
-}
 
-/// Start an app and a coordinator; create an LN channel between them with double the specified
-/// amounts; add a DLC channel with the specified amounts; and close the DLC channel giving the
-/// coordinator 50% losses.
-async fn dlc_collaborative_settlement(
-    app_dlc_collateral: u64,
-    coordinator_dlc_collateral: u64,
-) -> Result<(Node<PaymentMap>, Node<PaymentMap>)> {
-    // Arrange
+    coordinator
+        .open_channel(&app, coordinator_ln_balance, app_ln_balance)
+        .await
+        .unwrap();
 
-    let DlcChannelCreated {
-        coordinator,
-        coordinator_balance_channel_creation,
-        app,
-        app_balance_channel_creation,
-        channel_details,
-    } = create_dlc_channel(app_dlc_collateral, coordinator_dlc_collateral).await?;
+    let app_balance_channel_creation = app.get_ldk_balance().available;
+    let coordinator_balance_channel_creation = coordinator.get_ldk_balance().available;
 
-    // Act
+    create_dlc_channel(
+        &app,
+        &coordinator,
+        app_dlc_collateral,
+        coordinator_dlc_collateral,
+    )
+    .await
+    .unwrap();
 
     // The underlying API expects the settlement amount of the party who originally _accepted_ the
     // channel. Since we know in this case that the coordinator accepted the DLC channel, here we
     // specify the coordinator's settlement amount.
     let coordinator_settlement_amount = coordinator_dlc_collateral / 2;
-    let coordinator_loss_amount = coordinator_dlc_collateral - coordinator_settlement_amount;
 
-    app.propose_dlc_channel_collaborative_settlement(
-        channel_details.channel_id,
-        coordinator_settlement_amount,
-    )
-    .await?;
+    // Act
 
-    // Process the app's `CloseOffer`
-    let sub_channel = wait_until_dlc_channel_state(
-        Duration::from_secs(30),
-        &coordinator,
-        app.info.pubkey,
-        SubChannelStateName::CloseOffered,
-    )
-    .await?;
-
-    coordinator.accept_dlc_channel_collaborative_settlement(&sub_channel.channel_id)?;
-
-    // Process the coordinator's `CloseAccept` and send `CloseConfirm`
-    wait_until_dlc_channel_state(
-        Duration::from_secs(30),
-        &app,
-        coordinator.info.pubkey,
-        SubChannelStateName::CloseConfirmed,
-    )
-    .await?;
+    dlc_collaborative_settlement(&app, &coordinator, coordinator_settlement_amount)
+        .await
+        .unwrap();
 
     // Assert
 
-    // Process the app's `CloseConfirm` and send `CloseFinalize`
-    wait_until_dlc_channel_state(
-        Duration::from_secs(30),
-        &coordinator,
-        app.info.pubkey,
-        SubChannelStateName::OffChainClosed,
-    )
-    .await?;
-
-    // Process the coordinator's `CloseFinalize`
-    wait_until_dlc_channel_state(
-        Duration::from_secs(30),
-        &app,
-        coordinator.info.pubkey,
-        SubChannelStateName::OffChainClosed,
-    )
-    .await?;
+    let coordinator_loss_amount = coordinator_dlc_collateral - coordinator_settlement_amount;
 
     let app_balance_after = app.get_ldk_balance().available;
     let coordinator_balance_after = coordinator.get_ldk_balance().available;
@@ -106,8 +78,6 @@ async fn dlc_collaborative_settlement(
         coordinator_balance_channel_creation,
         coordinator_balance_after + coordinator_loss_amount
     );
-
-    Ok((app, coordinator))
 }
 
 #[tokio::test]
@@ -120,75 +90,110 @@ async fn open_dlc_channel_after_closing_dlc_channel() {
     let app_dlc_collateral = 50_000;
     let coordinator_dlc_collateral = 25_000;
 
-    let (app, coordinator) =
-        dlc_collaborative_settlement(app_dlc_collateral, coordinator_dlc_collateral)
-            .await
-            .unwrap();
+    let app_ln_balance = app_dlc_collateral * 2;
+    let coordinator_ln_balance = coordinator_dlc_collateral * 2;
 
-    let channel_details = app.channel_manager.list_usable_channels();
-    let channel_details = channel_details
-        .iter()
-        .find(|c| c.counterparty.node_id == coordinator.info.pubkey)
-        .context("No usable channels for app")
-        .unwrap()
-        .clone();
+    let fund_amount = (app_ln_balance + coordinator_ln_balance) * 2;
 
-    // Act
+    let app = Node::start_test_app("app").unwrap();
+    let coordinator = Node::start_test_coordinator("coordinator").unwrap();
 
-    let app_dlc_collateral = 20_000;
-    let coordinator_dlc_collateral = 10_000;
+    app.connect(coordinator.info).await.unwrap();
 
-    let oracle_pk = app.oracle_pk();
-    let contract_input =
-        dummy_contract_input(app_dlc_collateral, coordinator_dlc_collateral, oracle_pk);
-
-    app.propose_dlc_channel(channel_details, contract_input)
+    coordinator
+        .fund(Amount::from_sat(fund_amount))
         .await
         .unwrap();
 
-    // Process the app's `Offer`
-    let sub_channel = wait_until_dlc_channel_state(
-        Duration::from_secs(30),
-        &coordinator,
-        app.info.pubkey,
-        SubChannelStateName::Offered,
-    )
-    .await
-    .unwrap();
-
     coordinator
-        .accept_dlc_channel_offer(&sub_channel.channel_id)
+        .open_channel(&app, coordinator_ln_balance, app_ln_balance)
+        .await
         .unwrap();
 
-    // Process the coordinator's `Accept` and send `Confirm`
-    wait_until_dlc_channel_state(
-        Duration::from_secs(30),
+    create_dlc_channel(
         &app,
-        coordinator.info.pubkey,
-        SubChannelStateName::Confirmed,
+        &coordinator,
+        app_dlc_collateral,
+        coordinator_dlc_collateral,
     )
     .await
     .unwrap();
+
+    let coordinator_settlement_amount = coordinator_dlc_collateral / 2;
+    dlc_collaborative_settlement(&app, &coordinator, coordinator_settlement_amount)
+        .await
+        .unwrap();
+
+    // Act and assert
+
+    create_dlc_channel(
+        &app,
+        &coordinator,
+        app_dlc_collateral,
+        coordinator_dlc_collateral,
+    )
+    .await
+    .unwrap();
+}
+
+async fn dlc_collaborative_settlement(
+    app: &Node<PaymentMap>,
+    coordinator: &Node<PaymentMap>,
+    coordinator_settlement_amount: u64,
+) -> Result<()> {
+    let channel_details = app
+        .channel_manager
+        .list_usable_channels()
+        .iter()
+        .find(|c| c.counterparty.node_id == coordinator.info.pubkey)
+        .context("Could not find usable channel with peer")?
+        .clone();
+
+    app.propose_dlc_channel_collaborative_settlement(
+        channel_details.channel_id,
+        coordinator_settlement_amount,
+    )
+    .await?;
+
+    // Process the app's `CloseOffer`
+    let sub_channel = wait_until_dlc_channel_state(
+        Duration::from_secs(30),
+        coordinator,
+        app.info.pubkey,
+        SubChannelStateName::CloseOffered,
+    )
+    .await?;
+
+    coordinator.accept_dlc_channel_collaborative_settlement(&sub_channel.channel_id)?;
+
+    // Process the coordinator's `CloseAccept` and send `CloseConfirm`
+    wait_until_dlc_channel_state(
+        Duration::from_secs(30),
+        app,
+        coordinator.info.pubkey,
+        SubChannelStateName::CloseConfirmed,
+    )
+    .await?;
 
     // Assert
 
-    // Process the app's `Confirm` and send `Finalize`
+    // Process the app's `CloseConfirm` and send `CloseFinalize`
     wait_until_dlc_channel_state(
         Duration::from_secs(30),
-        &coordinator,
+        coordinator,
         app.info.pubkey,
-        SubChannelStateName::Signed,
+        SubChannelStateName::OffChainClosed,
     )
-    .await
-    .unwrap();
+    .await?;
 
-    // Process the coordinator's `Finalize`
+    // Process the coordinator's `CloseFinalize`
     wait_until_dlc_channel_state(
         Duration::from_secs(30),
-        &app,
+        app,
         coordinator.info.pubkey,
-        SubChannelStateName::Signed,
+        SubChannelStateName::OffChainClosed,
     )
-    .await
-    .unwrap();
+    .await?;
+
+    Ok(())
 }

--- a/crates/ln-dlc-node/src/tests/dlc/create.rs
+++ b/crates/ln-dlc-node/src/tests/dlc/create.rs
@@ -7,7 +7,6 @@ use crate::tests::SubChannelStateName;
 use anyhow::Context;
 use anyhow::Result;
 use bitcoin::Amount;
-use lightning::ln::channelmanager::ChannelDetails;
 use std::time::Duration;
 
 #[tokio::test]
@@ -15,59 +14,64 @@ use std::time::Duration;
 async fn given_lightning_channel_then_can_add_dlc_channel() {
     init_tracing();
 
+    // Arrange
+
     let app_dlc_collateral = 50_000;
     let coordinator_dlc_collateral = 25_000;
-
-    create_dlc_channel(app_dlc_collateral, coordinator_dlc_collateral)
-        .await
-        .unwrap();
-}
-
-pub struct DlcChannelCreated {
-    pub coordinator: Node<PaymentMap>,
-    /// Available balance for the coordinator after the LN channel was created. In sats.
-    pub coordinator_balance_channel_creation: u64,
-    pub app: Node<PaymentMap>,
-    /// Available balance for the app after the LN channel was created. In sats.
-    pub app_balance_channel_creation: u64,
-    pub channel_details: ChannelDetails,
-}
-
-pub async fn create_dlc_channel(
-    app_dlc_collateral: u64,
-    coordinator_dlc_collateral: u64,
-) -> Result<DlcChannelCreated> {
-    // Arrange
 
     let app_ln_balance = app_dlc_collateral * 2;
     let coordinator_ln_balance = coordinator_dlc_collateral * 2;
 
     let fund_amount = (app_ln_balance + coordinator_ln_balance) * 2;
 
-    let app = Node::start_test_app("app")?;
-    let coordinator = Node::start_test_coordinator("coordinator")?;
+    let app = Node::start_test_app("app").unwrap();
+    let coordinator = Node::start_test_coordinator("coordinator").unwrap();
 
-    app.connect(coordinator.info).await?;
+    app.connect(coordinator.info).await.unwrap();
 
-    coordinator.fund(Amount::from_sat(fund_amount)).await?;
+    coordinator
+        .fund(Amount::from_sat(fund_amount))
+        .await
+        .unwrap();
 
     coordinator
         .open_channel(&app, coordinator_ln_balance, app_ln_balance)
-        .await?;
-    let channel_details = app.channel_manager.list_usable_channels();
-    let channel_details = channel_details
-        .into_iter()
-        .find(|c| c.counterparty.node_id == coordinator.info.pubkey)
-        .context("No usable channels for app")?;
+        .await
+        .unwrap();
 
-    let app_balance_channel_creation = app.get_ldk_balance().available;
-    let coordinator_balance_channel_creation = coordinator.get_ldk_balance().available;
+    tokio::time::sleep(Duration::from_secs(5)).await;
 
+    // Act and assert
+
+    create_dlc_channel(
+        &app,
+        &coordinator,
+        app_dlc_collateral,
+        coordinator_dlc_collateral,
+    )
+    .await
+    .unwrap();
+}
+
+pub async fn create_dlc_channel(
+    app: &Node<PaymentMap>,
+    coordinator: &Node<PaymentMap>,
+    app_dlc_collateral: u64,
+    coordinator_dlc_collateral: u64,
+) -> Result<()> {
     // Act
 
     let oracle_pk = app.oracle_pk();
     let contract_input =
         dummy_contract_input(app_dlc_collateral, coordinator_dlc_collateral, oracle_pk);
+
+    let channel_details = app
+        .channel_manager
+        .list_usable_channels()
+        .iter()
+        .find(|c| c.counterparty.node_id == coordinator.info.pubkey)
+        .context("Could not find usable channel with peer")?
+        .clone();
 
     app.propose_dlc_channel(channel_details.clone(), contract_input)
         .await?;
@@ -75,52 +79,42 @@ pub async fn create_dlc_channel(
     // Process the app's `Offer`
     let sub_channel = wait_until_dlc_channel_state(
         Duration::from_secs(30),
-        &coordinator,
+        coordinator,
         app.info.pubkey,
         SubChannelStateName::Offered,
     )
-    .await
-    .unwrap();
+    .await?;
 
     coordinator.accept_dlc_channel_offer(&sub_channel.channel_id)?;
 
     // Process the coordinator's `Accept` and send `Confirm`
     wait_until_dlc_channel_state(
         Duration::from_secs(30),
-        &app,
+        app,
         coordinator.info.pubkey,
         SubChannelStateName::Confirmed,
     )
-    .await
-    .unwrap();
+    .await?;
 
     // Assert
 
     // Process the app's `Confirm` and send `Finalize`
     wait_until_dlc_channel_state(
         Duration::from_secs(30),
-        &coordinator,
+        coordinator,
         app.info.pubkey,
         SubChannelStateName::Signed,
     )
-    .await
-    .unwrap();
+    .await?;
 
     // Process the coordinator's `Finalize`
     wait_until_dlc_channel_state(
         Duration::from_secs(30),
-        &app,
+        app,
         coordinator.info.pubkey,
         SubChannelStateName::Signed,
     )
-    .await
-    .unwrap();
+    .await?;
 
-    Ok(DlcChannelCreated {
-        coordinator,
-        coordinator_balance_channel_creation,
-        app,
-        app_balance_channel_creation,
-        channel_details,
-    })
+    Ok(())
 }


### PR DESCRIPTION
It's probably not super important since we're moving away from these hopefully soon, but I arrived at this when working on trying to reproduce #792.

The main motivation is to ensure that `create_dlc_channel` and `dlc_collaborative_settlement` can be called without setting up nodes every time. This means that they are more easily composable.

The only downside is that we introduce a bit of repetition when setting up nodes plus the channel between them, but that could be mitigated by introducing another helper function.