### PR TITLE
fix: Fix recent db migration in the app

### DIFF
--- a/mobile/native/migrations/2023-08-07-232900_add_order_expiry_to_order/up.sql
+++ b/mobile/native/migrations/2023-08-07-232900_add_order_expiry_to_order/up.sql
@@ -1,3 +1,3 @@
 ALTER TABLE
     orders
-ADD COLUMN order_expiry_timestamp BIGINT NOT NULL DEFAULT (strftime('%s', 'now'));
+ADD COLUMN order_expiry_timestamp BIGINT NOT NULL DEFAULT 0;


### PR DESCRIPTION
If the orders table was not empty,
the migration would never succeed as sqlite does not allow setting
non-const default values unfortunately.

Given that all the historical orders in the DB would have been
outdated in 60 seconds anyway, set the default expiry to 0 instead.