### PR TITLE
fix: read scorer

### DIFF
--- a/crates/ln-dlc-node/src/disk.rs
+++ b/crates/ln-dlc-node/src/disk.rs
@@ -4,8 +4,10 @@ use bitcoin::Network;
 use lightning::routing::scoring::ProbabilisticScorer;
 use lightning::routing::scoring::ProbabilisticScoringParameters;
 use lightning::util::ser::ReadableArgs;
+use std::fs;
 use std::fs::File;
 use std::io::BufReader;
+use std::panic;
 use std::path::Path;
 use std::sync::Arc;
 
@@ -17,9 +19,21 @@ pub(crate) fn read_scorer(
     let params = ProbabilisticScoringParameters::default();
     if let Ok(file) = File::open(path) {
         let args = (params.clone(), graph.clone(), logger.clone());
-        match ProbabilisticScorer::read(&mut BufReader::new(file), args) {
-            Ok(scorer) => return scorer,
-            Err(e) => tracing::error!("Failed to read scorer from disk: {e}"),
+        let result =
+            panic::catch_unwind(|| ProbabilisticScorer::read(&mut BufReader::new(file), args));
+        match result {
+            Ok(Ok(scorer)) => {
+                return scorer;
+            }
+            Ok(Err(err)) => {
+                tracing::error!("Could not decode scorer {err:#}");
+            }
+            Err(_) => {
+                tracing::error!("Reading scorer panicked");
+                if let Err(err) = fs::remove_file(path) {
+                    tracing::error!("Could not even delete file #{err}");
+                }
+            }
         }
     }
     ProbabilisticScorer::new(params, graph, logger)


### PR DESCRIPTION
With this patch we don't read a historically stored scrorer from disk. It's not ideal, but at least users running into panics when loading the scorer will be able to run the app again

Workaround for #797 
fix #797 