### PR TITLE
Move our `rust-{dlc, lightning}` branches to `p2pderivatives`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -891,7 +891,7 @@ dependencies = [
 [[package]]
 name = "dlc"
 version = "0.4.0"
-source = "git+https://github.com/get10101/rust-dlc?rev=11c746fc55d6a7a95f17bce61d4989a48454d581#11c746fc55d6a7a95f17bce61d4989a48454d581"
+source = "git+https://github.com/p2pderivatives/rust-dlc?rev=11c746f#11c746fc55d6a7a95f17bce61d4989a48454d581"
 dependencies = [
  "bitcoin",
  "miniscript 8.0.0",
@@ -903,7 +903,7 @@ dependencies = [
 [[package]]
 name = "dlc-manager"
 version = "0.4.0"
-source = "git+https://github.com/get10101/rust-dlc?rev=11c746fc55d6a7a95f17bce61d4989a48454d581#11c746fc55d6a7a95f17bce61d4989a48454d581"
+source = "git+https://github.com/p2pderivatives/rust-dlc?rev=11c746f#11c746fc55d6a7a95f17bce61d4989a48454d581"
 dependencies = [
  "async-trait",
  "bitcoin",
@@ -919,7 +919,7 @@ dependencies = [
 [[package]]
 name = "dlc-messages"
 version = "0.4.0"
-source = "git+https://github.com/get10101/rust-dlc?rev=11c746fc55d6a7a95f17bce61d4989a48454d581#11c746fc55d6a7a95f17bce61d4989a48454d581"
+source = "git+https://github.com/p2pderivatives/rust-dlc?rev=11c746f#11c746fc55d6a7a95f17bce61d4989a48454d581"
 dependencies = [
  "bitcoin",
  "dlc",
@@ -931,7 +931,7 @@ dependencies = [
 [[package]]
 name = "dlc-sled-storage-provider"
 version = "0.1.0"
-source = "git+https://github.com/get10101/rust-dlc?rev=11c746fc55d6a7a95f17bce61d4989a48454d581#11c746fc55d6a7a95f17bce61d4989a48454d581"
+source = "git+https://github.com/p2pderivatives/rust-dlc?rev=11c746f#11c746fc55d6a7a95f17bce61d4989a48454d581"
 dependencies = [
  "bitcoin",
  "dlc-manager",
@@ -945,7 +945,7 @@ dependencies = [
 [[package]]
 name = "dlc-trie"
 version = "0.4.0"
-source = "git+https://github.com/get10101/rust-dlc?rev=11c746fc55d6a7a95f17bce61d4989a48454d581#11c746fc55d6a7a95f17bce61d4989a48454d581"
+source = "git+https://github.com/p2pderivatives/rust-dlc?rev=11c746f#11c746fc55d6a7a95f17bce61d4989a48454d581"
 dependencies = [
  "bitcoin",
  "dlc",
@@ -1592,7 +1592,7 @@ dependencies = [
 [[package]]
 name = "lightning"
 version = "0.0.114"
-source = "git+https://github.com/get10101/rust-lightning/?rev=a663e1fb3415e0b7060e3b7f76f25d96a182006e#a663e1fb3415e0b7060e3b7f76f25d96a182006e"
+source = "git+https://github.com/p2pderivatives/rust-lightning/?rev=a663e1fb#a663e1fb3415e0b7060e3b7f76f25d96a182006e"
 dependencies = [
  "bitcoin",
 ]
@@ -1600,7 +1600,7 @@ dependencies = [
 [[package]]
 name = "lightning-background-processor"
 version = "0.0.114"
-source = "git+https://github.com/get10101/rust-lightning/?rev=a663e1fb3415e0b7060e3b7f76f25d96a182006e#a663e1fb3415e0b7060e3b7f76f25d96a182006e"
+source = "git+https://github.com/p2pderivatives/rust-lightning/?rev=a663e1fb#a663e1fb3415e0b7060e3b7f76f25d96a182006e"
 dependencies = [
  "bitcoin",
  "futures-util",
@@ -1624,7 +1624,7 @@ dependencies = [
 [[package]]
 name = "lightning-net-tokio"
 version = "0.0.114"
-source = "git+https://github.com/get10101/rust-lightning/?rev=a663e1fb3415e0b7060e3b7f76f25d96a182006e#a663e1fb3415e0b7060e3b7f76f25d96a182006e"
+source = "git+https://github.com/p2pderivatives/rust-lightning/?rev=a663e1fb#a663e1fb3415e0b7060e3b7f76f25d96a182006e"
 dependencies = [
  "bitcoin",
  "lightning",
@@ -1634,7 +1634,7 @@ dependencies = [
 [[package]]
 name = "lightning-persister"
 version = "0.0.114"
-source = "git+https://github.com/get10101/rust-lightning/?rev=a663e1fb3415e0b7060e3b7f76f25d96a182006e#a663e1fb3415e0b7060e3b7f76f25d96a182006e"
+source = "git+https://github.com/p2pderivatives/rust-lightning/?rev=a663e1fb#a663e1fb3415e0b7060e3b7f76f25d96a182006e"
 dependencies = [
  "bitcoin",
  "libc",
@@ -1645,7 +1645,7 @@ dependencies = [
 [[package]]
 name = "lightning-rapid-gossip-sync"
 version = "0.0.114"
-source = "git+https://github.com/get10101/rust-lightning/?rev=a663e1fb3415e0b7060e3b7f76f25d96a182006e#a663e1fb3415e0b7060e3b7f76f25d96a182006e"
+source = "git+https://github.com/p2pderivatives/rust-lightning/?rev=a663e1fb#a663e1fb3415e0b7060e3b7f76f25d96a182006e"
 dependencies = [
  "bitcoin",
  "lightning",
@@ -1654,7 +1654,7 @@ dependencies = [
 [[package]]
 name = "lightning-transaction-sync"
 version = "0.0.114"
-source = "git+https://github.com/get10101/rust-lightning/?rev=a663e1fb3415e0b7060e3b7f76f25d96a182006e#a663e1fb3415e0b7060e3b7f76f25d96a182006e"
+source = "git+https://github.com/p2pderivatives/rust-lightning/?rev=a663e1fb#a663e1fb3415e0b7060e3b7f76f25d96a182006e"
 dependencies = [
  "bdk-macros",
  "bitcoin",
@@ -2285,7 +2285,7 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 [[package]]
 name = "p2pd-oracle-client"
 version = "0.1.0"
-source = "git+https://github.com/get10101/rust-dlc?rev=11c746fc55d6a7a95f17bce61d4989a48454d581#11c746fc55d6a7a95f17bce61d4989a48454d581"
+source = "git+https://github.com/p2pderivatives/rust-dlc?rev=11c746f#11c746fc55d6a7a95f17bce61d4989a48454d581"
 dependencies = [
  "chrono",
  "dlc-manager",
@@ -3100,7 +3100,7 @@ dependencies = [
 [[package]]
 name = "simple-wallet"
 version = "0.1.0"
-source = "git+https://github.com/get10101/rust-dlc?rev=11c746fc55d6a7a95f17bce61d4989a48454d581#11c746fc55d6a7a95f17bce61d4989a48454d581"
+source = "git+https://github.com/p2pderivatives/rust-dlc?rev=11c746f#11c746fc55d6a7a95f17bce61d4989a48454d581"
 dependencies = [
  "bitcoin",
  "dlc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,16 +3,20 @@ members = ["coordinator", "maker", "mobile/native", "crates/*"]
 resolver = "2"
 
 [patch.crates-io]
-dlc-manager = { git = "https://github.com/get10101/rust-dlc", rev = "11c746fc55d6a7a95f17bce61d4989a48454d581" }
-dlc-messages = { git = "https://github.com/get10101/rust-dlc", rev = "11c746fc55d6a7a95f17bce61d4989a48454d581" }
-dlc = { git = "https://github.com/get10101/rust-dlc", rev = "11c746fc55d6a7a95f17bce61d4989a48454d581" }
-dlc-sled-storage-provider = { git = "https://github.com/get10101/rust-dlc", rev = "11c746fc55d6a7a95f17bce61d4989a48454d581" }
-p2pd-oracle-client = { git = "https://github.com/get10101/rust-dlc", rev = "11c746fc55d6a7a95f17bce61d4989a48454d581" }
-dlc-trie = { git = "https://github.com/get10101/rust-dlc", rev = "11c746fc55d6a7a95f17bce61d4989a48454d581" }
-simple-wallet = { git = "https://github.com/get10101/rust-dlc", rev = "11c746fc55d6a7a95f17bce61d4989a48454d581" }
-lightning = { git = "https://github.com/get10101/rust-lightning/", rev = "a663e1fb3415e0b7060e3b7f76f25d96a182006e" }
-lightning-background-processor = { git = "https://github.com/get10101/rust-lightning/", rev = "a663e1fb3415e0b7060e3b7f76f25d96a182006e" }
-lightning-transaction-sync = { git = "https://github.com/get10101/rust-lightning/", rev = "a663e1fb3415e0b7060e3b7f76f25d96a182006e" }
-lightning-net-tokio = { git = "https://github.com/get10101/rust-lightning/", rev = "a663e1fb3415e0b7060e3b7f76f25d96a182006e" }
-lightning-persister = { git = "https://github.com/get10101/rust-lightning/", rev = "a663e1fb3415e0b7060e3b7f76f25d96a182006e" }
+# We should usually track the `feature/ln-dlc-channels[-10101]` branch
+dlc-manager = { git = "https://github.com/p2pderivatives/rust-dlc", rev = "11c746f" }
+dlc-messages = { git = "https://github.com/p2pderivatives/rust-dlc", rev = "11c746f" }
+dlc = { git = "https://github.com/p2pderivatives/rust-dlc", rev = "11c746f" }
+dlc-sled-storage-provider = { git = "https://github.com/p2pderivatives/rust-dlc", rev = "11c746f" }
+p2pd-oracle-client = { git = "https://github.com/p2pderivatives/rust-dlc", rev = "11c746f" }
+dlc-trie = { git = "https://github.com/p2pderivatives/rust-dlc", rev = "11c746f" }
+simple-wallet = { git = "https://github.com/p2pderivatives/rust-dlc", rev = "11c746f" }
+
+# We should usually track the `split-tx-experiment[-10101]` branch
+lightning = { git = "https://github.com/p2pderivatives/rust-lightning/", rev = "a663e1fb" }
+lightning-background-processor = { git = "https://github.com/p2pderivatives/rust-lightning/", rev = "a663e1fb" }
+lightning-transaction-sync = { git = "https://github.com/p2pderivatives/rust-lightning/", rev = "a663e1fb" }
+lightning-net-tokio = { git = "https://github.com/p2pderivatives/rust-lightning/", rev = "a663e1fb" }
+lightning-persister = { git = "https://github.com/p2pderivatives/rust-lightning/", rev = "a663e1fb" }
+
 rust-bitcoin-coin-selection = { git = "https://github.com/p2pderivatives/rust-bitcoin-coin-selection" }


### PR DESCRIPTION
Fixes #837.

We are still pretty far away from replacing these git dependencies.

Currently we point to our own branches in the `p2pderivatives` repos: `feature/ln-dlc-channels-10101` and `split-tx-experiment-10101`. These are based on `feature/ln-dlc-channels` and `split-tx-experiment` respectively.

They diverge slightly at the moment for convenience and they will inevitably diverge slightly once in a while in the future. This is because we cannot expect a library such as `rust-dlc` to accept changes at the same rate as a product such as 10101 might need.