### PR TITLE
chore(justfile): Don't invalidate the cache between iOS and native builds

### DIFF
--- a/justfile
+++ b/justfile
@@ -75,8 +75,8 @@ android-release:
 
 # Build Rust library for iOS (debug mode)
 ios:
-    cd mobile/native && cargo lipo
-    cp target/universal/debug/libnative.a mobile/ios/Runner
+    cd mobile/native && CARGO_TARGET_DIR=../../target/ios_debug cargo lipo
+    cp target/ios_debug/universal/debug/libnative.a mobile/ios/Runner
 
 # Build Rust library for iOS (release mode)
 ios-release:
@@ -267,7 +267,7 @@ services: docker run-coordinator-detached run-maker-detached wait-for-coordinato
 # Note: if you have mobile simulator running, it will start that one instead of native, but will *not* rebuild the mobile rust library.
 all: services gen native run
 
-# Run everything at once, tailored for iOS development (rebuilds iOS)
+# Run everything at once, tailored for iOS development
 all-ios: services gen ios run
 
 # Run everything at once, tailored for Android development (rebuilds Android)


### PR DESCRIPTION
It was a major slowdown to wait for the project to recompile as cache was being invalidated.

By specifying a different target directory we ensure build artefacts will be
preserved when switching between `just ios` and `just native`.

Note: Only the debug build has been adjusted, as this should not matter for the releases.