### PR TITLE
Pin `dprint` to version 0.39.1 temporarily

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: dprint/check@v2.1
+        with:
+          dprint-version: 0.39.1
 
   lint-commits:
     runs-on: ubuntu-latest


### PR DESCRIPTION
There are breaking changes in version 0.40 which we need to handle before we can upgrade.