### PR TITLE
fix: Query fee estimates from internal port 80

### DIFF
--- a/services/faucet/lnd.conf
+++ b/services/faucet/lnd.conf
@@ -34,7 +34,7 @@ payments-expiration-grace-period=30s
 maxpendingchannels=10
 
 # we using a static fee estimates for our local test
-feeurl=http://10.5.0.7:8080/fee/btc-fee-estimates.json
+feeurl=http://10.5.0.7/fee/btc-fee-estimates.json
 
 # 400 MB (1024 * 1024 * 400)
 blockcachesize=419430400


### PR DESCRIPTION
Internally the faucet is listening to the port 80. This is fixing the following error messages in lnd.

```
2023-07-22 05:18:04.923 [ERR] LNWL: unable to query web api for fee response: Get "http://10.5.0.7:8080/fee/btc-fee-estimates.json": dial tcp 10.5.0.7:8080: connect: connection refused
2023-07-22 05:18:04.923 [ERR] LNWL: unable to query estimator: web API error: fee rate cache is empty
``