### PR TITLE
chore: Separate building Node from starting it

### DIFF
--- a/coordinator/src/bin/coordinator.rs
+++ b/coordinator/src/bin/coordinator.rs
@@ -105,10 +105,10 @@ async fn main() -> Result<()> {
         ephemeral_randomness,
         settings.ln_dlc.clone(),
         opts.get_oracle_info(),
-        node_event_sender,
     )?);
 
-    let node = Node::new(node, pool.clone(), settings.to_node_settings());
+    let running = node.start(Some(node_event_sender))?;
+    let node = Node::new(node, running, pool.clone(), settings.to_node_settings());
 
     // TODO: Pass the tokio metrics into Prometheus
     if let Some(interval) = opts.tokio_metrics_interval_seconds {

--- a/coordinator/src/node.rs
+++ b/coordinator/src/node.rs
@@ -34,6 +34,7 @@ use lightning_invoice::Invoice;
 use ln_dlc_node::node;
 use ln_dlc_node::node::dlc_message_name;
 use ln_dlc_node::node::sub_channel_message_name;
+use ln_dlc_node::node::RunningNode;
 use ln_dlc_node::WalletSettings;
 use ln_dlc_node::CONTRACT_TX_FEE_RATE;
 use rust_decimal::prelude::ToPrimitive;
@@ -79,6 +80,7 @@ impl NodeSettings {
 #[derive(Clone)]
 pub struct Node {
     pub inner: Arc<node::Node<NodeStorage>>,
+    _running: Arc<RunningNode>,
     pub pool: Pool<ConnectionManager<PgConnection>>,
     settings: Arc<RwLock<NodeSettings>>,
 }
@@ -86,6 +88,7 @@ pub struct Node {
 impl Node {
     pub fn new(
         inner: Arc<node::Node<NodeStorage>>,
+        running: RunningNode,
         pool: Pool<ConnectionManager<PgConnection>>,
         settings: NodeSettings,
     ) -> Self {
@@ -93,6 +96,7 @@ impl Node {
             inner,
             pool,
             settings: Arc::new(RwLock::new(settings)),
+            _running: Arc::new(running),
         }
     }
 

--- a/crates/ln-dlc-node/src/tests/dlc/collaborative_settlement.rs
+++ b/crates/ln-dlc-node/src/tests/dlc/collaborative_settlement.rs
@@ -24,8 +24,8 @@ async fn dlc_collaborative_settlement_test() {
 
     let fund_amount = (app_ln_balance + coordinator_ln_balance) * 2;
 
-    let app = Node::start_test_app("app").unwrap();
-    let coordinator = Node::start_test_coordinator("coordinator").unwrap();
+    let (app, _running_app) = Node::start_test_app("app").unwrap();
+    let (coordinator, _running_coord) = Node::start_test_coordinator("coordinator").unwrap();
 
     app.connect(coordinator.info).await.unwrap();
 
@@ -95,8 +95,8 @@ async fn open_dlc_channel_after_closing_dlc_channel() {
 
     let fund_amount = (app_ln_balance + coordinator_ln_balance) * 2;
 
-    let app = Node::start_test_app("app").unwrap();
-    let coordinator = Node::start_test_coordinator("coordinator").unwrap();
+    let (app, _running_app) = Node::start_test_app("app").unwrap();
+    let (coordinator, _running_coord) = Node::start_test_coordinator("coordinator").unwrap();
 
     app.connect(coordinator.info).await.unwrap();
 

--- a/crates/ln-dlc-node/src/tests/dlc/create.rs
+++ b/crates/ln-dlc-node/src/tests/dlc/create.rs
@@ -24,8 +24,8 @@ async fn given_lightning_channel_then_can_add_dlc_channel() {
 
     let fund_amount = (app_ln_balance + coordinator_ln_balance) * 2;
 
-    let app = Node::start_test_app("app").unwrap();
-    let coordinator = Node::start_test_coordinator("coordinator").unwrap();
+    let (app, _running_app) = Node::start_test_app("app").unwrap();
+    let (coordinator, _running_coord) = Node::start_test_coordinator("coordinator").unwrap();
 
     app.connect(coordinator.info).await.unwrap();
 

--- a/crates/ln-dlc-node/src/tests/dlc/dlc_setup_with_reconnects.rs
+++ b/crates/ln-dlc-node/src/tests/dlc/dlc_setup_with_reconnects.rs
@@ -9,7 +9,6 @@ use anyhow::Context;
 use bitcoin::Amount;
 use dlc_manager::subchannel::SubChannelState;
 use dlc_manager::Storage;
-use std::sync::Arc;
 use std::time::Duration;
 
 #[tokio::test(flavor = "multi_thread")]
@@ -19,8 +18,8 @@ async fn reconnecting_during_dlc_channel_setup() {
 
     // Arrange
 
-    let app = Arc::new(Node::start_test_app("app").unwrap());
-    let coordinator = Arc::new(Node::start_test_coordinator("coordinator").unwrap());
+    let (app, _running_app) = Node::start_test_app("app").unwrap();
+    let (coordinator, _running_coord) = Node::start_test_coordinator("coordinator").unwrap();
 
     let coordinator_info = coordinator.info;
 
@@ -242,8 +241,8 @@ async fn can_lose_connection_before_processing_subchannel_close_finalize() {
 
     let fund_amount = (app_ln_balance + coordinator_ln_balance) * 2;
 
-    let app = Node::start_test_app("app").unwrap();
-    let coordinator = Node::start_test_coordinator("coordinator").unwrap();
+    let (app, _running_app) = Node::start_test_app("app").unwrap();
+    let (coordinator, _running_coord) = Node::start_test_coordinator("coordinator").unwrap();
 
     app.connect(coordinator.info).await.unwrap();
 

--- a/crates/ln-dlc-node/src/tests/dlc/non_collaborative_settlement.rs
+++ b/crates/ln-dlc-node/src/tests/dlc/non_collaborative_settlement.rs
@@ -20,8 +20,8 @@ async fn force_close_ln_dlc_channel() {
 
     let fund_amount = (app_ln_balance + coordinator_ln_balance) * 2;
 
-    let app = Node::start_test_app("app").unwrap();
-    let coordinator = Node::start_test_coordinator("coordinator").unwrap();
+    let (app, _running_app) = Node::start_test_app("app").unwrap();
+    let (coordinator, _running_coord) = Node::start_test_coordinator("coordinator").unwrap();
 
     app.connect(coordinator.info).await.unwrap();
 

--- a/crates/ln-dlc-node/src/tests/just_in_time_channel/channel_close.rs
+++ b/crates/ln-dlc-node/src/tests/just_in_time_channel/channel_close.rs
@@ -12,9 +12,9 @@ async fn ln_collab_close() {
 
     // Arrange
 
-    let payer = Node::start_test_app("payer").unwrap();
-    let coordinator = Node::start_test_coordinator("coordinator").unwrap();
-    let payee = Node::start_test_app("payee").unwrap();
+    let (payer, _running_payer) = Node::start_test_app("payer").unwrap();
+    let (coordinator, _running_coord) = Node::start_test_coordinator("coordinator").unwrap();
+    let (payee, _running_payee) = Node::start_test_app("payee").unwrap();
 
     payer.connect(coordinator.info).await.unwrap();
     payee.connect(coordinator.info).await.unwrap();
@@ -87,9 +87,9 @@ async fn ln_force_close() {
 
     // Arrange
 
-    let payer = Node::start_test_app("payer").unwrap();
-    let coordinator = Node::start_test_coordinator("coordinator").unwrap();
-    let payee = Node::start_test_app("payee").unwrap();
+    let (payer, _running_payer) = Node::start_test_app("payer").unwrap();
+    let (coordinator, _running_coord) = Node::start_test_coordinator("coordinator").unwrap();
+    let (payee, _running_payee) = Node::start_test_app("payee").unwrap();
 
     payer.connect(coordinator.info).await.unwrap();
     payee.connect(coordinator.info).await.unwrap();

--- a/crates/ln-dlc-node/src/tests/just_in_time_channel/fail_intercepted_htlc.rs
+++ b/crates/ln-dlc-node/src/tests/just_in_time_channel/fail_intercepted_htlc.rs
@@ -17,9 +17,9 @@ async fn fail_intercepted_htlc_if_coordinator_cannot_reconnect_to_payee() {
 
     // Arrange
 
-    let payer = Node::start_test_app("payer").unwrap();
-    let coordinator = Node::start_test_coordinator("coordinator").unwrap();
-    let payee = Node::start_test_app("payee").unwrap();
+    let (payer, _running_payer) = Node::start_test_app("payer").unwrap();
+    let (coordinator, _running_coord) = Node::start_test_coordinator("coordinator").unwrap();
+    let (payee, _running_payee) = Node::start_test_app("payee").unwrap();
 
     payer.connect(coordinator.info).await.unwrap();
     payee.connect(coordinator.info).await.unwrap();
@@ -69,11 +69,11 @@ async fn fail_intercepted_htlc_if_connection_lost_after_funding_tx_generated() {
 
     // Arrange
 
-    let payer = Node::start_test_app("payer").unwrap();
+    let (payer, _running_payer) = Node::start_test_app("payer").unwrap();
 
-    let (coordinator, mut ldk_node_event_receiver_coordinator) = {
+    let (coordinator, _running_coord, mut ldk_node_event_receiver_coordinator) = {
         let (sender, receiver) = tokio::sync::watch::channel(None);
-        let node = Node::start_test_coordinator_internal(
+        let (coordinator, _running_coord) = Node::start_test_coordinator_internal(
             "coordinator",
             Arc::new(InMemoryStore::default()),
             LnDlcNodeSettings::default(),
@@ -81,10 +81,10 @@ async fn fail_intercepted_htlc_if_connection_lost_after_funding_tx_generated() {
         )
         .unwrap();
 
-        (node, receiver)
+        (coordinator, _running_coord, receiver)
     };
 
-    let payee = Node::start_test_app("payee").unwrap();
+    let (payee, _running_payee) = Node::start_test_app("payee").unwrap();
 
     payer.connect(coordinator.info).await.unwrap();
     payee.connect(coordinator.info).await.unwrap();
@@ -141,9 +141,9 @@ async fn fail_intercepted_htlc_if_coordinator_cannot_pay_to_open_jit_channel() {
 
     // Arrange
 
-    let payer = Node::start_test_app("payer").unwrap();
-    let coordinator = Node::start_test_coordinator("coordinator").unwrap();
-    let payee = Node::start_test_app("payee").unwrap();
+    let (payer, _running_payer) = Node::start_test_app("payer").unwrap();
+    let (coordinator, _running_coord) = Node::start_test_coordinator("coordinator").unwrap();
+    let (payee, _running_payee) = Node::start_test_app("payee").unwrap();
 
     payer.connect(coordinator.info).await.unwrap();
     payee.connect(coordinator.info).await.unwrap();

--- a/crates/ln-dlc-node/src/tests/just_in_time_channel/payments.rs
+++ b/crates/ln-dlc-node/src/tests/just_in_time_channel/payments.rs
@@ -11,9 +11,9 @@ async fn just_in_time_channel_with_multiple_payments() {
 
     // Arrange
 
-    let payer = Node::start_test_app("payer").unwrap();
-    let coordinator = Node::start_test_coordinator("coordinator").unwrap();
-    let payee = Node::start_test_app("payee").unwrap();
+    let (payer, _running_payer) = Node::start_test_app("payer").unwrap();
+    let (coordinator, _running_coord) = Node::start_test_coordinator("coordinator").unwrap();
+    let (payee, _running_payee) = Node::start_test_app("payee").unwrap();
 
     payer.connect(coordinator.info).await.unwrap();
     payee.connect(coordinator.info).await.unwrap();
@@ -64,9 +64,9 @@ async fn new_config_affects_routing_fees() {
 
     // Arrange
 
-    let payer = Node::start_test_app("payer").unwrap();
-    let coordinator = Node::start_test_coordinator("coordinator").unwrap();
-    let payee = Node::start_test_app("payee").unwrap();
+    let (payer, _running_payer) = Node::start_test_app("payer").unwrap();
+    let (coordinator, _running_coord) = Node::start_test_coordinator("coordinator").unwrap();
+    let (payee, _running_payee) = Node::start_test_app("payee").unwrap();
 
     payer.connect(coordinator.info).await.unwrap();
     payee.connect(coordinator.info).await.unwrap();

--- a/crates/ln-dlc-node/src/tests/load.rs
+++ b/crates/ln-dlc-node/src/tests/load.rs
@@ -28,21 +28,20 @@ async fn single_app_many_positions_load() {
     init_tracing();
 
     let coordinator = Coordinator::new_public_regtest();
-    let app = Arc::new(
-        Node::start_test(
-            "app",
-            app_config(),
-            ESPLORA_ORIGIN_PUBLIC_REGTEST.to_string(),
-            OracleInfo {
-                endpoint: ORACLE_ORIGIN_PUBLIC_REGTEST.to_string(),
-                public_key: XOnlyPublicKey::from_str(ORACLE_PUBKEY_PUBLIC_REGTEST).unwrap(),
-            },
-            Arc::new(InMemoryStore::default()),
-            LnDlcNodeSettings::default(),
-            None,
-        )
-        .unwrap(),
-    );
+    let (app, _running_app) = Node::start_test(
+        "app",
+        app_config(),
+        ESPLORA_ORIGIN_PUBLIC_REGTEST.to_string(),
+        OracleInfo {
+            endpoint: ORACLE_ORIGIN_PUBLIC_REGTEST.to_string(),
+            public_key: XOnlyPublicKey::from_str(ORACLE_PUBKEY_PUBLIC_REGTEST).unwrap(),
+        },
+        Arc::new(InMemoryStore::default()),
+        LnDlcNodeSettings::default(),
+        None,
+    )
+    .unwrap();
+    let app = Arc::new(app);
 
     tokio::spawn({
         let app = app.clone();

--- a/crates/ln-dlc-node/src/tests/mod.rs
+++ b/crates/ln-dlc-node/src/tests/mod.rs
@@ -7,6 +7,7 @@ use crate::node::LnDlcNodeSettings;
 use crate::node::Node;
 use crate::node::NodeInfo;
 use crate::node::OracleInfo;
+use crate::node::RunningNode;
 use crate::seed::Bip39Seed;
 use crate::util;
 use anyhow::Result;
@@ -85,7 +86,7 @@ fn init_tracing() {
 }
 
 impl Node<InMemoryStore> {
-    fn start_test_app(name: &str) -> Result<Self> {
+    fn start_test_app(name: &str) -> Result<(Self, RunningNode)> {
         Self::start_test(
             name,
             app_config(),
@@ -100,7 +101,7 @@ impl Node<InMemoryStore> {
         )
     }
 
-    fn start_test_coordinator(name: &str) -> Result<Self> {
+    fn start_test_coordinator(name: &str) -> Result<(Self, RunningNode)> {
         Self::start_test_coordinator_internal(
             name,
             Arc::new(InMemoryStore::default()),
@@ -114,7 +115,7 @@ impl Node<InMemoryStore> {
         storage: Arc<InMemoryStore>,
         settings: LnDlcNodeSettings,
         ldk_event_sender: Option<watch::Sender<Option<Event>>>,
-    ) -> Result<Self> {
+    ) -> Result<(Self, RunningNode)> {
         Self::start_test(
             name,
             coordinator_config(),
@@ -137,7 +138,7 @@ impl Node<InMemoryStore> {
         storage: Arc<InMemoryStore>,
         settings: LnDlcNodeSettings,
         ldk_event_sender: Option<watch::Sender<Option<Event>>>,
-    ) -> Result<Self> {
+    ) -> Result<(Self, RunningNode)> {
         let data_dir = random_tmp_dir().join(name);
 
         let seed = Bip39Seed::new().expect("A valid bip39 seed");
@@ -164,13 +165,14 @@ impl Node<InMemoryStore> {
             ldk_config,
             settings,
             oracle.into(),
-            ldk_event_sender,
             disk::in_memory_scorer,
         )?;
 
+        let running = node.start(ldk_event_sender)?;
+
         tracing::debug!(%name, info = %node.info, "Node started");
 
-        Ok(node)
+        Ok((node, running))
     }
 
     /// Trigger on-chain wallet sync.

--- a/crates/ln-dlc-node/src/tests/multi_hop_payment.rs
+++ b/crates/ln-dlc-node/src/tests/multi_hop_payment.rs
@@ -13,9 +13,9 @@ async fn multi_hop_payment() {
 
     // Arrange
 
-    let payer = Node::start_test_app("payer").unwrap();
-    let coordinator = Node::start_test_coordinator("coordinator").unwrap();
-    let payee = Node::start_test_app("payee").unwrap();
+    let (payer, _running_payer) = Node::start_test_app("payer").unwrap();
+    let (coordinator, _running_coord) = Node::start_test_coordinator("coordinator").unwrap();
+    let (payee, _running_payee) = Node::start_test_app("payee").unwrap();
 
     payer.connect(coordinator.info).await.unwrap();
     payee.connect(coordinator.info).await.unwrap();

--- a/crates/ln-dlc-node/src/tests/single_hop_payment.rs
+++ b/crates/ln-dlc-node/src/tests/single_hop_payment.rs
@@ -9,8 +9,8 @@ async fn single_hop_payment() {
 
     // Arrange
 
-    let payer = Node::start_test_app("payer").unwrap();
-    let payee = Node::start_test_app("payee").unwrap();
+    let (payer, _running_payer) = Node::start_test_app("payer").unwrap();
+    let (payee, _running_payee) = Node::start_test_app("payee").unwrap();
 
     payer.connect(payee.info).await.unwrap();
 

--- a/mobile/native/src/ln_dlc/mod.rs
+++ b/mobile/native/src/ln_dlc/mod.rs
@@ -36,7 +36,6 @@ use ln_dlc_node::seed::Bip39Seed;
 use ln_dlc_node::CONFIRMATION_TARGET;
 use orderbook_commons::RouteHintHop;
 use orderbook_commons::FEE_INVOICE_DESCRIPTION_PREFIX_TAKER;
-use parking_lot::RwLock;
 use rust_decimal::Decimal;
 use state::Storage;
 use std::net::IpAddr;
@@ -175,7 +174,7 @@ pub fn run(data_dir: String, seed_dir: String, runtime: &Runtime) -> Result<()> 
 
         let (event_sender, event_receiver) = watch::channel::<Option<Event>>(None);
 
-        let node = Arc::new(ln_dlc_node::node::Node::new_app(
+        let node = ln_dlc_node::node::Node::new_app(
             "10101",
             network,
             data_dir.as_path(),
@@ -186,12 +185,10 @@ pub fn run(data_dir: String, seed_dir: String, runtime: &Runtime) -> Result<()> 
             seed,
             ephemeral_randomness,
             config::get_oracle_info(),
-            event_sender,
-        )?);
-        let node = Arc::new(Node {
-            inner: node,
-            order_matching_fee_invoice: Arc::new(RwLock::new(None)),
-        });
+        )?;
+
+        let _running = node.start(Some(event_sender))?;
+        let node = Arc::new(Node::new(node, _running));
 
         runtime.spawn({
             let node = node.clone();

--- a/mobile/native/src/ln_dlc/node.rs
+++ b/mobile/native/src/ln_dlc/node.rs
@@ -27,6 +27,7 @@ use ln_dlc_node::node::rust_dlc_manager::Storage as _;
 use ln_dlc_node::node::sub_channel_message_name;
 use ln_dlc_node::node::NodeInfo;
 use ln_dlc_node::node::PaymentDetails;
+use ln_dlc_node::node::RunningNode;
 use ln_dlc_node::transaction::Transaction;
 use ln_dlc_node::HTLCStatus;
 use ln_dlc_node::MillisatAmount;
@@ -40,10 +41,21 @@ use time::OffsetDateTime;
 #[derive(Clone)]
 pub struct Node {
     pub inner: Arc<ln_dlc_node::node::Node<NodeStorage>>,
+    _running: Arc<RunningNode>,
     /// The order-matching fee invoice to be paid once the current trade is executed.
     ///
     /// We assume that only one trade can be executed at a time.
     pub order_matching_fee_invoice: Arc<RwLock<Option<Invoice>>>,
+}
+
+impl Node {
+    pub fn new(node: node::Node<NodeStorage>, running: RunningNode) -> Self {
+        Self {
+            inner: Arc::new(node),
+            _running: Arc::new(running),
+            order_matching_fee_invoice: Arc::new(RwLock::new(None)),
+        }
+    }
 }
 
 pub struct Balances {


### PR DESCRIPTION
Another step towards customising behaviour for different applications.

Everything has the same init order to avoid unintended changes
  during refactor.

As a side effect, we can stop the node now by simply dropping the instance of
`RunningNode`. This can become useful in tests.