### PR TITLE
feat: enable wumbo channels of up to 1 BTC

### DIFF
--- a/crates/ln-dlc-node/src/ln/config.rs
+++ b/crates/ln-dlc-node/src/ln/config.rs
@@ -27,6 +27,7 @@ pub fn app_config() -> UserConfig {
             // We want app users to only have to wait ~24 hours in case of a force-close. We choose
             // 144 because we can't go any lower according to LDK.
             their_to_self_delay: 144,
+            max_funding_satoshis: 100_000_000,
             ..Default::default()
         },
         channel_config: ChannelConfig {


### PR DESCRIPTION
Our current max channel size was `2^24 - 1` sats. With this we allow users to open channels to us with up to 1 BTC. 