### PR TITLE
chore: Bump rust-dlc dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -891,7 +891,7 @@ dependencies = [
 [[package]]
 name = "dlc"
 version = "0.4.0"
-source = "git+https://github.com/get10101/rust-dlc?rev=d4b69cb913f79e2abadeb5ca58f7938d46b346f3#d4b69cb913f79e2abadeb5ca58f7938d46b346f3"
+source = "git+https://github.com/get10101/rust-dlc?rev=11c746fc55d6a7a95f17bce61d4989a48454d581#11c746fc55d6a7a95f17bce61d4989a48454d581"
 dependencies = [
  "bitcoin",
  "miniscript 8.0.0",
@@ -903,7 +903,7 @@ dependencies = [
 [[package]]
 name = "dlc-manager"
 version = "0.4.0"
-source = "git+https://github.com/get10101/rust-dlc?rev=d4b69cb913f79e2abadeb5ca58f7938d46b346f3#d4b69cb913f79e2abadeb5ca58f7938d46b346f3"
+source = "git+https://github.com/get10101/rust-dlc?rev=11c746fc55d6a7a95f17bce61d4989a48454d581#11c746fc55d6a7a95f17bce61d4989a48454d581"
 dependencies = [
  "async-trait",
  "bitcoin",
@@ -919,7 +919,7 @@ dependencies = [
 [[package]]
 name = "dlc-messages"
 version = "0.4.0"
-source = "git+https://github.com/get10101/rust-dlc?rev=d4b69cb913f79e2abadeb5ca58f7938d46b346f3#d4b69cb913f79e2abadeb5ca58f7938d46b346f3"
+source = "git+https://github.com/get10101/rust-dlc?rev=11c746fc55d6a7a95f17bce61d4989a48454d581#11c746fc55d6a7a95f17bce61d4989a48454d581"
 dependencies = [
  "bitcoin",
  "dlc",
@@ -931,7 +931,7 @@ dependencies = [
 [[package]]
 name = "dlc-sled-storage-provider"
 version = "0.1.0"
-source = "git+https://github.com/get10101/rust-dlc?rev=d4b69cb913f79e2abadeb5ca58f7938d46b346f3#d4b69cb913f79e2abadeb5ca58f7938d46b346f3"
+source = "git+https://github.com/get10101/rust-dlc?rev=11c746fc55d6a7a95f17bce61d4989a48454d581#11c746fc55d6a7a95f17bce61d4989a48454d581"
 dependencies = [
  "bitcoin",
  "dlc-manager",
@@ -945,7 +945,7 @@ dependencies = [
 [[package]]
 name = "dlc-trie"
 version = "0.4.0"
-source = "git+https://github.com/get10101/rust-dlc?rev=d4b69cb913f79e2abadeb5ca58f7938d46b346f3#d4b69cb913f79e2abadeb5ca58f7938d46b346f3"
+source = "git+https://github.com/get10101/rust-dlc?rev=11c746fc55d6a7a95f17bce61d4989a48454d581#11c746fc55d6a7a95f17bce61d4989a48454d581"
 dependencies = [
  "bitcoin",
  "dlc",
@@ -2266,7 +2266,7 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 [[package]]
 name = "p2pd-oracle-client"
 version = "0.1.0"
-source = "git+https://github.com/get10101/rust-dlc?rev=d4b69cb913f79e2abadeb5ca58f7938d46b346f3#d4b69cb913f79e2abadeb5ca58f7938d46b346f3"
+source = "git+https://github.com/get10101/rust-dlc?rev=11c746fc55d6a7a95f17bce61d4989a48454d581#11c746fc55d6a7a95f17bce61d4989a48454d581"
 dependencies = [
  "chrono",
  "dlc-manager",
@@ -3058,7 +3058,7 @@ dependencies = [
 [[package]]
 name = "simple-wallet"
 version = "0.1.0"
-source = "git+https://github.com/get10101/rust-dlc?rev=d4b69cb913f79e2abadeb5ca58f7938d46b346f3#d4b69cb913f79e2abadeb5ca58f7938d46b346f3"
+source = "git+https://github.com/get10101/rust-dlc?rev=11c746fc55d6a7a95f17bce61d4989a48454d581#11c746fc55d6a7a95f17bce61d4989a48454d581"
 dependencies = [
  "bitcoin",
  "dlc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,13 +3,13 @@ members = ["coordinator", "maker", "mobile/native", "crates/*"]
 resolver = "2"
 
 [patch.crates-io]
-dlc-manager = { git = "https://github.com/get10101/rust-dlc", rev = "d4b69cb913f79e2abadeb5ca58f7938d46b346f3" }
-dlc-messages = { git = "https://github.com/get10101/rust-dlc", rev = "d4b69cb913f79e2abadeb5ca58f7938d46b346f3" }
-dlc = { git = "https://github.com/get10101/rust-dlc", rev = "d4b69cb913f79e2abadeb5ca58f7938d46b346f3" }
-dlc-sled-storage-provider = { git = "https://github.com/get10101/rust-dlc", rev = "d4b69cb913f79e2abadeb5ca58f7938d46b346f3" }
-p2pd-oracle-client = { git = "https://github.com/get10101/rust-dlc", rev = "d4b69cb913f79e2abadeb5ca58f7938d46b346f3" }
-dlc-trie = { git = "https://github.com/get10101/rust-dlc", rev = "d4b69cb913f79e2abadeb5ca58f7938d46b346f3" }
-simple-wallet = { git = "https://github.com/get10101/rust-dlc", rev = "d4b69cb913f79e2abadeb5ca58f7938d46b346f3" }
+dlc-manager = { git = "https://github.com/get10101/rust-dlc", rev = "11c746fc55d6a7a95f17bce61d4989a48454d581" }
+dlc-messages = { git = "https://github.com/get10101/rust-dlc", rev = "11c746fc55d6a7a95f17bce61d4989a48454d581" }
+dlc = { git = "https://github.com/get10101/rust-dlc", rev = "11c746fc55d6a7a95f17bce61d4989a48454d581" }
+dlc-sled-storage-provider = { git = "https://github.com/get10101/rust-dlc", rev = "11c746fc55d6a7a95f17bce61d4989a48454d581" }
+p2pd-oracle-client = { git = "https://github.com/get10101/rust-dlc", rev = "11c746fc55d6a7a95f17bce61d4989a48454d581" }
+dlc-trie = { git = "https://github.com/get10101/rust-dlc", rev = "11c746fc55d6a7a95f17bce61d4989a48454d581" }
+simple-wallet = { git = "https://github.com/get10101/rust-dlc", rev = "11c746fc55d6a7a95f17bce61d4989a48454d581" }
 lightning = { git = "https://github.com/get10101/rust-lightning/", rev = "a663e1fb3415e0b7060e3b7f76f25d96a182006e" }
 lightning-background-processor = { git = "https://github.com/get10101/rust-lightning/", rev = "a663e1fb3415e0b7060e3b7f76f25d96a182006e" }
 lightning-transaction-sync = { git = "https://github.com/get10101/rust-lightning/", rev = "a663e1fb3415e0b7060e3b7f76f25d96a182006e" }


### PR DESCRIPTION
This bumps our `rust-dlc` dependency to include https://github.com/get10101/rust-dlc/commit/11c746fc55d6a7a95f17bce61d4989a48454d581

Although it does not fix #792, it does recover incomplete dlc state on the coordinator upon restart. Allowing the user to continue trading.

This will at least mitigate the impact of bug #792.