### PR TITLE
Wallet history details

### DIFF
--- a/mobile/lib/common/expansion_tile_with_arrow.dart
+++ b/mobile/lib/common/expansion_tile_with_arrow.dart
@@ -1,0 +1,63 @@
+import 'package:flutter/material.dart';
+
+class ExpansionTileWithArrow extends StatefulWidget {
+  const ExpansionTileWithArrow(
+      {super.key,
+      required this.leading,
+      required this.title,
+      required this.subtitle,
+      required this.trailing,
+      required this.children});
+
+  final Widget leading;
+  final Widget title;
+  final Widget subtitle;
+  final Widget trailing;
+  final List<Widget> children;
+
+  @override
+  State<ExpansionTileWithArrow> createState() => _ExpansionTileWithArrowState();
+}
+
+class _ExpansionTileWithArrowState extends State<ExpansionTileWithArrow> with SingleTickerProviderStateMixin {
+  static final Animatable<double> _iconCurve = Tween<double>(begin: 0.0, end: 0.5).chain(CurveTween(curve: Curves.easeIn));
+  late Animation<double> _iconTurns;
+  late AnimationController _animationController;
+
+  @override
+  void initState() {
+    _animationController = AnimationController(duration: const Duration(milliseconds: 200), vsync: this);
+    _iconTurns = _animationController.drive(_iconCurve);
+    super.initState();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return ExpansionTile(
+      leading: widget.leading,
+      title: widget.title,
+      subtitle: widget.subtitle,
+      trailing: FittedBox(
+        child: Row(
+          children: [
+            widget.trailing,
+            RotationTransition(
+              turns: _iconTurns,
+              child: const Icon(Icons.expand_more),
+            )
+          ],
+        ),
+      ),
+      onExpansionChanged: (bool expanded) {
+        setState(() {
+          if (expanded) {
+            _animationController.forward();
+          } else {
+            _animationController.reverse();
+          }
+        });
+      },
+      children: widget.children,
+    );
+  }
+}

--- a/mobile/lib/common/expansion_tile_with_arrow.dart
+++ b/mobile/lib/common/expansion_tile_with_arrow.dart
@@ -1,32 +1,40 @@
 import 'package:flutter/material.dart';
 
 class ExpansionTileWithArrow extends StatefulWidget {
-  const ExpansionTileWithArrow(
-      {super.key,
-      required this.leading,
-      required this.title,
-      required this.subtitle,
-      required this.trailing,
-      required this.children});
+  const ExpansionTileWithArrow({
+    super.key,
+    required this.leading,
+    required this.title,
+    required this.subtitle,
+    required this.trailing,
+    required this.children,
+    this.expandedCrossAxisAlignment,
+    this.expandedAlignment,
+  });
 
   final Widget leading;
   final Widget title;
   final Widget subtitle;
   final Widget trailing;
   final List<Widget> children;
+  final CrossAxisAlignment? expandedCrossAxisAlignment;
+  final Alignment? expandedAlignment;
 
   @override
   State<ExpansionTileWithArrow> createState() => _ExpansionTileWithArrowState();
 }
 
-class _ExpansionTileWithArrowState extends State<ExpansionTileWithArrow> with SingleTickerProviderStateMixin {
-  static final Animatable<double> _iconCurve = Tween<double>(begin: 0.0, end: 0.5).chain(CurveTween(curve: Curves.easeIn));
+class _ExpansionTileWithArrowState extends State<ExpansionTileWithArrow>
+    with SingleTickerProviderStateMixin {
+  static final Animatable<double> _iconCurve =
+      Tween<double>(begin: 0.0, end: 0.5).chain(CurveTween(curve: Curves.easeIn));
   late Animation<double> _iconTurns;
   late AnimationController _animationController;
 
   @override
   void initState() {
-    _animationController = AnimationController(duration: const Duration(milliseconds: 200), vsync: this);
+    _animationController =
+        AnimationController(duration: const Duration(milliseconds: 200), vsync: this);
     _iconTurns = _animationController.drive(_iconCurve);
     super.initState();
   }
@@ -37,6 +45,8 @@ class _ExpansionTileWithArrowState extends State<ExpansionTileWithArrow> with Si
       leading: widget.leading,
       title: widget.title,
       subtitle: widget.subtitle,
+      expandedCrossAxisAlignment: widget.expandedCrossAxisAlignment,
+      expandedAlignment: widget.expandedAlignment,
       trailing: FittedBox(
         child: Row(
           children: [

--- a/mobile/lib/features/wallet/wallet_history_item.dart
+++ b/mobile/lib/features/wallet/wallet_history_item.dart
@@ -1,4 +1,6 @@
 import 'package:flutter/material.dart';
+import 'package:get_10101/common/amount_text.dart';
+import 'package:get_10101/common/expansion_tile_with_arrow.dart';
 import 'package:get_10101/features/wallet/domain/payment_flow.dart';
 import 'package:get_10101/features/wallet/domain/wallet_history.dart';
 import 'package:intl/intl.dart';
@@ -6,6 +8,7 @@ import 'package:timeago/timeago.dart' as timeago;
 
 class WalletHistoryItem extends StatelessWidget {
   final WalletHistoryItemData data;
+  static final dateFormat = DateFormat("yyyy-MM-dd HH:mm:ss");
 
   const WalletHistoryItem({super.key, required this.data});
 
@@ -52,20 +55,30 @@ class WalletHistoryItem extends StatelessWidget {
     String title = () {
       switch (data.type) {
         case WalletHistoryItemDataType.lightning:
-          return data.paymentHash ?? "";
         case WalletHistoryItemDataType.onChain:
-          return data.txid ?? "";
+          return "Payment";
         case WalletHistoryItemDataType.trade:
-          final orderId = data.orderId!.substring(0, 8);
           switch (data.flow) {
             case PaymentFlow.inbound:
-              return "Closed position with order $orderId";
+              return "Closed position";
             case PaymentFlow.outbound:
-              return "Opened position with order $orderId";
+              return "Opened position";
           }
         case WalletHistoryItemDataType.orderMatchingFee:
+          return "Matching fee";
+      }
+    }();
+
+    String txOrOrder = () {
+      switch (data.type) {
+        case WalletHistoryItemDataType.lightning:
+          return "Payment hash: ${data.paymentHash ?? ''}";
+        case WalletHistoryItemDataType.onChain:
+          return "Transaction id: ${data.txid ?? ''}";
+        case WalletHistoryItemDataType.trade:
+        case WalletHistoryItemDataType.orderMatchingFee:
           final orderId = data.orderId!.substring(0, 8);
-          return "Matching fee for $orderId";
+          return "Order: $orderId";
       }
     }();
 
@@ -98,59 +111,66 @@ class WalletHistoryItem extends StatelessWidget {
       }
     }();
 
-    var amountFormatter = NumberFormat.compact(locale: "en_IN");
+    var amountFormatter = NumberFormat.compact(locale: "en_UK");
 
     return Card(
-      child: ListTile(
-          leading: Stack(children: [
-            Container(
-              padding: const EdgeInsets.only(bottom: 20.0),
-              child: SizedBox(height: statusIconSize, width: statusIconSize, child: statusIcon),
-            ),
-            Container(
-                padding: const EdgeInsets.only(left: 5.0, top: 10.0),
-                child: SizedBox(height: flowIconSize, width: flowIconSize, child: flowIcon)),
-          ]),
-          title: RichText(
-            overflow: TextOverflow.ellipsis,
-            text: TextSpan(
-              style: DefaultTextStyle.of(context).style,
-              children: <TextSpan>[
-                TextSpan(text: title),
-              ],
-            ),
+      child: ExpansionTileWithArrow(
+        leading: Stack(children: [
+          Container(
+            padding: const EdgeInsets.only(bottom: 20.0),
+            child: SizedBox(height: statusIconSize, width: statusIconSize, child: statusIcon),
           ),
-          subtitle: RichText(
-              textWidthBasis: TextWidthBasis.longestLine,
-              text: TextSpan(style: DefaultTextStyle.of(context).style, children: <TextSpan>[
-                TextSpan(
-                    text: timeago.format(data.timestamp),
-                    style: const TextStyle(color: Colors.grey)),
-              ])),
-          trailing: Padding(
-            padding: const EdgeInsets.only(top: 11.0, bottom: 5.0),
-            child: Column(
-              mainAxisAlignment: MainAxisAlignment.spaceBetween,
-              crossAxisAlignment: CrossAxisAlignment.end,
-              children: [
-                RichText(
-                  text: TextSpan(style: DefaultTextStyle.of(context).style, children: <InlineSpan>[
-                    TextSpan(
-                        text: "$sign${amountFormatter.format(data.amount.sats)} sats",
-                        style: TextStyle(
-                            color: color,
-                            fontFamily: "Courier",
-                            fontSize: 16,
-                            fontWeight: FontWeight.bold))
-                  ]),
-                ),
-                RichText(
-                    text: TextSpan(style: DefaultTextStyle.of(context).style, children: <TextSpan>[
-                  TextSpan(text: onOrOff, style: const TextStyle(color: Colors.grey)),
-                ]))
-              ],
-            ),
-          )),
+          Container(
+              padding: const EdgeInsets.only(left: 5.0, top: 10.0),
+              child: SizedBox(height: flowIconSize, width: flowIconSize, child: flowIcon)),
+        ]),
+        title: RichText(
+          overflow: TextOverflow.ellipsis,
+          text: TextSpan(
+            style: DefaultTextStyle.of(context).style,
+            children: <TextSpan>[
+              TextSpan(text: title),
+            ],
+          ),
+        ),
+        subtitle: RichText(
+            textWidthBasis: TextWidthBasis.longestLine,
+            text: TextSpan(style: DefaultTextStyle.of(context).style, children: <TextSpan>[
+              TextSpan(
+                  text: timeago.format(data.timestamp), style: const TextStyle(color: Colors.grey)),
+            ])),
+        trailing: Padding(
+          padding: const EdgeInsets.only(top: 11.0, bottom: 5.0),
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            crossAxisAlignment: CrossAxisAlignment.end,
+            children: [
+              RichText(
+                text: TextSpan(style: DefaultTextStyle.of(context).style, children: <InlineSpan>[
+                  TextSpan(
+                      text: "$sign${amountFormatter.format(data.amount.sats)} sats",
+                      style: TextStyle(
+                          color: color,
+                          fontFamily: "Courier",
+                          fontSize: 16,
+                          fontWeight: FontWeight.bold))
+                ]),
+              ),
+              RichText(
+                  text: TextSpan(style: DefaultTextStyle.of(context).style, children: <TextSpan>[
+                TextSpan(text: onOrOff, style: const TextStyle(color: Colors.grey)),
+              ]))
+            ],
+          ),
+        ),
+        expandedCrossAxisAlignment: CrossAxisAlignment.start,
+        expandedAlignment: Alignment.centerLeft,
+        children: [
+          Text(txOrOrder),
+          Text("Amount: ${formatSats(data.amount)}"),
+          Text("Time: ${dateFormat.format(data.timestamp)}")
+        ],
+      ),
     );
   }
 }


### PR DESCRIPTION
I'm opening this as a draft since I want a second opinion on the type of info to show in the expanded view before I put more work into styling it.
![image](https://github.com/get10101/10101/assets/6688948/102b6e97-0dad-4e46-b359-966c7505de26)

Possibilities:
- Add "Lighting" or "On-chain" to the title (it is displayed on the right hand side, though)
- Truncate the payment hash
- If it's an on-chain payment, link to a block explorer for that txid
- Change date format
- other info to add?

Fixes #1011 and #872