### PR TITLE
Enable "Send Payment" button only when the invoice is validated

### DIFF
--- a/mobile/lib/features/wallet/send_payment_change_notifier.dart
+++ b/mobile/lib/features/wallet/send_payment_change_notifier.dart
@@ -11,6 +11,7 @@ enum PendingPaymentState {
 
 class PendingPayment {
   PendingPaymentState state;
+  bool displayed = false;
   final String rawInvoice;
   final LightningInvoice decodedInvoice;
 

--- a/mobile/lib/features/wallet/send_screen.dart
+++ b/mobile/lib/features/wallet/send_screen.dart
@@ -207,14 +207,13 @@ class _SendScreenState extends State<SendScreen> {
                       mainAxisAlignment: MainAxisAlignment.end,
                       children: [
                         ElevatedButton(
-                            onPressed: () async {
-                              if (_formKey.currentState!.validate()) {
-                                context
-                                    .read<SendPaymentChangeNotifier>()
-                                    .sendPayment(_textEditingController.text, _lightningInvoice!);
-                                GoRouter.of(context).go(WalletScreen.route);
-                              }
-                            },
+                            onPressed: !(_formKey.currentState?.validate() ?? false)
+                                ? null
+                                : () async {
+                                    context.read<SendPaymentChangeNotifier>().sendPayment(
+                                        _textEditingController.text, _lightningInvoice!);
+                                    GoRouter.of(context).go(WalletScreen.route);
+                                  },
                             child: const Text("Send Payment")),
                       ],
                     ),

--- a/mobile/lib/features/wallet/wallet_screen.dart
+++ b/mobile/lib/features/wallet/wallet_screen.dart
@@ -44,7 +44,8 @@ class _WalletScreenState extends State<WalletScreen> {
         context.watch<SendPaymentChangeNotifier>();
 
     if (sendPaymentChangeNotifier.pendingPayment != null &&
-        sendPaymentChangeNotifier.pendingPayment!.state == PendingPaymentState.pending) {
+        !sendPaymentChangeNotifier.pendingPayment!.displayed) {
+      sendPaymentChangeNotifier.pendingPayment!.displayed = true;
       WidgetsBinding.instance.addPostFrameCallback((_) async {
         return await showDialog(
             context: context,


### PR DESCRIPTION
This is still a work-in-progress, because if a valid but already paid invoice is pasted, then the "Send Payment" button still exhibits the weird behaviour described in #1024. Fixes #1024.