### PR TITLE
Run `rustfmt` with nightly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@nightly
+        with:
+          components: rustfmt
       - uses: dprint/check@v2.1
 
   lint-commits:

--- a/coordinator/src/db/user.rs
+++ b/coordinator/src/db/user.rs
@@ -1,10 +1,9 @@
+use crate::schema::users;
 use coordinator_commons::RegisterParams;
 use diesel::prelude::*;
 use serde::Deserialize;
 use serde::Serialize;
 use time::OffsetDateTime;
-
-use crate::schema::users;
 
 #[derive(Insertable, Queryable, Identifiable, Debug, Clone, Serialize, Deserialize)]
 #[diesel(primary_key(id))]

--- a/coordinator/src/orderbook/tests/registration_test.rs
+++ b/coordinator/src/orderbook/tests/registration_test.rs
@@ -1,5 +1,3 @@
-use std::str::FromStr;
-
 use crate::db::user;
 use crate::db::user::User;
 use crate::orderbook::tests::init_tracing;
@@ -7,6 +5,7 @@ use crate::orderbook::tests::setup_db;
 use crate::orderbook::tests::start_postgres;
 use bitcoin::secp256k1::PublicKey;
 use coordinator_commons::RegisterParams;
+use std::str::FromStr;
 use testcontainers::clients::Cli;
 
 #[tokio::test]

--- a/crates/bitmex-stream/src/lib.rs
+++ b/crates/bitmex-stream/src/lib.rs
@@ -1,5 +1,6 @@
 use crate::tungstenite::http::Method;
 use anyhow::Context;
+use anyhow::Error;
 use async_stream::stream;
 use futures::SinkExt;
 use futures::Stream;
@@ -15,8 +16,6 @@ use std::time::UNIX_EPOCH;
 use tokio_tungstenite::tungstenite;
 use tracing::Instrument;
 use url::Url;
-
-pub use anyhow::Error;
 
 /// Connects to the BitMex websocket API
 ///

--- a/crates/ln-dlc-node/src/node/peer_manager.rs
+++ b/crates/ln-dlc-node/src/node/peer_manager.rs
@@ -1,7 +1,6 @@
+use crate::PeerManager;
 use anyhow::ensure;
 use lightning::ln::msgs::NetAddress;
-
-use crate::PeerManager;
 
 const NODE_COLOR: [u8; 3] = [0; 3];
 

--- a/crates/ln-dlc-node/src/seed.rs
+++ b/crates/ln-dlc-node/src/seed.rs
@@ -1,5 +1,3 @@
-use std::path::Path;
-
 use anyhow::bail;
 use anyhow::Result;
 use bdk::bitcoin;
@@ -9,6 +7,7 @@ use bip39::Mnemonic;
 use bitcoin::Network;
 use hkdf::Hkdf;
 use sha2::Sha256;
+use std::path::Path;
 
 #[derive(Clone)]
 pub struct Bip39Seed {
@@ -119,10 +118,9 @@ pub type LightningSeed = [u8; 32];
 
 #[cfg(test)]
 mod tests {
+    use crate::seed::Bip39Seed;
     use bip39::Mnemonic;
     use std::env::temp_dir;
-
-    use crate::seed::Bip39Seed;
 
     #[test]
     fn create_bip39_seed() {

--- a/crates/orderbook-client/src/lib.rs
+++ b/crates/orderbook-client/src/lib.rs
@@ -1,5 +1,5 @@
 use anyhow::Context;
-pub use anyhow::Error;
+use anyhow::Error;
 use anyhow::Result;
 use async_stream::stream;
 use futures::SinkExt;

--- a/crates/tests-e2e/src/setup.rs
+++ b/crates/tests-e2e/src/setup.rs
@@ -1,3 +1,11 @@
+use crate::app::run_app;
+use crate::app::AppHandle;
+use crate::bitcoind::Bitcoind;
+use crate::coordinator::Coordinator;
+use crate::fund::fund_app_with_faucet;
+use crate::http::init_reqwest;
+use crate::logger::init_tracing;
+use crate::wait_until;
 use bitcoin::Address;
 use bitcoin::Amount;
 use native::api;
@@ -7,15 +15,6 @@ use native::trade::order::api::OrderType;
 use native::trade::position::PositionState;
 use std::str::FromStr;
 use tokio::task::spawn_blocking;
-
-use crate::app::run_app;
-use crate::app::AppHandle;
-use crate::bitcoind::Bitcoind;
-use crate::coordinator::Coordinator;
-use crate::fund::fund_app_with_faucet;
-use crate::http::init_reqwest;
-use crate::logger::init_tracing;
-use crate::wait_until;
 
 pub struct TestSetup {
     pub app: AppHandle,

--- a/dprint.json
+++ b/dprint.json
@@ -24,7 +24,7 @@
   "exec": {
     "commands": [
       {
-        "command": "rustfmt",
+        "command": "rustfmt +nightly",
         "exts": [
           "rs"
         ]

--- a/mobile/native/src/event/mod.rs
+++ b/mobile/native/src/event/mod.rs
@@ -3,17 +3,16 @@ mod event_hub;
 pub mod subscriber;
 
 use crate::api::WalletInfo;
+use crate::event::event_hub::get;
+use crate::event::subscriber::Subscriber;
 use crate::health::ServiceUpdate;
+use crate::trade::order::Order;
+use crate::trade::position::Position;
 use coordinator_commons::TradeParams;
 use ln_dlc_node::node::rust_dlc_manager::ChannelId;
 use orderbook_commons::Prices;
 use std::hash::Hash;
 use trade::ContractSymbol;
-
-use crate::event::event_hub::get;
-use crate::event::subscriber::Subscriber;
-use crate::trade::order::Order;
-use crate::trade::position::Position;
 
 pub fn subscribe(subscriber: impl Subscriber + 'static + Send + Sync + Clone) {
     get().subscribe(subscriber);

--- a/mobile/native/src/trade/order/orderbook_client.rs
+++ b/mobile/native/src/trade/order/orderbook_client.rs
@@ -1,10 +1,9 @@
+use crate::commons::reqwest_client;
 use anyhow::bail;
 use anyhow::Result;
 use orderbook_commons::NewOrder;
 use orderbook_commons::OrderResponse;
 use reqwest::Url;
-
-use crate::commons::reqwest_client;
 
 pub struct OrderbookClient {
     url: Url,


### PR DESCRIPTION
We must do this if we want `dprint` to respect some of the unstable options we have configured in our `rustfmt.toml`. This is what we get if we run `cargo fmt` (as opposed to `cargo +nightly fmt`):

```
Warning: can't set `wrap_comments = true`, unstable features are only available in nightly channel.
Warning: can't set `comment_width = 100`, unstable features are only available in nightly channel.
Warning: can't set `imports_granularity = Item`, unstable features are only available in nightly channel.
Warning: can't set `group_imports = One`, unstable features are only available in nightly channel.
```

After running `dprint fmt` with the new configuration we can see that the autoformatter consistently applies `group_imports = One` to our codebase.