### PR TITLE
Share to twitter only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Change the share button after opening to only share to Twitter
+
 ## [1.1.0] - 2023-07-27
 
 - Charge funding transaction on-chain fees upon receiving and inbound JIT Channel

--- a/mobile/android/app/src/main/AndroidManifest.xml
+++ b/mobile/android/app/src/main/AndroidManifest.xml
@@ -1,4 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     package="finance.get10101.app">
 
     <uses-permission android:name="android.permission.INTERNET" />
@@ -30,6 +31,19 @@
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
         </activity>
+
+       <!-- Used by social_share package -->
+       <provider
+           android:name="androidx.core.content.FileProvider"
+           android:authorities="${applicationId}.com.shekarmudaliyar.social_share"
+           android:exported="false"
+           android:grantUriPermissions="true"
+           tools:replace="android:authorities">
+           <meta-data
+               android:name="android.support.FILE_PROVIDER_PATHS"
+               android:resource="@xml/filepaths" />
+       </provider>
+
         <!-- Don't delete the meta-data below.
              This is used by the Flutter tool to generate GeneratedPluginRegistrant.java -->
         <meta-data

--- a/mobile/android/app/src/main/res/xml/filepaths.xml
+++ b/mobile/android/app/src/main/res/xml/filepaths.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths xmlns:android="http://schemas.android.com/apk/res/android">
+    <cache-path name="image" path="/"/>
+</paths>

--- a/mobile/android/build.gradle
+++ b/mobile/android/build.gradle
@@ -26,6 +26,6 @@ subprojects {
     project.evaluationDependsOn(':app')
 }
 
-task clean(type: Delete) {
+tasks.register("clean", Delete) {
     delete rootProject.buildDir
 }

--- a/mobile/ios/Flutter/AppFrameworkInfo.plist
+++ b/mobile/ios/Flutter/AppFrameworkInfo.plist
@@ -22,5 +22,9 @@
   <string>1.0</string>
   <key>MinimumOSVersion</key>
   <string>13.0</string>
+  <key>LSApplicationQueriesSchemes</key>
+    <array>
+      <string>twitter</string>
+    </array>
 </dict>
 </plist>

--- a/mobile/lib/features/trade/trade_screen.dart
+++ b/mobile/lib/features/trade/trade_screen.dart
@@ -21,7 +21,9 @@ import 'package:get_10101/features/trade/trade_value_change_notifier.dart';
 import 'package:go_router/go_router.dart';
 import 'package:provider/provider.dart';
 import 'package:get_10101/util/constants.dart';
+import 'package:share_plus/share_plus.dart';
 import 'package:social_share/social_share.dart';
+import 'dart:io' show Platform;
 
 import 'order_submission_status_dialog.dart';
 
@@ -394,7 +396,13 @@ class TradeScreen extends StatelessWidget {
 
   Future<void> shareTweet(PositionAction action) async {
     String actionStr = action == PositionAction.open ? "opened" : "closed";
-    await SocialShare.shareTwitter(
-        "Just $actionStr a #selfcustodial position using #DLC with @get10101 🚀. The future of decentralised finance starts now! #Bitcoin");
+    String shareText =
+        "Just $actionStr a #selfcustodial position using #DLC with @get10101 🚀. The future of decentralised finance starts now! #Bitcoin";
+
+    if (Platform.isAndroid || Platform.isIOS) {
+      await SocialShare.shareTwitter(shareText);
+    } else {
+      await Share.share(shareText);
+    }
   }
 }

--- a/mobile/lib/features/trade/trade_screen.dart
+++ b/mobile/lib/features/trade/trade_screen.dart
@@ -21,7 +21,7 @@ import 'package:get_10101/features/trade/trade_value_change_notifier.dart';
 import 'package:go_router/go_router.dart';
 import 'package:provider/provider.dart';
 import 'package:get_10101/util/constants.dart';
-import 'package:share_plus/share_plus.dart';
+import 'package:social_share/social_share.dart';
 
 import 'order_submission_status_dialog.dart';
 
@@ -383,7 +383,7 @@ class TradeScreen extends StatelessWidget {
         padding: const EdgeInsets.only(top: 20, left: 10, right: 10, bottom: 5),
         child: ElevatedButton(
             onPressed: () async {
-              await shareText(pendingOrder.positionAction);
+              await shareTweet(pendingOrder.positionAction);
             },
             child: const Text("Share on Twitter")),
       ));
@@ -392,9 +392,9 @@ class TradeScreen extends StatelessWidget {
     return body;
   }
 
-  Future<void> shareText(PositionAction action) async {
+  Future<void> shareTweet(PositionAction action) async {
     String actionStr = action == PositionAction.open ? "opened" : "closed";
-    await Share.share(
+    await SocialShare.shareTwitter(
         "Just $actionStr a #selfcustodial position using #DLC with @get10101 🚀. The future of decentralised finance starts now! #Bitcoin");
   }
 }

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -893,6 +893,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.0"
+  social_share:
+    dependency: "direct main"
+    description:
+      name: social_share
+      sha256: eb19a0f6f5a29c7bb71e5bb1991145eb52472184363b6e2da70695befd8be041
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.1"
   source_gen:
     dependency: transitive
     description:

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -32,6 +32,7 @@ dependencies:
   package_info_plus: ^4.0.2
   uuid: ^3.0.7
   confetti: ^0.7.0
+  social_share: ^2.3.1
   test: ^1.24.1
 dev_dependencies:
   flutter_launcher_icons: ^0.13.1


### PR DESCRIPTION
Use the `social_share` package to share directly and specifically to twitter instead of opening a general share dialogue. This PR is currently a draft since I haven't been able to test this on the Android emulator due to unrelated problems with its setup. 

Fixes #824.