### PR TITLE
Await `spawn_blocking`, don't just drop the `JoinHandle`

### DIFF
--- a/coordinator/src/bin/coordinator.rs
+++ b/coordinator/src/bin/coordinator.rs
@@ -145,7 +145,7 @@ async fn main() -> Result<()> {
                 match node_event_receiver.changed().await {
                     Ok(()) => {
                         let event = node_event_receiver.borrow().clone();
-                        node::routing_fees::handle(node.clone(), event);
+                        node::routing_fees::handle(node.clone(), event).await;
                     }
                     Err(e) => {
                         tracing::error!("Failed to receive event: {e:#}");

--- a/coordinator/src/node/routing_fees.rs
+++ b/coordinator/src/node/routing_fees.rs
@@ -1,13 +1,15 @@
 use crate::db;
 use crate::node::Node;
 use crate::routing_fee::models::NewRoutingFee;
+use anyhow::anyhow;
+use anyhow::Context;
 use lightning::util::events::Event;
 
 /// Save the routing fee in the database upon `PaymentForwarded` event
 ///
 /// Only takes regular routing fees into account. This function does not handle force-close
 /// scenarios where the `fee_earned_msat` is set to `None`.
-pub fn handle(node: Node, event: Option<Event>) {
+pub async fn handle(node: Node, event: Option<Event>) {
     //
     if let Some(Event::PaymentForwarded {
         fee_earned_msat: Some(fee_earned_msat),
@@ -16,25 +18,28 @@ pub fn handle(node: Node, event: Option<Event>) {
         ..
     }) = event
     {
-        tokio::task::spawn_blocking(move || {
-            let mut conn = match node.pool.get() {
-                Ok(conn) => conn,
-                Err(e) => {
-                    tracing::error!("Failed to connect to database during node event post processing event: {e:#}");
-                    return;
-                }
-            };
+        if let Err(e) = tokio::task::spawn_blocking(move || {
+            let mut conn = node
+                .pool
+                .get()
+                .context("Failed to acquire database connection")?;
 
-            if let Err(e) = db::routing_fees::insert(
+            db::routing_fees::insert(
                 NewRoutingFee {
                     amount_msats: fee_earned_msat,
                     prev_channel_id,
                     next_channel_id,
                 },
                 &mut conn,
-            ) {
-                tracing::error!(%fee_earned_msat, "Failed to insert routing fee into database: {e:#}");
-            }
-        });
+            )
+            .context("Failed to insert routing fee into database")?;
+
+            anyhow::Ok(())
+        })
+        .await
+        .map_err(|e| anyhow!(e))
+        {
+            tracing::error!(?event, "Failed to insert routing fee: {e:#}")
+        }
     }
 }


### PR DESCRIPTION
Spotted this when working on another `spawn_blocking` - I think this was just wrong 😬