### PR TITLE
chore(justfile): Improve log browsing experience

### DIFF
--- a/justfile
+++ b/justfile
@@ -222,13 +222,13 @@ run-maker-detached:
 coordinator-logs:
     #!/usr/bin/env bash
     set -euxo pipefail
-    tail -f {{coordinator_log_file}}
+    less +F {{coordinator_log_file}}
 
 # Attach to the current maker logs
 maker-logs:
     #!/usr/bin/env bash
     set -euxo pipefail
-    tail -f {{maker_log_file}}
+    less +F {{maker_log_file}}
 
 # Run services in the background
 services: docker run-coordinator-detached run-maker-detached wait-for-coordinator-to-be-ready fund


### PR DESCRIPTION
Open by default with `less` in follow mode (so that it refreshes the contents).

It's like vim, one can search using `/` or by highlighting a word with `*`.

In order to stop following and start browsing historical entries
(with pagination!), hit Ctrl+C.