### PR TITLE
fix: no_route found in local dev setup

### DIFF
--- a/coordinator/src/bin/coordinator.rs
+++ b/coordinator/src/bin/coordinator.rs
@@ -38,6 +38,8 @@ const CLOSED_POSITION_SYNC_INTERVAL: Duration = Duration::from_secs(30);
 const UNREALIZED_PNL_SYNC_INTERVAL: Duration = Duration::from_secs(600);
 const CONNECTION_CHECK_INTERVAL: Duration = Duration::from_secs(30);
 
+const NODE_ALIAS: &str = "10101.finance";
+
 #[tokio::main]
 async fn main() -> Result<()> {
     std::panic::set_hook(
@@ -91,7 +93,7 @@ async fn main() -> Result<()> {
     let (node_event_sender, mut node_event_receiver) = watch::channel::<Option<Event>>(None);
 
     let node = Arc::new(ln_dlc_node::node::Node::new_coordinator(
-        "10101.finance",
+        NODE_ALIAS,
         network,
         data_dir.as_path(),
         Arc::new(NodeStorage::new(pool.clone())),
@@ -205,7 +207,14 @@ async fn main() -> Result<()> {
         connection::keep_public_channel_peers_connected(node.inner, CONNECTION_CHECK_INTERVAL)
     });
 
-    let app = router(node, pool, settings, exporter);
+    let app = router(
+        node,
+        pool,
+        settings,
+        exporter,
+        opts.p2p_announcement_addresses(),
+        NODE_ALIAS,
+    );
 
     // Start the metrics exporter
     autometrics::prometheus_exporter::init();

--- a/crates/ln-dlc-node/src/node/mod.rs
+++ b/crates/ln-dlc-node/src/node/mod.rs
@@ -7,6 +7,7 @@ use crate::ln::EventHandler;
 use crate::ln::TracingLogger;
 use crate::ln_dlc_wallet::LnDlcWallet;
 use crate::node::dlc_channel::sub_channel_manager_periodic_check;
+use crate::node::peer_manager::alias_as_bytes;
 use crate::node::peer_manager::broadcast_node_announcement;
 use crate::on_chain_wallet::OnChainWallet;
 use crate::seed::Bip39Seed;
@@ -15,7 +16,6 @@ use crate::ChainMonitor;
 use crate::FakeChannelPaymentRequests;
 use crate::NetworkGraph;
 use crate::PeerManager;
-use anyhow::ensure;
 use anyhow::Context;
 use anyhow::Result;
 use bitcoin::secp256k1::PublicKey;
@@ -731,16 +731,4 @@ impl Display for NodeInfo {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         format!("{}@{}", self.pubkey, self.address).fmt(f)
     }
-}
-
-fn alias_as_bytes(alias: &str) -> Result<[u8; 32]> {
-    ensure!(
-        alias.len() <= 32,
-        "Node Alias can not be longer than 32 bytes"
-    );
-
-    let mut bytes = [0; 32];
-    bytes[..alias.len()].copy_from_slice(alias.as_bytes());
-
-    Ok(bytes)
 }

--- a/crates/ln-dlc-node/src/node/mod.rs
+++ b/crates/ln-dlc-node/src/node/mod.rs
@@ -63,7 +63,7 @@ mod dlc_manager;
 pub(crate) mod invoice;
 mod ln_channel;
 mod oracle;
-mod peer_manager;
+pub mod peer_manager;
 mod storage;
 mod sub_channel_manager;
 mod wallet;

--- a/crates/ln-dlc-node/src/node/mod.rs
+++ b/crates/ln-dlc-node/src/node/mod.rs
@@ -85,7 +85,7 @@ pub use wallet::PaymentDetails;
 /// The interval at which the [`lightning::ln::msgs::NodeAnnouncement`] is broadcast.
 ///
 /// According to the LDK team, a value of up to 1 hour should be fine.
-const BROADCAST_NODE_ANNOUNCEMENT_INTERVAL: Duration = Duration::from_secs(600);
+const BROADCAST_NODE_ANNOUNCEMENT_INTERVAL: Duration = Duration::from_secs(3600);
 
 /// An LN-DLC node.
 pub struct Node<S> {
@@ -625,12 +625,11 @@ where
         };
 
         let alias = alias_as_bytes(alias)?;
-        let node_announcement_interval = node_announcement_interval(network);
         let broadcast_node_announcement_handle = {
             let announcement_addresses = announcement_addresses;
             let peer_manager = peer_manager.clone();
             let (fut, remote_handle) = async move {
-                let mut interval = tokio::time::interval(node_announcement_interval);
+                let mut interval = tokio::time::interval(BROADCAST_NODE_ANNOUNCEMENT_INTERVAL);
                 loop {
                     broadcast_node_announcement(
                         &peer_manager,
@@ -744,12 +743,4 @@ fn alias_as_bytes(alias: &str) -> Result<[u8; 32]> {
     bytes[..alias.len()].copy_from_slice(alias.as_bytes());
 
     Ok(bytes)
-}
-
-fn node_announcement_interval(network: Network) -> Duration {
-    match network {
-        // We want to broadcast node announcements more frequently on regtest to make testing easier
-        Network::Regtest => Duration::from_secs(30),
-        _ => BROADCAST_NODE_ANNOUNCEMENT_INTERVAL,
-    }
 }

--- a/crates/ln-dlc-node/src/node/peer_manager.rs
+++ b/crates/ln-dlc-node/src/node/peer_manager.rs
@@ -5,7 +5,7 @@ use crate::PeerManager;
 
 const NODE_COLOR: [u8; 3] = [0; 3];
 
-pub(crate) fn broadcast_node_announcement(
+pub fn broadcast_node_announcement(
     peer_manager: &PeerManager,
     alias: [u8; 32],
     inc_connection_addresses: Vec<NetAddress>,

--- a/crates/ln-dlc-node/src/node/peer_manager.rs
+++ b/crates/ln-dlc-node/src/node/peer_manager.rs
@@ -1,3 +1,4 @@
+use anyhow::ensure;
 use lightning::ln::msgs::NetAddress;
 
 use crate::PeerManager;
@@ -12,4 +13,16 @@ pub(crate) fn broadcast_node_announcement(
     tracing::debug!(?inc_connection_addresses, "Broadcasting node announcement");
 
     peer_manager.broadcast_node_announcement(NODE_COLOR, alias, inc_connection_addresses)
+}
+
+pub fn alias_as_bytes(alias: &str) -> anyhow::Result<[u8; 32]> {
+    ensure!(
+        alias.len() <= 32,
+        "Node Alias can not be longer than 32 bytes"
+    );
+
+    let mut bytes = [0; 32];
+    bytes[..alias.len()].copy_from_slice(alias.as_bytes());
+
+    Ok(bytes)
 }

--- a/crates/tests-e2e/src/coordinator.rs
+++ b/crates/tests-e2e/src/coordinator.rs
@@ -94,6 +94,14 @@ impl Coordinator {
             .context("could not parse json")
     }
 
+    pub async fn broadcast_node_announcement(&self) -> Result<reqwest::Response> {
+        let status = self
+            .post("/api/admin/broadcast_announcement")
+            .await?
+            .error_for_status()?;
+        Ok(status)
+    }
+
     async fn get(&self, path: &str) -> Result<reqwest::Response> {
         self.client
             .get(format!("{0}{path}", self.host))


### PR DESCRIPTION
We need to wait until the node announcement was processed correctly by lnd. This can be checked if lnd is aware of the coordinator's `node_alias`.

In the below patches we change the node announcement to 1/hour and allow triggering it manually using a http enpoint. With this I was so to always get into a working setup :)

fixes https://github.com/get10101/10101/issues/764