### PR TITLE
Ensure that wallet history text does not overflow

### DIFF
--- a/mobile/lib/features/wallet/wallet_history_item.dart
+++ b/mobile/lib/features/wallet/wallet_history_item.dart
@@ -125,13 +125,13 @@ class WalletHistoryItem extends StatelessWidget {
                         style: TextStyle(
                             color: color,
                             fontFamily: "Courier",
-                            fontSize: 16,
+                            fontSize: 14,
                             fontWeight: FontWeight.bold))
                   ]),
                 ),
                 RichText(
                     text: TextSpan(style: DefaultTextStyle.of(context).style, children: <TextSpan>[
-                  TextSpan(text: onOrOff, style: const TextStyle(color: Colors.grey)),
+                  TextSpan(text: onOrOff, style: const TextStyle(color: Colors.grey, fontSize: 10)),
                 ]))
               ],
             ),


### PR DESCRIPTION
At least on Linux, when running `just run` I would consistently get warnings directly on the UI on every wallet history item. Each one would say `Bottom overflowed by 6.0 pixels`. This is annoying when developing, but I believe it's also a sign that we were doing something wrong. Hence this fix.

Before:

![image](https://github.com/get10101/10101/assets/9418575/1eef1f36-e62e-4bde-8f5e-6822666bbe88)

After:

![image](https://github.com/get10101/10101/assets/9418575/c1f5aacf-3f46-40d0-a511-f5c62c3a60ee)
