### PR TITLE
Allow force-closing LN-DLC channel in all intermediate states

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - Automatically retry spendable outputs if not successfully published
+- Permit the closure of the LN-DLC channel in any intermediate state.
 
 ## [1.1.0] - 2023-07-27
 
@@ -16,10 +17,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Track channel data.
 - Track channel liquidity.
 - Track on-chain transactions.
-- Display service status in the app.
-- Fail HTLCs backwards in all scenarios.
-- Show local time in candlestick chart.
-- Enable wumbo channels for up to 1 BTC.
 
 ## [1.0.21] - 2023-07-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,55 +11,55 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.1.0] - 2023-07-27
 
-- Charge funding transaction on-chain fees upon receiving and inbound JIT Channel
-- Added prometheus metrics to coordinator: `channel_balance_satoshi`, `channel_outbound_capacity_satoshi`, `channel_inbound_capacity_satoshi`, `channel_is_usable`, `node_connected_peers_total`, `node_balance_satoshi`, `position_quantity_contracts`, `position_margin_sats`
-- Track channel data
-- Track channel liquidity
-- Track on-chain transactions
-- Display service status in the app
-- Fail HTLCs backwards
-- Show local time in candlestick chart
-- Enable wumbo channels for up to 1 BTC
+- Charge funding transaction on-chain fees upon receiving and inbound JIT Channel.
+- Added `prometheus` metrics to coordinator: `channel_balance_satoshi`, `channel_outbound_capacity_satoshi`, `channel_inbound_capacity_satoshi`, `channel_is_usable`, `node_connected_peers_total`, `node_balance_satoshi`, `position_quantity_contracts`, `position_margin_sats`.
+- Track channel data.
+- Track channel liquidity.
+- Track on-chain transactions.
+- Display service status in the app.
+- Fail HTLCs backwards in all scenarios.
+- Show local time in candlestick chart.
+- Enable wumbo channels for up to 1 BTC.
 
 ## [1.0.21] - 2023-07-02
 
 - Fix issue where `Next` button on the create invoice screen was hidden behind keyboard. The keyboard can now be closed by tapping outside the text-field.
 - Fix panic when processing accept message while peer is disconnected.
-- Configurable oracle endpoint and public key
+- Configurable oracle endpoint and public key.
 - Removed stop-gap from receiving payments with open position.
 - Reduced min amount of 50k sats on receiving payments.
 
 ## [1.0.20] - 2023-06-16
 
-- Do not trigger DLC manager periodic check twice
-- Simplify maker binary
-- Prefer unused addresses to new ones (temporarily)
-- chore: Remove share on twitter button temporarily
-- Use address caches in LnDlcWallet
-- Set background transaction priority to 24 blocks
-- Improve error message when trying to collab close LN with DLC channel
-- Simplify deserialisation of channel ID
-- Stabilise key dependencies
+- Do not trigger DLC manager periodic check twice.
+- Simplify maker binary.
+- Prefer unused addresses to new ones (temporarily).
+- Remove share-on-Twitter button temporarily.
+- Use address caches in `LnDlcWallet`.
+- Set background transaction priority to 24 blocks.
+- Improve error message when trying to collab close LN-DLC channel.
+- Simplify deserialisation of channel ID.
+- Stabilise key dependencies.
 
 ## [1.0.19] - 2023-06-12
 
-- Fixed a deadlock bug, resulting in the coordinator getting stuck
-- Upgrade our fork to rust-lightning 114
-- Added force closing a dlc channel feature
-- Replaced electrs with esplora client
+- Fixed a deadlock bug, resulting in the coordinator getting stuck.
+- Upgrade our fork to `rust-lightning:0.0.114`.
+- Added force closing a DLC channel feature.
+- Replaced `electrs` with `esplora` client.
 
 ## [1.0.6] - 2023-04-17
 
-- Change environment port to 80
+- Change environment port to 80.
 
 ## [1.0.5] - 2023-04-16
 
-- Announce coordinator with 10101.finance
+- Announce coordinator with `10101.finance`.
 
 ## [1.0.4] - 2023-04-14
 
-- Add new api to sign text with node
-- Auto settle expired positions
+- Add new API to sign text with node.
+- Auto-settle expired positions.
 
 ## [1.0.3] - 2023-04-14
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -901,7 +901,7 @@ dependencies = [
 [[package]]
 name = "dlc"
 version = "0.4.0"
-source = "git+https://github.com/p2pderivatives/rust-dlc?rev=51c3c3fc4c9f468a0aa31f51a73f87149697be50#51c3c3fc4c9f468a0aa31f51a73f87149697be50"
+source = "git+https://github.com/p2pderivatives/rust-dlc?rev=049388b#049388b0131f045547f09bc492cb881d69530822"
 dependencies = [
  "bitcoin",
  "miniscript 8.0.0",
@@ -913,7 +913,7 @@ dependencies = [
 [[package]]
 name = "dlc-manager"
 version = "0.4.0"
-source = "git+https://github.com/p2pderivatives/rust-dlc?rev=51c3c3fc4c9f468a0aa31f51a73f87149697be50#51c3c3fc4c9f468a0aa31f51a73f87149697be50"
+source = "git+https://github.com/p2pderivatives/rust-dlc?rev=049388b#049388b0131f045547f09bc492cb881d69530822"
 dependencies = [
  "async-trait",
  "bitcoin",
@@ -929,7 +929,7 @@ dependencies = [
 [[package]]
 name = "dlc-messages"
 version = "0.4.0"
-source = "git+https://github.com/p2pderivatives/rust-dlc?rev=51c3c3fc4c9f468a0aa31f51a73f87149697be50#51c3c3fc4c9f468a0aa31f51a73f87149697be50"
+source = "git+https://github.com/p2pderivatives/rust-dlc?rev=049388b#049388b0131f045547f09bc492cb881d69530822"
 dependencies = [
  "bitcoin",
  "dlc",
@@ -942,7 +942,7 @@ dependencies = [
 [[package]]
 name = "dlc-sled-storage-provider"
 version = "0.1.0"
-source = "git+https://github.com/p2pderivatives/rust-dlc?rev=51c3c3fc4c9f468a0aa31f51a73f87149697be50#51c3c3fc4c9f468a0aa31f51a73f87149697be50"
+source = "git+https://github.com/p2pderivatives/rust-dlc?rev=049388b#049388b0131f045547f09bc492cb881d69530822"
 dependencies = [
  "bitcoin",
  "dlc-manager",
@@ -956,7 +956,7 @@ dependencies = [
 [[package]]
 name = "dlc-trie"
 version = "0.4.0"
-source = "git+https://github.com/p2pderivatives/rust-dlc?rev=51c3c3fc4c9f468a0aa31f51a73f87149697be50#51c3c3fc4c9f468a0aa31f51a73f87149697be50"
+source = "git+https://github.com/p2pderivatives/rust-dlc?rev=049388b#049388b0131f045547f09bc492cb881d69530822"
 dependencies = [
  "bitcoin",
  "dlc",
@@ -1603,7 +1603,7 @@ dependencies = [
 [[package]]
 name = "lightning"
 version = "0.0.114"
-source = "git+https://github.com/p2pderivatives/rust-lightning/?rev=a663e1fb#a663e1fb3415e0b7060e3b7f76f25d96a182006e"
+source = "git+https://github.com/p2pderivatives/rust-lightning/?rev=26db9546#26db954698bfe2871fa267f63fa85374bb74c4a0"
 dependencies = [
  "bitcoin",
 ]
@@ -1611,7 +1611,7 @@ dependencies = [
 [[package]]
 name = "lightning-background-processor"
 version = "0.0.114"
-source = "git+https://github.com/p2pderivatives/rust-lightning/?rev=a663e1fb#a663e1fb3415e0b7060e3b7f76f25d96a182006e"
+source = "git+https://github.com/p2pderivatives/rust-lightning/?rev=26db9546#26db954698bfe2871fa267f63fa85374bb74c4a0"
 dependencies = [
  "bitcoin",
  "futures-util",
@@ -1635,7 +1635,7 @@ dependencies = [
 [[package]]
 name = "lightning-net-tokio"
 version = "0.0.114"
-source = "git+https://github.com/p2pderivatives/rust-lightning/?rev=a663e1fb#a663e1fb3415e0b7060e3b7f76f25d96a182006e"
+source = "git+https://github.com/p2pderivatives/rust-lightning/?rev=26db9546#26db954698bfe2871fa267f63fa85374bb74c4a0"
 dependencies = [
  "bitcoin",
  "lightning",
@@ -1645,7 +1645,7 @@ dependencies = [
 [[package]]
 name = "lightning-persister"
 version = "0.0.114"
-source = "git+https://github.com/p2pderivatives/rust-lightning/?rev=a663e1fb#a663e1fb3415e0b7060e3b7f76f25d96a182006e"
+source = "git+https://github.com/p2pderivatives/rust-lightning/?rev=26db9546#26db954698bfe2871fa267f63fa85374bb74c4a0"
 dependencies = [
  "bitcoin",
  "libc",
@@ -1656,7 +1656,7 @@ dependencies = [
 [[package]]
 name = "lightning-rapid-gossip-sync"
 version = "0.0.114"
-source = "git+https://github.com/p2pderivatives/rust-lightning/?rev=a663e1fb#a663e1fb3415e0b7060e3b7f76f25d96a182006e"
+source = "git+https://github.com/p2pderivatives/rust-lightning/?rev=26db9546#26db954698bfe2871fa267f63fa85374bb74c4a0"
 dependencies = [
  "bitcoin",
  "lightning",
@@ -1665,7 +1665,7 @@ dependencies = [
 [[package]]
 name = "lightning-transaction-sync"
 version = "0.0.114"
-source = "git+https://github.com/p2pderivatives/rust-lightning/?rev=a663e1fb#a663e1fb3415e0b7060e3b7f76f25d96a182006e"
+source = "git+https://github.com/p2pderivatives/rust-lightning/?rev=26db9546#26db954698bfe2871fa267f63fa85374bb74c4a0"
 dependencies = [
  "bdk-macros",
  "bitcoin",
@@ -2297,7 +2297,7 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 [[package]]
 name = "p2pd-oracle-client"
 version = "0.1.0"
-source = "git+https://github.com/p2pderivatives/rust-dlc?rev=51c3c3fc4c9f468a0aa31f51a73f87149697be50#51c3c3fc4c9f468a0aa31f51a73f87149697be50"
+source = "git+https://github.com/p2pderivatives/rust-dlc?rev=049388b#049388b0131f045547f09bc492cb881d69530822"
 dependencies = [
  "chrono",
  "dlc-manager",
@@ -3112,7 +3112,7 @@ dependencies = [
 [[package]]
 name = "simple-wallet"
 version = "0.1.0"
-source = "git+https://github.com/p2pderivatives/rust-dlc?rev=51c3c3fc4c9f468a0aa31f51a73f87149697be50#51c3c3fc4c9f468a0aa31f51a73f87149697be50"
+source = "git+https://github.com/p2pderivatives/rust-dlc?rev=049388b#049388b0131f045547f09bc492cb881d69530822"
 dependencies = [
  "bitcoin",
  "dlc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,19 +4,19 @@ resolver = "2"
 
 [patch.crates-io]
 # We should usually track the `feature/ln-dlc-channels[-10101]` branch
-dlc-manager = { git = "https://github.com/p2pderivatives/rust-dlc", rev = "51c3c3fc4c9f468a0aa31f51a73f87149697be50" }
-dlc-messages = { git = "https://github.com/p2pderivatives/rust-dlc", rev = "51c3c3fc4c9f468a0aa31f51a73f87149697be50" }
-dlc = { git = "https://github.com/p2pderivatives/rust-dlc", rev = "51c3c3fc4c9f468a0aa31f51a73f87149697be50" }
-dlc-sled-storage-provider = { git = "https://github.com/p2pderivatives/rust-dlc", rev = "51c3c3fc4c9f468a0aa31f51a73f87149697be50" }
-p2pd-oracle-client = { git = "https://github.com/p2pderivatives/rust-dlc", rev = "51c3c3fc4c9f468a0aa31f51a73f87149697be50" }
-dlc-trie = { git = "https://github.com/p2pderivatives/rust-dlc", rev = "51c3c3fc4c9f468a0aa31f51a73f87149697be50" }
-simple-wallet = { git = "https://github.com/p2pderivatives/rust-dlc", rev = "51c3c3fc4c9f468a0aa31f51a73f87149697be50" }
+dlc-manager = { git = "https://github.com/p2pderivatives/rust-dlc", rev = "049388b" }
+dlc-messages = { git = "https://github.com/p2pderivatives/rust-dlc", rev = "049388b" }
+dlc = { git = "https://github.com/p2pderivatives/rust-dlc", rev = "049388b" }
+dlc-sled-storage-provider = { git = "https://github.com/p2pderivatives/rust-dlc", rev = "049388b" }
+p2pd-oracle-client = { git = "https://github.com/p2pderivatives/rust-dlc", rev = "049388b" }
+dlc-trie = { git = "https://github.com/p2pderivatives/rust-dlc", rev = "049388b" }
+simple-wallet = { git = "https://github.com/p2pderivatives/rust-dlc", rev = "049388b" }
 
 # We should usually track the `split-tx-experiment[-10101]` branch
-lightning = { git = "https://github.com/p2pderivatives/rust-lightning/", rev = "a663e1fb" }
-lightning-background-processor = { git = "https://github.com/p2pderivatives/rust-lightning/", rev = "a663e1fb" }
-lightning-transaction-sync = { git = "https://github.com/p2pderivatives/rust-lightning/", rev = "a663e1fb" }
-lightning-net-tokio = { git = "https://github.com/p2pderivatives/rust-lightning/", rev = "a663e1fb" }
-lightning-persister = { git = "https://github.com/p2pderivatives/rust-lightning/", rev = "a663e1fb" }
+lightning = { git = "https://github.com/p2pderivatives/rust-lightning/", rev = "26db9546" }
+lightning-background-processor = { git = "https://github.com/p2pderivatives/rust-lightning/", rev = "26db9546" }
+lightning-transaction-sync = { git = "https://github.com/p2pderivatives/rust-lightning/", rev = "26db9546" }
+lightning-net-tokio = { git = "https://github.com/p2pderivatives/rust-lightning/", rev = "26db9546" }
+lightning-persister = { git = "https://github.com/p2pderivatives/rust-lightning/", rev = "26db9546" }
 
 rust-bitcoin-coin-selection = { git = "https://github.com/p2pderivatives/rust-bitcoin-coin-selection" }

--- a/coordinator/src/db/custom_types.rs
+++ b/coordinator/src/db/custom_types.rs
@@ -9,14 +9,14 @@ use crate::schema::sql_types::DirectionType;
 use crate::schema::sql_types::HtlcStatusType;
 use crate::schema::sql_types::PaymentFlowType;
 use crate::schema::sql_types::PositionStateType;
+use diesel::deserialize;
 use diesel::deserialize::FromSql;
-use diesel::deserialize::{self};
 use diesel::pg::Pg;
 use diesel::pg::PgValue;
+use diesel::serialize;
 use diesel::serialize::IsNull;
 use diesel::serialize::Output;
 use diesel::serialize::ToSql;
-use diesel::serialize::{self};
 use std::io::Write;
 use trade::Direction;
 

--- a/crates/ln-dlc-node/src/ln/dlc_channel_details.rs
+++ b/crates/ln-dlc-node/src/ln/dlc_channel_details.rs
@@ -23,6 +23,7 @@ pub struct DlcChannelDetails {
 pub enum SubChannelState {
     Offered,
     Accepted,
+    Finalized,
     Signed,
     Closing,
     OnChainClosed,
@@ -56,6 +57,7 @@ impl From<dlc_manager::subchannel::SubChannelState> for SubChannelState {
         match value {
             Offered(_) => SubChannelState::Offered,
             Accepted(_) => SubChannelState::Accepted,
+            Finalized(_) => SubChannelState::Finalized,
             Signed(_) => SubChannelState::Signed,
             Closing(_) => SubChannelState::Closing,
             OnChainClosed => SubChannelState::OnChainClosed,

--- a/crates/ln-dlc-node/src/ln/event_handler.rs
+++ b/crates/ln-dlc-node/src/ln/event_handler.rs
@@ -26,6 +26,7 @@ use anyhow::Context;
 use anyhow::Result;
 use autometrics::autometrics;
 use bitcoin::consensus::encode::serialize_hex;
+use bitcoin::hashes::hex::ToHex;
 use bitcoin::secp256k1::PublicKey;
 use dlc_manager::subchannel::LNChannelManager;
 use lightning::chain::chaininterface::BroadcasterInterface;
@@ -183,7 +184,7 @@ where
             } => {
                 tracing::info!(
                     %amount_msat,
-                    payment_hash = %hex::encode(payment_hash.0),
+                    payment_hash = %payment_hash.0.to_hex(),
                     "Claimed payment",
                 );
 
@@ -205,7 +206,10 @@ where
                     payment_preimage,
                     payment_secret,
                 ) {
-                    tracing::error!(payment_hash = %hex::encode(payment_hash.0), "Failed to update claimed payment: {e:#}")
+                    tracing::error!(
+                        payment_hash = %payment_hash.0.to_hex(),
+                        "Failed to update claimed payment: {e:#}"
+                    )
                 }
             }
             Event::PaymentSent {
@@ -225,7 +229,10 @@ where
                             Some(payment_preimage),
                             None,
                         ) {
-                            tracing::error!(payment_hash = %hex::encode(payment_hash.0), "Failed to update sent payment: {e:#}");
+                            tracing::error!(
+                                payment_hash = %payment_hash.0.to_hex(),
+                                "Failed to update sent payment: {e:#}"
+                            );
 
                             return Ok(());
                         }
@@ -251,7 +258,7 @@ where
                             },
                         ) {
                             tracing::error!(
-                                payment_hash = %hex::encode(payment_hash.0),
+                                payment_hash = %payment_hash.0.to_hex(),
                                 "Failed to insert sent payment: {e:#}"
                             );
                         }
@@ -260,7 +267,7 @@ where
                     }
                     Err(e) => {
                         tracing::error!(
-                            payment_hash = %hex::encode(payment_hash.0),
+                            payment_hash = %payment_hash.0.to_hex(),
                             "Failed to verify payment state before handling sent payment: {e:#}"
                         );
 
@@ -271,8 +278,8 @@ where
                 tracing::info!(
                     amount_msat = ?amount_msat.0,
                     fee_paid_msat = ?fee_paid_msat,
-                    payment_hash = %hex::encode(payment_hash.0),
-                    preimage_hash = %hex::encode(payment_preimage.0),
+                    payment_hash = %payment_hash.0.to_hex(),
+                    preimage_hash = %payment_preimage.0.to_hex(),
                     "Successfully sent payment",
                 );
             }
@@ -312,12 +319,12 @@ where
             }
             Event::PaymentPathFailed { payment_hash, .. } => {
                 tracing::warn!(
-                payment_hash = %hex::encode(payment_hash.0),
+                    payment_hash = %payment_hash.0.to_hex(),
                 "Payment path failed");
             }
             Event::PaymentFailed { payment_hash, .. } => {
                 tracing::warn!(
-                    payment_hash = %hex::encode(payment_hash.0),
+                    payment_hash = %payment_hash.0.to_hex(),
                     "Failed to send payment to payment hash: exhausted payment retry attempts",
                 );
 
@@ -330,7 +337,10 @@ where
                     None,
                     None,
                 ) {
-                    tracing::error!(payment_hash = %hex::encode(payment_hash.0), "Failed to update failed payment: {e:#}")
+                    tracing::error!(
+                        payment_hash = %payment_hash.0.to_hex(),
+                        "Failed to update failed payment: {e:#}"
+                    )
                 }
             }
             Event::PaymentForwarded {
@@ -363,7 +373,7 @@ where
                 };
                 let channel_str = |channel_id: &Option<[u8; 32]>| {
                     channel_id
-                        .map(|channel_id| format!(" with channel {}", hex::encode(channel_id)))
+                        .map(|channel_id| format!(" with channel {}", channel_id.to_hex()))
                         .unwrap_or_default()
                 };
                 let from_prev_str = format!(
@@ -456,7 +466,7 @@ where
                     let user_channel_id = Uuid::from_u128(user_channel_id).to_string();
                     tracing::info!(
                         %user_channel_id,
-                        channel_id = %hex::encode(channel_id),
+                        channel_id = %channel_id.to_hex(),
                         ?reason,
                         "Channel closed",
                     );
@@ -488,7 +498,7 @@ where
             } => {
                 let tx_hex = serialize_hex(&transaction);
                 tracing::info!(
-                    channel_id = %hex::encode(channel_id),
+                    channel_id = %channel_id.to_hex(),
                     %tx_hex,
                     "Discarding funding transaction"
                 );
@@ -513,7 +523,7 @@ where
                 failed_next_destination,
             } => {
                 tracing::info!(
-                    prev_channel_id = %hex::encode(prev_channel_id),
+                    prev_channel_id = %prev_channel_id.to_hex(),
                     failed_next_destination = ?failed_next_destination,
                     "HTLC handling failed"
                 );
@@ -600,8 +610,8 @@ where
         inbound_amount_msat: u64,
         expected_outbound_amount_msat: u64,
     ) -> Result<()> {
-        let intercept_id_str = hex::encode(intercept_id.0);
-        let payment_hash = hex::encode(payment_hash.0);
+        let intercept_id_str = intercept_id.0.to_hex();
+        let payment_hash = payment_hash.0.to_hex();
 
         tracing::info!(
             intercept_id = %intercept_id_str,
@@ -725,7 +735,7 @@ where
         tracing::info!(
             peer = %target_node_id,
             %payment_hash,
-            temp_channel_id = %hex::encode(temp_channel_id),
+            temp_channel_id = %temp_channel_id.to_hex(),
             "Started JIT channel creation for intercepted HTLC"
         );
 
@@ -772,7 +782,7 @@ where
 
         tracing::info!(
             user_channel_id,
-            channel_id = %hex::encode(channel_id),
+            channel_id = %channel_id.to_hex(),
             counterparty = %counterparty_node_id.to_string(),
             "Channel ready"
         );
@@ -782,7 +792,7 @@ where
             .get_channel_details(&channel_id)
             .ok_or(anyhow!(
                 "Failed to get channel details by channel_id {}",
-                hex::encode(channel_id)
+                channel_id.to_hex()
             ))?;
 
         let channel = self.storage.get_channel(&user_channel_id)?;
@@ -794,7 +804,7 @@ where
             pending_intercepted_htlcs.get(&counterparty_node_id)
         {
             tracing::info!(
-                intercept_id = %hex::encode(intercept_id.0),
+                intercept_id = %intercept_id.0.to_hex(),
                 counterparty = %counterparty_node_id.to_string(),
                 forward_amount_msat = %expected_outbound_amount_msat,
                 "Pending intercepted HTLC found, forwarding payment"
@@ -817,7 +827,7 @@ where
     /// Fail an intercepted HTLC backwards.
     fn fail_intercepted_htlc(&self, intercept_id: &InterceptId) {
         tracing::error!(
-            intercept_id = %hex::encode(intercept_id.0),
+            intercept_id = %intercept_id.0.to_hex(),
             "Failing intercepted HTLC backwards"
         );
 

--- a/crates/ln-dlc-node/src/node/dlc_channel.rs
+++ b/crates/ln-dlc-node/src/node/dlc_channel.rs
@@ -257,7 +257,7 @@ where
         use SubChannelState::*;
         match state {
             // The channel is in an opening state
-            Offered(_) | Accepted(_) | Confirmed(_) => bail!("It's unsafe to collaboratively close LN channel when the DLC channel is being opened"),
+            Offered(_) | Accepted(_) | Confirmed(_) | Finalized(_) => bail!("It's unsafe to collaboratively close LN channel when the DLC channel is being opened"),
             // The channel is open,
             Signed(_) => bail!("It's unsafe to collaboratively close LN channel when the DLC channel is open"),
             // The channel is being closed,
@@ -363,6 +363,7 @@ pub fn dlc_message_name(msg: &Message) -> String {
         Message::Channel(ChannelMessage::RenewAccept(_)) => "ChannelRenewAccept",
         Message::Channel(ChannelMessage::RenewConfirm(_)) => "ChannelRenewConfirm",
         Message::Channel(ChannelMessage::RenewFinalize(_)) => "ChannelRenewFinalize",
+        Message::Channel(ChannelMessage::RenewRevoke(_)) => "ChannelRenewRevoke",
         Message::Channel(ChannelMessage::CollaborativeCloseOffer(_)) => {
             "ChannelCollaborativeCloseOffer"
         }
@@ -380,6 +381,7 @@ pub fn sub_channel_message_name(msg: &SubChannelMessage) -> &str {
         Accept(_) => "SubChannelAccept",
         Confirm(_) => "SubChannelConfirm",
         Finalize(_) => "SubChannelFinalize",
+        Revoke(_) => "SubChannelRevoke",
         CloseOffer(_) => "SubChannelCloseOffer",
         CloseAccept(_) => "SubChannelCloseAccept",
         CloseConfirm(_) => "SubChannelCloseConfirm",

--- a/crates/ln-dlc-node/src/node/mod.rs
+++ b/crates/ln-dlc-node/src/node/mod.rs
@@ -536,6 +536,7 @@ where
 
         let event_handler = EventHandler::new(
             channel_manager.clone(),
+            sub_channel_manager.clone(),
             ln_dlc_wallet.clone(),
             network_graph.clone(),
             keys_manager.clone(),

--- a/crates/ln-dlc-node/src/tests/dlc/create.rs
+++ b/crates/ln-dlc-node/src/tests/dlc/create.rs
@@ -96,22 +96,31 @@ pub async fn create_dlc_channel(
     )
     .await?;
 
-    // Assert
-
     // Process the app's `Confirm` and send `Finalize`
     wait_until_dlc_channel_state(
         Duration::from_secs(30),
         coordinator,
         app.info.pubkey,
-        SubChannelStateName::Signed,
+        SubChannelStateName::Finalized,
     )
     .await?;
 
-    // Process the coordinator's `Finalize`
+    // Assert
+
+    // Process the coordinator's `Finalize` and send `Revoke`
     wait_until_dlc_channel_state(
         Duration::from_secs(30),
         app,
         coordinator.info.pubkey,
+        SubChannelStateName::Signed,
+    )
+    .await?;
+
+    // Process the app's `Revoke`
+    wait_until_dlc_channel_state(
+        Duration::from_secs(30),
+        coordinator,
+        app.info.pubkey,
         SubChannelStateName::Signed,
     )
     .await?;

--- a/crates/ln-dlc-node/src/tests/dlc/dlc_setup_with_reconnects.rs
+++ b/crates/ln-dlc-node/src/tests/dlc/dlc_setup_with_reconnects.rs
@@ -124,12 +124,12 @@ async fn reconnecting_during_dlc_channel_setup() {
     // message.
     app.process_incoming_messages().unwrap();
 
-    // Process the resend `Confirm` message from the App.
+    // Process the resent `Confirm` message from the App.
     wait_until_dlc_channel_state(
         Duration::from_secs(30),
         &coordinator,
         app.info.pubkey,
-        SubChannelStateName::Signed,
+        SubChannelStateName::Finalized,
     )
     .await
     .unwrap();

--- a/crates/ln-dlc-node/src/tests/mod.rs
+++ b/crates/ln-dlc-node/src/tests/mod.rs
@@ -461,7 +461,12 @@ async fn wait_until_dlc_channel_state(
             .find(|channel| {
                 let current_state = SubChannelStateName::from(&channel.state);
 
-                tracing::info!(target = ?target_state, current = ?current_state, "Waiting for DLC subchannel to reach state");
+                tracing::info!(
+                    node_id = %node.info.pubkey,
+                    target = ?target_state,
+                    current = ?current_state,
+                    "Waiting for DLC subchannel to reach state"
+                );
 
                 channel.counter_party == counterparty_pk && current_state == target_state
             })
@@ -494,6 +499,7 @@ enum SubChannelStateName {
     Offered,
     Accepted,
     Confirmed,
+    Finalized,
     Signed,
     Closing,
     OnChainClosed,
@@ -513,6 +519,7 @@ impl From<&SubChannelState> for SubChannelStateName {
             Offered(_) => SubChannelStateName::Offered,
             Accepted(_) => SubChannelStateName::Accepted,
             Confirmed(_) => SubChannelStateName::Confirmed,
+            Finalized(_) => SubChannelStateName::Finalized,
             Signed(_) => SubChannelStateName::Signed,
             Closing(_) => SubChannelStateName::Closing,
             OnChainClosed => SubChannelStateName::OnChainClosed,

--- a/crates/tests-e2e/tests/close_position.rs
+++ b/crates/tests-e2e/tests/close_position.rs
@@ -1,4 +1,4 @@
-use native::api::{self};
+use native::api;
 use native::trade::position::PositionState;
 use tests_e2e::setup;
 use tests_e2e::setup::dummy_order;


### PR DESCRIPTION
Fixes #842.
Fixes https://github.com/get10101/meta/issues/198.

The notable changes are:

- Add new `Revoke` message to the subchannel-opening protocol. This has forced us to adapt the tests. More importantly we now update the position and order of the _app_ when receiving this message, rather than when sending the `Finalize` message. This is because the `Revoke` message is what actually marks the end of the subchannel-opening protocol now[^1].

- Require consumers to notify the `SubChannelManager` about the closure of a channel according to LDK. This is necessary so that the subchannel manager can react to the counterparty force-closing the channel using an untracked transaction.

Finally, by now depending on latest `rust-dlc#feature/ln-dlc-channels` we have replaced https://github.com/lightningdevkit/rust-lightning/commit/a663e1f with https://github.com/lightningdevkit/rust-lightning/commit/74690be.

[^1]: To be fair, without the `Revoke` message both versions of the LN-DLC channel are valid: one with the subchannel channel and one without. This is because the coordinator can still commit to the old version without the subchannel. Since the app doesn't currently attempt to convey this information to the user, it seems simpler to default to only updating this data after the protocol is complete.