### PR TITLE
feat: build ci in merge queue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,7 @@ name: CI
 
 on:
   pull_request:
+  merge_group:
   push:
     branches:
       - "staging"


### PR DESCRIPTION
Bors is dead, long live merge queues. 

Given we don't have any special things to run on `staging` anymore, we can start using github merge queues.


Resolves https://github.com/get10101/10101/issues/571

everyone is a reviewer so that you are aware. For the time being, we have both enabled: bors and merge queues. 
If we are happy with merge queues, we can retire bors :) 