### PR TITLE
Check coordinator status from 10101 wallet (backend)

### DIFF
--- a/coordinator/src/routes.rs
+++ b/coordinator/src/routes.rs
@@ -115,6 +115,7 @@ pub fn router(
         )
         .route("/api/admin/sync", post(post_sync))
         .route("/metrics", get(get_metrics))
+        .route("/health", get(get_health))
         .with_state(app_state)
 }
 
@@ -380,4 +381,10 @@ pub async fn get_metrics(State(state): State<Arc<AppState>>) -> impl IntoRespons
     };
 
     (StatusCode::OK, open_telemetry_metrics + &autometrics)
+}
+
+pub async fn get_health() -> Result<Json<String>, AppError> {
+    // TODO: Implement any health check logic we'd need
+    // So far this just returns if the server is running
+    Ok(Json("Server is healthy".to_string()))
 }

--- a/crates/tests-e2e/src/app.rs
+++ b/crates/tests-e2e/src/app.rs
@@ -26,7 +26,7 @@ pub async fn run_app() -> AppHandle {
         let seed_dir = as_string(&seed_dir);
         tokio::task::spawn_blocking(move || {
             native::api::run(
-                default_config(),
+                test_config(),
                 app_dir,
                 seed_dir,
                 native::api::IncludeBacktraceOnPanic::No,
@@ -51,9 +51,8 @@ pub async fn run_app() -> AppHandle {
     app
 }
 
-// Values taken from `environment.dart`
-// TODO: move to default impl of Config
-fn default_config() -> native::config::api::Config {
+// Values mostly taken from `environment.dart`
+fn test_config() -> native::config::api::Config {
     native::config::api::Config {
         coordinator_pubkey: "02dd6abec97f9a748bf76ad502b004ce05d1b2d1f43a9e76bd7d85e767ffb022c9"
             .to_string(),
@@ -65,5 +64,6 @@ fn default_config() -> native::config::api::Config {
         oracle_endpoint: "http://127.0.0.1:8081".to_string(),
         oracle_pubkey: "16f88cf7d21e6c0f46bcbc983a4e3b19726c6c98858cc31c83551a88fde171c0"
             .to_string(),
+        health_check_interval_secs: 1, // We want to measure health more often in tests
     }
 }

--- a/crates/tests-e2e/src/app.rs
+++ b/crates/tests-e2e/src/app.rs
@@ -35,7 +35,7 @@ pub async fn run_app() -> AppHandle {
         })
     };
 
-    let (rx, tx) = TestSubscriber::new();
+    let (rx, tx) = TestSubscriber::new().await;
     let app = AppHandle {
         _app_dir: app_dir,
         _seed_dir: seed_dir,

--- a/crates/tests-e2e/src/coordinator.rs
+++ b/crates/tests-e2e/src/coordinator.rs
@@ -26,8 +26,7 @@ impl Coordinator {
 
     /// Check whether the coordinator is running
     pub async fn is_running(&self) -> bool {
-        // We assume that if we can generate new address, the service is running
-        self.get("/api/newaddress").await.is_ok()
+        self.get("/health").await.is_ok()
     }
 
     pub async fn is_node_connected(&self, node_id: &str) -> Result<bool> {

--- a/crates/tests-e2e/tests/open_position.rs
+++ b/crates/tests-e2e/tests/open_position.rs
@@ -1,6 +1,8 @@
 use native::api;
 use native::api::ContractSymbol;
 use native::api::WalletType;
+use native::health::Service;
+use native::health::ServiceStatus;
 use native::trade::order::api::NewOrder;
 use native::trade::order::api::OrderType;
 use native::trade::position::PositionState;
@@ -31,6 +33,8 @@ async fn can_open_position() {
     })
     .await
     .unwrap();
+
+    assert_eq!(app.rx.status(Service::Orderbook), ServiceStatus::Online);
 
     // Assert that the order was posted
     wait_until!(app.rx.order().is_some());

--- a/crates/tests-e2e/tests/open_position.rs
+++ b/crates/tests-e2e/tests/open_position.rs
@@ -35,6 +35,7 @@ async fn can_open_position() {
     .unwrap();
 
     assert_eq!(app.rx.status(Service::Orderbook), ServiceStatus::Online);
+    assert_eq!(app.rx.status(Service::Coordinator), ServiceStatus::Online);
 
     // Assert that the order was posted
     wait_until!(app.rx.order().is_some());

--- a/justfile
+++ b/justfile
@@ -69,7 +69,7 @@ ios-release:
 run args="":
     #!/usr/bin/env bash
     cd mobile && flutter run {{args}} --dart-define="COMMIT=$(git rev-parse HEAD)" --dart-define="BRANCH=$(git rev-parse --abbrev-ref HEAD)" \
-    --dart-define="REGTEST_FAUCET=http://localhost:8080"
+    --dart-define="REGTEST_FAUCET=http://localhost:8080" --dart-define="HEALTH_CHECK_INTERVAL_SECONDS=2" \
 
 # Run against our public regtest server
 run-regtest args="":

--- a/mobile/lib/util/environment.dart
+++ b/mobile/lib/util/environment.dart
@@ -26,6 +26,9 @@ class Environment {
       }
     }
 
+    int healthCheckIntervalSeconds =
+        const int.fromEnvironment('HEALTH_CHECK_INTERVAL_SECONDS', defaultValue: 10);
+
     return Config(
       host: host,
       esploraEndpoint: esploraEndpoint,
@@ -35,6 +38,7 @@ class Environment {
       network: network,
       oracleEndpoint: oracleEndpoint,
       oraclePubkey: oraclePubkey,
+      healthCheckIntervalSecs: healthCheckIntervalSeconds,
     );
   }
 }

--- a/mobile/native/src/api.rs
+++ b/mobile/native/src/api.rs
@@ -8,6 +8,7 @@ use crate::config::get_network;
 use crate::db;
 use crate::event;
 use crate::event::api::FlutterSubscriber;
+use crate::health;
 use crate::ln_dlc;
 use crate::ln_dlc::FUNDING_TX_WEIGHT_ESTIMATE;
 use crate::logger;
@@ -231,7 +232,10 @@ pub fn run(
     let runtime = ln_dlc::get_or_create_tokio_runtime()?;
     ln_dlc::run(app_dir, seed_dir, runtime)?;
     event::subscribe(ChannelFeePaymentSubscriber::new());
-    orderbook::subscribe(ln_dlc::get_node_key(), runtime)
+
+    let (_health, tx) = health::Health::new(runtime);
+
+    orderbook::subscribe(ln_dlc::get_node_key(), runtime, tx.orderbook)
 }
 
 pub fn get_unused_address() -> SyncReturn<String> {

--- a/mobile/native/src/api.rs
+++ b/mobile/native/src/api.rs
@@ -227,13 +227,13 @@ pub fn run(
         );
     }
 
-    config::set(config);
+    config::set(config.clone());
     db::init_db(&app_dir, get_network())?;
     let runtime = ln_dlc::get_or_create_tokio_runtime()?;
     ln_dlc::run(app_dir, seed_dir, runtime)?;
     event::subscribe(ChannelFeePaymentSubscriber::new());
 
-    let (_health, tx) = health::Health::new(runtime);
+    let (_health, tx) = health::Health::new(config, runtime);
 
     orderbook::subscribe(ln_dlc::get_node_key(), runtime, tx.orderbook)
 }

--- a/mobile/native/src/config/api.rs
+++ b/mobile/native/src/config/api.rs
@@ -6,7 +6,7 @@ use std::str::FromStr;
 use url::Url;
 
 #[frb]
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Config {
     pub coordinator_pubkey: String,
     pub esplora_endpoint: String,
@@ -16,6 +16,7 @@ pub struct Config {
     pub network: String,
     pub oracle_endpoint: String,
     pub oracle_pubkey: String,
+    pub health_check_interval_secs: u64,
 }
 
 impl From<Config> for ConfigInternal {
@@ -35,6 +36,9 @@ impl From<Config> for ConfigInternal {
             oracle_endpoint: config.oracle_endpoint,
             oracle_pubkey: XOnlyPublicKey::from_str(config.oracle_pubkey.as_str())
                 .expect("Valid oracle public key"),
+            health_check_interval: std::time::Duration::from_secs(
+                config.health_check_interval_secs,
+            ),
         }
     }
 }

--- a/mobile/native/src/config/mod.rs
+++ b/mobile/native/src/config/mod.rs
@@ -8,12 +8,13 @@ use ln_dlc_node::node::NodeInfo;
 use ln_dlc_node::node::OracleInfo;
 use state::Storage;
 use std::net::SocketAddr;
+use std::time::Duration;
 use url::Url;
 
 static CONFIG: Storage<ConfigInternal> = Storage::new();
 
 #[derive(Clone)]
-struct ConfigInternal {
+pub struct ConfigInternal {
     coordinator_pubkey: PublicKey,
     esplora_endpoint: Url,
     http_endpoint: SocketAddr,
@@ -21,6 +22,17 @@ struct ConfigInternal {
     network: bitcoin::Network,
     oracle_endpoint: String,
     oracle_pubkey: XOnlyPublicKey,
+    health_check_interval: Duration,
+}
+
+impl ConfigInternal {
+    pub fn coordinator_health_endpoint(&self) -> String {
+        format!("http://{}/health", self.http_endpoint)
+    }
+
+    pub fn health_check_interval(&self) -> Duration {
+        self.health_check_interval
+    }
 }
 
 pub fn set(config: Config) {

--- a/mobile/native/src/event/api.rs
+++ b/mobile/native/src/event/api.rs
@@ -2,6 +2,7 @@ use crate::api::WalletInfo;
 use crate::event::subscriber::Subscriber;
 use crate::event::EventInternal;
 use crate::event::EventType;
+use crate::health::ServiceUpdate;
 use crate::trade::order::api::Order;
 use crate::trade::position::api::Position;
 use core::convert::From;
@@ -20,6 +21,7 @@ pub enum Event {
     PositionUpdateNotification(Position),
     PositionClosedNotification(PositionClosed),
     PriceUpdateNotification(BestPrice),
+    ServiceHealthUpdate(ServiceUpdate),
 }
 
 impl From<EventInternal> for Event {
@@ -50,6 +52,7 @@ impl From<EventInternal> for Event {
                     .into();
                 Event::PriceUpdateNotification(best_price)
             }
+            EventInternal::ServiceHealthUpdate(update) => Event::ServiceHealthUpdate(update),
             EventInternal::ChannelReady(_) => {
                 unreachable!("This internal event is not exposed to the UI")
             }

--- a/mobile/native/src/event/mod.rs
+++ b/mobile/native/src/event/mod.rs
@@ -3,6 +3,7 @@ mod event_hub;
 pub mod subscriber;
 
 use crate::api::WalletInfo;
+use crate::health::ServiceUpdate;
 use coordinator_commons::TradeParams;
 use ln_dlc_node::node::rust_dlc_manager::ChannelId;
 use orderbook_commons::Prices;
@@ -34,6 +35,7 @@ pub enum EventInternal {
     PriceUpdateNotification(Prices),
     ChannelReady(ChannelId),
     PaymentClaimed(u64),
+    ServiceHealthUpdate(ServiceUpdate),
 }
 
 impl From<EventInternal> for EventType {
@@ -51,6 +53,7 @@ impl From<EventInternal> for EventType {
             EventInternal::PriceUpdateNotification(_) => EventType::PriceUpdateNotification,
             EventInternal::ChannelReady(_) => EventType::ChannelReady,
             EventInternal::PaymentClaimed(_) => EventType::PaymentClaimed,
+            EventInternal::ServiceHealthUpdate(_) => EventType::ServiceHealthUpdate,
         }
     }
 }
@@ -67,4 +70,5 @@ pub enum EventType {
     PriceUpdateNotification,
     ChannelReady,
     PaymentClaimed,
+    ServiceHealthUpdate,
 }

--- a/mobile/native/src/health.rs
+++ b/mobile/native/src/health.rs
@@ -1,0 +1,65 @@
+use tokio::runtime::Runtime;
+use tokio::select;
+use tokio::sync::watch;
+
+use crate::event::EventInternal;
+use crate::event::{self};
+
+/// Services which status is monitored
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Service {
+    Orderbook,
+}
+
+/// Health status of the node
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub enum ServiceStatus {
+    #[default]
+    Unknown,
+    Online,
+    Offline,
+}
+
+pub type ServiceUpdate = (Service, ServiceStatus);
+
+pub struct Tx {
+    pub orderbook: watch::Sender<ServiceStatus>,
+}
+
+/// Entity that gathers all the health data and sends notifications
+pub struct Health {
+    _monitoring_task: tokio::task::JoinHandle<()>,
+}
+
+impl Health {
+    pub fn new(runtime: &Runtime) -> (Self, Tx) {
+        let (orderbook_tx, mut orderbook_rx) = watch::channel(ServiceStatus::Unknown);
+
+        let _monitoring_task = runtime.spawn(async move {
+            loop {
+                select! {
+                    result = orderbook_rx.changed() => {
+                        match result {
+                            Ok(()) => {
+                                let status = orderbook_rx.borrow();
+                                event::publish(&EventInternal::ServiceHealthUpdate((Service::Orderbook, *status)));
+                            }
+                            Err(_) => {
+                                tracing::error!("Sender dropped");
+                                event::publish(&EventInternal::ServiceHealthUpdate((Service::Orderbook, ServiceStatus::Unknown)));
+                                break;
+                            },
+                        }
+                    },
+                }
+            }
+        });
+
+        (
+            Self { _monitoring_task },
+            Tx {
+                orderbook: orderbook_tx,
+            },
+        )
+    }
+}

--- a/mobile/native/src/health.rs
+++ b/mobile/native/src/health.rs
@@ -1,14 +1,21 @@
-use tokio::runtime::Runtime;
-use tokio::select;
-use tokio::sync::watch;
-
+use crate::config::api::Config;
+use crate::config::ConfigInternal;
+use crate::event;
 use crate::event::EventInternal;
-use crate::event::{self};
+use anyhow::Context;
+use anyhow::Result;
+use futures::future::RemoteHandle;
+use futures::FutureExt;
+use reqwest::StatusCode;
+use std::time::Duration;
+use tokio::runtime::Runtime;
+use tokio::sync::watch;
 
 /// Services which status is monitored
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum Service {
     Orderbook,
+    Coordinator,
 }
 
 /// Health status of the node
@@ -22,44 +29,102 @@ pub enum ServiceStatus {
 
 pub type ServiceUpdate = (Service, ServiceStatus);
 
+/// Senders for the health status updates.
+///
+/// Meant to be injected into the services that need to publish their health status.
 pub struct Tx {
     pub orderbook: watch::Sender<ServiceStatus>,
 }
 
-/// Entity that gathers all the health data and sends notifications
+/// Entity that gathers all the service health data and publishes notifications
 pub struct Health {
-    _monitoring_task: tokio::task::JoinHandle<()>,
+    _tasks: Vec<RemoteHandle<std::result::Result<(), tokio::task::JoinError>>>,
 }
 
 impl Health {
-    pub fn new(runtime: &Runtime) -> (Self, Tx) {
-        let (orderbook_tx, mut orderbook_rx) = watch::channel(ServiceStatus::Unknown);
+    pub fn new(config: Config, runtime: &Runtime) -> (Self, Tx) {
+        let (orderbook_tx, orderbook_rx) = watch::channel(ServiceStatus::Unknown);
 
-        let _monitoring_task = runtime.spawn(async move {
-            loop {
-                select! {
-                    result = orderbook_rx.changed() => {
-                        match result {
-                            Ok(()) => {
-                                let status = orderbook_rx.borrow();
-                                event::publish(&EventInternal::ServiceHealthUpdate((Service::Orderbook, *status)));
-                            }
-                            Err(_) => {
-                                tracing::error!("Sender dropped");
-                                event::publish(&EventInternal::ServiceHealthUpdate((Service::Orderbook, ServiceStatus::Unknown)));
-                                break;
-                            },
-                        }
-                    },
-                }
-            }
-        });
+        let config: ConfigInternal = config.into();
+
+        let mut tasks = Vec::new();
+
+        let orderbook_monitoring = runtime
+            .spawn(publish_status_updates(Service::Orderbook, orderbook_rx))
+            .remote_handle()
+            .1;
+        tasks.push(orderbook_monitoring);
+
+        let (coordinator_tx, coordinator_rx) = watch::channel(ServiceStatus::Unknown);
+
+        let check_coordinator = runtime
+            .spawn(check_health_endpoint(
+                config.coordinator_health_endpoint(),
+                coordinator_tx,
+                config.health_check_interval(),
+            ))
+            .remote_handle()
+            .1;
+        tasks.push(check_coordinator);
+        let coordinator_monitoring = runtime
+            .spawn(publish_status_updates(Service::Coordinator, coordinator_rx))
+            .remote_handle()
+            .1;
+        tasks.push(coordinator_monitoring);
 
         (
-            Self { _monitoring_task },
+            Self { _tasks: tasks },
             Tx {
                 orderbook: orderbook_tx,
             },
         )
     }
+}
+
+/// Publishes the health status updates for a given service to the event hub
+async fn publish_status_updates(service: Service, mut rx: watch::Receiver<ServiceStatus>) {
+    loop {
+        match rx.changed().await {
+            Ok(()) => {
+                let status = rx.borrow();
+                event::publish(&EventInternal::ServiceHealthUpdate((service, *status)));
+            }
+            Err(_) => {
+                tracing::error!("Sender dropped");
+                event::publish(&EventInternal::ServiceHealthUpdate((
+                    service,
+                    ServiceStatus::Unknown,
+                )));
+                break;
+            }
+        }
+    }
+}
+
+/// Periodically checks the health of a given service and updates the watch channel
+async fn check_health_endpoint(
+    endpoint: String,
+    tx: watch::Sender<ServiceStatus>,
+    interval: Duration,
+) {
+    loop {
+        let status = if send_request(&endpoint).await.is_ok() {
+            ServiceStatus::Online
+        } else {
+            ServiceStatus::Offline
+        };
+
+        tx.send(status).expect("Receiver not to be dropped");
+        tokio::time::sleep(interval).await;
+    }
+}
+
+// Returns the status code of the health endpoint, returning an error if the request fails
+async fn send_request(endpoint: &str) -> Result<StatusCode> {
+    tracing::trace!(%endpoint, "Sending request");
+    let response = reqwest::get(endpoint)
+        .await
+        .context("could not send request")?
+        .error_for_status()?;
+    Ok(response.status())
 }

--- a/mobile/native/src/lib.rs
+++ b/mobile/native/src/lib.rs
@@ -11,6 +11,7 @@ mod channel_fee;
 pub mod commons;
 pub mod config;
 pub mod event;
+pub mod health;
 pub mod logger;
 mod orderbook;
 

--- a/mobile/native/src/orderbook.rs
+++ b/mobile/native/src/orderbook.rs
@@ -1,4 +1,5 @@
 use crate::config;
+use crate::health::ServiceStatus;
 use crate::trade::position;
 use anyhow::Result;
 use bdk::bitcoin::secp256k1::SecretKey;
@@ -13,13 +14,18 @@ use std::sync::Arc;
 use std::time::Duration;
 use time::OffsetDateTime;
 use tokio::runtime::Runtime;
+use tokio::sync::watch;
 use tokio::task::spawn_blocking;
 use uuid::Uuid;
 
 const WS_RECONNECT_TIMEOUT: Duration = Duration::from_secs(2);
 const EXPIRED_ORDER_PRUNING_INTERVAL: Duration = Duration::from_secs(30);
 
-pub fn subscribe(secret_key: SecretKey, runtime: &Runtime) -> Result<()> {
+pub fn subscribe(
+    secret_key: SecretKey,
+    runtime: &Runtime,
+    orderbook_status: watch::Sender<ServiceStatus>,
+) -> Result<()> {
     runtime.spawn(async move {
         let url = format!(
             "ws://{}/api/orderbook/websocket",
@@ -34,6 +40,7 @@ pub fn subscribe(secret_key: SecretKey, runtime: &Runtime) -> Result<()> {
 
         // Need a Mutex as it's being accessed from websocket stream and pruning task
         let orders = Arc::new(Mutex::new(Vec::<Order>::new()));
+
 
         let _prune_expired_orders_task = {
             let orders = orders.clone();
@@ -71,6 +78,10 @@ pub fn subscribe(secret_key: SecretKey, runtime: &Runtime) -> Result<()> {
             let mut stream =
                 spawn_blocking(move || orderbook_client::subscribe_with_authentication(url, authenticate)).await.expect("joined task not to panic");
 
+            if let Err(e) =
+                orderbook_status.send(ServiceStatus::Online) {
+                    tracing::warn!("Cannot update orderbook status: {e:#}");
+                };
 
             loop {
                 match stream.try_next().await {
@@ -148,6 +159,11 @@ pub fn subscribe(secret_key: SecretKey, runtime: &Runtime) -> Result<()> {
                         break;
                     }
                 }
+            };
+
+            if let Err(e) =
+            orderbook_status.send(ServiceStatus::Offline) {
+                tracing::warn!("Cannot update orderbook status: {e:#}");
             };
 
             tokio::time::sleep(WS_RECONNECT_TIMEOUT).await;

--- a/mobile/native/src/orderbook.rs
+++ b/mobile/native/src/orderbook.rs
@@ -41,7 +41,6 @@ pub fn subscribe(
         // Need a Mutex as it's being accessed from websocket stream and pruning task
         let orders = Arc::new(Mutex::new(Vec::<Order>::new()));
 
-
         let _prune_expired_orders_task = {
             let orders = orders.clone();
             tokio::spawn(async move {


### PR DESCRIPTION
- Introduce a mechanism for communicating service status to the frontend.

- Communicate about the orderbook status (websocket stream connection) and
  coordinator status (responsive on HTTP API).

- Verify in e2e test that the status is updated correctly.

Note: The frontend part is well underway, it will come in a separate PR.