### PR TITLE
Fix just command to run app on android device against locally running services

### DIFF
--- a/justfile
+++ b/justfile
@@ -80,7 +80,7 @@ run-regtest args="":
 
 run-local-android args="":
     #!/usr/bin/env bash
-    $LOCAL_IP=(curl -sS ifconfig.co)
+    LOCAL_IP=$(ifconfig | grep -Eo 'inet (addr:)?([0-9]*\.){3}[0-9]*' | grep -Eo '([0-9]*\.){3}[0-9]*' | grep -v '127.0.0.1')
     cd mobile && flutter run {{args}} --dart-define="COMMIT=$(git rev-parse HEAD)" --dart-define="BRANCH=$(git rev-parse --abbrev-ref HEAD)" \
     --dart-define="ESPLORA_ENDPOINT=http://${LOCAL_IP}:3000" --dart-define="COORDINATOR_P2P_ENDPOINT=02dd6abec97f9a748bf76ad502b004ce05d1b2d1f43a9e76bd7d85e767ffb022c9@${LOCAL_IP}:9045" \
     --dart-define="COORDINATOR_PORT_HTTP=8000" --flavor local


### PR DESCRIPTION
The `$` was misplaced.
Additionally, fetching the internet address using `ifconfig.co` does not always work - a more resilient solution is to grep ifconfig output to fetch the local network address.

Thanks to stackoverflow https://stackoverflow.com/questions/13322485/how-to-get-the-primary-ip-address-of-the-local-machine-on-linux-and-os-x