### PR TITLE
Remove created payment types in `down` migration

### DIFF
--- a/coordinator/migrations/2023-07-10-060138_payments/down.sql
+++ b/coordinator/migrations/2023-07-10-060138_payments/down.sql
@@ -1,3 +1,5 @@
 -- This file should undo anything in `up.sql`
-DROP INDEX IF EXISTS payments_payment_hash ON payments(payment_hash);
+DROP INDEX IF EXISTS payments_payment_hash;
 DROP TABLE "payments";
+DROP TYPE "Payment_Flow_Type";
+DROP TYPE "Htlc_Status_Type";

--- a/coordinator/readme.md
+++ b/coordinator/readme.md
@@ -49,3 +49,9 @@ diesel setup --database-url=postgres://postgres:mysecretpassword@localhost:5432/
 ```bash
 diesel migration run --database-url=postgres://postgres:mysecretpassword@localhost:5432/orderbook --migration-dir ./migrations
 ```
+
+To re-run (i.e. revert all and then run all) migrations you can use:
+
+```bash
+diesel migration redo --all --database-url=postgres://postgres:mysecretpassword@localhost:5432/orderbook --migration-dir ./migrations
+```


### PR DESCRIPTION
Can be tested with:

```
diesel migration redo --all --database-url=postgres://postgres:mysecretpassword@localhost:5432/orderbook --migration-dir ./migrations
```