### PR TITLE
Fail intercepted HTLC backwards when we should

### DIFF
--- a/crates/ln-dlc-node/src/ln/event_handler.rs
+++ b/crates/ln-dlc-node/src/ln/event_handler.rs
@@ -31,6 +31,7 @@ use lightning::chain::chaininterface::ConfirmationTarget;
 use lightning::chain::chaininterface::FeeEstimator;
 use lightning::chain::keysinterface::SpendableOutputDescriptor;
 use lightning::ln::channelmanager::InterceptId;
+use lightning::ln::PaymentHash;
 use lightning::routing::gossip::NodeId;
 use lightning::util::config::UserConfig;
 use lightning::util::events::Event;
@@ -572,175 +573,182 @@ where
                 inbound_amount_msat,
                 expected_outbound_amount_msat,
             } => {
-                let intercepted_id = hex::encode(intercept_id.0);
-                let payment_hash = hex::encode(payment_hash.0);
-                tracing::info!(
-                    intercepted_id,
-                    requested_next_hop_scid,
+                self.handle_intercepted_htlc(
+                    intercept_id,
                     payment_hash,
+                    requested_next_hop_scid,
                     inbound_amount_msat,
                     expected_outbound_amount_msat,
-                    "Intercepted HTLC"
-                );
-
-                let target_node_id = {
-                    let fake_channel_payments = self.fake_channel_payments_lock();
-                    match fake_channel_payments.get(&requested_next_hop_scid) {
-                        None => {
-                            tracing::warn!(fake_scid = requested_next_hop_scid, "Could not forward the intercepted HTLC because we didn't have a node registered with said fake scid");
-
-                            if let Err(err) =
-                                self.channel_manager.fail_intercepted_htlc(intercept_id)
-                            {
-                                tracing::error!("Could not fail intercepted htlc {err:?}")
-                            }
-
-                            return Ok(());
-                        }
-                        Some(target_node_id) => *target_node_id,
-                    }
-                };
-
-                // FIXME: This is only a temporary quick fix for the MVP and should be fixed
-                // properly. Ideally the app would run in the background. Not necessarily for ever
-                // but for at least a couple of seconds / minutes
-                tokio::time::timeout(Duration::from_secs(HTLC_INTERCEPTED_CONNECTION_TIMEOUT), async {
-                    loop {
-                        if self.peer_manager
-                            .get_peer_node_ids()
-                            .iter()
-                            .any(|(id, _)| *id == target_node_id) {
-                            tracing::info!(%target_node_id, "Found connection to target peer. Continuing HTLCIntercepted event.");
-
-                            return;
-                        }
-                        tracing::debug!(%target_node_id, "Waiting for target node to come online.");
-                        tokio::time::sleep(Duration::from_secs(2)).await;
-                    }
-                }).await?;
-
-                // if we have already a channel with them, we try to forward the payment.
-                if let Some(channel) = self
-                    .channel_manager
-                    .list_channels()
-                    .iter()
-                    // The coordinator can only have one channel with each app. Hence, if we find a
-                    // channel with the target of the intercepted HTLC, we know
-                    // that it is the only channel between coordinator and
-                    // target app and we can forward the intercepted HTLC through it.
-                    .find(|channel_details| channel_details.counterparty.node_id == target_node_id)
-                {
-                    // Note, the forward intercepted htlc might fail due to insufficient balance,
-                    // since we do not check yet if the channel outbound capacity is sufficient.
-                    if let Err(error) = self.channel_manager.forward_intercepted_htlc(
-                        intercept_id,
-                        &channel.channel_id,
-                        channel.counterparty.node_id,
-                        expected_outbound_amount_msat,
-                    ) {
-                        tracing::warn!(?error, "Failed to forward intercepted HTLC");
-
-                        self.channel_manager
-                            .fail_intercepted_htlc(intercept_id)
-                            .map_err(|e| anyhow!("{e:?}"))?;
-                    }
-
-                    return Ok(());
-                }
-
-                let opt_max_allowed_fee = self
-                    .wallet
-                    .inner()
-                    .settings()
-                    .await
-                    .max_allowed_tx_fee_rate_when_opening_channel;
-
-                // Do not open a channel if the fee is too high for us
-                if let Some(max_allowed_tx_fee) = opt_max_allowed_fee {
-                    let current_fee = self
-                        .fee_rate_estimator
-                        .get_est_sat_per_1000_weight(CONFIRMATION_TARGET);
-                    if max_allowed_tx_fee < current_fee {
-                        tracing::warn!(%max_allowed_tx_fee, %current_fee, "Not opening a channel because the fee is too high");
-                        if let Err(err) = self.channel_manager.fail_intercepted_htlc(intercept_id) {
-                            tracing::error!(%intercepted_id, "Could not fail intercepted htlc {err:?}")
-                        }
-                        return Ok(());
-                    }
-                }
-
-                let channel_value = expected_outbound_amount_msat / 1000 * LIQUIDITY_MULTIPLIER;
-
-                if channel_value > JUST_IN_TIME_CHANNEL_OUTBOUND_LIQUIDITY_SAT_MAX {
-                    tracing::warn!(%intercepted_id, %channel_value, channel_value_maximum=%JUST_IN_TIME_CHANNEL_OUTBOUND_LIQUIDITY_SAT_MAX, "Failed to open channel because maximum channel value exceeded");
-                    if let Err(err) = self.channel_manager.fail_intercepted_htlc(intercept_id) {
-                        tracing::error!(%intercepted_id, "Could not fail intercepted htlc {err:?}")
-                    }
-                    return Ok(());
-                }
-
-                let mut channel_config = *self.channel_config.read();
-                // We are overwriting the coordinators channel handshake configuration to prevent
-                // the just-in-time-channel from being announced (private). This is required as both
-                // parties need to agree on this configuration. For other channels, like with the
-                // channel to an external node we want this channel to be announced (public).
-                // NOTE: we want private channels with the mobile app, as this will allow us to make
-                // use of 0-conf channels.
-                channel_config.channel_handshake_config.announced_channel = false;
-
-                // NOTE: We actually might want to override the `UserConfig`
-                // for this just-in-time channel so that the
-                // intercepted HTLC is allowed to be added to the
-                // channel according to its
-                // `max_inbound_htlc_value_in_flight_percent_of_channel`
-                // configuration value
-
-                let new_channel = Channel::new(0, channel_value, target_node_id);
-                tracing::debug!(%new_channel, "Creating shadow channel");
-                if let Err(err) = self.storage.upsert_channel(new_channel.clone()) {
-                    tracing::error!(%intercepted_id, "Failed to insert channel to database. Error: {err:#}");
-                    if let Err(err) = self.channel_manager.fail_intercepted_htlc(intercept_id) {
-                        tracing::error!(%intercepted_id, "Could not fail intercepted htlc {err:?}")
-                    }
-                    return Ok(());
-                }
-
-                let temp_channel_id = match self.channel_manager.create_channel(
-                    target_node_id,
-                    channel_value,
-                    0,
-                    new_channel.user_channel_id.to_u128(),
-                    Some(channel_config),
-                ) {
-                    Ok(temp_channel_id) => temp_channel_id,
-                    Err(err) => {
-                        tracing::warn!(?err, "Failed to open just in time channel");
-
-                        if let Err(err) = self
-                            .channel_manager
-                            .fail_intercepted_htlc(intercept_id)
-                            .map_err(|e| anyhow!("{e:?}"))
-                        {
-                            tracing::error!("Could not fail intercepted htlc {err:?}");
-                        };
-
-                        return Ok(());
-                    }
-                };
-
-                tracing::info!(
-                    peer = %target_node_id,
-                    temp_channel_id = %hex::encode(temp_channel_id),
-                    "Started channel creation for in-flight payment"
-                );
-
-                let mut pending_intercepted_htlcs = self.pending_intercepted_htlcs_lock();
-                pending_intercepted_htlcs.insert(
-                    target_node_id,
-                    (intercept_id, expected_outbound_amount_msat),
-                );
+                )
+                .await?;
             }
         };
+
+        Ok(())
+    }
+
+    /// Handle an [`Event::HTLCIntercepted`].
+    async fn handle_intercepted_htlc(
+        &self,
+        intercept_id: InterceptId,
+        payment_hash: PaymentHash,
+        requested_next_hop_scid: u64,
+        inbound_amount_msat: u64,
+        expected_outbound_amount_msat: u64,
+    ) -> Result<()> {
+        let intercepted_id = hex::encode(intercept_id.0);
+        let payment_hash = hex::encode(payment_hash.0);
+
+        tracing::info!(
+            intercepted_id,
+            requested_next_hop_scid,
+            payment_hash,
+            inbound_amount_msat,
+            expected_outbound_amount_msat,
+            "Intercepted HTLC"
+        );
+
+        let target_node_id = {
+            let fake_channel_payments = self.fake_channel_payments_lock();
+            match fake_channel_payments.get(&requested_next_hop_scid) {
+                None => {
+                    tracing::warn!(fake_scid = requested_next_hop_scid, "Could not forward the intercepted HTLC because we didn't have a node registered with said fake scid");
+
+                    if let Err(err) = self.channel_manager.fail_intercepted_htlc(intercept_id) {
+                        tracing::error!("Could not fail intercepted htlc {err:?}")
+                    }
+
+                    return Ok(());
+                }
+                Some(target_node_id) => *target_node_id,
+            }
+        };
+
+        tokio::time::timeout(Duration::from_secs(HTLC_INTERCEPTED_CONNECTION_TIMEOUT), async {
+            loop {
+                if self.peer_manager
+                    .get_peer_node_ids()
+                    .iter()
+                    .any(|(id, _)| *id == target_node_id) {
+                    tracing::info!(%target_node_id, "Found connection to target peer. Continuing HTLCIntercepted event.");
+
+                    return;
+                }
+                tracing::debug!(%target_node_id, "Waiting for target node to come online.");
+                tokio::time::sleep(Duration::from_secs(2)).await;
+            }
+        }).await?;
+
+        if let Some(channel) = self
+            .channel_manager
+            .list_channels()
+            .iter()
+            // The coordinator can only have one channel with each app. Hence, if we find a
+            // channel with the target of the intercepted HTLC, we know
+            // that it is the only channel between coordinator and
+            // target app and we can forward the intercepted HTLC through it.
+            .find(|channel_details| channel_details.counterparty.node_id == target_node_id)
+        {
+            // Note, the forward intercepted htlc might fail due to insufficient balance,
+            // since we do not check yet if the channel outbound capacity is sufficient.
+            if let Err(error) = self.channel_manager.forward_intercepted_htlc(
+                intercept_id,
+                &channel.channel_id,
+                channel.counterparty.node_id,
+                expected_outbound_amount_msat,
+            ) {
+                tracing::warn!(?error, "Failed to forward intercepted HTLC");
+
+                self.channel_manager
+                    .fail_intercepted_htlc(intercept_id)
+                    .map_err(|e| anyhow!("{e:?}"))?;
+            }
+
+            return Ok(());
+        }
+
+        let opt_max_allowed_fee = self
+            .wallet
+            .inner()
+            .settings()
+            .await
+            .max_allowed_tx_fee_rate_when_opening_channel;
+        if let Some(max_allowed_tx_fee) = opt_max_allowed_fee {
+            let current_fee = self
+                .fee_rate_estimator
+                .get_est_sat_per_1000_weight(CONFIRMATION_TARGET);
+            if max_allowed_tx_fee < current_fee {
+                tracing::warn!(%max_allowed_tx_fee, %current_fee, "Not opening a channel because the fee is too high");
+                if let Err(err) = self.channel_manager.fail_intercepted_htlc(intercept_id) {
+                    tracing::error!(%intercepted_id, "Could not fail intercepted htlc {err:?}")
+                }
+                return Ok(());
+            }
+        }
+
+        let channel_value = expected_outbound_amount_msat / 1000 * LIQUIDITY_MULTIPLIER;
+        if channel_value > JUST_IN_TIME_CHANNEL_OUTBOUND_LIQUIDITY_SAT_MAX {
+            tracing::warn!(%intercepted_id, %channel_value, channel_value_maximum=%JUST_IN_TIME_CHANNEL_OUTBOUND_LIQUIDITY_SAT_MAX, "Failed to open channel because maximum channel value exceeded");
+
+            if let Err(err) = self.channel_manager.fail_intercepted_htlc(intercept_id) {
+                tracing::error!(%intercepted_id, "Could not fail intercepted htlc {err:?}")
+            }
+
+            return Ok(());
+        }
+
+        let mut channel_config = *self.channel_config.read();
+        channel_config.channel_handshake_config.announced_channel = false;
+
+        let new_channel = Channel::new(0, channel_value, target_node_id);
+
+        tracing::debug!(%new_channel, "Creating shadow channel");
+
+        if let Err(err) = self.storage.upsert_channel(new_channel.clone()) {
+            tracing::error!(%intercepted_id, "Failed to insert channel to database. Error: {err:#}");
+
+            if let Err(err) = self.channel_manager.fail_intercepted_htlc(intercept_id) {
+                tracing::error!(%intercepted_id, "Could not fail intercepted htlc {err:?}")
+            }
+
+            return Ok(());
+        }
+
+        let temp_channel_id = match self.channel_manager.create_channel(
+            target_node_id,
+            channel_value,
+            0,
+            new_channel.user_channel_id.to_u128(),
+            Some(channel_config),
+        ) {
+            Ok(temp_channel_id) => temp_channel_id,
+            Err(err) => {
+                tracing::warn!(?err, "Failed to open just in time channel");
+
+                if let Err(err) = self
+                    .channel_manager
+                    .fail_intercepted_htlc(intercept_id)
+                    .map_err(|e| anyhow!("{e:?}"))
+                {
+                    tracing::error!("Could not fail intercepted htlc {err:?}");
+                };
+
+                return Ok(());
+            }
+        };
+
+        tracing::info!(
+            peer = %target_node_id,
+            temp_channel_id = %hex::encode(temp_channel_id),
+            "Started channel creation for in-flight payment"
+        );
+
+        let mut pending_intercepted_htlcs = self.pending_intercepted_htlcs_lock();
+
+        pending_intercepted_htlcs.insert(
+            target_node_id,
+            (intercept_id, expected_outbound_amount_msat),
+        );
 
         Ok(())
     }

--- a/crates/ln-dlc-node/src/ln/event_handler.rs
+++ b/crates/ln-dlc-node/src/ln/event_handler.rs
@@ -754,7 +754,7 @@ where
     }
 }
 
-impl<P> EventHandler<P> {
+impl<S> EventHandler<S> {
     #[autometrics]
     fn fake_channel_payments_lock(&self) -> MutexGuard<HashMap<RequestedScid, PublicKey>> {
         self.fake_channel_payments

--- a/crates/ln-dlc-node/src/ln/event_handler.rs
+++ b/crates/ln-dlc-node/src/ln/event_handler.rs
@@ -612,7 +612,10 @@ where
             let fake_channel_payments = self.fake_channel_payments_lock();
             match fake_channel_payments.get(&requested_next_hop_scid) {
                 None => {
-                    tracing::warn!(fake_scid = requested_next_hop_scid, "Could not forward the intercepted HTLC because we didn't have a node registered with said fake scid");
+                    tracing::warn!(
+                        fake_scid = requested_next_hop_scid,
+                        "Could not forward the intercepted HTLC because we didn't have a node registered with said fake scid"
+                    );
 
                     if let Err(err) = self.channel_manager.fail_intercepted_htlc(intercept_id) {
                         tracing::error!("Could not fail intercepted htlc {err:?}")
@@ -634,6 +637,7 @@ where
 
                     return;
                 }
+
                 tracing::debug!(%target_node_id, "Waiting for target node to come online.");
                 tokio::time::sleep(Duration::from_secs(2)).await;
             }
@@ -679,16 +683,23 @@ where
                 .get_est_sat_per_1000_weight(CONFIRMATION_TARGET);
             if max_allowed_tx_fee < current_fee {
                 tracing::warn!(%max_allowed_tx_fee, %current_fee, "Not opening a channel because the fee is too high");
+
                 if let Err(err) = self.channel_manager.fail_intercepted_htlc(intercept_id) {
                     tracing::error!(intercept_id = %intercept_id_str, "Could not fail intercepted htlc {err:?}")
                 }
+
                 return Ok(());
             }
         }
 
         let channel_value = expected_outbound_amount_msat / 1000 * LIQUIDITY_MULTIPLIER;
         if channel_value > JUST_IN_TIME_CHANNEL_OUTBOUND_LIQUIDITY_SAT_MAX {
-            tracing::warn!(intercept_id = %intercept_id_str, %channel_value, channel_value_maximum=%JUST_IN_TIME_CHANNEL_OUTBOUND_LIQUIDITY_SAT_MAX, "Failed to open channel because maximum channel value exceeded");
+            tracing::warn!(
+                intercept_id = %intercept_id_str,
+                %channel_value,
+                channel_value_maximum=%JUST_IN_TIME_CHANNEL_OUTBOUND_LIQUIDITY_SAT_MAX,
+                "Failed to open channel because maximum channel value exceeded"
+            );
 
             if let Err(err) = self.channel_manager.fail_intercepted_htlc(intercept_id) {
                 tracing::error!(intercept_id = %intercept_id_str, "Could not fail intercepted htlc {err:?}")

--- a/crates/ln-dlc-node/src/ln/event_handler.rs
+++ b/crates/ln-dlc-node/src/ln/event_handler.rs
@@ -20,6 +20,7 @@ use crate::PeerManager;
 use crate::PendingInterceptedHtlcs;
 use crate::RequestedScid;
 use anyhow::anyhow;
+use anyhow::ensure;
 use anyhow::Context;
 use anyhow::Result;
 use autometrics::autometrics;
@@ -596,6 +597,35 @@ where
         inbound_amount_msat: u64,
         expected_outbound_amount_msat: u64,
     ) -> Result<()> {
+        let res = self
+            .handle_intercepted_htlc_internal(
+                intercept_id,
+                payment_hash,
+                requested_next_hop_scid,
+                inbound_amount_msat,
+                expected_outbound_amount_msat,
+            )
+            .await;
+
+        if let Err(ref e) = res {
+            tracing::error!("Failed to handle HTLCIntercepted event: {e:#}");
+
+            if let Err(e) = self.channel_manager.fail_intercepted_htlc(intercept_id) {
+                tracing::debug!("HTLC automatically failed backwards: {e:?}");
+            }
+        }
+
+        res
+    }
+
+    async fn handle_intercepted_htlc_internal(
+        &self,
+        intercept_id: InterceptId,
+        payment_hash: PaymentHash,
+        requested_next_hop_scid: u64,
+        inbound_amount_msat: u64,
+        expected_outbound_amount_msat: u64,
+    ) -> Result<()> {
         let intercept_id_str = hex::encode(intercept_id.0);
         let payment_hash = hex::encode(payment_hash.0);
 
@@ -610,63 +640,65 @@ where
 
         let target_node_id = {
             let fake_channel_payments = self.fake_channel_payments_lock();
-            match fake_channel_payments.get(&requested_next_hop_scid) {
-                None => {
-                    tracing::warn!(
-                        fake_scid = requested_next_hop_scid,
-                        "Could not forward the intercepted HTLC because we didn't have a node registered with said fake scid"
-                    );
+            fake_channel_payments.get(&requested_next_hop_scid).copied()
+        }
+        .with_context(|| {
+            format!(
+                "Could not forward the intercepted HTLC because we didn't have a node registered \
+                 with fake scid {requested_next_hop_scid}"
+            )
+        })?;
 
-                    if let Err(err) = self.channel_manager.fail_intercepted_htlc(intercept_id) {
-                        tracing::error!("Could not fail intercepted htlc {err:?}")
+        tokio::time::timeout(
+            Duration::from_secs(HTLC_INTERCEPTED_CONNECTION_TIMEOUT),
+            async {
+                loop {
+                    if self
+                        .peer_manager
+                        .get_peer_node_ids()
+                        .iter()
+                        .any(|(id, _)| *id == target_node_id)
+                    {
+                        tracing::info!(
+                            %target_node_id,
+                            %payment_hash,
+                            "Found connection with target of intercepted HTLC"
+                        );
+
+                        return;
                     }
 
-                    return Ok(());
+                    tracing::debug!(
+                        %target_node_id,
+                        %payment_hash,
+                        "Waiting for connection with target of intercepted HTLC"
+                    );
+                    tokio::time::sleep(Duration::from_secs(2)).await;
                 }
-                Some(target_node_id) => *target_node_id,
-            }
-        };
+            },
+        )
+        .await
+        .context("Timed out waiting to get connection with target of interceptable HTLC")?;
 
-        tokio::time::timeout(Duration::from_secs(HTLC_INTERCEPTED_CONNECTION_TIMEOUT), async {
-            loop {
-                if self.peer_manager
-                    .get_peer_node_ids()
-                    .iter()
-                    .any(|(id, _)| *id == target_node_id) {
-                    tracing::info!(%target_node_id, "Found connection to target peer. Continuing HTLCIntercepted event.");
-
-                    return;
-                }
-
-                tracing::debug!(%target_node_id, "Waiting for target node to come online.");
-                tokio::time::sleep(Duration::from_secs(2)).await;
-            }
-        }).await?;
-
+        // We only support one channel between coordinator and app. Also, we are unfortunately using
+        // interceptable HTLCs for regular payments (not just to open JIT channels). With all this
+        // in mind, if the coordinator (the only party that can handle this event) has a channel
+        // with the target of this payment we must treat this interceptable HTLC as a regular
+        // payment.
         if let Some(channel) = self
             .channel_manager
             .list_channels()
             .iter()
-            // The coordinator can only have one channel with each app. Hence, if we find a
-            // channel with the target of the intercepted HTLC, we know
-            // that it is the only channel between coordinator and
-            // target app and we can forward the intercepted HTLC through it.
             .find(|channel_details| channel_details.counterparty.node_id == target_node_id)
         {
-            // Note, the forward intercepted htlc might fail due to insufficient balance,
-            // since we do not check yet if the channel outbound capacity is sufficient.
-            if let Err(error) = self.channel_manager.forward_intercepted_htlc(
-                intercept_id,
-                &channel.channel_id,
-                channel.counterparty.node_id,
-                expected_outbound_amount_msat,
-            ) {
-                tracing::warn!(?error, "Failed to forward intercepted HTLC");
-
-                self.channel_manager
-                    .fail_intercepted_htlc(intercept_id)
-                    .map_err(|e| anyhow!("{e:?}"))?;
-            }
+            self.channel_manager
+                .forward_intercepted_htlc(
+                    intercept_id,
+                    &channel.channel_id,
+                    channel.counterparty.node_id,
+                    expected_outbound_amount_msat,
+                )
+                .map_err(|e| anyhow!("Failed to forward intercepted HTLC: {e:?}"))?;
 
             return Ok(());
         }
@@ -681,82 +713,49 @@ where
             let current_fee = self
                 .fee_rate_estimator
                 .get_est_sat_per_1000_weight(CONFIRMATION_TARGET);
-            if max_allowed_tx_fee < current_fee {
-                tracing::warn!(%max_allowed_tx_fee, %current_fee, "Not opening a channel because the fee is too high");
 
-                if let Err(err) = self.channel_manager.fail_intercepted_htlc(intercept_id) {
-                    tracing::error!(intercept_id = %intercept_id_str, "Could not fail intercepted htlc {err:?}")
-                }
-
-                return Ok(());
-            }
+            ensure!(
+                max_allowed_tx_fee >= current_fee,
+                "Not opening JIT channel because the fee is too high"
+            );
         }
 
         let channel_value = expected_outbound_amount_msat / 1000 * LIQUIDITY_MULTIPLIER;
-        if channel_value > JUST_IN_TIME_CHANNEL_OUTBOUND_LIQUIDITY_SAT_MAX {
-            tracing::warn!(
-                intercept_id = %intercept_id_str,
-                %channel_value,
-                channel_value_maximum=%JUST_IN_TIME_CHANNEL_OUTBOUND_LIQUIDITY_SAT_MAX,
-                "Failed to open channel because maximum channel value exceeded"
-            );
+        ensure!(
+            channel_value <= JUST_IN_TIME_CHANNEL_OUTBOUND_LIQUIDITY_SAT_MAX,
+            "Failed to open channel because maximum channel value exceeded"
+        );
 
-            if let Err(err) = self.channel_manager.fail_intercepted_htlc(intercept_id) {
-                tracing::error!(intercept_id = %intercept_id_str, "Could not fail intercepted htlc {err:?}")
-            }
+        let shadow_channel = Channel::new(0, channel_value, target_node_id);
 
-            return Ok(());
-        }
+        tracing::debug!(%shadow_channel, "Creating shadow channel");
+
+        self.storage
+            .upsert_channel(shadow_channel.clone())
+            .context("Failed to upsert shadow channel")?;
 
         let mut channel_config = *self.channel_config.read();
         channel_config.channel_handshake_config.announced_channel = false;
 
-        let new_channel = Channel::new(0, channel_value, target_node_id);
-
-        tracing::debug!(%new_channel, "Creating shadow channel");
-
-        if let Err(err) = self.storage.upsert_channel(new_channel.clone()) {
-            tracing::error!(intercept_id = %intercept_id_str, "Failed to insert channel to database. Error: {err:#}");
-
-            if let Err(err) = self.channel_manager.fail_intercepted_htlc(intercept_id) {
-                tracing::error!(intercept_id = %intercept_id_str, "Could not fail intercepted htlc {err:?}")
-            }
-
-            return Ok(());
-        }
-
-        let temp_channel_id = match self.channel_manager.create_channel(
-            target_node_id,
-            channel_value,
-            0,
-            new_channel.user_channel_id.to_u128(),
-            Some(channel_config),
-        ) {
-            Ok(temp_channel_id) => temp_channel_id,
-            Err(err) => {
-                tracing::warn!(?err, "Failed to open just in time channel");
-
-                if let Err(err) = self
-                    .channel_manager
-                    .fail_intercepted_htlc(intercept_id)
-                    .map_err(|e| anyhow!("{e:?}"))
-                {
-                    tracing::error!("Could not fail intercepted htlc {err:?}");
-                };
-
-                return Ok(());
-            }
-        };
+        let temp_channel_id = self
+            .channel_manager
+            .create_channel(
+                target_node_id,
+                channel_value,
+                0,
+                shadow_channel.user_channel_id.to_u128(),
+                Some(channel_config),
+            )
+            .map_err(|e| anyhow!("Failed to open just in time channel: {e:?}"))?;
 
         tracing::info!(
             peer = %target_node_id,
+            %payment_hash,
             temp_channel_id = %hex::encode(temp_channel_id),
-            "Started channel creation for in-flight payment"
+            "Started JIT channel creation for intercepted HTLC"
         );
 
-        let mut pending_intercepted_htlcs = self.pending_intercepted_htlcs_lock();
-
-        pending_intercepted_htlcs.insert(
+        self.pending_intercepted_htlcs_lock().insert(
             target_node_id,
             (intercept_id, expected_outbound_amount_msat),
         );

--- a/crates/ln-dlc-node/src/node/invoice.rs
+++ b/crates/ln-dlc-node/src/node/invoice.rs
@@ -221,7 +221,8 @@ where
         &self,
         hash: &sha256::Hash,
     ) -> Result<(), tokio::time::error::Elapsed> {
-        self.wait_for_payment(HTLCStatus::Succeeded, hash).await
+        self.wait_for_payment(HTLCStatus::Succeeded, hash, None)
+            .await
     }
 
     #[autometrics]
@@ -229,6 +230,7 @@ where
         &self,
         expected_status: HTLCStatus,
         hash: &sha256::Hash,
+        timeout: Option<Duration>,
     ) -> Result<(), tokio::time::error::Elapsed> {
         assert_ne!(
             expected_status,
@@ -237,7 +239,7 @@ where
         );
         let payment_hash = PaymentHash(hash.into_inner());
 
-        tokio::time::timeout(Duration::from_secs(10), async {
+        tokio::time::timeout(timeout.unwrap_or(Duration::from_secs(10)), async {
             loop {
                 tokio::time::sleep(Duration::from_secs(1)).await;
 

--- a/crates/ln-dlc-node/src/tests/dlc/collaborative_settlement.rs
+++ b/crates/ln-dlc-node/src/tests/dlc/collaborative_settlement.rs
@@ -35,7 +35,7 @@ async fn dlc_collaborative_settlement_test() {
         .unwrap();
 
     coordinator
-        .open_channel(&app, coordinator_ln_balance, app_ln_balance)
+        .open_private_channel(&app, coordinator_ln_balance, app_ln_balance)
         .await
         .unwrap();
 
@@ -106,7 +106,7 @@ async fn open_dlc_channel_after_closing_dlc_channel() {
         .unwrap();
 
     coordinator
-        .open_channel(&app, coordinator_ln_balance, app_ln_balance)
+        .open_private_channel(&app, coordinator_ln_balance, app_ln_balance)
         .await
         .unwrap();
 

--- a/crates/ln-dlc-node/src/tests/dlc/create.rs
+++ b/crates/ln-dlc-node/src/tests/dlc/create.rs
@@ -35,7 +35,7 @@ async fn given_lightning_channel_then_can_add_dlc_channel() {
         .unwrap();
 
     coordinator
-        .open_channel(&app, coordinator_ln_balance, app_ln_balance)
+        .open_private_channel(&app, coordinator_ln_balance, app_ln_balance)
         .await
         .unwrap();
 

--- a/crates/ln-dlc-node/src/tests/dlc/dlc_setup_with_reconnects.rs
+++ b/crates/ln-dlc-node/src/tests/dlc/dlc_setup_with_reconnects.rs
@@ -32,7 +32,7 @@ async fn reconnecting_during_dlc_channel_setup() {
         .unwrap();
 
     coordinator
-        .open_channel(&app, 50_000, 50_000)
+        .open_private_channel(&app, 50_000, 50_000)
         .await
         .unwrap();
     let channel_details = app.channel_manager.list_usable_channels();
@@ -253,7 +253,7 @@ async fn can_lose_connection_before_processing_subchannel_close_finalize() {
         .unwrap();
 
     coordinator
-        .open_channel(&app, coordinator_ln_balance, app_ln_balance)
+        .open_private_channel(&app, coordinator_ln_balance, app_ln_balance)
         .await
         .unwrap();
 

--- a/crates/ln-dlc-node/src/tests/dlc/non_collaborative_settlement.rs
+++ b/crates/ln-dlc-node/src/tests/dlc/non_collaborative_settlement.rs
@@ -31,7 +31,7 @@ async fn force_close_ln_dlc_channel() {
         .unwrap();
 
     let channel_details = coordinator
-        .open_channel(&app, coordinator_ln_balance, app_ln_balance)
+        .open_private_channel(&app, coordinator_ln_balance, app_ln_balance)
         .await
         .unwrap();
 

--- a/crates/ln-dlc-node/src/tests/just_in_time_channel/create.rs
+++ b/crates/ln-dlc-node/src/tests/just_in_time_channel/create.rs
@@ -36,7 +36,8 @@ async fn open_jit_channel() {
         ..LnDlcNodeSettings::default()
     };
     let coordinator =
-        Node::start_test_coordinator_internal("coordinator", storage.clone(), settings).unwrap();
+        Node::start_test_coordinator_internal("coordinator", storage.clone(), settings, None)
+            .unwrap();
     let payee = Node::start_test_app("payee").unwrap();
 
     payer.connect(coordinator.info).await.unwrap();
@@ -137,7 +138,7 @@ async fn fail_to_open_jit_channel_with_fee_rate_over_max() {
     // We would like to assert on the payment failing, but this is not guaranteed as the payment can
     // still be retried after the first payment path failure. Thus, we check that it doesn't succeed
     payee
-        .wait_for_payment(HTLCStatus::Succeeded, invoice.payment_hash())
+        .wait_for_payment(HTLCStatus::Succeeded, invoice.payment_hash(), None)
         .await
         .expect_err("payment should not succeed");
 }

--- a/crates/ln-dlc-node/src/tests/just_in_time_channel/fail_intercepted_htlc.rs
+++ b/crates/ln-dlc-node/src/tests/just_in_time_channel/fail_intercepted_htlc.rs
@@ -1,0 +1,179 @@
+use crate::ln::HTLC_INTERCEPTED_CONNECTION_TIMEOUT;
+use crate::node::InMemoryStore;
+use crate::node::LnDlcNodeSettings;
+use crate::node::Node;
+use crate::tests::init_tracing;
+use crate::tests::setup_coordinator_payer_channel;
+use crate::HTLCStatus;
+use bitcoin::Amount;
+use lightning::util::events::Event;
+use std::sync::Arc;
+use std::time::Duration;
+
+#[tokio::test(flavor = "multi_thread")]
+#[ignore]
+async fn fail_intercepted_htlc_if_coordinator_cannot_reconnect_to_payee() {
+    init_tracing();
+
+    // Arrange
+
+    let payer = Node::start_test_app("payer").unwrap();
+    let coordinator = Node::start_test_coordinator("coordinator").unwrap();
+    let payee = Node::start_test_app("payee").unwrap();
+
+    payer.connect(coordinator.info).await.unwrap();
+    payee.connect(coordinator.info).await.unwrap();
+
+    let invoice_amount = 10_000;
+    setup_coordinator_payer_channel(invoice_amount, &coordinator, &payer).await;
+
+    let interceptable_route_hint_hop = coordinator.prepare_jit_channel(payee.info.pubkey);
+
+    let invoice = payee
+        .create_interceptable_invoice(
+            Some(invoice_amount),
+            0,
+            "interceptable-invoice".to_string(),
+            interceptable_route_hint_hop,
+        )
+        .unwrap();
+
+    // Act
+
+    // We wait a second for payee and coordinator to be disconnected
+    payee.disconnect(coordinator.info);
+    tokio::time::sleep(Duration::from_secs(1)).await;
+
+    payer.send_payment(&invoice).unwrap();
+
+    // Assert
+
+    payer
+        .wait_for_payment(
+            HTLCStatus::Failed,
+            invoice.payment_hash(),
+            // We wait a bit longer than what the coordinator should wait for the payee to
+            // reconnect
+            Some(Duration::from_secs(HTLC_INTERCEPTED_CONNECTION_TIMEOUT + 5)),
+        )
+        .await
+        .unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[ignore]
+async fn fail_intercepted_htlc_if_connection_lost_after_funding_tx_generated() {
+    init_tracing();
+
+    // Arrange
+
+    let payer = Node::start_test_app("payer").unwrap();
+
+    let (coordinator, mut ldk_node_event_receiver_coordinator) = {
+        let (sender, receiver) = tokio::sync::watch::channel(None);
+        let node = Node::start_test_coordinator_internal(
+            "coordinator",
+            Arc::new(InMemoryStore::default()),
+            LnDlcNodeSettings::default(),
+            Some(sender),
+        )
+        .unwrap();
+
+        (node, receiver)
+    };
+
+    let payee = Node::start_test_app("payee").unwrap();
+
+    payer.connect(coordinator.info).await.unwrap();
+    payee.connect(coordinator.info).await.unwrap();
+
+    let invoice_amount = 10_000;
+    setup_coordinator_payer_channel(invoice_amount, &coordinator, &payer).await;
+
+    let interceptable_route_hint_hop = coordinator.prepare_jit_channel(payee.info.pubkey);
+
+    let invoice = payee
+        .create_interceptable_invoice(
+            Some(invoice_amount),
+            0,
+            "interceptable-invoice".to_string(),
+            interceptable_route_hint_hop,
+        )
+        .unwrap();
+
+    // Act
+
+    payer.send_payment(&invoice).unwrap();
+
+    tokio::time::timeout(Duration::from_secs(30), async {
+        loop {
+            ldk_node_event_receiver_coordinator.changed().await.unwrap();
+            let event = ldk_node_event_receiver_coordinator.borrow().clone();
+
+            if let Some(Event::FundingGenerationReady { .. }) = event {
+                // We wait a second for payee and coordinator to be disconnected
+                payee.disconnect(coordinator.info);
+                tokio::time::sleep(Duration::from_secs(1)).await;
+
+                break;
+            }
+        }
+    })
+    .await
+    .unwrap();
+
+    // Assert
+
+    payer
+        .wait_for_payment(HTLCStatus::Failed, invoice.payment_hash(), None)
+        .await
+        .unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[ignore]
+async fn fail_intercepted_htlc_if_coordinator_cannot_pay_to_open_jit_channel() {
+    init_tracing();
+
+    // Arrange
+
+    let payer = Node::start_test_app("payer").unwrap();
+    let coordinator = Node::start_test_coordinator("coordinator").unwrap();
+    let payee = Node::start_test_app("payee").unwrap();
+
+    payer.connect(coordinator.info).await.unwrap();
+    payee.connect(coordinator.info).await.unwrap();
+
+    let payer_outbound_liquidity = 200_000;
+
+    payer.fund(Amount::ONE_BTC).await.unwrap();
+    payer
+        .open_public_channel(&coordinator, payer_outbound_liquidity, 0)
+        .await
+        .unwrap();
+
+    // Act
+
+    // The coordinator should not be able to open any JIT channel because we have not funded their
+    // on-chain wallet
+    let invoice_amount = 10_000;
+
+    let interceptable_route_hint_hop = coordinator.prepare_jit_channel(payee.info.pubkey);
+    let invoice = payee
+        .create_interceptable_invoice(
+            Some(invoice_amount),
+            0,
+            "interceptable-invoice".to_string(),
+            interceptable_route_hint_hop,
+        )
+        .unwrap();
+
+    payer.send_payment(&invoice).unwrap();
+
+    // Assert
+
+    payer
+        .wait_for_payment(HTLCStatus::Failed, invoice.payment_hash(), None)
+        .await
+        .unwrap();
+}

--- a/crates/ln-dlc-node/src/tests/just_in_time_channel/mod.rs
+++ b/crates/ln-dlc-node/src/tests/just_in_time_channel/mod.rs
@@ -1,3 +1,4 @@
 mod channel_close;
 mod create;
+mod fail_intercepted_htlc;
 mod multiple_payments;

--- a/crates/ln-dlc-node/src/tests/load.rs
+++ b/crates/ln-dlc-node/src/tests/load.rs
@@ -39,6 +39,7 @@ async fn single_app_many_positions_load() {
             },
             Arc::new(InMemoryStore::default()),
             LnDlcNodeSettings::default(),
+            None,
         )
         .unwrap(),
     );

--- a/crates/ln-dlc-node/src/tests/multi_hop_payment.rs
+++ b/crates/ln-dlc-node/src/tests/multi_hop_payment.rs
@@ -26,7 +26,7 @@ async fn multi_hop_payment() {
     let coordinator_outbound_liquidity_sat =
         min_outbound_liquidity_channel_creator(&payer, payer_outbound_liquidity_sat);
     coordinator
-        .open_channel(
+        .open_private_channel(
             &payer,
             coordinator_outbound_liquidity_sat,
             payer_outbound_liquidity_sat,
@@ -34,7 +34,10 @@ async fn multi_hop_payment() {
         .await
         .unwrap();
 
-    coordinator.open_channel(&payee, 20_000, 0).await.unwrap();
+    coordinator
+        .open_private_channel(&payee, 20_000, 0)
+        .await
+        .unwrap();
 
     let payer_balance_before = payer.get_ldk_balance();
     let coordinator_balance_before = coordinator.get_ldk_balance();

--- a/crates/ln-dlc-node/src/tests/single_hop_payment.rs
+++ b/crates/ln-dlc-node/src/tests/single_hop_payment.rs
@@ -16,7 +16,7 @@ async fn single_hop_payment() {
 
     payer.fund(Amount::from_btc(0.1).unwrap()).await.unwrap();
 
-    payer.open_channel(&payee, 30_000, 0).await.unwrap();
+    payer.open_private_channel(&payee, 30_000, 0).await.unwrap();
 
     let payer_balance_before = payer.get_ldk_balance();
     let payee_balance_before = payee.get_ldk_balance();


### PR DESCRIPTION
Fixes #943.
Fixes #944.

---

This is yet another instance where we have to consider the fact that the same event handler code runs for both app and coordinator even though certain parts need to be specific to each role. I've increased the implicit annoyance counter of https://github.com/get10101/10101/issues/885.