### PR TITLE
Do not attempt to publish transaction spending no LDK spendable outputs

### DIFF
--- a/crates/ln-dlc-node/src/ln/manage_spendable_outputs.rs
+++ b/crates/ln-dlc-node/src/ln/manage_spendable_outputs.rs
@@ -58,6 +58,10 @@ pub fn manage_spendable_outputs(
         }
     }
 
+    if spendable_outputs.is_empty() {
+        return Ok(());
+    }
+
     let destination_script = wallet.borrow().inner().get_last_unused_address()?;
     let tx_feerate = fee_rate_estimator
         .borrow()


### PR DESCRIPTION
Otherwise we see errors in the logs, because transactions spending no UTXOs are obviously invalid!