### PR TITLE
chore: Remove bors.toml

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -1,7 +1,0 @@
-status = [
-  "formatting",
-  "lint-commits",
-  "lint-flutter",
-  "clippy",
-  "e2e-tests",
-]


### PR DESCRIPTION
R.I.P. Bors [']

Prevent accidentally calling bors, when we should be using merge queue instead.