### PR TITLE
fix: app cannot receive payment with open position

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - Fix panic when processing accept message while peer is disconnected.
+- Removed stop-gap from receiving payments with open position.
+- Reduced min amount of 50k sats on receiving payments.
 
 ## [1.0.20] - 2023-06-16
 

--- a/mobile/lib/features/wallet/create_invoice_screen.dart
+++ b/mobile/lib/features/wallet/create_invoice_screen.dart
@@ -48,16 +48,13 @@ class _CreateInvoiceScreenState extends State<CreateInvoiceScreen> {
     // it can go below 0 if the user has an unbalanced channel
     Amount maxAmount = Amount(max(usableChannelCapacity.sats - balance.sats, 0));
 
-    // TODO: Re-enable this once we support anchor outputs
     // if we already have a balance that is > 5666 then 1 is the minimum to receive
-    // int minAmount = max(
-    //     channelConstraintsService.getChannelReserve() +
-    //         channelConstraintsService.getFeeReserve() +
-    //         channelConstraintsService.getMinTradeMargin() -
-    //         balance,
-    //     1);
-
-    Amount minAmount = Amount(50000);
+    Amount minAmount = Amount(max(
+        channelConstraintsService.getChannelReserve() +
+            channelConstraintsService.getFeeReserve() +
+            channelConstraintsService.getMinTradeMargin() -
+            balance.sats,
+        1));
 
     return Scaffold(
       appBar: AppBar(title: const Text("Receive funds")),
@@ -133,10 +130,8 @@ class _CreateInvoiceScreenState extends State<CreateInvoiceScreen> {
                   child: Padding(
                 padding: const EdgeInsets.only(bottom: 10.0, left: 32.0, right: 32.0),
                 child: Text(
-                  "Due to recent channel fees the initial deposit should be at least ${formatSats(Amount(50000))}."
-                  "\nDuring the beta we recommend a maximum wallet balance of ${formatSats(Amount(100000))}."
-                  "\nYour wallet balance is ${formatSats(balance)} so you should only receive up to ${formatSats(maxAmount)}.",
-                  style: const TextStyle(color: Colors.grey),
+                  "Your wallet balance is ${formatSats(balance)} so you should only receive up to ${formatSats(maxAmount)}.",
+                  style: const TextStyle(color: Colors.black),
                 ),
               )),
               Expanded(

--- a/mobile/lib/features/wallet/create_invoice_screen.dart
+++ b/mobile/lib/features/wallet/create_invoice_screen.dart
@@ -5,8 +5,6 @@ import 'package:get_10101/common/amount_text.dart';
 import 'package:get_10101/common/amount_text_input_form_field.dart';
 import 'package:get_10101/common/application/channel_constraints_service.dart';
 import 'package:get_10101/common/domain/model.dart';
-import 'package:get_10101/features/trade/domain/contract_symbol.dart';
-import 'package:get_10101/features/trade/position_change_notifier.dart';
 import 'package:get_10101/features/wallet/share_invoice_screen.dart';
 import 'package:get_10101/features/wallet/wallet_change_notifier.dart';
 import 'package:get_10101/features/wallet/wallet_screen.dart';
@@ -46,8 +44,7 @@ class _CreateInvoiceScreenState extends State<CreateInvoiceScreen> {
     Amount channelCapacity = Amount(channelConstraintsService.getLightningChannelCapacity());
     Amount usableChannelCapacity = Amount(channelConstraintsService.getUsableChannelCapacity());
     Amount balance = context.watch<WalletChangeNotifier>().walletInfo.balances.lightning;
-    bool hasOpenPosition =
-        context.watch<PositionChangeNotifier>().positions[ContractSymbol.btcusd] != null;
+
     // it can go below 0 if the user has an unbalanced channel
     Amount maxAmount = Amount(max(usableChannelCapacity.sats - balance.sats, 0));
 
@@ -95,11 +92,6 @@ class _CreateInvoiceScreenState extends State<CreateInvoiceScreen> {
                           setState(() => amount = Amount.parse(value));
                         },
                         validator: (value) {
-                          // FIXME: a temporary stop-gap for https://github.com/get10101/10101/issues/498
-                          if (hasOpenPosition) {
-                            return "Cannot receive funds whilst a position is open";
-                          }
-
                           if (value == null) {
                             return "Enter receive amount";
                           }


### PR DESCRIPTION
- **Remove stop-gap on receiving payment with open position**: It seems a change in the past fixed that issue implicitly. Probably upgrading to ldk 114. Anyhow, I tested receiving a payment from the faucet and it worked just fine.
- **Remove constraint on min amount**: Receiving min 50k sats was an arbitrary amount and did at most only mitigate the chances of preventing https://github.com/get10101/10101/issues/580. Given that the current mempool situation does not ask for this constraint anymore, we returning to the original min amount.

fixes #498 
