### PR TITLE
fix: Align funding tx fee invoice parameters with endpoint

### DIFF
--- a/mobile/native/src/channel_fee.rs
+++ b/mobile/native/src/channel_fee.rs
@@ -152,7 +152,7 @@ async fn fetch_funding_transaction_fee_invoice(
 ) -> Result<String> {
     reqwest_client()
         .get(format!(
-            "http://{}/api/invoice/open_channel_fee?amount={}?txid={}",
+            "http://{}/api/invoice/open_channel_fee?amount={}&channel_funding_txid={}",
             config::get_http_endpoint(),
             funding_tx_fee,
             funding_txid.as_str()


### PR DESCRIPTION
The parameters were out of sync resulting in an error which was tried to be parsed as invoice. Which obviously failed.

The `basic.rs` was unfortunately not able to catch that due to a workaround for https://github.com/get10101/10101/issues/883