### PR TITLE
Check if client outdated

### DIFF
--- a/.github/workflows/draft_new_release.yml
+++ b/.github/workflows/draft_new_release.yml
@@ -43,6 +43,13 @@ jobs:
           commitChange: false
           updateFile: true
 
+      - name: Bump coordinator Cargo.toml version
+        uses: ciiiii/toml-editor@1.0.0
+        with:
+          file: "coordinator/Cargo.toml"
+          key: "package.version"
+          value: ${{ github.event.inputs.version }}
+
       - name: Commit changelog and manifest files
         id: make-commit
         run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -601,7 +601,7 @@ dependencies = [
 
 [[package]]
 name = "coordinator"
-version = "0.1.0"
+version = "1.1.0"
 dependencies = [
  "anyhow",
  "atty",

--- a/coordinator/Cargo.toml
+++ b/coordinator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coordinator"
-version = "0.1.0"
+version = "1.1.0"
 edition = "2021"
 
 [dependencies]

--- a/coordinator/src/routes.rs
+++ b/coordinator/src/routes.rs
@@ -92,6 +92,7 @@ pub fn router(
 
     Router::new()
         .route("/", get(index))
+        .route("/api/version", get(version))
         .route(
             "/api/prepare_jit_channel/:target_node",
             post(prepare_jit_channel),
@@ -449,4 +450,8 @@ pub async fn get_health() -> Result<Json<String>, AppError> {
     // TODO: Implement any health check logic we'd need
     // So far this just returns if the server is running
     Ok(Json("Server is healthy".to_string()))
+}
+
+pub async fn version() -> Result<Json<String>, AppError> {
+    Ok(Json(env!("CARGO_PKG_VERSION").to_string()))
 }

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -1117,6 +1117,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
+  version:
+    dependency: "direct main"
+    description:
+      name: version
+      sha256: "3d4140128e6ea10d83da32fef2fa4003fccbf6852217bb854845802f04191f94"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.2"
   vm_service:
     dependency: transitive
     description:

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -34,6 +34,7 @@ dependencies:
   confetti: ^0.7.0
   social_share: ^2.3.1
   test: ^1.24.1
+  version: ^3.0.2
 dev_dependencies:
   flutter_launcher_icons: ^0.13.1
   flutter_test:


### PR DESCRIPTION
This PR is based on the advice from @klochowicz in #916. It introduces a new `/api/version` endpoint to the coordinator, which returns its version as recorded in `coordinator/Cargo.toml`. This, in turn, is kept in sync by the `draft_new_release` action (I am not quite sure how to test it locally). Then, on startup, the mobile client will perform a GET request to `/api/version`, compare it to its own version, and if it is out of date it will create a snackbar notification.

I'm not sure if we want to add an action to direct the user to an update page, or to add something else to the snackbar.

There might also be considerations for local/regtest development where we might want to handle this differently.

In line with what was discussed, this PR does not disable anything, merely informing the user that they are out of date. A future PR could introduce a confirm prompt for taking actions (or on startup) if the user is deemed "too" out of date such that it would be dangerous.

Fixes #916.