### PR TITLE
chore: Remove Dart developer logs

### DIFF
--- a/mobile/lib/common/application/event_service.dart
+++ b/mobile/lib/common/application/event_service.dart
@@ -1,6 +1,6 @@
 import 'dart:collection';
-import 'dart:developer';
 
+import 'package:f_logs/model/flog/flog.dart';
 import 'package:get_10101/ffi.dart';
 
 abstract class Subscriber {
@@ -13,7 +13,7 @@ class EventService {
   EventService.create() {
     api.subscribe().listen((Event event) {
       if (subscribers[event.runtimeType] == null) {
-        log("found no subscribers, skipping event");
+        FLog.debug(text: "found no subscribers, skipping event");
         return;
       }
 

--- a/mobile/lib/features/trade/order_change_notifier.dart
+++ b/mobile/lib/features/trade/order_change_notifier.dart
@@ -1,5 +1,5 @@
-import 'dart:developer';
 import 'package:flutter/material.dart';
+import 'package:f_logs/model/flog/flog.dart';
 import 'package:get_10101/bridge_generated/bridge_definitions.dart' as bridge;
 import 'package:get_10101/common/application/event_service.dart';
 import 'package:get_10101/features/trade/application/order_service.dart';
@@ -26,15 +26,13 @@ class OrderChangeNotifier extends ChangeNotifier implements Subscriber {
   // TODO: This is not optimal, because we map the Order in the change notifier. We can do this, but it would be better to do this on the service level.
   @override
   void notify(bridge.Event event) {
-    log("Receiving this in the order notifier: ${event.toString()}");
-
     if (event is bridge.Event_OrderUpdateNotification) {
       Order order = Order.fromApi(event.field0);
       orders[order.id] = order;
 
       sortOrderByTimestampDesc();
     } else {
-      log("Received unexpected event: ${event.toString()}");
+      FLog.warning(text: "Received unexpected event: ${event.toString()}");
     }
 
     notifyListeners();

--- a/mobile/lib/features/trade/position_change_notifier.dart
+++ b/mobile/lib/features/trade/position_change_notifier.dart
@@ -1,4 +1,4 @@
-import 'dart:developer';
+import 'package:f_logs/model/flog/flog.dart';
 import 'package:flutter/material.dart';
 import 'package:get_10101/common/application/event_service.dart';
 import 'package:get_10101/common/domain/model.dart';
@@ -29,8 +29,6 @@ class PositionChangeNotifier extends ChangeNotifier implements Subscriber {
 
   @override
   void notify(bridge.Event event) {
-    log("Receiving this in the position notifier: ${event.toString()}");
-
     if (event is bridge.Event_PositionUpdateNotification) {
       Position position = Position.fromApi(event.field0);
 
@@ -55,7 +53,7 @@ class PositionChangeNotifier extends ChangeNotifier implements Subscriber {
         }
       }
     } else {
-      log("Received unexpected event: ${event.toString()}");
+      FLog.warning(text: "Received unexpected event: ${event.toString()}");
     }
 
     notifyListeners();

--- a/mobile/lib/features/trade/submit_order_change_notifier.dart
+++ b/mobile/lib/features/trade/submit_order_change_notifier.dart
@@ -1,4 +1,3 @@
-import 'dart:developer';
 import 'package:f_logs/model/flog/flog.dart';
 import 'package:flutter/material.dart';
 import 'package:get_10101/common/application/event_service.dart';
@@ -63,8 +62,6 @@ class SubmitOrderChangeNotifier extends ChangeNotifier implements Subscriber {
   // TODO: This is not optimal, because we map the Order in the change notifier. We can do this, but it would be better to do this on the service level.
   @override
   void notify(bridge.Event event) {
-    log("Receiving this in the submit order change notifier: ${event.toString()}");
-
     if (event is bridge.Event_OrderUpdateNotification) {
       Order order = Order.fromApi(event.field0);
 
@@ -83,7 +80,7 @@ class SubmitOrderChangeNotifier extends ChangeNotifier implements Subscriber {
         notifyListeners();
       }
     } else {
-      log("Received unexpected event: ${event.toString()}");
+      FLog.warning(text: "Received unexpected event: ${event.toString()}");
     }
   }
 

--- a/mobile/lib/features/wallet/share_invoice_screen.dart
+++ b/mobile/lib/features/wallet/share_invoice_screen.dart
@@ -1,6 +1,4 @@
 import 'dart:convert';
-import 'dart:developer';
-
 import 'package:f_logs/f_logs.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -39,7 +37,7 @@ class _ShareInvoiceScreenState extends State<ShareInvoiceScreen> {
     WalletInfo info = context.watch<WalletChangeNotifier>().walletInfo;
     final bridge.Config config = context.read<bridge.Config>();
 
-    log("Refresh receive screen: ${info.balances.onChain}");
+    FLog.debug(text: "Refresh receive screen: ${info.balances.onChain}");
 
     const EdgeInsets buttonSpacing = EdgeInsets.symmetric(vertical: 8.0, horizontal: 24.0);
 

--- a/mobile/lib/features/wallet/wallet_change_notifier.dart
+++ b/mobile/lib/features/wallet/wallet_change_notifier.dart
@@ -1,5 +1,4 @@
 import 'package:f_logs/f_logs.dart';
-import 'dart:developer';
 import 'package:flutter/material.dart' hide Flow;
 import 'package:get_10101/bridge_generated/bridge_definitions.dart' as bridge;
 import 'package:get_10101/common/application/event_service.dart';
@@ -43,12 +42,10 @@ class WalletChangeNotifier extends ChangeNotifier implements Subscriber {
   // TODO: This is not optimal, because we map the WalletInfo in the change notifier. We can do this, but it would be better to do this on the service level.
   @override
   void notify(bridge.Event event) {
-    log("Receiving this in the order notifier: ${event.toString()}");
-
     if (event is bridge.Event_WalletInfoUpdateNotification) {
       update(WalletInfo.fromApi(event.field0));
     } else {
-      log("Received unexpected event: ${event.toString()}");
+      FLog.warning(text: "Received unexpected event: ${event.toString()}");
     }
   }
 }


### PR DESCRIPTION
We are using a dedicated logging framework.