### PR TITLE
fix: use in-memory scorer for app and persistent for coordinator

### DIFF
--- a/crates/ln-dlc-node/src/tests/mod.rs
+++ b/crates/ln-dlc-node/src/tests/mod.rs
@@ -1,3 +1,4 @@
+use crate::disk;
 use crate::ln::app_config;
 use crate::ln::coordinator_config;
 use crate::ln::LIQUIDITY_MULTIPLIER;
@@ -136,6 +137,7 @@ impl Node<InMemoryStore> {
             LnDlcNodeSettings::default(),
             oracle.into(),
             None,
+            disk::in_memory_scorer,
         )?;
 
         tracing::debug!(%name, info = %node.info, "Node started");


### PR DESCRIPTION
Reading the scorer from disk on iOS seems to panic sometimes, hence, we use an in-memory scorer for the app and a persistant scorer for the coordinator.

fix: #797 