### PR TITLE
Avoid specific serialisation errors in `rust-dlc`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -901,7 +901,7 @@ dependencies = [
 [[package]]
 name = "dlc"
 version = "0.4.0"
-source = "git+https://github.com/p2pderivatives/rust-dlc?rev=049388b#049388b0131f045547f09bc492cb881d69530822"
+source = "git+https://github.com/p2pderivatives/rust-dlc?rev=78a8b46#78a8b46582ce193bc2dcacbc246338563ebc0ab7"
 dependencies = [
  "bitcoin",
  "miniscript 8.0.0",
@@ -913,7 +913,7 @@ dependencies = [
 [[package]]
 name = "dlc-manager"
 version = "0.4.0"
-source = "git+https://github.com/p2pderivatives/rust-dlc?rev=049388b#049388b0131f045547f09bc492cb881d69530822"
+source = "git+https://github.com/p2pderivatives/rust-dlc?rev=78a8b46#78a8b46582ce193bc2dcacbc246338563ebc0ab7"
 dependencies = [
  "async-trait",
  "bitcoin",
@@ -929,7 +929,7 @@ dependencies = [
 [[package]]
 name = "dlc-messages"
 version = "0.4.0"
-source = "git+https://github.com/p2pderivatives/rust-dlc?rev=049388b#049388b0131f045547f09bc492cb881d69530822"
+source = "git+https://github.com/p2pderivatives/rust-dlc?rev=78a8b46#78a8b46582ce193bc2dcacbc246338563ebc0ab7"
 dependencies = [
  "bitcoin",
  "dlc",
@@ -942,7 +942,7 @@ dependencies = [
 [[package]]
 name = "dlc-sled-storage-provider"
 version = "0.1.0"
-source = "git+https://github.com/p2pderivatives/rust-dlc?rev=049388b#049388b0131f045547f09bc492cb881d69530822"
+source = "git+https://github.com/p2pderivatives/rust-dlc?rev=78a8b46#78a8b46582ce193bc2dcacbc246338563ebc0ab7"
 dependencies = [
  "bitcoin",
  "dlc-manager",
@@ -956,7 +956,7 @@ dependencies = [
 [[package]]
 name = "dlc-trie"
 version = "0.4.0"
-source = "git+https://github.com/p2pderivatives/rust-dlc?rev=049388b#049388b0131f045547f09bc492cb881d69530822"
+source = "git+https://github.com/p2pderivatives/rust-dlc?rev=78a8b46#78a8b46582ce193bc2dcacbc246338563ebc0ab7"
 dependencies = [
  "bitcoin",
  "dlc",
@@ -2297,7 +2297,7 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 [[package]]
 name = "p2pd-oracle-client"
 version = "0.1.0"
-source = "git+https://github.com/p2pderivatives/rust-dlc?rev=049388b#049388b0131f045547f09bc492cb881d69530822"
+source = "git+https://github.com/p2pderivatives/rust-dlc?rev=78a8b46#78a8b46582ce193bc2dcacbc246338563ebc0ab7"
 dependencies = [
  "chrono",
  "dlc-manager",
@@ -3112,7 +3112,7 @@ dependencies = [
 [[package]]
 name = "simple-wallet"
 version = "0.1.0"
-source = "git+https://github.com/p2pderivatives/rust-dlc?rev=049388b#049388b0131f045547f09bc492cb881d69530822"
+source = "git+https://github.com/p2pderivatives/rust-dlc?rev=78a8b46#78a8b46582ce193bc2dcacbc246338563ebc0ab7"
 dependencies = [
  "bitcoin",
  "dlc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,13 +4,13 @@ resolver = "2"
 
 [patch.crates-io]
 # We should usually track the `feature/ln-dlc-channels[-10101]` branch
-dlc-manager = { git = "https://github.com/p2pderivatives/rust-dlc", rev = "049388b" }
-dlc-messages = { git = "https://github.com/p2pderivatives/rust-dlc", rev = "049388b" }
-dlc = { git = "https://github.com/p2pderivatives/rust-dlc", rev = "049388b" }
-dlc-sled-storage-provider = { git = "https://github.com/p2pderivatives/rust-dlc", rev = "049388b" }
-p2pd-oracle-client = { git = "https://github.com/p2pderivatives/rust-dlc", rev = "049388b" }
-dlc-trie = { git = "https://github.com/p2pderivatives/rust-dlc", rev = "049388b" }
-simple-wallet = { git = "https://github.com/p2pderivatives/rust-dlc", rev = "049388b" }
+dlc-manager = { git = "https://github.com/p2pderivatives/rust-dlc", rev = "78a8b46" }
+dlc-messages = { git = "https://github.com/p2pderivatives/rust-dlc", rev = "78a8b46" }
+dlc = { git = "https://github.com/p2pderivatives/rust-dlc", rev = "78a8b46" }
+dlc-sled-storage-provider = { git = "https://github.com/p2pderivatives/rust-dlc", rev = "78a8b46" }
+p2pd-oracle-client = { git = "https://github.com/p2pderivatives/rust-dlc", rev = "78a8b46" }
+dlc-trie = { git = "https://github.com/p2pderivatives/rust-dlc", rev = "78a8b46" }
+simple-wallet = { git = "https://github.com/p2pderivatives/rust-dlc", rev = "78a8b46" }
 
 # We should usually track the `split-tx-experiment[-10101]` branch
 lightning = { git = "https://github.com/p2pderivatives/rust-lightning/", rev = "26db9546" }


### PR DESCRIPTION
Fixes #1058.
Fixes #1056.

See https://github.com/p2pderivatives/rust-dlc/commit/8dfff94 for context.

---

I've been able to confirm that we don't run into #1058 or #1056 when upgrading to this patch instead of latest `main`.