### PR TITLE
Add ScrollableSafeArea to scroll widgets if keyboard would squish them

### DIFF
--- a/mobile/lib/common/scrollable_safe_area.dart
+++ b/mobile/lib/common/scrollable_safe_area.dart
@@ -1,0 +1,24 @@
+import 'package:flutter/cupertino.dart';
+
+class ScrollableSafeArea extends StatelessWidget {
+  const ScrollableSafeArea({
+    required this.child,
+    Key? key,
+  }) : super(key: key);
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return SafeArea(
+        child: LayoutBuilder(
+            builder: (BuildContext context, BoxConstraints viewportConstraints) =>
+                SingleChildScrollView(
+                    child: ConstrainedBox(
+                  constraints: BoxConstraints(
+                    minHeight: viewportConstraints.maxHeight,
+                  ),
+                  child: IntrinsicHeight(child: child),
+                ))));
+  }
+}

--- a/mobile/lib/common/settings_screen.dart
+++ b/mobile/lib/common/settings_screen.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 
 import 'package:f_logs/f_logs.dart';
 import 'package:flutter/material.dart';
+import 'package:get_10101/common/scrollable_safe_area.dart';
 import 'package:get_10101/features/trade/settings_screen.dart';
 import 'package:get_10101/features/wallet/settings_screen.dart';
 import 'package:get_10101/bridge_generated/bridge_definitions.dart' as bridge;
@@ -54,7 +55,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
 
     return Scaffold(
       appBar: AppBar(title: const Text("Settings")),
-      body: SafeArea(
+      body: ScrollableSafeArea(
           child: Column(children: [
         Text(
           "Wallet Settings",

--- a/mobile/lib/common/status_screen.dart
+++ b/mobile/lib/common/status_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:get_10101/bridge_generated/bridge_definitions.dart';
+import 'package:get_10101/common/scrollable_safe_area.dart';
 import 'package:get_10101/common/service_status_notifier.dart';
 import 'package:get_10101/common/value_data_row.dart';
 import 'package:provider/provider.dart';
@@ -26,7 +27,7 @@ class _StatusScreenState extends State<StatusScreen> {
 
     return Scaffold(
       appBar: AppBar(title: const Text("Status")),
-      body: SafeArea(
+      body: ScrollableSafeArea(
         child: Center(
             child: Padding(
                 padding: const EdgeInsets.all(32.0),

--- a/mobile/lib/features/trade/trade_bottom_sheet.dart
+++ b/mobile/lib/features/trade/trade_bottom_sheet.dart
@@ -30,11 +30,13 @@ tradeBottomSheet({required BuildContext context, required Direction direction}) 
                 currentFocus.unfocus();
               }
             },
-            child: SizedBox(
-                // TODO: Find a way to make height dynamic depending on the children size
-                // This is needed because otherwise the keyboard does not push the sheet up correctly
-                height: 450,
-                child: TradeBottomSheet(direction: direction)),
+            child: SingleChildScrollView(
+              child: SizedBox(
+                  // TODO: Find a way to make height dynamic depending on the children size
+                  // This is needed because otherwise the keyboard does not push the sheet up correctly
+                  height: 450,
+                  child: TradeBottomSheet(direction: direction)),
+            ),
           ),
         ),
       );

--- a/mobile/lib/features/trade/trade_bottom_sheet_confirmation.dart
+++ b/mobile/lib/features/trade/trade_bottom_sheet_confirmation.dart
@@ -50,15 +50,17 @@ tradeBottomSheetConfirmation(
                 currentFocus.unfocus();
               }
             },
-            child: SizedBox(
-                height: 350,
-                child: TradeBottomSheetConfirmation(
-                  direction: direction,
-                  sliderButtonKey: sliderButtonKey,
-                  sliderKey: sliderKey,
-                  onConfirmation: onConfirmation,
-                  close: close,
-                )),
+            child: SingleChildScrollView(
+              child: SizedBox(
+                  height: 350,
+                  child: TradeBottomSheetConfirmation(
+                    direction: direction,
+                    sliderButtonKey: sliderButtonKey,
+                    sliderKey: sliderKey,
+                    onConfirmation: onConfirmation,
+                    close: close,
+                  )),
+            ),
           ),
         ),
       );

--- a/mobile/lib/features/wallet/create_invoice_screen.dart
+++ b/mobile/lib/features/wallet/create_invoice_screen.dart
@@ -13,6 +13,7 @@ import 'package:go_router/go_router.dart';
 import 'package:provider/provider.dart';
 import 'package:get_10101/common/modal_bottom_sheet_info.dart';
 import 'package:get_10101/common/domain/channel.dart';
+import 'package:get_10101/common/scrollable_safe_area.dart';
 
 class CreateInvoiceScreen extends StatefulWidget {
   static const route = "${WalletScreen.route}/$subRouteName";
@@ -103,118 +104,115 @@ class _CreateInvoiceScreenState extends State<CreateInvoiceScreen> {
             FocusScope.of(context).requestFocus(FocusNode());
           },
           behavior: HitTestBehavior.opaque,
-          child: SafeArea(
-            child: Container(
-              constraints: const BoxConstraints.expand(),
-              child: Column(crossAxisAlignment: CrossAxisAlignment.stretch, children: [
-                const Center(
-                    child: Padding(
-                        padding: EdgeInsets.only(top: 25.0),
-                        child: Text(
-                          "What is the amount?",
-                          style: TextStyle(fontSize: 18.0, fontWeight: FontWeight.bold),
-                        ))),
-                Padding(
-                  padding: const EdgeInsets.all(32.0),
-                  child: Row(
-                    children: [
-                      Expanded(
-                        child: AmountInputField(
-                          value: amount != null ? amount! : Amount(0),
-                          hint: "e.g. ${formatSats(Amount(5000))}",
-                          label: "Amount",
-                          controller: _amountController,
-                          onChanged: (value) {
-                            if (value.isEmpty) {
-                              return;
+          child: ScrollableSafeArea(
+            child: Column(crossAxisAlignment: CrossAxisAlignment.stretch, children: [
+              const Center(
+                  child: Padding(
+                      padding: EdgeInsets.only(top: 25.0),
+                      child: Text(
+                        "What is the amount?",
+                        style: TextStyle(fontSize: 18.0, fontWeight: FontWeight.bold),
+                      ))),
+              Padding(
+                padding: const EdgeInsets.all(32.0),
+                child: Row(
+                  children: [
+                    Expanded(
+                      child: AmountInputField(
+                        value: amount != null ? amount! : Amount(0),
+                        hint: "e.g. ${formatSats(Amount(5000))}",
+                        label: "Amount",
+                        controller: _amountController,
+                        onChanged: (value) {
+                          if (value.isEmpty) {
+                            return;
+                          }
+
+                          setState(() => amount = Amount.parse(value));
+                        },
+                        validator: (value) {
+                          if (value == null) {
+                            return "Enter receive amount";
+                          }
+
+                          try {
+                            int amount = int.parse(value);
+
+                            if (balance.sats > maxAllowedOutboundCapacity.sats) {
+                              return "Maximum channel balance exceeded";
                             }
 
-                            setState(() => amount = Amount.parse(value));
-                          },
-                          validator: (value) {
-                            if (value == null) {
-                              return "Enter receive amount";
+                            if (amount < minReceiveAmount.sats) {
+                              return "Min amount to receive is ${formatSats(minReceiveAmount)}";
                             }
 
-                            try {
-                              int amount = int.parse(value);
-
-                              if (balance.sats > maxAllowedOutboundCapacity.sats) {
-                                return "Maximum channel balance exceeded";
-                              }
-
-                              if (amount < minReceiveAmount.sats) {
-                                return "Min amount to receive is ${formatSats(minReceiveAmount)}";
-                              }
-
-                              if (amount > maxReceiveAmount.sats) {
-                                return "Max amount to receive is ${formatSats(maxReceiveAmount)}";
-                              }
-                            } on Exception {
-                              return "Enter a number";
+                            if (amount > maxReceiveAmount.sats) {
+                              return "Max amount to receive is ${formatSats(maxReceiveAmount)}";
                             }
+                          } on Exception {
+                            return "Enter a number";
+                          }
 
-                            return null;
-                          },
-                        ),
+                          return null;
+                        },
                       ),
-                      if (showValidationHint)
-                        ModalBottomSheetInfo(
-                            closeButtonText: "Back to Receive...",
-                            child: Text(
-                                "While in beta, maximum channel capacity is limited to ${formatSats(maxChannelCapacity)}; channels above this capacity might get rejected."
-                                "\nThe maximum is enforced initially to ensure users only trade with small stakes until the software has proven to be stable."
-                                "\n\nYour current balance is ${formatSats(balance)}, so you can receive up to ${formatSats(maxReceiveAmount)}."
-                                "\nIf you hold less than ${formatSats(minAmountToBeAbleToTrade)} or more than ${formatSats(maxAllowedOutboundCapacity)} in your wallet you might not be able to trade.")),
+                    ),
+                    if (showValidationHint)
+                      ModalBottomSheetInfo(
+                          closeButtonText: "Back to Receive...",
+                          child: Text(
+                              "While in beta, maximum channel capacity is limited to ${formatSats(maxChannelCapacity)}; channels above this capacity might get rejected."
+                              "\nThe maximum is enforced initially to ensure users only trade with small stakes until the software has proven to be stable."
+                              "\n\nYour current balance is ${formatSats(balance)}, so you can receive up to ${formatSats(maxReceiveAmount)}."
+                              "\nIf you hold less than ${formatSats(minAmountToBeAbleToTrade)} or more than ${formatSats(maxAllowedOutboundCapacity)} in your wallet you might not be able to trade.")),
+                  ],
+                ),
+              ),
+              Center(
+                  child: Padding(
+                padding: const EdgeInsets.only(bottom: 10.0, left: 32.0, right: 32.0),
+                child: Text(
+                  "Your wallet balance is ${formatSats(balance)} so you should only receive up to ${formatSats(maxReceiveAmount)}.",
+                  style: const TextStyle(color: Colors.black),
+                ),
+              )),
+              Expanded(
+                child: Padding(
+                  padding: const EdgeInsets.all(32.0),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.stretch,
+                    mainAxisAlignment: MainAxisAlignment.end,
+                    children: [
+                      ElevatedButton(
+                          onPressed: (amount == null || amount == Amount(0))
+                              ? null
+                              : () {
+                                  if (_formKey.currentState!.validate()) {
+                                    showValidationHint = false;
+
+                                    walletChangeNotifier.service
+                                        .createInvoice(amount!)
+                                        .then((invoice) {
+                                      if (invoice != null) {
+                                        GoRouter.of(context).go(ShareInvoiceScreen.route,
+                                            extra: ShareInvoice(
+                                                rawInvoice: invoice,
+                                                invoiceAmount: amount!,
+                                                channelOpenFee: feeEstimate));
+                                      }
+                                    });
+                                  } else {
+                                    setState(() {
+                                      showValidationHint = true;
+                                    });
+                                  }
+                                },
+                          child: const Text("Next")),
                     ],
                   ),
                 ),
-                Center(
-                    child: Padding(
-                  padding: const EdgeInsets.only(bottom: 10.0, left: 32.0, right: 32.0),
-                  child: Text(
-                    "Your wallet balance is ${formatSats(balance)} so you should only receive up to ${formatSats(maxReceiveAmount)}.",
-                    style: const TextStyle(color: Colors.black),
-                  ),
-                )),
-                Expanded(
-                  child: Padding(
-                    padding: const EdgeInsets.all(32.0),
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.stretch,
-                      mainAxisAlignment: MainAxisAlignment.end,
-                      children: [
-                        ElevatedButton(
-                            onPressed: (amount == null || amount == Amount(0))
-                                ? null
-                                : () {
-                                    if (_formKey.currentState!.validate()) {
-                                      showValidationHint = false;
-
-                                      walletChangeNotifier.service
-                                          .createInvoice(amount!)
-                                          .then((invoice) {
-                                        if (invoice != null) {
-                                          GoRouter.of(context).go(ShareInvoiceScreen.route,
-                                              extra: ShareInvoice(
-                                                  rawInvoice: invoice,
-                                                  invoiceAmount: amount!,
-                                                  channelOpenFee: feeEstimate));
-                                        }
-                                      });
-                                    } else {
-                                      setState(() {
-                                        showValidationHint = true;
-                                      });
-                                    }
-                                  },
-                            child: const Text("Next")),
-                      ],
-                    ),
-                  ),
-                )
-              ]),
-            ),
+              )
+            ]),
           ),
         ),
       ),

--- a/mobile/lib/features/wallet/send_screen.dart
+++ b/mobile/lib/features/wallet/send_screen.dart
@@ -14,6 +14,7 @@ import 'package:go_router/go_router.dart';
 import 'package:provider/provider.dart';
 import 'package:get_10101/common/domain/model.dart';
 import 'package:get_10101/features/wallet/domain/lightning_invoice.dart';
+import 'package:get_10101/common/scrollable_safe_area.dart';
 
 class SendScreen extends StatefulWidget {
   static const route = "${WalletScreen.route}/$subRouteName";
@@ -84,7 +85,7 @@ class _SendScreenState extends State<SendScreen> {
             FocusScope.of(context).requestFocus(FocusNode());
           },
           behavior: HitTestBehavior.opaque,
-          child: SafeArea(
+          child: ScrollableSafeArea(
             child: Container(
               constraints: const BoxConstraints.expand(),
               child: Column(crossAxisAlignment: CrossAxisAlignment.stretch, children: [

--- a/mobile/lib/features/welcome/welcome_screen.dart
+++ b/mobile/lib/features/welcome/welcome_screen.dart
@@ -1,5 +1,6 @@
 import 'package:f_logs/model/flog/flog.dart';
 import 'package:flutter/material.dart';
+import 'package:get_10101/common/scrollable_safe_area.dart';
 import 'package:get_10101/features/wallet/wallet_screen.dart';
 import 'package:get_10101/util/preferences.dart';
 import 'package:go_router/go_router.dart';
@@ -31,7 +32,7 @@ class _WelcomeScreenState extends State<WelcomeScreen> {
   Widget build(BuildContext context) {
     return Scaffold(
         appBar: AppBar(title: const Text("Welcome to 10101 beta.")),
-        body: SafeArea(
+        body: ScrollableSafeArea(
             child: Form(
           key: _formKey,
           child: Container(


### PR DESCRIPTION
Fixes #1026. This just makes the content scroll vertically if it would be too small to fit on the screen (due to its size or due to the on-screen keyboard being opened).