### PR TITLE
bug - cannot fund wallet after open/close position

### DIFF
--- a/crates/tests-e2e/src/fund.rs
+++ b/crates/tests-e2e/src/fund.rs
@@ -26,7 +26,7 @@ pub async fn fund_app_with_faucet(client: &Client, funding_amount: u64) -> Resul
     Ok(funding_amount - FUNDING_TRANSACTION_FEES)
 }
 
-async fn pay_with_faucet(client: &Client, invoice: String) -> Result<()> {
+pub async fn pay_with_faucet(client: &Client, invoice: String) -> Result<()> {
     tracing::info!("Paying invoice with faucet: {}", invoice);
 
     #[derive(serde::Serialize)]

--- a/crates/tests-e2e/tests/close_position.rs
+++ b/crates/tests-e2e/tests/close_position.rs
@@ -1,5 +1,6 @@
 use native::api::{self};
 use native::trade::position::PositionState;
+use tests_e2e::fund::pay_with_faucet;
 use tests_e2e::setup;
 use tests_e2e::setup::dummy_order;
 use tests_e2e::wait_until;
@@ -24,4 +25,24 @@ async fn can_collab_close_position() {
     wait_until!(test.app.rx.position().unwrap().position_state == PositionState::Closing);
 
     // TODO: Assert that the position is closed in the app and the coordinator
+
+    tracing::info!("Position closed");
+
+    // Ensure we sync the wallet info after funding
+    spawn_blocking(move || api::refresh_wallet_info().expect("to succeed"))
+        .await
+        .unwrap();
+
+    let balance_at_closing = test.app.rx.wallet_info().unwrap().balances.on_chain;
+
+    let invoice =
+        spawn_blocking(move || api::create_invoice_with_amount(50_000).expect("to succeed"))
+            .await
+            .unwrap();
+    api::decode_invoice(invoice.clone()).expect("to decode invoice we created");
+
+    let client = reqwest::Client::new();
+    pay_with_faucet(&client, invoice).await.unwrap();
+
+    wait_until!(test.app.rx.wallet_info().unwrap().balances.on_chain > balance_at_closing);
 }


### PR DESCRIPTION
After trying to add balance to the wallet after closing a position, it says that
it cannot find a route from the faucet to the app.

This should not be the case.