### PR TITLE
Add logs to flaky `force_close_ln_dlc_channel` test

### DIFF
--- a/crates/ln-dlc-node/src/tests/dlc/non_collaborative_settlement.rs
+++ b/crates/ln-dlc-node/src/tests/dlc/non_collaborative_settlement.rs
@@ -91,13 +91,18 @@ async fn force_close_ln_dlc_channel() {
 
     // Confirm CET
     mine(1).await.unwrap();
+    tracing::info!("Mined 1 block");
 
     coordinator.sync_on_chain().await.unwrap();
+    tracing::info!("Coordinator synced on-chain");
     app.sync_on_chain().await.unwrap();
+    tracing::info!("App synced on-chain");
 
     let coordinator_on_chain_balance_after_force_close =
         coordinator.get_on_chain_balance().unwrap().confirmed;
+    tracing::info!(balance = %coordinator_on_chain_balance_after_force_close, "Coordinator on-chain balance");
     let app_on_chain_balance_after_force_close = app.get_on_chain_balance().unwrap().confirmed;
+    tracing::info!(balance = %app_on_chain_balance_after_force_close, "App on-chain balance");
 
     // Given that we have dynamic transaction fees based on the state of the regtest mempool, it's
     // less error-prone to choose a conservative lower bound on the expected funds after


### PR DESCRIPTION
This test can hang on CI. From the logs we do see a message corresponding to line 93 (where we mine one block), so it should be sufficient to log everything after that in order to identify where we are hanging.

---

Related to #807.
We don't need to merge this. I just want to keep re-triggering the relevant job to reproduce the hang with extra context.