### PR TITLE
Fix outdated schema and correctly handle temporary contract id

### DIFF
--- a/coordinator/src/db/positions.rs
+++ b/coordinator/src/db/positions.rs
@@ -31,7 +31,7 @@ pub struct Position {
     pub expiry_timestamp: OffsetDateTime,
     pub update_timestamp: OffsetDateTime,
     pub trader_pubkey: String,
-    pub temporary_contract_id: String,
+    pub temporary_contract_id: Option<String>,
     pub realized_pnl: Option<i64>,
 }
 
@@ -158,8 +158,9 @@ impl From<Position> for crate::position::models::Position {
             expiry_timestamp: value.expiry_timestamp,
             update_timestamp: value.update_timestamp,
             trader: value.trader_pubkey.parse().expect("to be valid public key"),
-            temporary_contract_id: ContractId::from_hex(value.temporary_contract_id.as_str())
-                .expect("contract id to decode"),
+            temporary_contract_id: value.temporary_contract_id.map(|contract_id| {
+                ContractId::from_hex(contract_id.as_str()).expect("contract id to decode")
+            }),
         }
     }
 }

--- a/coordinator/src/position/models.rs
+++ b/coordinator/src/position/models.rs
@@ -46,5 +46,7 @@ pub struct Position {
     /// We use the temporary contract id because the actual contract id might not be known at that
     /// point. The temporary contract id is propagated to all states until the contract is
     /// closed.
-    pub temporary_contract_id: ContractId,
+    /// This field is optional for backwards compatibility because we cannot deterministically
+    /// associate already existing contracts with positions.
+    pub temporary_contract_id: Option<ContractId>,
 }

--- a/coordinator/src/schema.rs
+++ b/coordinator/src/schema.rs
@@ -107,7 +107,7 @@ diesel::table! {
         expiry_timestamp -> Timestamptz,
         update_timestamp -> Timestamptz,
         trader_pubkey -> Text,
-        temporary_contract_id -> Text,
+        temporary_contract_id -> Nullable<Text>,
         realized_pnl -> Nullable<Int8>,
     }
 }


### PR DESCRIPTION
Unfortunately https://github.com/get10101/10101/pull/966 merged with an outdated `schema.rs` version in the coordinator. 
This PR fixes this!