### PR TITLE
feat: Display service status in the app

### DIFF
--- a/crates/tests-e2e/src/test_subscriber.rs
+++ b/crates/tests-e2e/src/test_subscriber.rs
@@ -68,7 +68,7 @@ impl TestSubscriber {
             let services = services.clone();
             tokio::spawn(async move {
                 while let Ok(()) = service_rx.changed().await {
-                    if let Some((service, status)) = *service_rx.borrow() {
+                    if let Some(ServiceUpdate { service, status }) = *service_rx.borrow() {
                         tracing::debug!(?service, ?status, "Updating status in the services map");
                         services
                             .lock()
@@ -181,7 +181,7 @@ impl Senders {
                 self.prices.send(Some(prices.clone()))?;
             }
             native::event::EventInternal::ServiceHealthUpdate(update) => {
-                self.service.send(Some(*update))?;
+                self.service.send(Some(update.clone()))?;
             }
             native::event::EventInternal::ChannelReady(_channel_id) => {
                 unreachable!("ChannelReady event should not be sent to the subscriber");

--- a/mobile/lib/common/app_bar_wrapper.dart
+++ b/mobile/lib/common/app_bar_wrapper.dart
@@ -1,6 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:get_10101/common/color.dart';
 import 'package:get_10101/features/trade/settings_screen.dart';
+import 'package:get_10101/features/trade/trade_screen.dart';
+import 'package:get_10101/features/wallet/settings_screen.dart';
+import 'package:get_10101/features/wallet/wallet_screen.dart';
+import 'package:get_10101/features/wallet/status_screen.dart';
 import 'package:go_router/go_router.dart';
 
 class AppBarWrapper extends StatelessWidget {
@@ -10,16 +14,44 @@ class AppBarWrapper extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final currentRoute = GoRouterState.of(context).location;
     const appBarHeight = 35.0;
 
-    var actionButtons = <Widget>[];
-    Widget leadingButton = IconButton(
-      icon: const Icon(Icons.settings),
-      tooltip: 'Settings',
-      onPressed: () {
-        context.go(TradeSettingsScreen.route);
-      },
-    );
+    var actionButtons = [
+      IconButton(
+        icon: const Icon(Icons.thermostat),
+        tooltip: 'Status',
+        onPressed: () {
+          context.go(WalletStatusScreen.route);
+        },
+      )
+    ];
+
+    Widget? leadingButton;
+
+    if (currentRoute == WalletScreen.route) {
+      leadingButton = Row(mainAxisSize: MainAxisSize.min, children: [
+        IconButton(
+          icon: const Icon(Icons.settings),
+          tooltip: 'Settings',
+          onPressed: () {
+            context.go(WalletSettingsScreen.route);
+          },
+        )
+      ]);
+    }
+
+    if (currentRoute == TradeScreen.route) {
+      leadingButton = Row(mainAxisSize: MainAxisSize.min, children: [
+        IconButton(
+          icon: const Icon(Icons.settings),
+          tooltip: 'Settings',
+          onPressed: () {
+            context.go(TradeSettingsScreen.route);
+          },
+        )
+      ]);
+    }
 
     return Container(
         margin: const EdgeInsets.only(left: 2.0),

--- a/mobile/lib/common/domain/service_status.dart
+++ b/mobile/lib/common/domain/service_status.dart
@@ -1,0 +1,6 @@
+import 'package:get_10101/bridge_generated/bridge_definitions.dart' as bridge;
+
+bridge.ServiceUpdate serviceUpdateApiDummy() {
+  return const bridge.ServiceUpdate(
+      service: bridge.Service.Orderbook, status: bridge.ServiceStatus.Unknown);
+}

--- a/mobile/lib/common/service_status_notifier.dart
+++ b/mobile/lib/common/service_status_notifier.dart
@@ -1,0 +1,44 @@
+import 'package:f_logs/f_logs.dart';
+import 'package:flutter/material.dart';
+import 'package:get_10101/bridge_generated/bridge_definitions.dart' as bridge;
+import 'package:get_10101/common/application/event_service.dart';
+
+class ServiceStatusNotifier extends ChangeNotifier implements Subscriber {
+  Map<bridge.Service, bridge.ServiceStatus> services = <bridge.Service, bridge.ServiceStatus>{};
+
+  ServiceStatusNotifier();
+
+  bridge.ServiceStatus getServiceStatus(bridge.Service service) {
+    return services[service] ?? bridge.ServiceStatus.Unknown;
+  }
+
+  /// Overall health status of the application
+  bridge.ServiceStatus overall() {
+    return foldValues(services);
+  }
+
+  @override
+  void notify(bridge.Event event) {
+    if (event is bridge.Event_ServiceHealthUpdate) {
+      FLog.debug(text: "Received event: ${event.toString()}");
+      var update = event.field0;
+      services[update.service] = update.status;
+    } else {
+      FLog.warning(text: "Received unexpected event: ${event.toString()}");
+    }
+    notifyListeners();
+  }
+}
+
+bridge.ServiceStatus foldValues(Map<bridge.Service, bridge.ServiceStatus> map) {
+  return map.values.fold(bridge.ServiceStatus.Online, (previousValue, element) {
+    if (previousValue == bridge.ServiceStatus.Offline || element == bridge.ServiceStatus.Offline) {
+      return bridge.ServiceStatus.Offline;
+    } else if (previousValue == bridge.ServiceStatus.Unknown ||
+        element == bridge.ServiceStatus.Unknown) {
+      return bridge.ServiceStatus.Unknown;
+    } else {
+      return bridge.ServiceStatus.Online;
+    }
+  });
+}

--- a/mobile/lib/common/service_status_notifier_test.dart
+++ b/mobile/lib/common/service_status_notifier_test.dart
@@ -1,0 +1,31 @@
+import 'package:get_10101/common/service_status_notifier.dart';
+import 'package:get_10101/bridge_generated/bridge_definitions.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('Fold values in service map to determine overall status', () {
+    Map<Service, ServiceStatus> testMap1 = <Service, ServiceStatus>{
+      Service.Orderbook: ServiceStatus.Online,
+      Service.Coordinator: ServiceStatus.Online,
+    };
+    expect(foldValues(testMap1), ServiceStatus.Online, reason: 'Everything is online');
+
+    Map<Service, ServiceStatus> testMap2 = <Service, ServiceStatus>{
+      Service.Orderbook: ServiceStatus.Online,
+      Service.Coordinator: ServiceStatus.Unknown,
+    };
+    expect(foldValues(testMap2), ServiceStatus.Unknown, reason: 'At least one service is unknown');
+
+    Map<Service, ServiceStatus> testMap3 = <Service, ServiceStatus>{
+      Service.Orderbook: ServiceStatus.Offline,
+      Service.Coordinator: ServiceStatus.Online,
+    };
+    expect(foldValues(testMap3), ServiceStatus.Offline, reason: 'At least one service is offline');
+
+    Map<Service, ServiceStatus> testMap4 = <Service, ServiceStatus>{
+      Service.Orderbook: ServiceStatus.Unknown,
+      Service.Coordinator: ServiceStatus.Offline,
+    };
+    expect(foldValues(testMap4), ServiceStatus.Offline, reason: 'At least one service is offline');
+  });
+}

--- a/mobile/lib/common/status_screen.dart
+++ b/mobile/lib/common/status_screen.dart
@@ -1,0 +1,76 @@
+import 'package:flutter/material.dart';
+import 'package:get_10101/bridge_generated/bridge_definitions.dart';
+import 'package:get_10101/common/service_status_notifier.dart';
+import 'package:get_10101/common/value_data_row.dart';
+import 'package:provider/provider.dart';
+
+class StatusScreen extends StatefulWidget {
+  const StatusScreen({required this.fromRoute, super.key});
+
+  final String fromRoute;
+
+  @override
+  State<StatusScreen> createState() => _StatusScreenState();
+}
+
+class _StatusScreenState extends State<StatusScreen> {
+  @override
+  Widget build(BuildContext context) {
+    ServiceStatusNotifier serviceStatusNotifier = context.watch<ServiceStatusNotifier>();
+
+    final orderbookStatus =
+        statusToString(serviceStatusNotifier.getServiceStatus(Service.Orderbook));
+    final coordinatorStatus =
+        statusToString(serviceStatusNotifier.getServiceStatus(Service.Coordinator));
+    final overallStatus = statusToString(serviceStatusNotifier.overall());
+
+    return Scaffold(
+      appBar: AppBar(title: const Text("Status")),
+      body: SafeArea(
+        child: Center(
+            child: Padding(
+                padding: const EdgeInsets.all(32.0),
+                child: Column(
+                  children: [
+                    const SizedBox(height: 20),
+                    ValueDataRow(
+                      type: ValueType.text,
+                      value: overallStatus,
+                      label: "App health",
+                    ),
+                    const Divider(),
+                    ValueDataRow(
+                      type: ValueType.text,
+                      value: orderbookStatus,
+                      label: "Orderbook",
+                    ),
+                    const SizedBox(height: 10),
+                    ValueDataRow(
+                      type: ValueType.text,
+                      value: coordinatorStatus,
+                      label: "LSP",
+                    ),
+                  ],
+                ))),
+      ),
+    );
+  }
+
+  @override
+  void initState() {
+    super.initState();
+  }
+}
+
+String statusToString(ServiceStatus enumValue) {
+  switch (enumValue) {
+    case ServiceStatus.Offline:
+      return "Offline";
+    case ServiceStatus.Online:
+      return "Online";
+    case ServiceStatus.Unknown:
+      return "Unknown";
+    default:
+      throw Exception("Unknown enum value: $enumValue");
+  }
+}

--- a/mobile/lib/features/trade/status_screen.dart
+++ b/mobile/lib/features/trade/status_screen.dart
@@ -1,0 +1,15 @@
+import 'package:flutter/material.dart';
+import 'package:get_10101/common/status_screen.dart';
+import 'package:get_10101/features/trade/trade_screen.dart';
+
+class TradeStatusScreen extends StatelessWidget {
+  static const route = "${TradeScreen.route}/$subRouteName";
+  static const subRouteName = "status";
+
+  const TradeStatusScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const StatusScreen(fromRoute: route);
+  }
+}

--- a/mobile/lib/features/wallet/status_screen.dart
+++ b/mobile/lib/features/wallet/status_screen.dart
@@ -1,0 +1,15 @@
+import 'package:flutter/material.dart';
+import 'package:get_10101/common/status_screen.dart';
+import 'package:get_10101/features/wallet/wallet_screen.dart';
+
+class WalletStatusScreen extends StatelessWidget {
+  static const route = "${WalletScreen.route}/$subRouteName";
+  static const subRouteName = "status";
+
+  const WalletStatusScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const StatusScreen(fromRoute: route);
+  }
+}

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -7,14 +7,17 @@ import 'package:get_10101/bridge_generated/bridge_definitions.dart' as bridge;
 import 'package:get_10101/common/application/channel_info_service.dart';
 import 'package:get_10101/common/application/event_service.dart';
 import 'package:get_10101/common/color.dart';
+import 'package:get_10101/common/service_status_notifier.dart';
 import 'package:get_10101/features/trade/application/candlestick_service.dart';
 import 'package:get_10101/features/trade/application/order_service.dart';
 import 'package:get_10101/features/trade/application/position_service.dart';
 import 'package:get_10101/features/trade/application/trade_values_service.dart';
 import 'package:get_10101/features/trade/candlestick_change_notifier.dart';
 import 'package:get_10101/features/trade/domain/position.dart';
+import 'package:get_10101/common/domain/service_status.dart';
 import 'package:get_10101/features/trade/order_change_notifier.dart';
 import 'package:get_10101/features/trade/position_change_notifier.dart';
+import 'package:get_10101/features/trade/status_screen.dart';
 import 'package:get_10101/features/trade/submit_order_change_notifier.dart';
 import 'package:get_10101/features/trade/trade_value_change_notifier.dart';
 import 'package:get_10101/features/trade/settings_screen.dart';
@@ -29,6 +32,7 @@ import 'package:get_10101/features/wallet/scanner_screen.dart';
 import 'package:get_10101/features/wallet/send_screen.dart';
 import 'package:get_10101/features/wallet/settings_screen.dart';
 import 'package:get_10101/features/trade/trade_screen.dart';
+import 'package:get_10101/features/wallet/status_screen.dart';
 import 'package:get_10101/features/wallet/wallet_change_notifier.dart';
 import 'package:get_10101/features/wallet/wallet_screen.dart';
 import 'package:get_10101/common/app_bar_wrapper.dart';
@@ -69,6 +73,7 @@ void main() {
     ChangeNotifierProvider(create: (context) => SendPaymentChangeNotifier(const WalletService())),
     ChangeNotifierProvider(
         create: (context) => CandlestickChangeNotifier(const CandlestickService())),
+    ChangeNotifierProvider(create: (context) => ServiceStatusNotifier()),
     Provider(create: (context) => Environment.parse()),
     Provider(create: (context) => channelInfoService)
   ], child: const TenTenOneApp()));
@@ -162,6 +167,12 @@ class _TenTenOneAppState extends State<TenTenOneApp> {
                     parentNavigatorKey: _rootNavigatorKey,
                     builder: (BuildContext context, GoRouterState state) {
                       return const WalletSettingsScreen();
+                    }),
+                GoRoute(
+                    path: WalletStatusScreen.subRouteName,
+                    parentNavigatorKey: _rootNavigatorKey,
+                    builder: (BuildContext context, GoRouterState state) {
+                      return const WalletStatusScreen();
                     })
               ],
             ),
@@ -176,6 +187,12 @@ class _TenTenOneAppState extends State<TenTenOneApp> {
                     parentNavigatorKey: _rootNavigatorKey,
                     builder: (BuildContext context, GoRouterState state) {
                       return const TradeSettingsScreen();
+                    }),
+                GoRoute(
+                    path: TradeStatusScreen.subRouteName,
+                    parentNavigatorKey: _rootNavigatorKey,
+                    builder: (BuildContext context, GoRouterState state) {
+                      return const TradeStatusScreen();
                     })
               ],
             ),
@@ -384,6 +401,7 @@ void subscribeToNotifiers(BuildContext context) {
   final walletChangeNotifier = context.read<WalletChangeNotifier>();
   final tradeValuesChangeNotifier = context.read<TradeValuesChangeNotifier>();
   final submitOrderChangeNotifier = context.read<SubmitOrderChangeNotifier>();
+  final serviceStatusNotifier = context.read<ServiceStatusNotifier>();
 
   eventService.subscribe(
       orderChangeNotifier, bridge.Event.orderUpdateNotification(Order.apiDummy()));
@@ -407,6 +425,9 @@ void subscribeToNotifiers(BuildContext context) {
 
   eventService.subscribe(
       positionChangeNotifier, bridge.Event.priceUpdateNotification(Price.apiDummy()));
+
+  eventService.subscribe(
+      serviceStatusNotifier, bridge.Event.serviceHealthUpdate(serviceUpdateApiDummy()));
 
   eventService.subscribe(
       AnonSubscriber((event) => FLog.info(text: event.field0)), const bridge.Event.log(""));

--- a/mobile/native/src/event/api.rs
+++ b/mobile/native/src/event/api.rs
@@ -81,6 +81,7 @@ pub struct FlutterSubscriber {
 /// Subscribes to event relevant for flutter and forwards them to the stream sink.
 impl Subscriber for FlutterSubscriber {
     fn notify(&self, event: &EventInternal) {
+        tracing::debug!(?event, "Forwarding event to flutter");
         self.stream.add(event.clone().into());
     }
 
@@ -92,6 +93,7 @@ impl Subscriber for FlutterSubscriber {
             EventType::PositionUpdateNotification,
             EventType::PositionClosedNotification,
             EventType::PriceUpdateNotification,
+            EventType::ServiceHealthUpdate,
         ]
     }
 }

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -201,6 +201,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.1.1"
+  coverage:
+    dependency: transitive
+    description:
+      name: coverage
+      sha256: "2fb815080e44a09b85e0f2ca8a820b15053982b2e714b59267719e8a9ff17097"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.6.3"
   cross_file:
     dependency: transitive
     description:
@@ -552,6 +560,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.0"
+  node_preamble:
+    dependency: transitive
+    description:
+      name: node_preamble
+      sha256: "6e7eac89047ab8a8d26cf16127b5ed26de65209847630400f9aefd7cd5c730db"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.2"
   package_config:
     dependency: transitive
     description:
@@ -840,6 +856,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.1"
+  shelf_packages_handler:
+    dependency: transitive
+    description:
+      name: shelf_packages_handler
+      sha256: "89f967eca29607c933ba9571d838be31d67f53f6e4ee15147d5dc2934fee1b1e"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.2"
   shelf_static:
     dependency: transitive
     description:
@@ -877,6 +901,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.0"
+  source_map_stack_trace:
+    dependency: transitive
+    description:
+      name: source_map_stack_trace
+      sha256: "84cf769ad83aa6bb61e0aa5a18e53aea683395f196a6f39c4c881fb90ed4f7ae"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.1"
+  source_maps:
+    dependency: transitive
+    description:
+      name: source_maps
+      sha256: "708b3f6b97248e5781f493b765c3337db11c5d2c81c3094f10904bfa8004c703"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.10.12"
   source_span:
     dependency: transitive
     description:
@@ -933,11 +973,27 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.2.1"
+  test:
+    dependency: "direct main"
+    description:
+      name: test
+      sha256: "3dac9aecf2c3991d09b9cdde4f98ded7b30804a88a0d7e4e7e1678e78d6b97f4"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.24.1"
   test_api:
     dependency: transitive
     description:
       name: test_api
       sha256: eb6ac1540b26de412b3403a163d919ba86f6a973fe6cc50ae3541b80092fdcfb
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.5.1"
+  test_core:
+    dependency: transitive
+    description:
+      name: test_core
+      sha256: "5138dbffb77b2289ecb12b81c11ba46036590b72a64a7a90d6ffb880f1a29e93"
       url: "https://pub.dev"
     source: hosted
     version: "0.5.1"
@@ -1053,6 +1109,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
+  vm_service:
+    dependency: transitive
+    description:
+      name: vm_service
+      sha256: ada49637c27973c183dad90beb6bd781eea4c9f5f955d35da172de0af7bd3440
+      url: "https://pub.dev"
+    source: hosted
+    version: "11.8.0"
   watcher:
     dependency: transitive
     description:
@@ -1069,6 +1133,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.4.0"
+  webkit_inspection_protocol:
+    dependency: transitive
+    description:
+      name: webkit_inspection_protocol
+      sha256: "67d3a8b6c79e1987d19d848b0892e582dbb0c66c57cc1fef58a177dd2aa2823d"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.0"
   win32:
     dependency: transitive
     description:

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -32,6 +32,7 @@ dependencies:
   package_info_plus: ^4.0.2
   uuid: ^3.0.7
   confetti: ^0.7.0
+  test: ^1.24.1
 dev_dependencies:
   flutter_launcher_icons: ^0.13.1
   flutter_test:


### PR DESCRIPTION
- Add the status to the AppBar, next to Settings screen
- display service status as well as overall status

TODO:
  - [ ] Colour-coding for the status?
  - [ ] Status icon should be a circle coloured with the value of enum

Posting as-is as I suspect that this will spark the conversation whether we'd
like to have a hamburger menu or not instead of row of icons.


https://github.com/get10101/10101/assets/8319440/459362cb-a2ba-4572-8f17-23f13ad5b3a6

only difference since the video: "overall" -> "App Health"
