### PR TITLE
Only generate flutter bindings when needed

### DIFF
--- a/.github/workflows/build-release-binaries.yml
+++ b/.github/workflows/build-release-binaries.yml
@@ -104,7 +104,7 @@ jobs:
 
       - name: Build Rust lib
         working-directory: ./mobile/native
-        run: cargo ndk -o ../android/app/src/main/jniLibs build
+        run: cargo ndk -o ../android/app/src/main/jniLibs build --features=flutter
 
       - name: Parse version from pubspec.yaml
         id: version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,10 +89,6 @@ jobs:
         with:
           flutter-version: "3.10.5"
           channel: "stable"
-      - name: Install FFI bindings
-        run: just deps-gen
-      - name: Generate FFI bindings
-        run: just gen
       - name: Running cargo tests
         run: cargo test
       - name: Running flutter tests
@@ -130,10 +126,6 @@ jobs:
         with:
           flutter-version: "3.10.5"
           channel: "stable"
-      - name: Install FFI bindings
-        run: just deps-gen
-      - name: Generate FFI bindings
-        run: just gen
       - name: Build Rust project
         run: cargo build --examples
       - name: Start containers

--- a/justfile
+++ b/justfile
@@ -46,23 +46,23 @@ gen:
         --dart-format-line-length {{line_length}}
 
 native:
-    cd mobile/native && cargo build
+    cd mobile/native && cargo build --features=flutter
 
 # Build Rust library for Android native targets
 android args="":
-    cd mobile/native && cargo ndk -o ../android/app/src/main/jniLibs build {{args}}
+    cd mobile/native && cargo ndk -o ../android/app/src/main/jniLibs build --features=flutter {{args}}
 
 android-release:
-    cd mobile/native && cargo ndk -o ../android/app/src/main/jniLibs build --release
+    cd mobile/native && cargo ndk -o ../android/app/src/main/jniLibs build --release --features=flutter
 
 # Build Rust library for iOS (debug mode)
 ios:
-    cd mobile/native && cargo lipo
+    cd mobile/native && cargo lipo --features=flutter
     cp target/universal/debug/libnative.a mobile/ios/Runner
 
 # Build Rust library for iOS (release mode)
 ios-release:
-    cd mobile/native && cargo lipo --release
+    cd mobile/native && cargo lipo --release --features=flutter
     cp target/universal/release/libnative.a mobile/ios/Runner
 
 

--- a/mobile/native/Cargo.toml
+++ b/mobile/native/Cargo.toml
@@ -42,3 +42,6 @@ uuid = { version = "1.3.0", features = ["v4", "fast-rng", "macro-diagnostics"] }
 
 [dev-dependencies]
 bitcoin = "0.29"
+
+[features]
+flutter = []

--- a/mobile/native/src/lib.rs
+++ b/mobile/native/src/lib.rs
@@ -19,4 +19,5 @@ mod orderbook;
     unused_import_braces,
     unused_qualifications
 )]
+#[cfg(feature = "flutter")]
 mod bridge_generated;


### PR DESCRIPTION
- flutter bindings are needed only for native, iOS and Android builds 
- CI test jobs, notably tests do not benefit from them
- we can save time by not compiling them