### PR TITLE
Persist spendable output descriptors generated by LDK in app

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1970,6 +1970,7 @@ dependencies = [
  "anyhow",
  "base64 0.21.0",
  "bdk",
+ "bitcoin",
  "coordinator-commons",
  "diesel",
  "diesel_migrations",

--- a/coordinator/src/bin/coordinator.rs
+++ b/coordinator/src/bin/coordinator.rs
@@ -14,7 +14,7 @@ use coordinator::settings::Settings;
 use diesel::r2d2;
 use diesel::r2d2::ConnectionManager;
 use diesel::PgConnection;
-use ln_dlc_node::node::PaymentMap;
+use ln_dlc_node::node::InMemoryStore;
 use ln_dlc_node::seed::Bip39Seed;
 use rand::thread_rng;
 use rand::RngCore;
@@ -76,7 +76,7 @@ async fn main() -> Result<()> {
         "10101.finance",
         network,
         data_dir.as_path(),
-        PaymentMap::default(),
+        InMemoryStore::default(),
         address,
         SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), address.port()),
         opts.p2p_announcement_addresses(),

--- a/coordinator/src/node.rs
+++ b/coordinator/src/node.rs
@@ -28,7 +28,7 @@ use dlc_messages::Message;
 use lightning::ln::channelmanager::ChannelDetails;
 use ln_dlc_node::node::dlc_message_name;
 use ln_dlc_node::node::sub_channel_message_name;
-use ln_dlc_node::node::PaymentMap;
+use ln_dlc_node::node::InMemoryStore;
 use ln_dlc_node::FeeRateFallbacks;
 use ln_dlc_node::WalletSettings;
 use rust_decimal::prelude::ToPrimitive;
@@ -86,14 +86,14 @@ impl Default for NodeSettings {
 
 #[derive(Clone)]
 pub struct Node {
-    pub inner: Arc<ln_dlc_node::node::Node<PaymentMap>>,
+    pub inner: Arc<ln_dlc_node::node::Node<InMemoryStore>>,
     pub pool: Pool<ConnectionManager<PgConnection>>,
     pub settings: Arc<RwLock<NodeSettings>>,
 }
 
 impl Node {
     pub fn new(
-        inner: Arc<ln_dlc_node::node::Node<PaymentMap>>,
+        inner: Arc<ln_dlc_node::node::Node<InMemoryStore>>,
         pool: Pool<ConnectionManager<PgConnection>>,
     ) -> Self {
         Self {

--- a/coordinator/src/node/connection.rs
+++ b/coordinator/src/node/connection.rs
@@ -1,8 +1,8 @@
 use autometrics::autometrics;
 use lightning::ln::msgs::NetAddress;
+use ln_dlc_node::node::InMemoryStore;
 use ln_dlc_node::node::Node;
 use ln_dlc_node::node::NodeInfo;
-use ln_dlc_node::node::PaymentMap;
 use rand::seq::SliceRandom;
 use rand::thread_rng;
 use std::net::IpAddr;
@@ -13,7 +13,7 @@ use tokio::task::spawn_blocking;
 
 #[autometrics]
 pub async fn keep_public_channel_peers_connected(
-    node: Arc<Node<PaymentMap>>,
+    node: Arc<Node<InMemoryStore>>,
     check_interval: Duration,
 ) {
     loop {
@@ -28,7 +28,7 @@ pub async fn keep_public_channel_peers_connected(
     }
 }
 
-fn reconnect_to_disconnected_public_channel_peers(node: Arc<Node<PaymentMap>>) {
+fn reconnect_to_disconnected_public_channel_peers(node: Arc<Node<InMemoryStore>>) {
     let connected_peers = node
         .peer_manager
         .get_peer_node_ids()

--- a/crates/ln-dlc-node/src/ln/event_handler.rs
+++ b/crates/ln-dlc-node/src/ln/event_handler.rs
@@ -6,7 +6,7 @@ use crate::ln::JUST_IN_TIME_CHANNEL_OUTBOUND_LIQUIDITY_SAT;
 use crate::ln_dlc_wallet::LnDlcWallet;
 use crate::node::invoice::HTLCStatus;
 use crate::node::ChannelManager;
-use crate::node::PaymentPersister;
+use crate::node::Storage;
 use crate::util;
 use crate::FakeChannelPaymentRequests;
 use crate::MillisatAmount;
@@ -44,12 +44,12 @@ use time::OffsetDateTime;
 /// We set it to high priority because the channel funding transaction should be included fast.
 const CONFIRMATION_TARGET: ConfirmationTarget = ConfirmationTarget::HighPriority;
 
-pub struct EventHandler<P> {
+pub struct EventHandler<S> {
     channel_manager: Arc<ChannelManager>,
     wallet: Arc<LnDlcWallet>,
     network_graph: Arc<NetworkGraph>,
     keys_manager: Arc<CustomKeysManager>,
-    payment_persister: Arc<P>,
+    storage: Arc<S>,
     fake_channel_payments: FakeChannelPaymentRequests,
     pending_intercepted_htlcs: PendingInterceptedHtlcs,
     peer_manager: Arc<PeerManager>,
@@ -57,16 +57,16 @@ pub struct EventHandler<P> {
 }
 
 #[allow(clippy::too_many_arguments)]
-impl<P> EventHandler<P>
+impl<S> EventHandler<S>
 where
-    P: PaymentPersister,
+    S: Storage,
 {
     pub(crate) fn new(
         channel_manager: Arc<ChannelManager>,
         wallet: Arc<LnDlcWallet>,
         network_graph: Arc<NetworkGraph>,
         keys_manager: Arc<CustomKeysManager>,
-        payment_persister: Arc<P>,
+        storage: Arc<S>,
         fake_channel_payments: FakeChannelPaymentRequests,
         pending_intercepted_htlcs: PendingInterceptedHtlcs,
         peer_manager: Arc<PeerManager>,
@@ -77,7 +77,7 @@ where
             wallet,
             network_graph,
             keys_manager,
-            payment_persister,
+            storage,
             fake_channel_payments,
             pending_intercepted_htlcs,
             peer_manager,
@@ -173,7 +173,7 @@ where
                 };
 
                 let amount_msat = MillisatAmount(Some(amount_msat));
-                if let Err(e) = self.payment_persister.merge(
+                if let Err(e) = self.storage.merge_payment(
                     &payment_hash,
                     PaymentFlow::Inbound,
                     amount_msat,
@@ -190,10 +190,10 @@ where
                 fee_paid_msat,
                 ..
             } => {
-                let amount_msat = match self.payment_persister.get(&payment_hash) {
+                let amount_msat = match self.storage.get_payment(&payment_hash) {
                     Ok(Some((_, PaymentInfo { amt_msat, .. }))) => {
                         let amount_msat = MillisatAmount(None);
-                        if let Err(e) = self.payment_persister.merge(
+                        if let Err(e) = self.storage.merge_payment(
                             &payment_hash,
                             PaymentFlow::Outbound,
                             amount_msat,
@@ -214,7 +214,7 @@ where
                         );
 
                         let amt_msat = MillisatAmount(None);
-                        if let Err(e) = self.payment_persister.insert(
+                        if let Err(e) = self.storage.insert_payment(
                             payment_hash,
                             PaymentInfo {
                                 preimage: Some(payment_preimage),
@@ -297,7 +297,7 @@ where
                 );
 
                 let amount_msat = MillisatAmount(None);
-                if let Err(e) = self.payment_persister.merge(
+                if let Err(e) = self.storage.merge_payment(
                     &payment_hash,
                     PaymentFlow::Outbound,
                     amount_msat,

--- a/crates/ln-dlc-node/src/ln/event_handler.rs
+++ b/crates/ln-dlc-node/src/ln/event_handler.rs
@@ -400,6 +400,15 @@ where
                     return Ok(());
                 }
 
+                for spendable_output in ldk_outputs.iter() {
+                    if let Err(e) = self
+                        .storage
+                        .insert_spendable_output((*spendable_output).clone())
+                    {
+                        tracing::error!("Failed to persist spendable output: {e:#}")
+                    }
+                }
+
                 let destination_script = self.wallet.inner().get_last_unused_address()?;
                 let tx_feerate = self
                     .fee_rate_estimator

--- a/crates/ln-dlc-node/src/ln/event_handler.rs
+++ b/crates/ln-dlc-node/src/ln/event_handler.rs
@@ -39,7 +39,7 @@ use std::sync::MutexGuard;
 use std::time::Duration;
 use time::OffsetDateTime;
 
-///  The speed at which we want a transaction to confirm used for feerate estimation.
+/// The speed at which we want a transaction to confirm used for feerate estimation.
 ///
 /// We set it to high priority because the channel funding transaction should be included fast.
 const CONFIRMATION_TARGET: ConfirmationTarget = ConfirmationTarget::HighPriority;

--- a/crates/ln-dlc-node/src/node/storage.rs
+++ b/crates/ln-dlc-node/src/node/storage.rs
@@ -3,6 +3,10 @@ use crate::MillisatAmount;
 use crate::PaymentFlow;
 use crate::PaymentInfo;
 use anyhow::Result;
+use lightning::chain::keysinterface::DelayedPaymentOutputDescriptor;
+use lightning::chain::keysinterface::SpendableOutputDescriptor;
+use lightning::chain::keysinterface::StaticPaymentOutputDescriptor;
+use lightning::chain::transaction::OutPoint;
 use lightning::ln::PaymentHash;
 use lightning::ln::PaymentPreimage;
 use lightning::ln::PaymentSecret;
@@ -16,6 +20,8 @@ use time::OffsetDateTime;
 ///
 /// It exists so that consumers of [`crate::node::Node`] can define their own storage.
 pub trait Storage {
+    // Payments
+
     /// Add a new payment.
     fn insert_payment(&self, payment_hash: PaymentHash, info: PaymentInfo) -> Result<()>;
     /// Add a new payment or update an existing one.
@@ -39,14 +45,36 @@ pub trait Storage {
         -> Result<Option<(PaymentHash, PaymentInfo)>>;
     /// Get all payments stored in the store.
     fn all_payments(&self) -> Result<Vec<(PaymentHash, PaymentInfo)>>;
+
+    // Spendable outputs
+
+    /// Add a new [`SpendableOutputDescriptor`] to the store.
+    fn insert_spendable_output(&self, descriptor: SpendableOutputDescriptor) -> Result<()>;
+    /// Get a [`SpendableOutputDescriptor`] by its [`OutPoint`].
+    ///
+    /// # Returns
+    ///
+    /// A [`SpendableOutputDescriptor`] if the [`OutPoint`] hash was found in the store; `Ok(None)`
+    /// if the [`OutPoint`] was not found in the store; an error if accessing the store failed.
+    fn get_spendable_output(
+        &self,
+        outpoint: &OutPoint,
+    ) -> Result<Option<SpendableOutputDescriptor>>;
+    /// Get all [`SpendableOutputDescriptor`]s stored.
+    fn all_spendable_outputs(&self) -> Result<Vec<SpendableOutputDescriptor>>;
 }
 
 #[derive(Default, Clone)]
-pub struct InMemoryStore(Arc<Mutex<HashMap<PaymentHash, PaymentInfo>>>);
+pub struct InMemoryStore {
+    payments: Arc<Mutex<HashMap<PaymentHash, PaymentInfo>>>,
+    spendable_outputs: Arc<Mutex<HashMap<OutPoint, SpendableOutputDescriptor>>>,
+}
 
 impl Storage for InMemoryStore {
+    // Payments
+
     fn insert_payment(&self, payment_hash: PaymentHash, info: PaymentInfo) -> Result<()> {
-        self.lock().insert(payment_hash, info);
+        self.payments_lock().insert(payment_hash, info);
 
         Ok(())
     }
@@ -60,7 +88,7 @@ impl Storage for InMemoryStore {
         preimage: Option<PaymentPreimage>,
         secret: Option<PaymentSecret>,
     ) -> Result<()> {
-        let mut payments = self.lock();
+        let mut payments = self.payments_lock();
         match payments.get_mut(payment_hash) {
             Some(mut payment) => {
                 payment.status = htlc_status;
@@ -99,7 +127,7 @@ impl Storage for InMemoryStore {
         &self,
         payment_hash: &PaymentHash,
     ) -> Result<Option<(PaymentHash, PaymentInfo)>> {
-        let payments = self.lock();
+        let payments = self.payments_lock();
         let info = payments.get(payment_hash);
 
         let payment = info.map(|info| (*payment_hash, *info));
@@ -108,15 +136,49 @@ impl Storage for InMemoryStore {
     }
 
     fn all_payments(&self) -> Result<Vec<(PaymentHash, PaymentInfo)>> {
-        let payments = self.lock();
+        let payments = self.payments_lock();
         let payments = payments.iter().map(|(a, b)| (*a, *b)).collect();
 
         Ok(payments)
     }
+
+    // Spendable outputs
+
+    fn insert_spendable_output(&self, descriptor: SpendableOutputDescriptor) -> Result<()> {
+        use SpendableOutputDescriptor::*;
+        let outpoint = match &descriptor {
+            // Static outputs don't need to be persisted because they pay directly to an address
+            // owned by the on-chain wallet
+            StaticOutput { .. } => return Ok(()),
+            DelayedPaymentOutput(DelayedPaymentOutputDescriptor { outpoint, .. }) => outpoint,
+            StaticPaymentOutput(StaticPaymentOutputDescriptor { outpoint, .. }) => outpoint,
+        };
+
+        self.spendable_outputs_lock().insert(*outpoint, descriptor);
+
+        Ok(())
+    }
+
+    fn get_spendable_output(
+        &self,
+        outpoint: &OutPoint,
+    ) -> Result<Option<SpendableOutputDescriptor>> {
+        Ok(self.spendable_outputs_lock().get(outpoint).cloned())
+    }
+
+    fn all_spendable_outputs(&self) -> Result<Vec<SpendableOutputDescriptor>> {
+        Ok(self.spendable_outputs_lock().values().cloned().collect())
+    }
 }
 
 impl InMemoryStore {
-    fn lock(&self) -> MutexGuard<HashMap<PaymentHash, PaymentInfo>> {
-        self.0.lock().expect("Mutex to not be poisoned")
+    fn payments_lock(&self) -> MutexGuard<HashMap<PaymentHash, PaymentInfo>> {
+        self.payments.lock().expect("Mutex to not be poisoned")
+    }
+
+    fn spendable_outputs_lock(&self) -> MutexGuard<HashMap<OutPoint, SpendableOutputDescriptor>> {
+        self.spendable_outputs
+            .lock()
+            .expect("Mutex to not be poisoned")
     }
 }

--- a/crates/ln-dlc-node/src/node/wallet.rs
+++ b/crates/ln-dlc-node/src/node/wallet.rs
@@ -1,7 +1,7 @@
 use crate::ldk_node_wallet;
 use crate::node::HTLCStatus;
 use crate::node::Node;
-use crate::node::PaymentPersister;
+use crate::node::Storage;
 use crate::PaymentFlow;
 use anyhow::Context;
 use anyhow::Result;
@@ -20,7 +20,7 @@ pub struct OffChainBalance {
 
 impl<P> Node<P>
 where
-    P: PaymentPersister,
+    P: Storage,
 {
     pub fn get_seed_phrase(&self) -> Vec<String> {
         self.wallet.get_seed_phrase()
@@ -112,8 +112,8 @@ where
 
     pub fn get_off_chain_history(&self) -> Result<Vec<PaymentDetails>> {
         let mut payments = self
-            .payment_persister
-            .all()?
+            .storage
+            .all_payments()?
             .iter()
             .map(|(hash, info)| PaymentDetails {
                 payment_hash: *hash,

--- a/crates/ln-dlc-node/src/tests/dlc/collaborative_settlement.rs
+++ b/crates/ln-dlc-node/src/tests/dlc/collaborative_settlement.rs
@@ -1,5 +1,5 @@
+use crate::node::InMemoryStore;
 use crate::node::Node;
-use crate::node::PaymentMap;
 use crate::tests::dlc::create::create_dlc_channel;
 use crate::tests::init_tracing;
 use crate::tests::wait_until_dlc_channel_state;
@@ -137,8 +137,8 @@ async fn open_dlc_channel_after_closing_dlc_channel() {
 }
 
 async fn dlc_collaborative_settlement(
-    app: &Node<PaymentMap>,
-    coordinator: &Node<PaymentMap>,
+    app: &Node<InMemoryStore>,
+    coordinator: &Node<InMemoryStore>,
     coordinator_settlement_amount: u64,
 ) -> Result<()> {
     let channel_details = app

--- a/crates/ln-dlc-node/src/tests/dlc/create.rs
+++ b/crates/ln-dlc-node/src/tests/dlc/create.rs
@@ -1,5 +1,5 @@
+use crate::node::InMemoryStore;
 use crate::node::Node;
-use crate::node::PaymentMap;
 use crate::tests::dummy_contract_input;
 use crate::tests::init_tracing;
 use crate::tests::wait_until_dlc_channel_state;
@@ -54,8 +54,8 @@ async fn given_lightning_channel_then_can_add_dlc_channel() {
 }
 
 pub async fn create_dlc_channel(
-    app: &Node<PaymentMap>,
-    coordinator: &Node<PaymentMap>,
+    app: &Node<InMemoryStore>,
+    coordinator: &Node<InMemoryStore>,
     app_dlc_collateral: u64,
     coordinator_dlc_collateral: u64,
 ) -> Result<()> {

--- a/crates/ln-dlc-node/src/tests/just_in_time_channel/create.rs
+++ b/crates/ln-dlc-node/src/tests/just_in_time_channel/create.rs
@@ -1,6 +1,6 @@
 use crate::ln::JUST_IN_TIME_CHANNEL_OUTBOUND_LIQUIDITY_SAT;
+use crate::node::InMemoryStore;
 use crate::node::Node;
-use crate::node::PaymentMap;
 use crate::tests::init_tracing;
 use crate::tests::min_outbound_liquidity_channel_creator;
 use crate::HTLCStatus;
@@ -203,9 +203,9 @@ async fn open_jit_channel_with_disconnected_payee() {
 /// `max_inbound_htlc_value_in_flight_percent_of_channel` configuration value for said channel. This
 /// is verified within this function.
 pub(crate) async fn send_interceptable_payment(
-    payer: &Node<PaymentMap>,
-    payee: &Node<PaymentMap>,
-    coordinator: &Node<PaymentMap>,
+    payer: &Node<InMemoryStore>,
+    payee: &Node<InMemoryStore>,
+    coordinator: &Node<InMemoryStore>,
     invoice_amount: u64,
     coordinator_just_in_time_channel_creation_outbound_liquidity: Option<u64>,
 ) -> Result<()> {
@@ -302,7 +302,7 @@ pub(crate) async fn send_interceptable_payment(
 /// `max_inbound_htlc_value_in_flight_percent_of_channel` configuration flag of the receiving end of
 /// the channel.
 fn does_inbound_htlc_fit_as_percent_of_channel(
-    receiving_node: &Node<PaymentMap>,
+    receiving_node: &Node<InMemoryStore>,
     channel_id: &[u8; 32],
     htlc_amount_sat: u64,
 ) -> Result<bool> {

--- a/crates/ln-dlc-node/src/tests/lnd.rs
+++ b/crates/ln-dlc-node/src/tests/lnd.rs
@@ -1,5 +1,5 @@
+use crate::node::InMemoryStore;
 use crate::node::Node;
-use crate::node::PaymentMap;
 use crate::tests;
 use crate::tests::bitcoind;
 use anyhow::bail;
@@ -45,7 +45,7 @@ impl LndNode {
     /// there is no other channel.
     pub async fn open_channel(
         &self,
-        target: &Node<PaymentMap>,
+        target: &Node<InMemoryStore>,
         amount: bitcoin::Amount,
     ) -> Result<()> {
         let port = target.info.address.port();

--- a/crates/ln-dlc-node/src/tests/load.rs
+++ b/crates/ln-dlc-node/src/tests/load.rs
@@ -1,7 +1,7 @@
 use crate::ln::app_config;
+use crate::node::InMemoryStore;
 use crate::node::Node;
 use crate::node::NodeInfo;
-use crate::node::PaymentMap;
 use crate::tests::init_tracing;
 use crate::tests::wait_until_dlc_channel_state;
 use crate::tests::SubChannelStateName;
@@ -55,7 +55,7 @@ async fn single_app_many_positions_load() {
     }
 }
 
-async fn open_position(coordinator: &Coordinator, app: &Node<PaymentMap>) -> Result<()> {
+async fn open_position(coordinator: &Coordinator, app: &Node<InMemoryStore>) -> Result<()> {
     tracing::info!("Opening position");
 
     tokio::time::timeout(Duration::from_secs(30), async {
@@ -100,7 +100,7 @@ async fn open_position(coordinator: &Coordinator, app: &Node<PaymentMap>) -> Res
     Ok(())
 }
 
-async fn close_position(coordinator: &Coordinator, app: &Node<PaymentMap>) -> Result<()> {
+async fn close_position(coordinator: &Coordinator, app: &Node<InMemoryStore>) -> Result<()> {
     tracing::info!("Closing position");
 
     tokio::time::timeout(Duration::from_secs(30), async {
@@ -146,7 +146,7 @@ async fn close_position(coordinator: &Coordinator, app: &Node<PaymentMap>) -> Re
     Ok(())
 }
 
-async fn keep_connected(node: impl Borrow<Node<PaymentMap>>, peer: NodeInfo) {
+async fn keep_connected(node: impl Borrow<Node<InMemoryStore>>, peer: NodeInfo) {
     let reconnect_interval = Duration::from_secs(1);
     loop {
         let connection_closed_future = match node.borrow().connect(peer).await {

--- a/crates/ln-dlc-node/src/tests/load/coordinator.rs
+++ b/crates/ln-dlc-node/src/tests/load/coordinator.rs
@@ -1,6 +1,6 @@
+use crate::node::InMemoryStore;
 use crate::node::Node;
 use crate::node::NodeInfo;
-use crate::node::PaymentMap;
 use anyhow::bail;
 use anyhow::Result;
 use bitcoin::secp256k1::PublicKey;
@@ -57,7 +57,7 @@ impl Coordinator {
     /// Assumes that the app node is already connected to the coordinator.
     pub async fn open_channel(
         &self,
-        app: &Node<PaymentMap>,
+        app: &Node<InMemoryStore>,
         coordinator_balance: u64,
         app_balance: u64,
     ) -> Result<()> {
@@ -120,7 +120,7 @@ impl Coordinator {
         Ok(())
     }
 
-    pub async fn post_trade(&self, app: &Node<PaymentMap>, direction: Direction) -> Result<()> {
+    pub async fn post_trade(&self, app: &Node<InMemoryStore>, direction: Direction) -> Result<()> {
         #[derive(Serialize)]
         pub struct TradeParams {
             pub pubkey: PublicKey,

--- a/crates/ln-dlc-node/src/tests/mod.rs
+++ b/crates/ln-dlc-node/src/tests/mod.rs
@@ -1,9 +1,9 @@
 use crate::ln::app_config;
 use crate::ln::coordinator_config;
+use crate::node::InMemoryStore;
 use crate::node::LnDlcNodeSettings;
 use crate::node::Node;
 use crate::node::NodeInfo;
-use crate::node::PaymentMap;
 use crate::seed::Bip39Seed;
 use crate::util;
 use anyhow::Result;
@@ -77,7 +77,7 @@ fn init_tracing() {
     })
 }
 
-impl Node<PaymentMap> {
+impl Node<InMemoryStore> {
     fn start_test_app(name: &str) -> Result<Self> {
         Self::start_test(name, app_config(), ESPLORA_ORIGIN.to_string())
     }
@@ -103,7 +103,7 @@ impl Node<PaymentMap> {
             name,
             Network::Regtest,
             data_dir.as_path(),
-            PaymentMap::default(),
+            InMemoryStore::default(),
             address,
             address,
             vec![util::build_net_address(address.ip(), address.port())],
@@ -163,7 +163,7 @@ impl Node<PaymentMap> {
     /// to be usable.
     async fn open_channel(
         &self,
-        peer: &Node<PaymentMap>,
+        peer: &Node<InMemoryStore>,
         amount_us: u64,
         amount_them: u64,
     ) -> Result<ChannelDetails> {
@@ -242,7 +242,7 @@ async fn fund_and_mine(address: Address, amount: Amount) -> Result<()> {
 ///
 /// This is useful when the channel creator wants to push as many
 /// coins as possible to their peer on channel creation.
-fn min_outbound_liquidity_channel_creator(peer: &Node<PaymentMap>, peer_balance: u64) -> u64 {
+fn min_outbound_liquidity_channel_creator(peer: &Node<InMemoryStore>, peer_balance: u64) -> u64 {
     let min_reserve_millionths_creator = Decimal::from(
         peer.user_config
             .channel_handshake_config
@@ -293,7 +293,7 @@ fn random_tmp_dir() -> PathBuf {
 }
 
 #[allow(dead_code)]
-fn log_channel_id(node: &Node<PaymentMap>, index: usize, pair: &str) {
+fn log_channel_id(node: &Node<InMemoryStore>, index: usize, pair: &str) {
     let details = match node.channel_manager.list_channels().get(index) {
         Some(details) => details.clone(),
         None => {
@@ -337,7 +337,7 @@ where
 
 async fn wait_until_dlc_channel_state(
     timeout: Duration,
-    node: &Node<PaymentMap>,
+    node: &Node<InMemoryStore>,
     counterparty_pk: PublicKey,
     target_state: SubChannelStateName,
 ) -> Result<SubChannel> {

--- a/maker/src/routes.rs
+++ b/maker/src/routes.rs
@@ -11,9 +11,9 @@ use bitcoin::secp256k1::PublicKey;
 use diesel::r2d2::ConnectionManager;
 use diesel::r2d2::Pool;
 use diesel::PgConnection;
+use ln_dlc_node::node::InMemoryStore;
 use ln_dlc_node::node::Node;
 use ln_dlc_node::node::NodeInfo;
-use ln_dlc_node::node::PaymentMap;
 use ln_dlc_node::ChannelDetails;
 use serde::Deserialize;
 use serde::Serialize;
@@ -22,11 +22,14 @@ use std::str::FromStr;
 use std::sync::Arc;
 
 pub struct AppState {
-    pub node: Arc<Node<PaymentMap>>,
+    pub node: Arc<Node<InMemoryStore>>,
     pub pool: Pool<ConnectionManager<PgConnection>>,
 }
 
-pub fn router(node: Arc<Node<PaymentMap>>, pool: Pool<ConnectionManager<PgConnection>>) -> Router {
+pub fn router(
+    node: Arc<Node<InMemoryStore>>,
+    pool: Pool<ConnectionManager<PgConnection>>,
+) -> Router {
     let app_state = Arc::new(AppState { node, pool });
 
     Router::new()

--- a/mobile/native/Cargo.toml
+++ b/mobile/native/Cargo.toml
@@ -39,3 +39,6 @@ tracing-subscriber = { version = "0.3", default-features = false, features = ["f
 trade = { path = "../../crates/trade" }
 url = "2.3.1"
 uuid = { version = "1.3.0", features = ["v4", "fast-rng", "macro-diagnostics"] }
+
+[dev-dependencies]
+bitcoin = "0.29"

--- a/mobile/native/migrations/2023-06-27-031253_spendable_outputs/down.sql
+++ b/mobile/native/migrations/2023-06-27-031253_spendable_outputs/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS spendable_outputs;

--- a/mobile/native/migrations/2023-06-27-031253_spendable_outputs/up.sql
+++ b/mobile/native/migrations/2023-06-27-031253_spendable_outputs/up.sql
@@ -1,0 +1,7 @@
+CREATE TABLE IF NOT EXISTS spendable_outputs (
+    id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+    -- formatted as <txid>:<vout>
+    outpoint TEXT UNIQUE NOT NULL,
+    -- hex representation of LDK's own encoding
+    descriptor TEXT NOT NULL
+)

--- a/mobile/native/src/ln_dlc/mod.rs
+++ b/mobile/native/src/ln_dlc/mod.rs
@@ -6,7 +6,7 @@ use crate::config;
 use crate::event;
 use crate::event::EventInternal;
 use crate::ln_dlc::node::Node;
-use crate::ln_dlc::node::Payments;
+use crate::ln_dlc::node::NodeStorage;
 use crate::trade::order;
 use crate::trade::order::FailureReason;
 use crate::trade::position;
@@ -137,7 +137,7 @@ pub fn run(data_dir: String, seed_dir: String, runtime: &Runtime) -> Result<()> 
             "10101",
             network,
             data_dir.as_path(),
-            Payments,
+            NodeStorage,
             address,
             SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), address.port()),
             config::get_esplora_endpoint().to_string(),

--- a/mobile/native/src/ln_dlc/node.rs
+++ b/mobile/native/src/ln_dlc/node.rs
@@ -11,14 +11,14 @@ use dlc_messages::SubChannelMessage;
 use lightning::ln::PaymentHash;
 use lightning::ln::PaymentPreimage;
 use lightning::ln::PaymentSecret;
+use ln_dlc_node::node;
 use ln_dlc_node::node::dlc_message_name;
 use ln_dlc_node::node::rust_dlc_manager::contract::signed_contract::SignedContract;
 use ln_dlc_node::node::rust_dlc_manager::contract::Contract;
-use ln_dlc_node::node::rust_dlc_manager::Storage;
+use ln_dlc_node::node::rust_dlc_manager::Storage as _;
 use ln_dlc_node::node::sub_channel_message_name;
 use ln_dlc_node::node::NodeInfo;
 use ln_dlc_node::node::PaymentDetails;
-use ln_dlc_node::node::PaymentPersister;
 use ln_dlc_node::HTLCStatus;
 use ln_dlc_node::MillisatAmount;
 use ln_dlc_node::PaymentFlow;
@@ -29,7 +29,7 @@ use time::OffsetDateTime;
 
 #[derive(Clone)]
 pub struct Node {
-    pub inner: Arc<ln_dlc_node::node::Node<Payments>>,
+    pub inner: Arc<ln_dlc_node::node::Node<NodeStorage>>,
 }
 
 pub struct Balances {
@@ -271,13 +271,13 @@ impl Node {
 }
 
 #[derive(Clone)]
-pub struct Payments;
+pub struct NodeStorage;
 
-impl PaymentPersister for Payments {
-    fn insert(&self, payment_hash: PaymentHash, info: PaymentInfo) -> Result<()> {
+impl node::Storage for NodeStorage {
+    fn insert_payment(&self, payment_hash: PaymentHash, info: PaymentInfo) -> Result<()> {
         db::insert_payment(payment_hash, info)
     }
-    fn merge(
+    fn merge_payment(
         &self,
         payment_hash: &PaymentHash,
         flow: PaymentFlow,
@@ -307,10 +307,13 @@ impl PaymentPersister for Payments {
 
         Ok(())
     }
-    fn get(&self, payment_hash: &PaymentHash) -> Result<Option<(PaymentHash, PaymentInfo)>> {
+    fn get_payment(
+        &self,
+        payment_hash: &PaymentHash,
+    ) -> Result<Option<(PaymentHash, PaymentInfo)>> {
         db::get_payment(*payment_hash)
     }
-    fn all(&self) -> Result<Vec<(PaymentHash, PaymentInfo)>> {
+    fn all_payments(&self) -> Result<Vec<(PaymentHash, PaymentInfo)>> {
         db::get_payments()
     }
 }

--- a/mobile/native/src/schema.rs
+++ b/mobile/native/src/schema.rs
@@ -53,4 +53,18 @@ diesel::table! {
     }
 }
 
-diesel::allow_tables_to_appear_in_same_query!(last_login, orders, payments, positions,);
+diesel::table! {
+    spendable_outputs (id) {
+        id -> Integer,
+        outpoint -> Text,
+        descriptor -> Text,
+    }
+}
+
+diesel::allow_tables_to_appear_in_same_query!(
+    last_login,
+    orders,
+    payments,
+    positions,
+    spendable_outputs,
+);


### PR DESCRIPTION
Fixes #844.

This ensures that claiming funds from LN commitment transactions can be retried as much as we need to.

Currently, only the app persists this across restarts. The coordinator still uses an in-memory map, like it does for payments. We still need to fix this.

---

Related to https://github.com/get10101/10101/issues/798.
Next steps captured in #845 and #846.