### PR TITLE
Display estimated order-matching fee when trading

### DIFF
--- a/mobile/lib/features/trade/trade_bottom_sheet_tab.dart
+++ b/mobile/lib/features/trade/trade_bottom_sheet_tab.dart
@@ -283,6 +283,15 @@ class _TradeBottomSheetTabState extends State<TradeBottomSheetTab> {
                       builder: (context, liquidationPrice, child) {
                         return Flexible(child: FiatText(amount: liquidationPrice));
                       }),
+                  const SizedBox(width: 20),
+                  const Flexible(child: Text("Estimated fee:")),
+                  const SizedBox(width: 5),
+                  Selector<TradeValuesChangeNotifier, Amount>(
+                      selector: (_, provider) =>
+                          provider.orderMatchingFee(direction) ?? Amount.zero(),
+                      builder: (context, fee, child) {
+                        return Flexible(child: AmountText(amount: fee));
+                      }),
                 ],
               )
             ],


### PR DESCRIPTION
This is important as otherwise it's unclear why we are not able to trade with a margin smaller than the usable balance.

On the other hand, I have a hard time making this look nice because my UI design skills are severely lacking. As such, suggestions and even force-pushes to the branch are welcome.

This is how it looks now:

![image](https://github.com/get10101/10101/assets/9418575/f77f2351-4601-4695-b335-838dab4c789a)
