### PR TITLE
Track channel opening transaction fee payments

### DIFF
--- a/coordinator/migrations/2023-07-18-045732_open_channel_transaction_fee_payment/down.sql
+++ b/coordinator/migrations/2023-07-18-045732_open_channel_transaction_fee_payment/down.sql
@@ -1,0 +1,3 @@
+-- This file should undo anything in `up.sql`
+ALTER TABLE
+    channels DROP COLUMN open_channel_fee_payment_hash;

--- a/coordinator/migrations/2023-07-18-045732_open_channel_transaction_fee_payment/down.sql
+++ b/coordinator/migrations/2023-07-18-045732_open_channel_transaction_fee_payment/down.sql
@@ -1,3 +1,4 @@
 -- This file should undo anything in `up.sql`
 ALTER TABLE
     channels DROP COLUMN open_channel_fee_payment_hash;
+DROP INDEX IF EXISTS channels_funding_txid;

--- a/coordinator/migrations/2023-07-18-045732_open_channel_transaction_fee_payment/up.sql
+++ b/coordinator/migrations/2023-07-18-045732_open_channel_transaction_fee_payment/up.sql
@@ -1,0 +1,5 @@
+-- Your SQL goes here
+ALTER TABLE
+    channels
+ADD
+    COLUMN open_channel_fee_payment_hash TEXT REFERENCES payments(payment_hash);

--- a/coordinator/migrations/2023-07-18-045732_open_channel_transaction_fee_payment/up.sql
+++ b/coordinator/migrations/2023-07-18-045732_open_channel_transaction_fee_payment/up.sql
@@ -3,3 +3,4 @@ ALTER TABLE
     channels
 ADD
     COLUMN open_channel_fee_payment_hash TEXT REFERENCES payments(payment_hash);
+CREATE INDEX IF NOT EXISTS channels_funding_txid ON channels(funding_txid);

--- a/coordinator/src/node.rs
+++ b/coordinator/src/node.rs
@@ -46,6 +46,7 @@ use trade::cfd::calculate_short_liquidation_price;
 use trade::cfd::BTCUSD_MAX_PRICE;
 use trade::Direction;
 
+pub mod channel_opening_fee;
 pub mod connection;
 pub mod order_matching_fee;
 pub mod routing_fees;

--- a/coordinator/src/node/channel_opening_fee.rs
+++ b/coordinator/src/node/channel_opening_fee.rs
@@ -1,0 +1,67 @@
+use crate::db;
+use crate::node::Node;
+use anyhow::Context;
+use anyhow::Result;
+use bitcoin::hashes::hex::ToHex;
+use bitcoin::secp256k1::ThirtyTwoByteHash;
+use lightning::ln::PaymentHash;
+use lightning_invoice::Invoice;
+use ln_dlc_node::PaymentInfo;
+
+impl Node {
+    pub async fn channel_opening_fee_invoice(
+        &self,
+        amount: u64,
+        funding_txid: String,
+        description: Option<String>,
+        expiry: Option<u32>,
+    ) -> Result<Invoice> {
+        let invoice = self.inner.create_invoice(
+            amount,
+            description.unwrap_or_default(),
+            expiry.unwrap_or(180),
+        )?;
+        let payment_hash = invoice.payment_hash().into_32();
+        let payment_hash_hex = payment_hash.to_hex();
+
+        // In case we run into an error here we still return the invoice to the user to collect the
+        // payment and log an error on the coordinator This means that it can happen that we receive
+        // a payment that we cannot associate if we run into an error here.
+        tokio::task::spawn_blocking({
+            let node = self.clone();
+            let invoice = invoice.clone();
+            move || {
+                if let Err(e) = associate_channel_open_fee_payment_with_channel(
+                    node,
+                    payment_hash,
+                    invoice.into(),
+                    funding_txid.clone(),
+                ) {
+                    tracing::error!(%funding_txid, payment_hash=%payment_hash_hex, "Failed to associate open channel fee payment with channel: {e:#}");
+                }
+            }
+        });
+
+        Ok(invoice)
+    }
+}
+
+fn associate_channel_open_fee_payment_with_channel(
+    node: Node,
+    payment_hash: [u8; 32],
+    payment_info: PaymentInfo,
+    funding_txid: String,
+) -> Result<()> {
+    let mut conn = node.pool.get().context("Failed to get connection")?;
+
+    // Insert the payment into the database
+    db::payments::insert((PaymentHash(payment_hash), payment_info), &mut conn)
+        .context("Failed to insert channel opening payment into database")?;
+
+    // Update the payment hash in the channels table. The channel is identified by the
+    // funding_tx
+    db::channels::update_payment_hash(PaymentHash(payment_hash), funding_txid, &mut conn)
+        .context("Failed to update payment hash in channels table")?;
+
+    Ok(())
+}

--- a/coordinator/src/routes.rs
+++ b/coordinator/src/routes.rs
@@ -90,6 +90,10 @@ pub fn router(
         .route("/api/newaddress", get(get_unused_address))
         .route("/api/node", get(get_node_info))
         .route("/api/invoice", get(get_invoice))
+        .route(
+            "/api/invoice/open_channel_fee",
+            get(get_open_channel_fee_invoice),
+        )
         .route("/api/orderbook/orders", get(get_orders).post(post_order))
         .route(
             "/api/orderbook/orders/:order_id",
@@ -174,6 +178,14 @@ pub struct InvoiceParams {
     pub expiry: Option<u32>,
 }
 
+#[derive(Debug, Deserialize, Serialize)]
+pub struct OpenChannelFeeInvoiceParams {
+    pub amount: u64,
+    pub channel_funding_txid: String,
+    pub description: Option<String>,
+    pub expiry: Option<u32>,
+}
+
 #[autometrics]
 pub async fn get_invoice(
     Query(params): Query<InvoiceParams>,
@@ -187,6 +199,25 @@ pub async fn get_invoice(
             params.description.unwrap_or_default(),
             params.expiry.unwrap_or(180),
         )
+        .map_err(|e| AppError::InternalServerError(format!("Failed to create invoice: {e:#}")))?;
+
+    Ok(invoice.to_string())
+}
+
+#[autometrics]
+pub async fn get_open_channel_fee_invoice(
+    Query(params): Query<OpenChannelFeeInvoiceParams>,
+    State(state): State<Arc<AppState>>,
+) -> Result<String, AppError> {
+    let invoice = state
+        .node
+        .channel_opening_fee_invoice(
+            params.amount,
+            params.channel_funding_txid,
+            params.description,
+            params.expiry,
+        )
+        .await
         .map_err(|e| AppError::InternalServerError(format!("Failed to create invoice: {e:#}")))?;
 
     Ok(invoice.to_string())

--- a/coordinator/src/schema.rs
+++ b/coordinator/src/schema.rs
@@ -44,6 +44,7 @@ diesel::table! {
         counterparty_pubkey -> Text,
         created_at -> Timestamptz,
         updated_at -> Timestamptz,
+        open_channel_fee_payment_hash -> Nullable<Text>,
     }
 }
 


### PR DESCRIPTION
fixes https://github.com/get10101/meta/issues/175

Upon requesting the invoice the user provides the amount to be paid and the funding transaction id that the fee was extracted from. The coordinator creates the invoice, records the payment in the database and then associates the `payment_hash` with with the `channels` in the database.

This PR is is stacked on top of https://github.com/get10101/10101/pull/950

Notes:

- After a chat with @luckysori we came to the conclusion that the funding transaction fee costs (that the app currently reimburses in a payment) should be the only missing piece for  https://github.com/get10101/meta/issues/175 because any other fees (charged for channel opening) should be covered by the routing fees already. If we want to somehow associate them with the channel as opening fees as well we would have to add additional handling for that. (not sure that's worth it). 