### PR TITLE
Pay order-matching fee on the app

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2262,6 +2262,7 @@ name = "orderbook-commons"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "bitcoin",
  "rust_decimal",
  "rust_decimal_macros",
  "secp256k1",

--- a/coordinator/src/node/order_matching_fee.rs
+++ b/coordinator/src/node/order_matching_fee.rs
@@ -2,14 +2,8 @@ use crate::node::Node;
 use anyhow::Result;
 use coordinator_commons::TradeParams;
 use lightning_invoice::Invoice;
+use orderbook_commons::order_matching_fee_taker;
 use orderbook_commons::FEE_INVOICE_DESCRIPTION_PREFIX_TAKER;
-use rust_decimal::prelude::FromPrimitive;
-use rust_decimal::prelude::ToPrimitive;
-use rust_decimal::Decimal;
-use rust_decimal::RoundingStrategy;
-
-/// The order-matching fee per cent for the taker.
-const TAKER_FEE: (i64, u32) = (30, 4);
 
 /// How long the fee invoice will last for.
 const INVOICE_EXPIRY: u32 = 3600;
@@ -19,40 +13,12 @@ impl Node {
         let order_id = trade_params.filled_with.order_id;
         let description = format!("{FEE_INVOICE_DESCRIPTION_PREFIX_TAKER}{order_id}");
 
-        let fee = order_matching_fee(
+        let fee = order_matching_fee_taker(
             trade_params.quantity,
             trade_params.average_execution_price(),
-            Decimal::new(TAKER_FEE.0, TAKER_FEE.1),
         )
         .to_sat();
 
         self.inner.create_invoice(fee, description, INVOICE_EXPIRY)
-    }
-}
-
-fn order_matching_fee(quantity: f32, price: Decimal, fee_per_cent: Decimal) -> bitcoin::Amount {
-    let quantity = Decimal::from_f32(quantity).expect("quantity to fit in Decimal");
-    let price = price;
-
-    let fee = quantity * (Decimal::ONE / price) * fee_per_cent;
-    let fee = fee
-        .round_dp_with_strategy(8, RoundingStrategy::MidpointAwayFromZero)
-        .to_f64()
-        .expect("fee to fit in f64");
-
-    bitcoin::Amount::from_btc(fee).expect("fee to fit in bitcoin::Amount")
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn calculate_order_matching_fee() {
-        let price = Decimal::new(30209, 0);
-
-        let fee = order_matching_fee(50.0, price, Decimal::new(TAKER_FEE.0, TAKER_FEE.1));
-
-        assert_eq!(fee.to_sat(), 497);
     }
 }

--- a/coordinator/src/node/order_matching_fee.rs
+++ b/coordinator/src/node/order_matching_fee.rs
@@ -1,0 +1,58 @@
+use crate::node::Node;
+use anyhow::Result;
+use coordinator_commons::TradeParams;
+use lightning_invoice::Invoice;
+use orderbook_commons::FEE_INVOICE_DESCRIPTION_PREFIX_TAKER;
+use rust_decimal::prelude::FromPrimitive;
+use rust_decimal::prelude::ToPrimitive;
+use rust_decimal::Decimal;
+use rust_decimal::RoundingStrategy;
+
+/// The order-matching fee per cent for the taker.
+const TAKER_FEE: (i64, u32) = (30, 4);
+
+/// How long the fee invoice will last for.
+const INVOICE_EXPIRY: u32 = 3600;
+
+impl Node {
+    pub async fn fee_invoice_taker(&self, trade_params: &TradeParams) -> Result<Invoice> {
+        let order_id = trade_params.filled_with.order_id;
+        let description = format!("{FEE_INVOICE_DESCRIPTION_PREFIX_TAKER}{order_id}");
+
+        let fee = order_matching_fee(
+            trade_params.quantity,
+            trade_params.average_execution_price(),
+            Decimal::new(TAKER_FEE.0, TAKER_FEE.1),
+        )
+        .to_sat();
+
+        self.inner.create_invoice(fee, description, INVOICE_EXPIRY)
+    }
+}
+
+fn order_matching_fee(quantity: f32, price: Decimal, fee_per_cent: Decimal) -> bitcoin::Amount {
+    let quantity = Decimal::from_f32(quantity).expect("quantity to fit in Decimal");
+    let price = price;
+
+    let fee = quantity * (Decimal::ONE / price) * fee_per_cent;
+    let fee = fee
+        .round_dp_with_strategy(8, RoundingStrategy::MidpointAwayFromZero)
+        .to_f64()
+        .expect("fee to fit in f64");
+
+    bitcoin::Amount::from_btc(fee).expect("fee to fit in bitcoin::Amount")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn calculate_order_matching_fee() {
+        let price = Decimal::new(30209, 0);
+
+        let fee = order_matching_fee(50.0, price, Decimal::new(TAKER_FEE.0, TAKER_FEE.1));
+
+        assert_eq!(fee.to_sat(), 497);
+    }
+}

--- a/coordinator/src/routes.rs
+++ b/coordinator/src/routes.rs
@@ -222,12 +222,12 @@ pub async fn get_invoice(
 pub async fn post_trade(
     State(state): State<Arc<AppState>>,
     trade_params: Json<TradeParams>,
-) -> Result<(), AppError> {
-    state.node.trade(&trade_params.0).await.map_err(|e| {
+) -> Result<String, AppError> {
+    let invoice = state.node.trade(&trade_params.0).await.map_err(|e| {
         AppError::InternalServerError(format!("Could not handle trade request: {e:#}"))
     })?;
 
-    Ok(())
+    Ok(invoice.to_string())
 }
 
 /// Internal API for syncing the wallet

--- a/crates/ln-dlc-node/src/lib.rs
+++ b/crates/ln-dlc-node/src/lib.rs
@@ -84,7 +84,7 @@ type RequestedScid = u64;
 type FakeChannelPaymentRequests = Arc<Mutex<HashMap<RequestedScid, PublicKey>>>;
 type PendingInterceptedHtlcs = Arc<Mutex<HashMap<PublicKey, (InterceptId, u64)>>>;
 
-#[derive(Clone, Copy)]
+#[derive(Clone)]
 pub struct PaymentInfo {
     pub preimage: Option<PaymentPreimage>,
     pub secret: Option<PaymentSecret>,
@@ -92,6 +92,7 @@ pub struct PaymentInfo {
     pub amt_msat: MillisatAmount,
     pub flow: PaymentFlow,
     pub timestamp: OffsetDateTime,
+    pub description: String,
 }
 
 #[derive(Debug, Clone, Copy)]

--- a/crates/ln-dlc-node/src/ln/event_handler.rs
+++ b/crates/ln-dlc-node/src/ln/event_handler.rs
@@ -235,6 +235,7 @@ where
                                 amt_msat,
                                 flow: PaymentFlow::Outbound,
                                 timestamp: OffsetDateTime::now_utc(),
+                                description: "".to_string(),
                             },
                         ) {
                             tracing::error!(

--- a/crates/ln-dlc-node/src/node/invoice.rs
+++ b/crates/ln-dlc-node/src/node/invoice.rs
@@ -24,6 +24,7 @@ use lightning_invoice::payment::PaymentError;
 use lightning_invoice::Currency;
 use lightning_invoice::Invoice;
 use lightning_invoice::InvoiceBuilder;
+use lightning_invoice::InvoiceDescription;
 use std::time::Duration;
 use std::time::SystemTime;
 use time::OffsetDateTime;
@@ -182,6 +183,11 @@ where
             }
         };
 
+        let description = match invoice.description() {
+            InvoiceDescription::Direct(des) => des.clone().into_inner(),
+            InvoiceDescription::Hash(lightning_invoice::Sha256(des)) => des.to_string(),
+        };
+
         self.storage.insert_payment(
             PaymentHash(invoice.payment_hash().into_inner()),
             PaymentInfo {
@@ -191,6 +197,7 @@ where
                 amt_msat: MillisatAmount(invoice.amount_milli_satoshis()),
                 flow: PaymentFlow::Outbound,
                 timestamp: OffsetDateTime::now_utc(),
+                description,
             },
         )?;
 

--- a/crates/ln-dlc-node/src/node/storage.rs
+++ b/crates/ln-dlc-node/src/node/storage.rs
@@ -115,6 +115,7 @@ impl Storage for InMemoryStore {
                         amt_msat: MillisatAmount(None),
                         flow,
                         timestamp: OffsetDateTime::now_utc(),
+                        description: "".to_string(),
                     },
                 );
             }
@@ -130,14 +131,14 @@ impl Storage for InMemoryStore {
         let payments = self.payments_lock();
         let info = payments.get(payment_hash);
 
-        let payment = info.map(|info| (*payment_hash, *info));
+        let payment = info.map(|info| (*payment_hash, info.clone()));
 
         Ok(payment)
     }
 
     fn all_payments(&self) -> Result<Vec<(PaymentHash, PaymentInfo)>> {
         let payments = self.payments_lock();
-        let payments = payments.iter().map(|(a, b)| (*a, *b)).collect();
+        let payments = payments.iter().map(|(a, b)| (*a, b.clone())).collect();
 
         Ok(payments)
     }

--- a/crates/ln-dlc-node/src/node/wallet.rs
+++ b/crates/ln-dlc-node/src/node/wallet.rs
@@ -121,6 +121,7 @@ where
                 flow: info.flow,
                 amount_msat: info.amt_msat.0,
                 timestamp: info.timestamp,
+                description: info.description.clone(),
             })
             .collect::<Vec<_>>();
 
@@ -137,4 +138,5 @@ pub struct PaymentDetails {
     pub flow: PaymentFlow,
     pub amount_msat: Option<u64>,
     pub timestamp: OffsetDateTime,
+    pub description: String,
 }

--- a/crates/orderbook-commons/Cargo.toml
+++ b/crates/orderbook-commons/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1"
+bitcoin = "0.29"
 rust_decimal = { version = "1", features = ["serde-with-float"] }
 secp256k1 = { version = "0.24.3", features = ["serde"] }
 serde = { version = "1", features = ["derive"] }

--- a/crates/orderbook-commons/src/lib.rs
+++ b/crates/orderbook-commons/src/lib.rs
@@ -21,6 +21,9 @@ use uuid::Uuid;
 // For now we hardcode a global expiry for all newly created orders.
 pub const DEFAULT_ORDER_EXPIRY: Duration = Duration::minutes(1);
 
+/// The prefix used in the description field of an order-matching fee invoice to be paid by a taker.
+pub const FEE_INVOICE_DESCRIPTION_PREFIX_TAKER: &str = "taker-fee-";
+
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct Order {
     pub id: Uuid,

--- a/crates/orderbook-commons/src/lib.rs
+++ b/crates/orderbook-commons/src/lib.rs
@@ -1,8 +1,3 @@
-mod price;
-
-pub use crate::price::best_current_price;
-pub use crate::price::Price;
-pub use crate::price::Prices;
 use rust_decimal::prelude::ToPrimitive;
 use rust_decimal::Decimal;
 use secp256k1::Message;
@@ -17,6 +12,14 @@ use time::Duration;
 use time::OffsetDateTime;
 use trade::Direction;
 use uuid::Uuid;
+
+mod order_matching_fee;
+mod price;
+
+pub use crate::order_matching_fee::order_matching_fee_taker;
+pub use crate::price::best_current_price;
+pub use crate::price::Price;
+pub use crate::price::Prices;
 
 // For now we hardcode a global expiry for all newly created orders.
 pub const DEFAULT_ORDER_EXPIRY: Duration = Duration::minutes(1);

--- a/crates/orderbook-commons/src/order_matching_fee.rs
+++ b/crates/orderbook-commons/src/order_matching_fee.rs
@@ -1,0 +1,38 @@
+use rust_decimal::prelude::FromPrimitive;
+use rust_decimal::prelude::ToPrimitive;
+use rust_decimal::Decimal;
+use rust_decimal::RoundingStrategy;
+
+/// The order-matching fee per cent for the taker.
+const TAKER_FEE: (i64, u32) = (30, 4);
+
+pub fn order_matching_fee_taker(quantity: f32, price: Decimal) -> bitcoin::Amount {
+    order_matching_fee(quantity, price, Decimal::new(TAKER_FEE.0, TAKER_FEE.1))
+}
+
+fn order_matching_fee(quantity: f32, price: Decimal, fee_per_cent: Decimal) -> bitcoin::Amount {
+    let quantity = Decimal::from_f32(quantity).expect("quantity to fit in Decimal");
+    let price = price;
+
+    let fee = quantity * (Decimal::ONE / price) * fee_per_cent;
+    let fee = fee
+        .round_dp_with_strategy(8, RoundingStrategy::MidpointAwayFromZero)
+        .to_f64()
+        .expect("fee to fit in f64");
+
+    bitcoin::Amount::from_btc(fee).expect("fee to fit in bitcoin::Amount")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn calculate_order_matching_fee() {
+        let price = Decimal::new(30209, 0);
+
+        let fee = order_matching_fee(50.0, price, Decimal::new(TAKER_FEE.0, TAKER_FEE.1));
+
+        assert_eq!(fee.to_sat(), 497);
+    }
+}

--- a/crates/tests-e2e/tests/open_position.rs
+++ b/crates/tests-e2e/tests/open_position.rs
@@ -1,5 +1,6 @@
 use native::api;
 use native::api::ContractSymbol;
+use native::api::WalletType;
 use native::trade::order::api::NewOrder;
 use native::trade::order::api::OrderType;
 use native::trade::position::PositionState;
@@ -51,4 +52,14 @@ async fn can_open_position() {
     );
     assert_eq!(app.rx.position().unwrap().leverage, order.leverage);
     wait_until!(app.rx.position().unwrap().position_state == PositionState::Open);
+
+    // Assert that the app has paid an order-matching fee
+    let order_id_original = app.rx.order().unwrap().id.to_string();
+    wait_until!(app
+        .rx
+        .wallet_info()
+        .unwrap()
+        .history
+        .iter()
+        .any(|item| matches!(item.wallet_type, WalletType::OrderMatchingFee { ref order_id } if order_id == &order_id_original)));
 }

--- a/mobile/lib/features/trade/submit_order_change_notifier.dart
+++ b/mobile/lib/features/trade/submit_order_change_notifier.dart
@@ -87,16 +87,16 @@ class SubmitOrderChangeNotifier extends ChangeNotifier implements Subscriber {
     }
   }
 
-  Future<void> closePosition(Position position) async {
+  Future<void> closePosition(Position position, double? closingPrice, Amount? fee) async {
     await submitPendingOrder(
         TradeValues(
             direction: position.direction.opposite(),
             margin: position.collateral,
             quantity: position.quantity,
             leverage: position.leverage,
-            price: 0,
+            price: closingPrice,
             liquidationPrice: position.liquidationPrice,
-            fee: Amount.zero(),
+            fee: fee,
             fundingRate: 0,
             tradeValuesService: TradeValuesService()),
         PositionAction.close);

--- a/mobile/lib/features/trade/trade_bottom_sheet_confirmation.dart
+++ b/mobile/lib/features/trade/trade_bottom_sheet_confirmation.dart
@@ -89,9 +89,9 @@ class TradeBottomSheetConfirmation extends StatelessWidget {
     TradeValues tradeValues =
         Provider.of<TradeValuesChangeNotifier>(context).fromDirection(direction);
 
-    // Fallback to 0 if we can't get the margin
-    Amount total = tradeValues.margin != null
-        ? Amount(tradeValues.fee.sats + tradeValues.margin!.sats)
+    // Fallback to 0 if we can't get the fee or the margin
+    Amount total = tradeValues.fee != null && tradeValues.margin != null
+        ? Amount(tradeValues.fee!.sats + tradeValues.margin!.sats)
         : Amount(0);
     Amount pnl = Amount(0);
     if (context.read<PositionChangeNotifier>().positions.containsKey(ContractSymbol.btcusd)) {
@@ -144,9 +144,8 @@ class TradeBottomSheetConfirmation extends StatelessWidget {
                               ),
                         ValueDataRow(
                           type: ValueType.amount,
-                          value: tradeValues.fee,
-                          label: "Fee",
-                          sublabel: "(Waived for Beta)",
+                          value: tradeValues.fee ?? Amount.zero(),
+                          label: "Fee estimate",
                         ),
                       ],
                     ),

--- a/mobile/lib/features/trade/trade_bottom_sheet_confirmation.dart
+++ b/mobile/lib/features/trade/trade_bottom_sheet_confirmation.dart
@@ -171,7 +171,7 @@ class TradeBottomSheetConfirmation extends StatelessWidget {
                         TextSpan(
                             text: formatSats(total),
                             style: const TextStyle(fontWeight: FontWeight.bold)),
-                        const TextSpan(text: ' will be locked up in a Lightning channel!'),
+                        const TextSpan(text: ' will be locked up in a DLC channel!'),
                       ],
                     ),
                   ),

--- a/mobile/lib/features/trade/trade_bottom_sheet_tab.dart
+++ b/mobile/lib/features/trade/trade_bottom_sheet_tab.dart
@@ -78,8 +78,10 @@ class _TradeBottomSheetTabState extends State<TradeBottomSheetTab> {
     Amount maxChannelCapacity = channelInfoService.getMaxCapacity();
     Amount initialReserve = channelInfoService.getInitialReserve();
 
-    String label = widget.direction == Direction.long ? "Buy" : "Sell";
-    Color color = widget.direction == Direction.long ? tradeTheme.buy : tradeTheme.sell;
+    Direction direction = widget.direction;
+
+    String label = direction == Direction.long ? "Buy" : "Sell";
+    Color color = direction == Direction.long ? tradeTheme.buy : tradeTheme.sell;
 
     Amount channelReserve = channelInfo?.reserve ?? initialReserve;
     int totalReserve = channelReserve.sats + tradeFeeReserve.sats;
@@ -131,7 +133,7 @@ class _TradeBottomSheetTabState extends State<TradeBottomSheetTab> {
                 ),
               ),
               Selector<TradeValuesChangeNotifier, double>(
-                  selector: (_, provider) => provider.fromDirection(widget.direction).price ?? 0,
+                  selector: (_, provider) => provider.fromDirection(direction).price ?? 0,
                   builder: (context, price, child) {
                     return DoubleTextInputFormField(
                       value: price,
@@ -145,8 +147,7 @@ class _TradeBottomSheetTabState extends State<TradeBottomSheetTab> {
                 children: [
                   Flexible(
                     child: Selector<TradeValuesChangeNotifier, double>(
-                      selector: (_, provider) =>
-                          provider.fromDirection(widget.direction).quantity ?? 0.0,
+                      selector: (_, provider) => provider.fromDirection(direction).quantity ?? 0.0,
                       builder: (context, quantity, child) {
                         return DoubleTextInputFormField(
                           value: quantity,
@@ -162,11 +163,11 @@ class _TradeBottomSheetTabState extends State<TradeBottomSheetTab> {
                               double quantity = double.parse(value);
                               context
                                   .read<TradeValuesChangeNotifier>()
-                                  .updateQuantity(widget.direction, quantity);
+                                  .updateQuantity(direction, quantity);
                             } on Exception {
                               context
                                   .read<TradeValuesChangeNotifier>()
-                                  .updateQuantity(widget.direction, 0);
+                                  .updateQuantity(direction, 0);
                             }
                           },
                         );
@@ -179,7 +180,7 @@ class _TradeBottomSheetTabState extends State<TradeBottomSheetTab> {
                   Flexible(
                     child: Selector<TradeValuesChangeNotifier, Amount>(
                       selector: (_, provider) =>
-                          provider.fromDirection(widget.direction).margin ?? Amount(0),
+                          provider.fromDirection(direction).margin ?? Amount(0),
                       builder: (context, margin, child) {
                         return AmountInputField(
                           value: margin,
@@ -195,11 +196,11 @@ class _TradeBottomSheetTabState extends State<TradeBottomSheetTab> {
                               Amount margin = Amount.parse(value);
                               context
                                   .read<TradeValuesChangeNotifier>()
-                                  .updateMargin(widget.direction, margin);
+                                  .updateMargin(direction, margin);
                             } on Exception {
                               context
                                   .read<TradeValuesChangeNotifier>()
-                                  .updateMargin(widget.direction, Amount.zero());
+                                  .updateMargin(direction, Amount.zero());
                             }
                           },
                           validator: (value) {
@@ -210,8 +211,7 @@ class _TradeBottomSheetTabState extends State<TradeBottomSheetTab> {
                             try {
                               int margin = int.parse(value);
 
-                              int? optCounterPartyMargin =
-                                  provider.counterpartyMargin(widget.direction);
+                              int? optCounterPartyMargin = provider.counterpartyMargin(direction);
                               if (optCounterPartyMargin == null) {
                                 return "Counterparty margin not available";
                               }
@@ -264,13 +264,13 @@ class _TradeBottomSheetTabState extends State<TradeBottomSheetTab> {
               LeverageSlider(
                   initialValue: context
                       .read<TradeValuesChangeNotifier>()
-                      .fromDirection(widget.direction)
+                      .fromDirection(direction)
                       .leverage
                       .leverage,
                   onLeverageChanged: (value) {
                     context
                         .read<TradeValuesChangeNotifier>()
-                        .updateLeverage(widget.direction, Leverage(value));
+                        .updateLeverage(direction, Leverage(value));
                   }),
               Row(
                 children: [
@@ -278,7 +278,7 @@ class _TradeBottomSheetTabState extends State<TradeBottomSheetTab> {
                   const SizedBox(width: 5),
                   Selector<TradeValuesChangeNotifier, double>(
                       selector: (_, provider) =>
-                          provider.fromDirection(widget.direction).liquidationPrice ?? 0.0,
+                          provider.fromDirection(direction).liquidationPrice ?? 0.0,
                       builder: (context, liquidationPrice, child) {
                         return Flexible(child: FiatText(amount: liquidationPrice));
                       }),
@@ -294,11 +294,11 @@ class _TradeBottomSheetTabState extends State<TradeBottomSheetTab> {
                   onPressed: () {
                     if (_formKey.currentState!.validate()) {
                       TradeValues tradeValues =
-                          context.read<TradeValuesChangeNotifier>().fromDirection(widget.direction);
+                          context.read<TradeValuesChangeNotifier>().fromDirection(direction);
                       final submitOrderChangeNotifier = context.read<SubmitOrderChangeNotifier>();
                       tradeBottomSheetConfirmation(
                           context: context,
-                          direction: widget.direction,
+                          direction: direction,
                           onConfirmation: () {
                             submitOrderChangeNotifier.submitPendingOrder(
                                 tradeValues, PositionAction.open);

--- a/mobile/lib/features/trade/trade_bottom_sheet_tab.dart
+++ b/mobile/lib/features/trade/trade_bottom_sheet_tab.dart
@@ -231,7 +231,8 @@ class _TradeBottomSheetTabState extends State<TradeBottomSheetTab> {
                                 });
                               }
 
-                              if (usableBalance < margin) {
+                              Amount fee = provider.orderMatchingFee(direction) ?? Amount.zero();
+                              if (usableBalance < margin + fee.sats) {
                                 return "Insufficient balance";
                               }
 

--- a/mobile/lib/features/trade/trade_screen.dart
+++ b/mobile/lib/features/trade/trade_screen.dart
@@ -200,15 +200,19 @@ class TradeScreen extends StatelessWidget {
                         return PositionListItem(
                           position: position,
                           onClose: () async {
-                            tradeValuesChangeNotifier.updateLeverage(
-                                position.direction.opposite(), position.leverage);
-                            tradeValuesChangeNotifier.updateQuantity(
-                                position.direction.opposite(), position.quantity);
+                            final direction = position.direction.opposite();
+
+                            tradeValuesChangeNotifier.updateLeverage(direction, position.leverage);
+                            tradeValuesChangeNotifier.updateQuantity(direction, position.quantity);
+
+                            final tradeValues = tradeValuesChangeNotifier.fromDirection(direction);
+
                             tradeBottomSheetConfirmation(
                                 context: context,
-                                direction: position.direction.opposite(),
+                                direction: direction,
                                 onConfirmation: () {
-                                  submitOrderChangeNotifier.closePosition(position);
+                                  submitOrderChangeNotifier.closePosition(
+                                      position, tradeValues.price, tradeValues.fee);
                                   GoRouter.of(context).pop();
                                 },
                                 close: true);

--- a/mobile/lib/features/trade/trade_value_change_notifier.dart
+++ b/mobile/lib/features/trade/trade_value_change_notifier.dart
@@ -67,6 +67,10 @@ class TradeValuesChangeNotifier extends ChangeNotifier implements Subscriber {
     }
   }
 
+  Amount? orderMatchingFee(Direction direction) {
+    return fromDirection(direction).fee;
+  }
+
   void updateQuantity(Direction direction, double quantity) {
     fromDirection(direction).updateQuantity(quantity);
     notifyListeners();

--- a/mobile/lib/features/wallet/domain/wallet_history.dart
+++ b/mobile/lib/features/wallet/domain/wallet_history.dart
@@ -2,7 +2,7 @@ import 'package:get_10101/common/domain/model.dart';
 import 'payment_flow.dart';
 import 'package:get_10101/bridge_generated/bridge_definitions.dart' as rust;
 
-enum WalletHistoryItemDataType { lightning, onChain, trade }
+enum WalletHistoryItemDataType { lightning, onChain, trade, orderMatchingFee }
 
 enum WalletHistoryStatus { pending, confirmed }
 
@@ -62,6 +62,18 @@ class WalletHistoryItemData {
           amount: amount,
           status: status,
           type: WalletHistoryItemDataType.trade,
+          timestamp: timestamp,
+          orderId: type.orderId);
+    }
+
+    if (item.walletType is rust.WalletType_OrderMatchingFee) {
+      rust.WalletType_OrderMatchingFee type = item.walletType as rust.WalletType_OrderMatchingFee;
+
+      return WalletHistoryItemData(
+          flow: flow,
+          amount: amount,
+          status: status,
+          type: WalletHistoryItemDataType.orderMatchingFee,
           timestamp: timestamp,
           orderId: type.orderId);
     }

--- a/mobile/lib/features/wallet/wallet_history_item.dart
+++ b/mobile/lib/features/wallet/wallet_history_item.dart
@@ -31,6 +31,11 @@ class WalletHistoryItem extends StatelessWidget {
           Icons.bar_chart,
           size: flowIconSize,
         );
+      } else if (data.type == WalletHistoryItemDataType.orderMatchingFee) {
+        return const Icon(
+          Icons.toll,
+          size: flowIconSize,
+        );
       }
 
       switch (data.flow) {
@@ -52,6 +57,8 @@ class WalletHistoryItem extends StatelessWidget {
           return data.txid ?? "";
         case WalletHistoryItemDataType.trade:
           return data.orderId ?? "";
+        case WalletHistoryItemDataType.orderMatchingFee:
+          return data.orderId is String ? "Matching fee for ${data.orderId!.substring(0, 8)}" : "";
       }
     }();
 
@@ -59,6 +66,7 @@ class WalletHistoryItem extends StatelessWidget {
       switch (data.type) {
         case WalletHistoryItemDataType.lightning:
         case WalletHistoryItemDataType.trade:
+        case WalletHistoryItemDataType.orderMatchingFee:
           return "off-chain";
         case WalletHistoryItemDataType.onChain:
           return "on-chain";

--- a/mobile/lib/features/wallet/wallet_history_item.dart
+++ b/mobile/lib/features/wallet/wallet_history_item.dart
@@ -56,9 +56,16 @@ class WalletHistoryItem extends StatelessWidget {
         case WalletHistoryItemDataType.onChain:
           return data.txid ?? "";
         case WalletHistoryItemDataType.trade:
-          return data.orderId ?? "";
+          final orderId = data.orderId!.substring(0, 8);
+          switch (data.flow) {
+            case PaymentFlow.inbound:
+              return "Closed position with order $orderId";
+            case PaymentFlow.outbound:
+              return "Opened position with order $orderId";
+          }
         case WalletHistoryItemDataType.orderMatchingFee:
-          return data.orderId is String ? "Matching fee for ${data.orderId!.substring(0, 8)}" : "";
+          final orderId = data.orderId!.substring(0, 8);
+          return "Matching fee for $orderId";
       }
     }();
 

--- a/mobile/native/migrations/2023-06-29-060753_add_description_to_payments/down.sql
+++ b/mobile/native/migrations/2023-06-29-060753_add_description_to_payments/down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE
+    payments DROP COLUMN description;

--- a/mobile/native/migrations/2023-06-29-060753_add_description_to_payments/up.sql
+++ b/mobile/native/migrations/2023-06-29-060753_add_description_to_payments/up.sql
@@ -1,0 +1,4 @@
+ALTER TABLE
+    payments
+ADD
+    COLUMN description TEXT NOT NULL DEFAULT '';

--- a/mobile/native/src/api.rs
+++ b/mobile/native/src/api.rs
@@ -23,6 +23,9 @@ use flutter_rust_bridge::StreamSink;
 use flutter_rust_bridge::SyncReturn;
 use lightning_invoice::Invoice;
 use lightning_invoice::InvoiceDescription;
+use orderbook_commons::order_matching_fee_taker;
+use rust_decimal::prelude::FromPrimitive;
+use rust_decimal::Decimal;
 use std::backtrace::Backtrace;
 use std::ops::Add;
 use std::str::FromStr;
@@ -139,6 +142,19 @@ pub fn calculate_pnl(
         )
         .unwrap_or(0),
     )
+}
+
+/// Calculate the order matching fee that the app user will have to pay for if the corresponding
+/// trade gets executed.
+///
+/// This is only an estimate as the price may change slightly. Also, the coordinator could choose to
+/// change the fee structure independently.
+pub fn order_matching_fee(quantity: f32, price: f32) -> SyncReturn<u64> {
+    let price = Decimal::from_f32(price).expect("price to fit in Decimal");
+
+    let order_matching_fee = order_matching_fee_taker(quantity, price).to_sat();
+
+    SyncReturn(order_matching_fee)
 }
 
 #[tokio::main(flavor = "current_thread")]

--- a/mobile/native/src/api.rs
+++ b/mobile/native/src/api.rs
@@ -70,6 +70,7 @@ pub enum WalletType {
     OnChain { txid: String },
     Lightning { payment_hash: String },
     Trade { order_id: String },
+    OrderMatchingFee { order_id: String },
 }
 
 #[derive(Clone, Debug, Default)]

--- a/mobile/native/src/ln_dlc/node.rs
+++ b/mobile/native/src/ln_dlc/node.rs
@@ -306,6 +306,7 @@ impl node::Storage for NodeStorage {
                         amt_msat,
                         flow,
                         timestamp: OffsetDateTime::now_utc(),
+                        description: "".to_string(),
                     },
                 )?;
             }

--- a/mobile/native/src/schema.rs
+++ b/mobile/native/src/schema.rs
@@ -34,6 +34,7 @@ diesel::table! {
         flow -> Text,
         created_at -> BigInt,
         updated_at -> BigInt,
+        description -> Text,
     }
 }
 


### PR DESCRIPTION
Fixes #838[^1].
Fixes https://github.com/get10101/meta/issues/170.
Fixes https://github.com/get10101/meta/issues/171.
Fixes #884.

We keep it simple for now: the coordinator returns an invoice and we trust the app to pay for it.

Invoice generation rationale
----------------------------
We choose to let the coordinator generate
an invoice rather than send an spontaneous payment from the app so that we can more easily update the coordinator fees without having to release a new version of the app.

Payment timing rationale
------------------------

In patch 7c6a4bbb808267a8e56633ba471487838e74f414 the app was paying the invoice as soon as possible, but this had two downsides:

1. The app could end up paying for a trade that didn't come to fruition.
2. Updating the LN-DLC channel from the `rust-dlc` side and `rust-lightning` side simultaneously is not currently supported, so we could run into channel-breaking issues.

As such, we eventually opted for the simple 74a0acf560a7768c43207cb07d0c688c0771eff8. The solution is not perfect and it assumes that the app will not be rebooted until the payment is sent, but it should be good enough for now.

Other thoughts
--------------

Eventually, the order-matching fee could be included in the payout curve or, perhaps even better, as a separate static output on the buffer transaction (this is currently not supported).

---

These are some TODOs that could be tackled here or in follow-ups:

- [x] Verify that the app can actually pay for both executing the trade and the order-matching fee _before_ executing the trade.
- [x] Only claim the order-matching fee once the trade has been executed. https://github.com/get10101/10101/issues/884
- [x] Tell the user about the estimated fee to be charged before they create the order. https://github.com/get10101/meta/issues/170
- [x] Show the user the charged fee on the success screen after executing the order. https://github.com/get10101/meta/issues/171


[^1]: Given that we can only charge taker fees for now. We should create a separate ticket for the maker once it's possible to do so.