### PR TITLE
fix(ui): Remove dummy initial price values from the GUI

### DIFF
--- a/mobile/lib/common/dummy_values.dart
+++ b/mobile/lib/common/dummy_values.dart
@@ -1,9 +1,6 @@
 // Assorted dummy values for expedience with prototyping.
 // Eventually we should replace them with the real values from the backend.
 
-const double dummyBidPrice = 22990.0;
-const double dummyAskPrice = 23010.0;
-
 // TODO replace dummy funding rate with funding rate from backend
 const double fundingRateBuy = 0.003;
 const double fundingRateSell = -0.003;

--- a/mobile/lib/features/trade/application/position_service.dart
+++ b/mobile/lib/features/trade/application/position_service.dart
@@ -11,13 +11,17 @@ class PositionService {
   }
 
   /// Returns the pnl in sat
-  int calculatePnl(Position position, Price price) {
+  int? calculatePnl(Position position, Price price) {
+    if (!price.isValid()) {
+      return null;
+    }
+    final closingPrice = rust.Price(
+      bid: price.bid!,
+      ask: price.ask!,
+    );
     return rust.api.calculatePnl(
         openingPrice: position.averageEntryPrice,
-        closingPrice: rust.Price(
-          bid: price.bid,
-          ask: price.ask,
-        ),
+        closingPrice: closingPrice,
         quantity: position.quantity,
         leverage: position.leverage.leverage,
         direction: position.direction.toApi());

--- a/mobile/lib/features/trade/application/trade_values_service.dart
+++ b/mobile/lib/features/trade/application/trade_values_service.dart
@@ -4,24 +4,39 @@ import 'package:get_10101/common/domain/model.dart';
 import 'package:get_10101/features/trade/domain/direction.dart';
 
 class TradeValuesService {
-  Amount calculateMargin(
-      {required double price, required double quantity, required Leverage leverage, dynamic hint}) {
-    return Amount(
-        rust.api.calculateMargin(price: price, quantity: quantity, leverage: leverage.leverage));
+  Amount? calculateMargin(
+      {required double? price,
+      required double? quantity,
+      required Leverage leverage,
+      dynamic hint}) {
+    if (price == null || quantity == null) {
+      return null;
+    } else {
+      return Amount(
+          rust.api.calculateMargin(price: price, quantity: quantity, leverage: leverage.leverage));
+    }
   }
 
-  double calculateQuantity(
-      {required double price, required Amount margin, required Leverage leverage, dynamic hint}) {
-    return rust.api
-        .calculateQuantity(price: price, margin: margin.sats, leverage: leverage.leverage);
+  double? calculateQuantity(
+      {required double? price, required Amount? margin, required Leverage leverage, dynamic hint}) {
+    if (price == null || margin == null) {
+      return null;
+    } else {
+      return rust.api
+          .calculateQuantity(price: price, margin: margin.sats, leverage: leverage.leverage);
+    }
   }
 
-  double calculateLiquidationPrice(
-      {required double price,
+  double? calculateLiquidationPrice(
+      {required double? price,
       required Leverage leverage,
       required Direction direction,
       dynamic hint}) {
-    return rust.api.calculateLiquidationPrice(
-        price: price, leverage: leverage.leverage, direction: direction.toApi());
+    if (price == null) {
+      return null;
+    } else {
+      return rust.api.calculateLiquidationPrice(
+          price: price, leverage: leverage.leverage, direction: direction.toApi());
+    }
   }
 }

--- a/mobile/lib/features/trade/domain/price.dart
+++ b/mobile/lib/features/trade/domain/price.dart
@@ -1,18 +1,20 @@
 import 'package:get_10101/bridge_generated/bridge_definitions.dart' as bridge;
-import 'package:get_10101/common/dummy_values.dart';
 
-/// TODO: We should be able to depict having no price from the orderbook (e.g. it's down, we're not connected to the internet, or there are no orders etc.)
 class Price {
-  final double bid;
-  final double ask;
+  final double? bid;
+  final double? ask;
 
   Price({required this.bid, required this.ask});
 
+  isValid() {
+    return bid != null && ask != null;
+  }
+
   static Price fromApi(bridge.BestPrice bestPrice) {
-    return Price(bid: bestPrice.bid ?? dummyBidPrice, ask: bestPrice.ask ?? dummyAskPrice);
+    return Price(bid: bestPrice.bid, ask: bestPrice.ask);
   }
 
   static bridge.BestPrice apiDummy() {
-    return const bridge.BestPrice(bid: dummyBidPrice, ask: dummyAskPrice);
+    return const bridge.BestPrice(bid: null, ask: null);
   }
 }

--- a/mobile/lib/features/trade/domain/trade_values.dart
+++ b/mobile/lib/features/trade/domain/trade_values.dart
@@ -4,13 +4,15 @@ import 'package:get_10101/common/domain/model.dart';
 import 'package:get_10101/features/trade/application/trade_values_service.dart';
 
 class TradeValues {
-  Amount margin;
-  double quantity;
+  Amount? margin;
   Leverage leverage;
   Direction direction;
 
-  double price;
-  double liquidationPrice;
+  // These values  can be null if coordinator is down
+  double? quantity;
+  double? price;
+  double? liquidationPrice;
+
   Amount fee;
   double fundingRate;
 
@@ -29,16 +31,18 @@ class TradeValues {
       required this.tradeValuesService});
 
   factory TradeValues.create(
-      {required Amount margin,
+      {required Amount? margin,
       required Leverage leverage,
-      required double price,
+      required double? price,
       required double fundingRate,
       required Direction direction,
       required TradeValuesService tradeValuesService}) {
-    double quantity =
+    double? quantity =
         tradeValuesService.calculateQuantity(price: price, margin: margin, leverage: leverage);
-    double liquidationPrice = tradeValuesService.calculateLiquidationPrice(
-        price: price, leverage: leverage, direction: direction);
+    double? liquidationPrice = price != null
+        ? tradeValuesService.calculateLiquidationPrice(
+            price: price, leverage: leverage, direction: direction)
+        : null;
 
     // TODO: Calculate fee based on price, quantity and funding rate
     Amount fee = Amount(0);
@@ -65,7 +69,7 @@ class TradeValues {
     _recalculateQuantity();
   }
 
-  updatePrice(double price) {
+  updatePrice(double? price) {
     this.price = price;
     _recalculateQuantity();
     _recalculateLiquidationPrice();
@@ -78,19 +82,19 @@ class TradeValues {
   }
 
   _recalculateMargin() {
-    Amount margin =
+    Amount? margin =
         tradeValuesService.calculateMargin(price: price, quantity: quantity, leverage: leverage);
     this.margin = margin;
   }
 
   _recalculateQuantity() {
-    double quantity =
+    double? quantity =
         tradeValuesService.calculateQuantity(price: price, margin: margin, leverage: leverage);
     this.quantity = quantity;
   }
 
   _recalculateLiquidationPrice() {
-    double liquidationPrice = tradeValuesService.calculateLiquidationPrice(
+    double? liquidationPrice = tradeValuesService.calculateLiquidationPrice(
         price: price, leverage: leverage, direction: direction);
     this.liquidationPrice = liquidationPrice;
   }

--- a/mobile/lib/features/trade/position_change_notifier.dart
+++ b/mobile/lib/features/trade/position_change_notifier.dart
@@ -2,7 +2,6 @@ import 'dart:developer';
 import 'package:flutter/material.dart';
 import 'package:get_10101/common/application/event_service.dart';
 import 'package:get_10101/common/domain/model.dart';
-import 'package:get_10101/common/dummy_values.dart';
 import 'package:get_10101/features/trade/application/position_service.dart';
 import 'package:get_10101/features/trade/domain/contract_symbol.dart';
 import 'package:get_10101/bridge_generated/bridge_definitions.dart' as bridge;
@@ -22,7 +21,6 @@ class PositionChangeNotifier extends ChangeNotifier implements Subscriber {
     for (Position position in positions) {
       this.positions[position.contractSymbol] = position;
     }
-    _price = Price(bid: dummyBidPrice, ask: dummyAskPrice);
 
     notifyListeners();
   }
@@ -37,7 +35,8 @@ class PositionChangeNotifier extends ChangeNotifier implements Subscriber {
       Position position = Position.fromApi(event.field0);
 
       if (_price != null) {
-        position.unrealizedPnl = Amount(_positionService.calculatePnl(position, _price!));
+        final pnl = _positionService.calculatePnl(position, _price!);
+        position.unrealizedPnl = pnl != null ? Amount(pnl) : null;
       } else {
         position.unrealizedPnl = null;
       }
@@ -50,8 +49,8 @@ class PositionChangeNotifier extends ChangeNotifier implements Subscriber {
       for (ContractSymbol symbol in positions.keys) {
         if (_price != null) {
           if (positions[symbol] != null) {
-            positions[symbol]!.unrealizedPnl =
-                Amount(_positionService.calculatePnl(positions[symbol]!, _price!));
+            final pnl = _positionService.calculatePnl(positions[symbol]!, _price!);
+            positions[symbol]!.unrealizedPnl = pnl != null ? Amount(pnl) : null;
           }
         }
       }

--- a/mobile/lib/features/trade/submit_order_change_notifier.dart
+++ b/mobile/lib/features/trade/submit_order_change_notifier.dart
@@ -47,8 +47,9 @@ class SubmitOrderChangeNotifier extends ChangeNotifier implements Subscriber {
     notifyListeners();
 
     try {
-      _pendingOrder!.id = await orderService.submitMarketOrder(
-          tradeValues.leverage, tradeValues.quantity, ContractSymbol.btcusd, tradeValues.direction);
+      assert(tradeValues.quantity != null, 'Quantity cannot be null when submitting order');
+      _pendingOrder!.id = await orderService.submitMarketOrder(tradeValues.leverage,
+          tradeValues.quantity!, ContractSymbol.btcusd, tradeValues.direction);
       _pendingOrder!.state = PendingOrderState.submittedSuccessfully;
     } catch (exception) {
       FLog.error(text: "Failed to submit order: $exception");

--- a/mobile/lib/features/trade/trade_bottom_sheet_confirmation.dart
+++ b/mobile/lib/features/trade/trade_bottom_sheet_confirmation.dart
@@ -89,7 +89,10 @@ class TradeBottomSheetConfirmation extends StatelessWidget {
     TradeValues tradeValues =
         Provider.of<TradeValuesChangeNotifier>(context).fromDirection(direction);
 
-    Amount total = Amount(tradeValues.fee.sats + tradeValues.margin.sats);
+    // Fallback to 0 if we can't get the margin
+    Amount total = tradeValues.margin != null
+        ? Amount(tradeValues.fee.sats + tradeValues.margin!.sats)
+        : Amount(0);
     Amount pnl = Amount(0);
     if (context.read<PositionChangeNotifier>().positions.containsKey(ContractSymbol.btcusd)) {
       final position = context.read<PositionChangeNotifier>().positions[ContractSymbol.btcusd];
@@ -122,7 +125,7 @@ class TradeBottomSheetConfirmation extends StatelessWidget {
                         close
                             ? ValueDataRow(
                                 type: ValueType.fiat,
-                                value: tradeValues.price,
+                                value: tradeValues.price ?? 0.0,
                                 label: 'Market Price')
                             : ValueDataRow(
                                 type: ValueType.amount, value: tradeValues.margin, label: 'Margin'),
@@ -136,7 +139,7 @@ class TradeBottomSheetConfirmation extends StatelessWidget {
                                         pnl.sats.isNegative ? tradeTheme.loss : tradeTheme.profit))
                             : ValueDataRow(
                                 type: ValueType.fiat,
-                                value: tradeValues.liquidationPrice,
+                                value: tradeValues.liquidationPrice ?? 0.0,
                                 label: 'Liquidation Price',
                               ),
                         ValueDataRow(

--- a/mobile/lib/features/trade/trade_bottom_sheet_tab.dart
+++ b/mobile/lib/features/trade/trade_bottom_sheet_tab.dart
@@ -106,7 +106,7 @@ class _TradeBottomSheetTabState extends State<TradeBottomSheetTab> {
                 ),
               ),
               Selector<TradeValuesChangeNotifier, double>(
-                  selector: (_, provider) => provider.fromDirection(widget.direction).price,
+                  selector: (_, provider) => provider.fromDirection(widget.direction).price ?? 0,
                   builder: (context, price, child) {
                     return DoubleTextInputFormField(
                       value: price,
@@ -120,7 +120,8 @@ class _TradeBottomSheetTabState extends State<TradeBottomSheetTab> {
                 children: [
                   Flexible(
                     child: Selector<TradeValuesChangeNotifier, double>(
-                      selector: (_, provider) => provider.fromDirection(widget.direction).quantity,
+                      selector: (_, provider) =>
+                          provider.fromDirection(widget.direction).quantity ?? 0.0,
                       builder: (context, quantity, child) {
                         return DoubleTextInputFormField(
                           value: quantity,
@@ -152,7 +153,8 @@ class _TradeBottomSheetTabState extends State<TradeBottomSheetTab> {
                   ),
                   Flexible(
                     child: Selector<TradeValuesChangeNotifier, Amount>(
-                      selector: (_, provider) => provider.fromDirection(widget.direction).margin,
+                      selector: (_, provider) =>
+                          provider.fromDirection(widget.direction).margin ?? Amount(0),
                       builder: (context, margin, child) {
                         return AmountInputField(
                           value: margin,
@@ -186,8 +188,13 @@ class _TradeBottomSheetTabState extends State<TradeBottomSheetTab> {
                               // the trading capacity does not take into account if the channel is balanced or not
                               int tradingCapacity =
                                   provider.availableTradingCapacity(widget.direction);
-                              int counterpartyMargin =
+
+                              int? optCounterPartyMargin =
                                   provider.counterpartyMargin(widget.direction);
+                              if (optCounterPartyMargin == null) {
+                                return "Counterparty margin not available";
+                              }
+                              int counterpartyMargin = optCounterPartyMargin;
 
                               // This condition has to stay as the first thing to check, so we reset showing the info
                               if (margin > tradingCapacity ||
@@ -250,7 +257,7 @@ class _TradeBottomSheetTabState extends State<TradeBottomSheetTab> {
                   const SizedBox(width: 5),
                   Selector<TradeValuesChangeNotifier, double>(
                       selector: (_, provider) =>
-                          provider.fromDirection(widget.direction).liquidationPrice,
+                          provider.fromDirection(widget.direction).liquidationPrice ?? 0.0,
                       builder: (context, liquidationPrice, child) {
                         return Flexible(child: FiatText(amount: liquidationPrice));
                       }),

--- a/mobile/lib/features/trade/trade_value_change_notifier.dart
+++ b/mobile/lib/features/trade/trade_value_change_notifier.dart
@@ -43,7 +43,7 @@ class TradeValuesChangeNotifier extends ChangeNotifier implements Subscriber {
         return TradeValues.create(
             margin: defaultMargin,
             leverage: defaultLeverage,
-            price: dummyAskPrice,
+            price: null,
             fundingRate: fundingRateBuy,
             direction: direction,
             tradeValuesService: tradeValuesService);
@@ -51,7 +51,7 @@ class TradeValuesChangeNotifier extends ChangeNotifier implements Subscriber {
         return TradeValues.create(
             margin: defaultMargin,
             leverage: defaultLeverage,
-            price: dummyBidPrice,
+            price: null,
             fundingRate: fundingRateSell,
             direction: direction,
             tradeValuesService: tradeValuesService);
@@ -65,7 +65,7 @@ class TradeValuesChangeNotifier extends ChangeNotifier implements Subscriber {
   int get capacity => _channelCapacity;
 
   /// Calculates the counterparty margin based on leverage one
-  int counterpartyMargin(Direction direction) {
+  int? counterpartyMargin(Direction direction) {
     switch (direction) {
       case Direction.long:
         return tradeValuesService
@@ -73,14 +73,14 @@ class TradeValuesChangeNotifier extends ChangeNotifier implements Subscriber {
                 price: _buyTradeValues.price,
                 quantity: _buyTradeValues.quantity,
                 leverage: Leverage(1))
-            .sats;
+            ?.sats;
       case Direction.short:
         return tradeValuesService
             .calculateMargin(
                 price: _sellTradeValues.price,
                 quantity: _sellTradeValues.quantity,
                 leverage: Leverage(1))
-            .sats;
+            ?.sats;
     }
   }
 
@@ -91,7 +91,7 @@ class TradeValuesChangeNotifier extends ChangeNotifier implements Subscriber {
     int channelCapacity = _channelConstraintsService.getLightningChannelCapacity();
     int totalReserve = reserve * 2;
 
-    return channelCapacity - totalReserve - counterpartyMargin(direction);
+    return channelCapacity - totalReserve - (counterpartyMargin(direction) ?? 0);
   }
 
   void updateQuantity(Direction direction, double quantity) {


### PR DESCRIPTION
Once introduced for expedience, they started confusing the beta users.

TradeValues allows nullable values for parameters that are taken from the coordinator.

Checks are inserted in place before each `!` defererence (Dart 2 unfortunately
does not detect all not-nullable values properly.).


when coordinator is off at startup - the order cannot be placed because we don't have the counterparty margin:
![image](https://github.com/get10101/10101/assets/8319440/9a6151b7-2ada-4526-9dc4-febeffc4a433)

(note: it would be great if we had a higher-level API check from the backend + a notifier in Dart about coordinator status).

