### PR TITLE
chore(justfile): Improve `just coordinator-detached`

### DIFF
--- a/justfile
+++ b/justfile
@@ -205,6 +205,7 @@ run-coordinator-detached:
 
     echo "Starting (and building) coordinator"
     cargo run --bin coordinator &> {{coordinator_log_file}} &
+    just wait-for-coordinator-to-be-ready
     echo "Coordinator successfully started. You can inspect the logs at {{coordinator_log_file}}"
 
 # Starts maker process in the background, piping logs to a file (used in other recipes)


### PR DESCRIPTION
Wait for coordinator to actually start before stating that it started successfully.

Note: We can't do this with maker for now, as there's no HTTP API there yet.