### PR TITLE
Allow using different event handlers

### DIFF
--- a/coordinator/src/bin/coordinator.rs
+++ b/coordinator/src/bin/coordinator.rs
@@ -105,10 +105,10 @@ async fn main() -> Result<()> {
         ephemeral_randomness,
         settings.ln_dlc.clone(),
         opts.get_oracle_info(),
-        node_event_sender,
     )?);
 
-    let node = Node::new(node, pool.clone(), settings.to_node_settings());
+    let running = node.start(Some(node_event_sender))?;
+    let node = Node::new(node, running, pool.clone(), settings.to_node_settings());
 
     // TODO: Pass the tokio metrics into Prometheus
     if let Some(interval) = opts.tokio_metrics_interval_seconds {

--- a/coordinator/src/bin/coordinator.rs
+++ b/coordinator/src/bin/coordinator.rs
@@ -19,6 +19,7 @@ use diesel::r2d2::ConnectionManager;
 use diesel::PgConnection;
 use lightning::util::events::Event;
 use ln_dlc_node::seed::Bip39Seed;
+use ln_dlc_node::EventHandler;
 use rand::thread_rng;
 use rand::RngCore;
 use std::backtrace::Backtrace;
@@ -107,7 +108,8 @@ async fn main() -> Result<()> {
         opts.get_oracle_info(),
     )?);
 
-    let running = node.start(Some(node_event_sender))?;
+    let event_handler = EventHandler::new(node.clone(), Some(node_event_sender));
+    let running = node.start(event_handler)?;
     let node = Node::new(node, running, pool.clone(), settings.to_node_settings());
 
     // TODO: Pass the tokio metrics into Prometheus

--- a/coordinator/src/node.rs
+++ b/coordinator/src/node.rs
@@ -34,6 +34,7 @@ use lightning_invoice::Invoice;
 use ln_dlc_node::node;
 use ln_dlc_node::node::dlc_message_name;
 use ln_dlc_node::node::sub_channel_message_name;
+use ln_dlc_node::node::RunningNode;
 use ln_dlc_node::WalletSettings;
 use ln_dlc_node::CONTRACT_TX_FEE_RATE;
 use rust_decimal::prelude::ToPrimitive;
@@ -79,6 +80,7 @@ impl NodeSettings {
 #[derive(Clone)]
 pub struct Node {
     pub inner: Arc<node::Node<NodeStorage>>,
+    _running: Arc<RunningNode>,
     pub pool: Pool<ConnectionManager<PgConnection>>,
     settings: Arc<RwLock<NodeSettings>>,
 }
@@ -86,6 +88,7 @@ pub struct Node {
 impl Node {
     pub fn new(
         inner: Arc<node::Node<NodeStorage>>,
+        running: RunningNode,
         pool: Pool<ConnectionManager<PgConnection>>,
         settings: NodeSettings,
     ) -> Self {
@@ -93,6 +96,7 @@ impl Node {
             inner,
             pool,
             settings: Arc::new(RwLock::new(settings)),
+            _running: Arc::new(running),
         }
     }
 

--- a/crates/ln-dlc-node/src/lib.rs
+++ b/crates/ln-dlc-node/src/lib.rs
@@ -43,6 +43,7 @@ pub mod seed;
 pub mod transaction;
 
 pub use ln::EventHandler;
+pub use ln::EventHandlerTrait;
 pub use ln::CONFIRMATION_TARGET;
 pub use ln::CONTRACT_TX_FEE_RATE;
 pub use ln::JUST_IN_TIME_CHANNEL_OUTBOUND_LIQUIDITY_SAT_MAX;

--- a/crates/ln-dlc-node/src/lib.rs
+++ b/crates/ln-dlc-node/src/lib.rs
@@ -42,6 +42,7 @@ pub mod node;
 pub mod seed;
 pub mod transaction;
 
+pub use ln::EventHandler;
 pub use ln::CONFIRMATION_TARGET;
 pub use ln::CONTRACT_TX_FEE_RATE;
 pub use ln::JUST_IN_TIME_CHANNEL_OUTBOUND_LIQUIDITY_SAT_MAX;

--- a/crates/ln-dlc-node/src/ln/mod.rs
+++ b/crates/ln-dlc-node/src/ln/mod.rs
@@ -12,6 +12,7 @@ pub(crate) use config::app_config;
 pub use config::coordinator_config;
 pub use dlc_channel_details::DlcChannelDetails;
 pub use event_handler::EventHandler;
+pub use event_handler::EventHandlerTrait;
 pub(crate) use logger::TracingLogger;
 pub(crate) use manage_spendable_outputs::manage_spendable_outputs;
 

--- a/crates/ln-dlc-node/src/ln/mod.rs
+++ b/crates/ln-dlc-node/src/ln/mod.rs
@@ -11,7 +11,7 @@ pub use channel_details::ChannelDetails;
 pub(crate) use config::app_config;
 pub use config::coordinator_config;
 pub use dlc_channel_details::DlcChannelDetails;
-pub(crate) use event_handler::EventHandler;
+pub use event_handler::EventHandler;
 pub(crate) use logger::TracingLogger;
 pub(crate) use manage_spendable_outputs::manage_spendable_outputs;
 

--- a/crates/ln-dlc-node/src/node/mod.rs
+++ b/crates/ln-dlc-node/src/node/mod.rs
@@ -98,6 +98,8 @@ type Scorer = ProbabilisticScorer<Arc<NetworkGraph>, Arc<TracingLogger>>;
 type NodeGossipSync =
     P2PGossipSync<Arc<NetworkGraph>, Arc<dyn UtxoLookup + Send + Sync>, Arc<TracingLogger>>;
 
+type NodeEsploraClient = EsploraSyncClient<Arc<TracingLogger>>;
+
 /// An LN-DLC node.
 pub struct Node<S> {
     pub settings: Arc<RwLock<LnDlcNodeSettings>>,
@@ -111,10 +113,6 @@ pub struct Node<S> {
     keys_manager: Arc<CustomKeysManager>,
     pub network_graph: Arc<NetworkGraph>,
     pub fee_rate_estimator: Arc<FeeRateEstimator>,
-    _background_processor_handle: RemoteHandle<()>,
-    _connection_manager_handle: RemoteHandle<()>,
-    _broadcast_node_announcement_handle: RemoteHandle<()>,
-    _sub_channel_manager_periodic_check_handle: RemoteHandle<()>,
 
     logger: Arc<TracingLogger>,
 
@@ -127,12 +125,27 @@ pub struct Node<S> {
     pub dlc_message_handler: Arc<DlcMessageHandler>,
     storage: Arc<S>,
     pub ldk_config: Arc<parking_lot::RwLock<UserConfig>>,
+
+    // fields below are needed only to start the node
+    listen_address: SocketAddr,
+    gossip_sync: Arc<NodeGossipSync>,
+    persister: Arc<FilesystemPersister>,
+    alias: String,
+    announcement_addresses: Vec<NetAddress>,
+    scorer: Arc<Mutex<Scorer>>,
+    esplora_server_url: String,
+    esplora_client: Arc<NodeEsploraClient>,
 }
 
 #[derive(Debug, Clone, Copy, Deserialize, Serialize)]
 pub struct NodeInfo {
     pub pubkey: PublicKey,
     pub address: SocketAddr,
+}
+
+/// Node is running until this struct is dropped
+pub struct RunningNode {
+    _handles: Vec<RemoteHandle<()>>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -198,7 +211,6 @@ where
         seed: Bip39Seed,
         ephemeral_randomness: [u8; 32],
         oracle: OracleInfo,
-        event_sender: watch::Sender<Option<Event>>,
     ) -> Result<Self> {
         let ldk_config = app_config();
         Node::new(
@@ -218,7 +230,6 @@ where
             ldk_config,
             LnDlcNodeSettings::default(),
             oracle.into(),
-            Some(event_sender),
             disk::in_memory_scorer,
         )
     }
@@ -241,7 +252,6 @@ where
         ephemeral_randomness: [u8; 32],
         settings: LnDlcNodeSettings,
         oracle: OracleInfo,
-        event_sender: watch::Sender<Option<Event>>,
     ) -> Result<Self> {
         let mut ldk_config = coordinator_config();
 
@@ -265,7 +275,6 @@ where
             ldk_config,
             settings,
             oracle.into(),
-            Some(event_sender),
             disk::persistent_scorer,
         )
     }
@@ -290,7 +299,6 @@ where
         ldk_config: UserConfig,
         settings: LnDlcNodeSettings,
         oracle_client: P2PDOracleClient,
-        event_sender: Option<watch::Sender<Option<Event>>>,
         read_scorer: SC,
     ) -> Result<Self>
     where
@@ -340,11 +348,6 @@ where
         };
 
         let settings = Arc::new(RwLock::new(settings));
-
-        tokio::spawn(update_fee_rate_estimates(
-            settings.clone(),
-            fee_rate_estimator.clone(),
-        ));
 
         let chain_monitor: Arc<ChainMonitor> = Arc::new(chainmonitor::ChainMonitor::new(
             Some(esplora_client.clone()),
@@ -402,25 +405,6 @@ where
 
         let channel_manager = Arc::new(channel_manager);
 
-        std::thread::spawn(sync_on_chain_wallet_periodically(
-            settings.clone(),
-            ln_dlc_wallet.clone(),
-        ));
-
-        std::thread::spawn(shadow_sync_periodically(
-            settings.clone(),
-            node_storage.clone(),
-            ln_dlc_wallet.clone(),
-            channel_manager.clone(),
-        ));
-
-        tokio::spawn(lightning_wallet_sync(
-            channel_manager.clone(),
-            chain_monitor.clone(),
-            settings.clone(),
-            esplora_client,
-        ));
-
         let gossip_sync = Arc::new(P2PGossipSync::new(
             network_graph.clone(),
             None::<Arc<dyn UtxoLookup + Send + Sync>>,
@@ -463,63 +447,10 @@ where
         let fake_channel_payments: FakeChannelPaymentRequests =
             Arc::new(Mutex::new(HashMap::new()));
 
-        let event_handler = EventHandler::new(
-            channel_manager.clone(),
-            sub_channel_manager.clone(),
-            ln_dlc_wallet.clone(),
-            network_graph.clone(),
-            keys_manager.clone(),
-            node_storage.clone(),
-            fake_channel_payments.clone(),
-            Arc::new(Mutex::new(HashMap::new())),
-            peer_manager.clone(),
-            fee_rate_estimator.clone(),
-            event_sender,
-            ldk_config.clone(),
-        );
-
-        // Connection manager
-        let connection_manager_handle =
-            spawn_connection_management(peer_manager.clone(), listen_address);
-
-        tracing::info!("Starting background processor");
-
-        let background_processor_handle = spawn_background_processor(
-            peer_manager.clone(),
-            channel_manager.clone(),
-            chain_monitor.clone(),
-            logger.clone(),
-            persister,
-            event_handler,
-            gossip_sync,
-            scorer,
-        );
-
-        let broadcast_node_announcement_handle =
-            spawn_broadcast_node_annoucements(alias, announcement_addresses, peer_manager.clone())?;
-
-        let sub_channel_manager_periodic_check_handle = manage_sub_channels(
-            sub_channel_manager.clone(),
-            dlc_message_handler.clone(),
-            settings.clone(),
-        );
-
-        tokio::spawn(manage_spendable_outputs_task(
-            esplora_server_url,
-            node_storage.clone(),
-            ln_dlc_wallet.clone(),
-            fee_rate_estimator.clone(),
-            keys_manager.clone(),
-        ));
-
-        std::thread::spawn(monitor_for_deadlocks());
-
         let node_info = NodeInfo {
             pubkey: channel_manager.get_our_node_id(),
             address: announcement_address,
         };
-
-        tracing::info!("Lightning node started with node ID {}", node_info);
 
         Ok(Self {
             network,
@@ -538,13 +469,103 @@ where
             storage: node_storage,
             fee_rate_estimator,
             ldk_config,
-            _background_processor_handle: background_processor_handle,
-            _connection_manager_handle: connection_manager_handle,
-            _broadcast_node_announcement_handle: broadcast_node_announcement_handle,
-            _sub_channel_manager_periodic_check_handle: sub_channel_manager_periodic_check_handle,
             network_graph,
             settings,
+            listen_address,
+            gossip_sync,
+            persister,
+            alias: alias.to_string(),
+            announcement_addresses,
+            scorer,
+            esplora_server_url,
+            esplora_client,
         })
+    }
+
+    /// Starts the background handles - if the returned handles are dropped, the
+    /// background tasks are stopped.
+    // TODO: Consider having handles for *all* the tasks & threads for a clean shutdown.
+    pub fn start(&self, event_sender: Option<watch::Sender<Option<Event>>>) -> Result<RunningNode> {
+        let mut handles = vec![spawn_connection_management(
+            self.peer_manager.clone(),
+            self.listen_address,
+        )];
+
+        let event_handler = EventHandler::new(
+            self.channel_manager.clone(),
+            self.sub_channel_manager.clone(),
+            self.wallet.clone(),
+            self.network_graph.clone(),
+            self.keys_manager.clone(),
+            self.storage.clone(),
+            self.fake_channel_payments.clone(),
+            Arc::new(Mutex::new(HashMap::new())),
+            self.peer_manager.clone(),
+            self.fee_rate_estimator.clone(),
+            event_sender,
+            self.ldk_config.clone(),
+        );
+
+        std::thread::spawn(sync_on_chain_wallet_periodically(
+            self.settings.clone(),
+            self.wallet.clone(),
+        ));
+
+        std::thread::spawn(shadow_sync_periodically(
+            self.settings.clone(),
+            self.storage.clone(),
+            self.wallet.clone(),
+            self.channel_manager.clone(),
+        ));
+
+        tokio::spawn(lightning_wallet_sync(
+            self.channel_manager.clone(),
+            self.chain_monitor.clone(),
+            self.settings.clone(),
+            self.esplora_client.clone(),
+        ));
+
+        tokio::spawn(update_fee_rate_estimates(
+            self.settings.clone(),
+            self.fee_rate_estimator.clone(),
+        ));
+
+        handles.push(spawn_background_processor(
+            self.peer_manager.clone(),
+            self.channel_manager.clone(),
+            self.chain_monitor.clone(),
+            self.logger.clone(),
+            self.persister.clone(),
+            event_handler,
+            self.gossip_sync.clone(),
+            self.scorer.clone(),
+        ));
+
+        handles.push(spawn_broadcast_node_annoucements(
+            &self.alias,
+            self.announcement_addresses.clone(),
+            self.peer_manager.clone(),
+        )?);
+
+        handles.push(manage_sub_channels(
+            self.sub_channel_manager.clone(),
+            self.dlc_message_handler.clone(),
+            self.settings.clone(),
+        ));
+
+        tokio::spawn(manage_spendable_outputs_task(
+            self.esplora_server_url.clone(),
+            self.storage.clone(),
+            self.wallet.clone(),
+            self.fee_rate_estimator.clone(),
+            self.keys_manager.clone(),
+        ));
+
+        std::thread::spawn(monitor_for_deadlocks());
+
+        tracing::info!("Lightning node started with node ID {}", self.info);
+
+        Ok(RunningNode { _handles: handles })
     }
 
     pub fn update_ldk_settings(&self, ldk_config: UserConfig) {
@@ -599,6 +620,7 @@ fn spawn_background_processor<S: Storage + Send + Sync + 'static>(
     gossip_sync: Arc<NodeGossipSync>,
     scorer: Arc<Mutex<Scorer>>,
 ) -> RemoteHandle<()> {
+    tracing::info!("Starting background processor");
     let (fut, remote_handle) = async move {
         if let Err(e) = process_events_async(
             persister,

--- a/crates/ln-dlc-node/src/tests/dlc/collaborative_settlement.rs
+++ b/crates/ln-dlc-node/src/tests/dlc/collaborative_settlement.rs
@@ -24,8 +24,8 @@ async fn dlc_collaborative_settlement_test() {
 
     let fund_amount = (app_ln_balance + coordinator_ln_balance) * 2;
 
-    let app = Node::start_test_app("app").unwrap();
-    let coordinator = Node::start_test_coordinator("coordinator").unwrap();
+    let (app, _running_app) = Node::start_test_app("app").unwrap();
+    let (coordinator, _running_coord) = Node::start_test_coordinator("coordinator").unwrap();
 
     app.connect(coordinator.info).await.unwrap();
 
@@ -95,8 +95,8 @@ async fn open_dlc_channel_after_closing_dlc_channel() {
 
     let fund_amount = (app_ln_balance + coordinator_ln_balance) * 2;
 
-    let app = Node::start_test_app("app").unwrap();
-    let coordinator = Node::start_test_coordinator("coordinator").unwrap();
+    let (app, _running_app) = Node::start_test_app("app").unwrap();
+    let (coordinator, _running_coord) = Node::start_test_coordinator("coordinator").unwrap();
 
     app.connect(coordinator.info).await.unwrap();
 

--- a/crates/ln-dlc-node/src/tests/dlc/create.rs
+++ b/crates/ln-dlc-node/src/tests/dlc/create.rs
@@ -24,8 +24,8 @@ async fn given_lightning_channel_then_can_add_dlc_channel() {
 
     let fund_amount = (app_ln_balance + coordinator_ln_balance) * 2;
 
-    let app = Node::start_test_app("app").unwrap();
-    let coordinator = Node::start_test_coordinator("coordinator").unwrap();
+    let (app, _running_app) = Node::start_test_app("app").unwrap();
+    let (coordinator, _running_coord) = Node::start_test_coordinator("coordinator").unwrap();
 
     app.connect(coordinator.info).await.unwrap();
 

--- a/crates/ln-dlc-node/src/tests/dlc/dlc_setup_with_reconnects.rs
+++ b/crates/ln-dlc-node/src/tests/dlc/dlc_setup_with_reconnects.rs
@@ -9,7 +9,6 @@ use anyhow::Context;
 use bitcoin::Amount;
 use dlc_manager::subchannel::SubChannelState;
 use dlc_manager::Storage;
-use std::sync::Arc;
 use std::time::Duration;
 
 #[tokio::test(flavor = "multi_thread")]
@@ -19,8 +18,8 @@ async fn reconnecting_during_dlc_channel_setup() {
 
     // Arrange
 
-    let app = Arc::new(Node::start_test_app("app").unwrap());
-    let coordinator = Arc::new(Node::start_test_coordinator("coordinator").unwrap());
+    let (app, _running_app) = Node::start_test_app("app").unwrap();
+    let (coordinator, _running_coord) = Node::start_test_coordinator("coordinator").unwrap();
 
     let coordinator_info = coordinator.info;
 
@@ -242,8 +241,8 @@ async fn can_lose_connection_before_processing_subchannel_close_finalize() {
 
     let fund_amount = (app_ln_balance + coordinator_ln_balance) * 2;
 
-    let app = Node::start_test_app("app").unwrap();
-    let coordinator = Node::start_test_coordinator("coordinator").unwrap();
+    let (app, _running_app) = Node::start_test_app("app").unwrap();
+    let (coordinator, _running_coord) = Node::start_test_coordinator("coordinator").unwrap();
 
     app.connect(coordinator.info).await.unwrap();
 

--- a/crates/ln-dlc-node/src/tests/dlc/dlc_setup_with_reconnects.rs
+++ b/crates/ln-dlc-node/src/tests/dlc/dlc_setup_with_reconnects.rs
@@ -346,8 +346,8 @@ async fn reconnecting_during_dlc_channel_setup_reversed() {
 
     // Arrange
 
-    let app = Arc::new(Node::start_test_app("app").unwrap());
-    let coordinator = Arc::new(Node::start_test_coordinator("coordinator").unwrap());
+    let (app, _running_app) = Node::start_test_app("app").unwrap();
+    let (coordinator, _running_coord) = Node::start_test_coordinator("coordinator").unwrap();
 
     let coordinator_info = coordinator.info;
 

--- a/crates/ln-dlc-node/src/tests/dlc/non_collaborative_settlement.rs
+++ b/crates/ln-dlc-node/src/tests/dlc/non_collaborative_settlement.rs
@@ -20,8 +20,8 @@ async fn force_close_ln_dlc_channel() {
 
     let fund_amount = (app_ln_balance + coordinator_ln_balance) * 2;
 
-    let app = Node::start_test_app("app").unwrap();
-    let coordinator = Node::start_test_coordinator("coordinator").unwrap();
+    let (app, _running_app) = Node::start_test_app("app").unwrap();
+    let (coordinator, _running_coord) = Node::start_test_coordinator("coordinator").unwrap();
 
     app.connect(coordinator.info).await.unwrap();
 

--- a/crates/ln-dlc-node/src/tests/just_in_time_channel/channel_close.rs
+++ b/crates/ln-dlc-node/src/tests/just_in_time_channel/channel_close.rs
@@ -12,9 +12,9 @@ async fn ln_collab_close() {
 
     // Arrange
 
-    let payer = Node::start_test_app("payer").unwrap();
-    let coordinator = Node::start_test_coordinator("coordinator").unwrap();
-    let payee = Node::start_test_app("payee").unwrap();
+    let (payer, _running_payer) = Node::start_test_app("payer").unwrap();
+    let (coordinator, _running_coord) = Node::start_test_coordinator("coordinator").unwrap();
+    let (payee, _running_payee) = Node::start_test_app("payee").unwrap();
 
     payer.connect(coordinator.info).await.unwrap();
     payee.connect(coordinator.info).await.unwrap();
@@ -87,9 +87,9 @@ async fn ln_force_close() {
 
     // Arrange
 
-    let payer = Node::start_test_app("payer").unwrap();
-    let coordinator = Node::start_test_coordinator("coordinator").unwrap();
-    let payee = Node::start_test_app("payee").unwrap();
+    let (payer, _running_payer) = Node::start_test_app("payer").unwrap();
+    let (coordinator, _running_coord) = Node::start_test_coordinator("coordinator").unwrap();
+    let (payee, _running_payee) = Node::start_test_app("payee").unwrap();
 
     payer.connect(coordinator.info).await.unwrap();
     payee.connect(coordinator.info).await.unwrap();

--- a/crates/ln-dlc-node/src/tests/just_in_time_channel/fail_intercepted_htlc.rs
+++ b/crates/ln-dlc-node/src/tests/just_in_time_channel/fail_intercepted_htlc.rs
@@ -17,9 +17,9 @@ async fn fail_intercepted_htlc_if_coordinator_cannot_reconnect_to_payee() {
 
     // Arrange
 
-    let payer = Node::start_test_app("payer").unwrap();
-    let coordinator = Node::start_test_coordinator("coordinator").unwrap();
-    let payee = Node::start_test_app("payee").unwrap();
+    let (payer, _running_payer) = Node::start_test_app("payer").unwrap();
+    let (coordinator, _running_coord) = Node::start_test_coordinator("coordinator").unwrap();
+    let (payee, _running_payee) = Node::start_test_app("payee").unwrap();
 
     payer.connect(coordinator.info).await.unwrap();
     payee.connect(coordinator.info).await.unwrap();
@@ -69,11 +69,11 @@ async fn fail_intercepted_htlc_if_connection_lost_after_funding_tx_generated() {
 
     // Arrange
 
-    let payer = Node::start_test_app("payer").unwrap();
+    let (payer, _running_payer) = Node::start_test_app("payer").unwrap();
 
-    let (coordinator, mut ldk_node_event_receiver_coordinator) = {
+    let (coordinator, _running_coord, mut ldk_node_event_receiver_coordinator) = {
         let (sender, receiver) = tokio::sync::watch::channel(None);
-        let node = Node::start_test_coordinator_internal(
+        let (coordinator, _running_coord) = Node::start_test_coordinator_internal(
             "coordinator",
             Arc::new(InMemoryStore::default()),
             LnDlcNodeSettings::default(),
@@ -81,10 +81,10 @@ async fn fail_intercepted_htlc_if_connection_lost_after_funding_tx_generated() {
         )
         .unwrap();
 
-        (node, receiver)
+        (coordinator, _running_coord, receiver)
     };
 
-    let payee = Node::start_test_app("payee").unwrap();
+    let (payee, _running_payee) = Node::start_test_app("payee").unwrap();
 
     payer.connect(coordinator.info).await.unwrap();
     payee.connect(coordinator.info).await.unwrap();
@@ -141,9 +141,9 @@ async fn fail_intercepted_htlc_if_coordinator_cannot_pay_to_open_jit_channel() {
 
     // Arrange
 
-    let payer = Node::start_test_app("payer").unwrap();
-    let coordinator = Node::start_test_coordinator("coordinator").unwrap();
-    let payee = Node::start_test_app("payee").unwrap();
+    let (payer, _running_payer) = Node::start_test_app("payer").unwrap();
+    let (coordinator, _running_coord) = Node::start_test_coordinator("coordinator").unwrap();
+    let (payee, _running_payee) = Node::start_test_app("payee").unwrap();
 
     payer.connect(coordinator.info).await.unwrap();
     payee.connect(coordinator.info).await.unwrap();

--- a/crates/ln-dlc-node/src/tests/just_in_time_channel/payments.rs
+++ b/crates/ln-dlc-node/src/tests/just_in_time_channel/payments.rs
@@ -11,9 +11,9 @@ async fn just_in_time_channel_with_multiple_payments() {
 
     // Arrange
 
-    let payer = Node::start_test_app("payer").unwrap();
-    let coordinator = Node::start_test_coordinator("coordinator").unwrap();
-    let payee = Node::start_test_app("payee").unwrap();
+    let (payer, _running_payer) = Node::start_test_app("payer").unwrap();
+    let (coordinator, _running_coord) = Node::start_test_coordinator("coordinator").unwrap();
+    let (payee, _running_payee) = Node::start_test_app("payee").unwrap();
 
     payer.connect(coordinator.info).await.unwrap();
     payee.connect(coordinator.info).await.unwrap();
@@ -64,9 +64,9 @@ async fn new_config_affects_routing_fees() {
 
     // Arrange
 
-    let payer = Node::start_test_app("payer").unwrap();
-    let coordinator = Node::start_test_coordinator("coordinator").unwrap();
-    let payee = Node::start_test_app("payee").unwrap();
+    let (payer, _running_payer) = Node::start_test_app("payer").unwrap();
+    let (coordinator, _running_coord) = Node::start_test_coordinator("coordinator").unwrap();
+    let (payee, _running_payee) = Node::start_test_app("payee").unwrap();
 
     payer.connect(coordinator.info).await.unwrap();
     payee.connect(coordinator.info).await.unwrap();

--- a/crates/ln-dlc-node/src/tests/load.rs
+++ b/crates/ln-dlc-node/src/tests/load.rs
@@ -28,21 +28,20 @@ async fn single_app_many_positions_load() {
     init_tracing();
 
     let coordinator = Coordinator::new_public_regtest();
-    let app = Arc::new(
-        Node::start_test(
-            "app",
-            app_config(),
-            ESPLORA_ORIGIN_PUBLIC_REGTEST.to_string(),
-            OracleInfo {
-                endpoint: ORACLE_ORIGIN_PUBLIC_REGTEST.to_string(),
-                public_key: XOnlyPublicKey::from_str(ORACLE_PUBKEY_PUBLIC_REGTEST).unwrap(),
-            },
-            Arc::new(InMemoryStore::default()),
-            LnDlcNodeSettings::default(),
-            None,
-        )
-        .unwrap(),
-    );
+    let (app, _running_app) = Node::start_test(
+        "app",
+        app_config(),
+        ESPLORA_ORIGIN_PUBLIC_REGTEST.to_string(),
+        OracleInfo {
+            endpoint: ORACLE_ORIGIN_PUBLIC_REGTEST.to_string(),
+            public_key: XOnlyPublicKey::from_str(ORACLE_PUBKEY_PUBLIC_REGTEST).unwrap(),
+        },
+        Arc::new(InMemoryStore::default()),
+        LnDlcNodeSettings::default(),
+        None,
+    )
+    .unwrap();
+    let app = Arc::new(app);
 
     tokio::spawn({
         let app = app.clone();

--- a/crates/ln-dlc-node/src/tests/load.rs
+++ b/crates/ln-dlc-node/src/tests/load.rs
@@ -41,7 +41,6 @@ async fn single_app_many_positions_load() {
         None,
     )
     .unwrap();
-    let app = Arc::new(app);
 
     tokio::spawn({
         let app = app.clone();

--- a/crates/ln-dlc-node/src/tests/mod.rs
+++ b/crates/ln-dlc-node/src/tests/mod.rs
@@ -7,6 +7,7 @@ use crate::node::LnDlcNodeSettings;
 use crate::node::Node;
 use crate::node::NodeInfo;
 use crate::node::OracleInfo;
+use crate::node::RunningNode;
 use crate::seed::Bip39Seed;
 use crate::util;
 use anyhow::Result;
@@ -85,7 +86,7 @@ fn init_tracing() {
 }
 
 impl Node<InMemoryStore> {
-    fn start_test_app(name: &str) -> Result<Self> {
+    fn start_test_app(name: &str) -> Result<(Self, RunningNode)> {
         Self::start_test(
             name,
             app_config(),
@@ -100,7 +101,7 @@ impl Node<InMemoryStore> {
         )
     }
 
-    fn start_test_coordinator(name: &str) -> Result<Self> {
+    fn start_test_coordinator(name: &str) -> Result<(Self, RunningNode)> {
         Self::start_test_coordinator_internal(
             name,
             Arc::new(InMemoryStore::default()),
@@ -114,7 +115,7 @@ impl Node<InMemoryStore> {
         storage: Arc<InMemoryStore>,
         settings: LnDlcNodeSettings,
         ldk_event_sender: Option<watch::Sender<Option<Event>>>,
-    ) -> Result<Self> {
+    ) -> Result<(Self, RunningNode)> {
         Self::start_test(
             name,
             coordinator_config(),
@@ -137,7 +138,7 @@ impl Node<InMemoryStore> {
         storage: Arc<InMemoryStore>,
         settings: LnDlcNodeSettings,
         ldk_event_sender: Option<watch::Sender<Option<Event>>>,
-    ) -> Result<Self> {
+    ) -> Result<(Self, RunningNode)> {
         let data_dir = random_tmp_dir().join(name);
 
         let seed = Bip39Seed::new().expect("A valid bip39 seed");
@@ -164,13 +165,14 @@ impl Node<InMemoryStore> {
             ldk_config,
             settings,
             oracle.into(),
-            ldk_event_sender,
             disk::in_memory_scorer,
         )?;
 
+        let running = node.start(ldk_event_sender)?;
+
         tracing::debug!(%name, info = %node.info, "Node started");
 
-        Ok(node)
+        Ok((node, running))
     }
 
     /// Trigger on-chain wallet sync.

--- a/crates/ln-dlc-node/src/tests/multi_hop_payment.rs
+++ b/crates/ln-dlc-node/src/tests/multi_hop_payment.rs
@@ -13,9 +13,9 @@ async fn multi_hop_payment() {
 
     // Arrange
 
-    let payer = Node::start_test_app("payer").unwrap();
-    let coordinator = Node::start_test_coordinator("coordinator").unwrap();
-    let payee = Node::start_test_app("payee").unwrap();
+    let (payer, _running_payer) = Node::start_test_app("payer").unwrap();
+    let (coordinator, _running_coord) = Node::start_test_coordinator("coordinator").unwrap();
+    let (payee, _running_payee) = Node::start_test_app("payee").unwrap();
 
     payer.connect(coordinator.info).await.unwrap();
     payee.connect(coordinator.info).await.unwrap();

--- a/crates/ln-dlc-node/src/tests/single_hop_payment.rs
+++ b/crates/ln-dlc-node/src/tests/single_hop_payment.rs
@@ -9,8 +9,8 @@ async fn single_hop_payment() {
 
     // Arrange
 
-    let payer = Node::start_test_app("payer").unwrap();
-    let payee = Node::start_test_app("payee").unwrap();
+    let (payer, _running_payer) = Node::start_test_app("payer").unwrap();
+    let (payee, _running_payee) = Node::start_test_app("payee").unwrap();
 
     payer.connect(payee.info).await.unwrap();
 

--- a/mobile/native/src/ln_dlc/mod.rs
+++ b/mobile/native/src/ln_dlc/mod.rs
@@ -33,6 +33,7 @@ use ln_dlc_node::node::rust_dlc_manager::ChannelId;
 use ln_dlc_node::node::LnDlcNodeSettings;
 use ln_dlc_node::node::NodeInfo;
 use ln_dlc_node::seed::Bip39Seed;
+use ln_dlc_node::EventHandler;
 use ln_dlc_node::CONFIRMATION_TARGET;
 use orderbook_commons::RouteHintHop;
 use orderbook_commons::FEE_INVOICE_DESCRIPTION_PREFIX_TAKER;
@@ -186,8 +187,10 @@ pub fn run(data_dir: String, seed_dir: String, runtime: &Runtime) -> Result<()> 
             ephemeral_randomness,
             config::get_oracle_info(),
         )?;
+        let node = Arc::new(node);
 
-        let _running = node.start(Some(event_sender))?;
+        let event_handler = EventHandler::new(node.clone(), Some(event_sender));
+        let _running = node.start(event_handler)?;
         let node = Arc::new(Node::new(node, _running));
 
         runtime.spawn({

--- a/mobile/native/src/ln_dlc/mod.rs
+++ b/mobile/native/src/ln_dlc/mod.rs
@@ -36,7 +36,6 @@ use ln_dlc_node::seed::Bip39Seed;
 use ln_dlc_node::CONFIRMATION_TARGET;
 use orderbook_commons::RouteHintHop;
 use orderbook_commons::FEE_INVOICE_DESCRIPTION_PREFIX_TAKER;
-use parking_lot::RwLock;
 use rust_decimal::Decimal;
 use state::Storage;
 use std::net::IpAddr;
@@ -175,7 +174,7 @@ pub fn run(data_dir: String, seed_dir: String, runtime: &Runtime) -> Result<()> 
 
         let (event_sender, event_receiver) = watch::channel::<Option<Event>>(None);
 
-        let node = Arc::new(ln_dlc_node::node::Node::new_app(
+        let node = ln_dlc_node::node::Node::new_app(
             "10101",
             network,
             data_dir.as_path(),
@@ -186,12 +185,10 @@ pub fn run(data_dir: String, seed_dir: String, runtime: &Runtime) -> Result<()> 
             seed,
             ephemeral_randomness,
             config::get_oracle_info(),
-            event_sender,
-        )?);
-        let node = Arc::new(Node {
-            inner: node,
-            order_matching_fee_invoice: Arc::new(RwLock::new(None)),
-        });
+        )?;
+
+        let _running = node.start(Some(event_sender))?;
+        let node = Arc::new(Node::new(node, _running));
 
         runtime.spawn({
             let node = node.clone();

--- a/mobile/native/src/ln_dlc/node.rs
+++ b/mobile/native/src/ln_dlc/node.rs
@@ -27,6 +27,7 @@ use ln_dlc_node::node::rust_dlc_manager::Storage as _;
 use ln_dlc_node::node::sub_channel_message_name;
 use ln_dlc_node::node::NodeInfo;
 use ln_dlc_node::node::PaymentDetails;
+use ln_dlc_node::node::RunningNode;
 use ln_dlc_node::transaction::Transaction;
 use ln_dlc_node::HTLCStatus;
 use ln_dlc_node::MillisatAmount;
@@ -40,10 +41,21 @@ use time::OffsetDateTime;
 #[derive(Clone)]
 pub struct Node {
     pub inner: Arc<ln_dlc_node::node::Node<NodeStorage>>,
+    _running: Arc<RunningNode>,
     /// The order-matching fee invoice to be paid once the current trade is executed.
     ///
     /// We assume that only one trade can be executed at a time.
     pub order_matching_fee_invoice: Arc<RwLock<Option<Invoice>>>,
+}
+
+impl Node {
+    pub fn new(node: node::Node<NodeStorage>, running: RunningNode) -> Self {
+        Self {
+            inner: Arc::new(node),
+            _running: Arc::new(running),
+            order_matching_fee_invoice: Arc::new(RwLock::new(None)),
+        }
+    }
 }
 
 pub struct Balances {

--- a/mobile/native/src/ln_dlc/node.rs
+++ b/mobile/native/src/ln_dlc/node.rs
@@ -49,9 +49,9 @@ pub struct Node {
 }
 
 impl Node {
-    pub fn new(node: node::Node<NodeStorage>, running: RunningNode) -> Self {
+    pub fn new(node: Arc<node::Node<NodeStorage>>, running: RunningNode) -> Self {
         Self {
-            inner: Arc::new(node),
+            inner: node,
             _running: Arc::new(running),
             order_matching_fee_invoice: Arc::new(RwLock::new(None)),
         }


### PR DESCRIPTION
The main motivation was as such:
Separate the boring things (e.g. initialisation of bajilion pieces of LDK) from the customisation points, which might be different.

As such, `ln_dlc_node::Node` is only a collection of entities needed to be used to run a LDK node with DLC capable.
For now, there's a single 'start' method into which different EventHandlers can be passed in.

It's easy to imagine that if we ever need/want to just have separate free functions in various node implementations for starting the node. They can be composed quite easily with the aid of the functions extracted from Node in a PR made recently.
As such, this is not the scope of the ticket, and I had to stop the refactor somewhere 😀