### PR TITLE
Add `await` to fix app initialisation

### DIFF
--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -257,9 +257,8 @@ class _TenTenOneAppState extends State<TenTenOneApp> {
 
       subscribeToNotifiers(context);
 
-      runBackend(config).then((_) {
-        FLog.info(text: "Backend started");
-      });
+      await runBackend(config);
+      FLog.info(text: "Backend started");
 
       await orderChangeNotifier.initialize();
       await positionChangeNotifier.initialize();


### PR DESCRIPTION
If this is not awaited, then something tries to access the database before it is ready.

@klochowicz I think you just left this out by mistake?  Trivial fix in the end!

Fixes #1002.