### PR TITLE
Enable end-to-end tests on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,3 +116,22 @@ jobs:
           curl -d '{"address":"bcrt1qylgu6ffkp3p0m8tw8kp4tt2dmdh755f4r5dq7s", "amount":"0.1"}' -H "Content-Type: application/json" -X POST http://localhost:3000/faucet
       - name: Run slow tests
         run: cargo test -p ln-dlc-node -- --ignored --nocapture --test-threads=1
+
+  e2e-tests:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v3
+      - uses: extractions/setup-just@v1
+      - name: Setup rust toolchain
+        run: rustup show
+      - uses: Swatinem/rust-cache@v2.2.0
+      - name: Start containers
+        run: |
+          docker-compose up -d
+          sleep 10 # We need to give docker a bit of time to startup
+      - name: Test containers are up
+        run: |
+          curl -d '{"address":"bcrt1qylgu6ffkp3p0m8tw8kp4tt2dmdh755f4r5dq7s", "amount":"0.1"}' -H "Content-Type: application/json" -X POST http://localhost:3000/faucet
+      - name: Run e2e tests
+        run: just e2e --nocapture

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,6 +126,8 @@ jobs:
       - name: Setup rust toolchain
         run: rustup show
       - uses: Swatinem/rust-cache@v2.2.0
+      - name: Build Rust project
+        run: cargo build --examples
       - name: Start containers
         run: |
           docker-compose up -d

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,6 +126,14 @@ jobs:
       - name: Setup rust toolchain
         run: rustup show
       - uses: Swatinem/rust-cache@v2.2.0
+      - uses: subosito/flutter-action@v2
+        with:
+          flutter-version: "3.7.7"
+          channel: "stable"
+      - name: Install FFI bindings
+        run: just deps-gen
+      - name: Generate FFI bindings
+        run: just gen
       - name: Build Rust project
         run: cargo build --examples
       - name: Start containers

--- a/justfile
+++ b/justfile
@@ -268,7 +268,7 @@ wait-for-coordinator-to-be-ready:
     set +e
 
     endpoint="http://localhost:8000/api/newaddress"
-    max_attempts=10
+    max_attempts=600
     sleep_duration=1
 
     check_endpoint() {


### PR DESCRIPTION
First run will probably take ages because of lack of cache.
Will closely monitor and optimise onwards.

I'm trying to remove the flutter dependency.