### PR TITLE
chore(bors): Check for e2e-tests passing before merging

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -3,4 +3,5 @@ status = [
   "lint-commits",
   "lint-flutter",
   "clippy",
+  "e2e-tests",
 ]


### PR DESCRIPTION
New end to end tests are not supposed to be flaky; check whether they pass
before merging.