### PR TITLE
Wait longer to pay for channel-opening fee

### DIFF
--- a/mobile/native/src/channel_fee.rs
+++ b/mobile/native/src/channel_fee.rs
@@ -21,14 +21,14 @@ use tokio::runtime::Handle;
 
 #[derive(Clone)]
 pub struct ChannelFeePaymentSubscriber {
-    pub open_channel_info: Arc<Mutex<Option<(ChannelId, EsploraTransaction)>>>,
-    pub channel_manager: Arc<ChannelManager>,
+    open_channel_info: Arc<Mutex<Option<(ChannelId, EsploraTransaction)>>>,
+    channel_manager: Arc<ChannelManager>,
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
-pub struct EsploraTransaction {
-    pub txid: String,
-    pub fee: u32,
+struct EsploraTransaction {
+    txid: String,
+    fee: u32,
 }
 
 impl Subscriber for ChannelFeePaymentSubscriber {

--- a/mobile/native/src/channel_fee.rs
+++ b/mobile/native/src/channel_fee.rs
@@ -19,6 +19,8 @@ use std::sync::Mutex;
 use std::time::Duration;
 use tokio::runtime::Handle;
 
+const WAIT_FOR_OUTBOUND_CAPACITY_TIMEOUT: Duration = Duration::from_secs(60);
+
 #[derive(Clone)]
 pub struct ChannelFeePaymentSubscriber {
     open_channel_info: Arc<Mutex<Option<(ChannelId, EsploraTransaction)>>>,
@@ -79,7 +81,8 @@ impl ChannelFeePaymentSubscriber {
             );
             Handle::current()
                 .block_on(self.wait_for_outbound_capacity(channel_id, funding_tx_fees_msats))
-        })?;
+        })
+        .context("Failed during wait for outbound capacity")?;
 
         tracing::debug!(
             "Trying to pay channel opening fees of {} sats",
@@ -153,7 +156,7 @@ impl ChannelFeePaymentSubscriber {
         channel_id: ChannelId,
         funding_tx_fees_msats: u64,
     ) -> Result<()> {
-        tokio::time::timeout(Duration::from_secs(5), async {
+        tokio::time::timeout(WAIT_FOR_OUTBOUND_CAPACITY_TIMEOUT, async {
             loop {
                 let channel_details = match self
                     .channel_manager


### PR DESCRIPTION
Fixes https://github.com/get10101/10101/issues/1030.

Waiting for 5 seconds proved insufficient in some cases. In theory we could wait for as long as we want to as this work will happen in the background.

It might still help to redesign this flow so that we just keep retrying if we owe the coordinator for opening the JIT channel, rather
than only trying once after claiming the interceptable payment.