### PR TITLE
Default to zero base fee for interceptable invoices

### DIFF
--- a/coordinator/src/settings.rs
+++ b/coordinator/src/settings.rs
@@ -38,7 +38,8 @@ impl Default for Settings {
         Self {
             jit_channels_enabled: true,
             new_positions_enabled: true,
-            jit_fee_rate_basis_points: 50,
+            // Configured as zero base fee by default
+            jit_fee_rate_basis_points: 0,
             fallback_tx_fee_rate_normal: 2000,
             fallback_tx_fee_rate_high_priority: 5000,
             max_allowed_tx_fee_rate_when_opening_channel: None,


### PR DESCRIPTION
fixes https://github.com/get10101/meta/issues/178

If I understood the conclusion of https://github.com/get10101/meta/issues/178 correctly then this is what we want for now: A zero base fee configuration when creating interceptable invoices.
My understanding is that the coordinator currently uses the `Default` config, so I adapted it there. I did not find a configuration file where we set explicit values - if I overlooked something and we better change it there let me know.

I consider this a follow up of https://github.com/get10101/10101/pull/921 so I gave it a quick crack.
@bonomat if I misunderstood something let me know :)