### PR TITLE
Fix constant flickering on app's wallet screen

### DIFF
--- a/mobile/lib/common/app_bar_wrapper.dart
+++ b/mobile/lib/common/app_bar_wrapper.dart
@@ -14,7 +14,7 @@ class AppBarWrapper extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final currentRoute = GoRouter.of(context).location;
+    final currentRoute = GoRouterState.of(context).location;
     const appBarHeight = 32.0;
 
     var actionButtons = <Widget>[];

--- a/mobile/lib/features/wallet/seed_screen.dart
+++ b/mobile/lib/features/wallet/seed_screen.dart
@@ -126,8 +126,8 @@ class _SendScreenState extends State<SeedScreen> {
                       ElevatedButton(
                           onPressed: checked
                               ? () {
-                                  Preferences.instance.setUserSeedBackupConfirmed(true);
-                                  context.go(WalletScreen.route);
+                                  Preferences.instance.setUserSeedBackupConfirmed();
+                                  context.pop(true);
                                 }
                               : null,
                           child: const Text('Done'))

--- a/mobile/lib/features/wallet/wallet_screen.dart
+++ b/mobile/lib/features/wallet/wallet_screen.dart
@@ -179,15 +179,21 @@ class _WalletScreenState extends State<WalletScreen> {
                     // `snapshot.data` to keep the `Backup Wallet` button visible at all times for
                     // now. We need to rework this.
                     if (snapshot.connectionState == ConnectionState.done) {
-                      return ElevatedButton(
-                        onPressed: () async {
-                          final res = await context.push(SeedScreen.route);
+                      return Column(
+                        crossAxisAlignment: CrossAxisAlignment.stretch,
+                        children: [
+                          const SizedBox(height: 3),
+                          ElevatedButton(
+                            onPressed: () async {
+                              final res = await context.push(SeedScreen.route);
 
-                          setState(() {
-                            isUserSeedBackupConfirmed = Future.value(res as bool);
-                          });
-                        },
-                        child: const Text("Backup Wallet"),
+                              setState(() {
+                                isUserSeedBackupConfirmed = Future.value(res as bool);
+                              });
+                            },
+                            child: const Text("Backup Wallet"),
+                          ),
+                        ],
                       );
                     }
                     // return an empty box if the wallet has already been backed up or the data has not been fetched yet.

--- a/mobile/lib/features/wallet/wallet_screen.dart
+++ b/mobile/lib/features/wallet/wallet_screen.dart
@@ -29,6 +29,13 @@ class WalletScreen extends StatefulWidget {
 
 class _WalletScreenState extends State<WalletScreen> {
   bool _isBalanceBreakdownOpen = false;
+  Future<bool>? isUserSeedBackupConfirmed;
+
+  @override
+  void initState() {
+    super.initState();
+    isUserSeedBackupConfirmed = Preferences.instance.isUserSeedBackupConfirmed();
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -166,12 +173,19 @@ class _WalletScreenState extends State<WalletScreen> {
                   child: const Text("Fund Wallet"),
                 ),
               FutureBuilder(
-                  future: Preferences.instance.isUserSeedBackupConfirmed(),
+                  future: isUserSeedBackupConfirmed,
                   builder: (BuildContext context, AsyncSnapshot<bool> snapshot) {
-                    if (snapshot.connectionState == ConnectionState.done && !snapshot.data!) {
+                    // FIXME: We ignore the value of `isUserSeedBackupConfirmed` stored in
+                    // `snapshot.data` to keep the `Backup Wallet` button visible at all times for
+                    // now. We need to rework this.
+                    if (snapshot.connectionState == ConnectionState.done) {
                       return ElevatedButton(
-                        onPressed: () {
-                          context.go(SeedScreen.route);
+                        onPressed: () async {
+                          final res = await context.push(SeedScreen.route);
+
+                          setState(() {
+                            isUserSeedBackupConfirmed = Future.value(res as bool);
+                          });
                         },
                         child: const Text("Backup Wallet"),
                       );

--- a/mobile/lib/util/preferences.dart
+++ b/mobile/lib/util/preferences.dart
@@ -8,16 +8,14 @@ class Preferences {
   static const userSeedBackupConfirmed = "userSeedBackupConfirmed";
   static const emailAddress = "emailAddress";
 
-  setUserSeedBackupConfirmed(bool value) async {
+  setUserSeedBackupConfirmed() async {
     SharedPreferences preferences = await SharedPreferences.getInstance();
-    preferences.setBool(userSeedBackupConfirmed, value);
+    preferences.setBool(userSeedBackupConfirmed, true);
   }
 
   Future<bool> isUserSeedBackupConfirmed() async {
-    // FIXME: disabling the user seed backup confirmed preference so that the backup button is always visible. Eventually, we should think about how we want to make the seed backup accessible to the user at all times.
-    // SharedPreferences preferences = await SharedPreferences.getInstance();
-    // return preferences.getBool(userSeedBackupConfirmed) ?? false;
-    return false;
+    SharedPreferences preferences = await SharedPreferences.getInstance();
+    return preferences.getBool(userSeedBackupConfirmed) ?? false;
   }
 
   setEmailAddress(String value) async {

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -396,10 +396,10 @@ packages:
     dependency: "direct main"
     description:
       name: go_router
-      sha256: b789ead597d3e9cd5d114cdb7af12440712da5599743f9a2358c43aa3f5e9d3e
+      sha256: "1531542666c2d052c44bbf6e2b48011bf3771da0404b94c60eabec1228a62906"
       url: "https://pub.dev"
     source: hosted
-    version: "6.0.2"
+    version: "9.0.0"
   graphs:
     dependency: transitive
     description:

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   flutter_rust_bridge: 1.68.0
   flutter_speed_dial: ^6.2.0
   meta: ^1.8.0
-  go_router: ^6.0.2
+  go_router: ^9.0.0
   flutter_native_splash: ^2.2.16
   flutter_svg: ^2.0.0+1
   provider: ^6.0.5


### PR DESCRIPTION
Fix #404.

This was caused by calling `isUserSeedBackupConfirmed` (the future passed to `FutureBuilder`) in `State<WalletScreen>.build`, something that the docs explicitly say we must not do.

As recommended, we call it in `State<WalletScreen>.initState`. This means that the `WalletScreen` is no longer informed about the updated value after confirming that the seed has been backed up.

The simplest way to know is to return a value after `pop`ping (returning from) the `SeedScreen`. This functionality is
only available in a later version of `go_router` so we update the dependency to the latest version. With the returned value we can
update the dependency of `isUserSeedBackupConfirmed`.

Finally, we move the responsibility of keeping the button always visible to the place where we actually enable the button. As such, we don't need to comment out code and the TODO can be moved next to the code that it references.