### PR TITLE
Wumbo trade: aka configurable channel size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - Add support for push notifications
+- Added new setting to coordinator to configure max channel size to traders
 
 ## [1.2.0] - 2023-08-04
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -389,7 +389,7 @@ checksum = "ed2f2e73fffe9455141e170fb9c1feb0ac521ec7e7dcd47a7cab72a658490fb8"
 dependencies = [
  "chrono",
  "serde",
- "serde_with",
+ "serde_with 1.14.0",
 ]
 
 [[package]]
@@ -804,8 +804,18 @@ version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a01d95850c592940db9b8194bc39f4bc0e89dee5c4265e4b1807c34a9aba453c"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.13.4",
+ "darling_macro 0.13.4",
+]
+
+[[package]]
+name = "darling"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0209d94da627ab5605dcccf08bb18afa5009cfbef48d8a8b7d7bdbc79be25c5e"
+dependencies = [
+ "darling_core 0.20.3",
+ "darling_macro 0.20.3",
 ]
 
 [[package]]
@@ -823,14 +833,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_core"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "177e3443818124b357d8e76f53be906d60937f0d3a90773a664fa63fa253e621"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.23",
+]
+
+[[package]]
 name = "darling_macro"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c972679f83bdf9c42bd905396b6c3588a843a17f0f16dfcfa3e2c5d57441835"
 dependencies = [
- "darling_core",
+ "darling_core 0.13.4",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "836a9bbc7ad63342d6d6e7b815ccab164bc77a2d95d84bc3117a8c0d5c98e2d5"
+dependencies = [
+ "darling_core 0.20.3",
+ "quote",
+ "syn 2.0.23",
 ]
 
 [[package]]
@@ -1000,6 +1035,12 @@ checksum = "071a31f4ee85403370b58aca746f01041ede6f0da2730960ad001edc2b71b394"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "equivalent"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
@@ -1291,7 +1332,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http",
- "indexmap",
+ "indexmap 1.9.2",
  "slab",
  "tokio",
  "tokio-util",
@@ -1315,6 +1356,12 @@ checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
 dependencies = [
  "ahash 0.8.3",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
 
 [[package]]
 name = "hdrhistogram"
@@ -1520,6 +1567,18 @@ checksum = "1885e79c1fc4b10f0e172c475f458b7f7b93061064d98c3293e98c5ba0c8b399"
 dependencies = [
  "autocfg",
  "hashbrown 0.12.3",
+ "serde",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5477fe2230a79769d8dc68e0eabf5437907c0457a5614a9e8dddb67f65eb65d"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.14.0",
+ "serde",
 ]
 
 [[package]]
@@ -1744,6 +1803,7 @@ dependencies = [
  "rust_decimal",
  "secp256k1-zkp",
  "serde",
+ "serde_with 3.2.0",
  "sha2",
  "simple-wallet",
  "time 0.3.20",
@@ -1892,7 +1952,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a4964177ddfdab1e3a2b37aec7cf320e14169abb0ed73999f558136409178d5"
 dependencies = [
  "base64 0.21.0",
- "indexmap",
+ "indexmap 1.9.2",
  "metrics",
  "metrics-util",
  "quanta",
@@ -2234,7 +2294,7 @@ dependencies = [
  "fnv",
  "futures-channel",
  "futures-util",
- "indexmap",
+ "indexmap 1.9.2",
  "once_cell",
  "pin-project-lite",
  "thiserror",
@@ -2387,7 +2447,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4dd7d28ee937e54fe3080c91faa1c3a46c06de6252988a7f4592ba2310ef22a4"
 dependencies = [
  "fixedbitset",
- "indexmap",
+ "indexmap 1.9.2",
 ]
 
 [[package]]
@@ -3004,22 +3064,22 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.152"
+version = "1.0.168"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb7d1f0d3021d347a83e556fc4683dea2ea09d87bccdf88ff5c12545d89d5efb"
+checksum = "d614f89548720367ded108b3c843be93f3a341e22d5674ca0dd5cd57f34926af"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.152"
+version = "1.0.168"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af487d118eecd09402d70a5d72551860e788df87b464af30e5ea6a38c75c541e"
+checksum = "d4fe589678c688e44177da4f27152ee2d190757271dc7f1d5b6b9f68d869d641"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.23",
 ]
 
 [[package]]
@@ -3070,7 +3130,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "678b5a069e50bf00ecd22d0cd8ddf7c236f68581b03db652061ed5eb13a312ff"
 dependencies = [
  "serde",
- "serde_with_macros",
+ "serde_with_macros 1.5.2",
+]
+
+[[package]]
+name = "serde_with"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1402f54f9a3b9e2efe71c1cea24e648acce55887983553eeb858cf3115acfd49"
+dependencies = [
+ "base64 0.21.0",
+ "chrono",
+ "hex",
+ "indexmap 1.9.2",
+ "indexmap 2.0.0",
+ "serde",
+ "serde_json",
+ "serde_with_macros 3.2.0",
+ "time 0.3.20",
 ]
 
 [[package]]
@@ -3079,10 +3156,22 @@ version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e182d6ec6f05393cc0e5ed1bf81ad6db3a8feedf8ee515ecdd369809bcce8082"
 dependencies = [
- "darling",
+ "darling 0.13.4",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9197f1ad0e3c173a0222d3c4404fb04c3afe87e962bcb327af73e8301fa203c7"
+dependencies = [
+ "darling 0.20.3",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.23",
 ]
 
 [[package]]
@@ -3569,7 +3658,7 @@ version = "0.19.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "239410c8609e8125456927e6707163a3b1fdb40561e4b803bc041f466ccfdc13"
 dependencies = [
- "indexmap",
+ "indexmap 1.9.2",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -3612,7 +3701,7 @@ checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
 dependencies = [
  "futures-core",
  "futures-util",
- "indexmap",
+ "indexmap 1.9.2",
  "pin-project",
  "pin-project-lite",
  "rand",

--- a/coordinator/src/bin/coordinator.rs
+++ b/coordinator/src/bin/coordinator.rs
@@ -111,7 +111,11 @@ async fn main() -> Result<()> {
         opts.get_oracle_info().into(),
     )?);
 
-    let event_handler = CoordinatorEventHandler::new(node.clone(), Some(node_event_sender));
+    let event_handler = CoordinatorEventHandler::new(
+        node.clone(),
+        Some(node_event_sender),
+        settings.ln_dlc.max_app_channel_size_sats,
+    );
     let running = node.start(event_handler)?;
     let node = Node::new(node, running, pool.clone(), settings.to_node_settings());
 

--- a/crates/coordinator-commons/src/lib.rs
+++ b/crates/coordinator-commons/src/lib.rs
@@ -62,3 +62,10 @@ impl RegisterParams {
         self.email.is_some() || self.nostr.is_some()
     }
 }
+
+/// LSP channel details
+#[derive(Serialize, Deserialize)]
+pub struct LspConfig {
+    /// The maximum size a new channel may have
+    pub max_channel_value_satoshi: u64,
+}

--- a/crates/ln-dlc-node/Cargo.toml
+++ b/crates/ln-dlc-node/Cargo.toml
@@ -36,6 +36,7 @@ reqwest = { version = "0.11", default-features = false, features = ["json"] }
 rust-bitcoin-coin-selection = { version = "0.1.0", features = ["rand"] }
 secp256k1-zkp = { version = "0.7.0", features = ["global-context"] }
 serde = "1.0.147"
+serde_with = "3.1.0"
 sha2 = "0.10"
 simple-wallet = "0.1.0"
 time = "0.3"

--- a/crates/ln-dlc-node/src/config.rs
+++ b/crates/ln-dlc-node/src/config.rs
@@ -6,18 +6,6 @@ use lightning::util::config::ChannelHandshakeLimits;
 use lightning::util::config::UserConfig;
 use std::time::Duration;
 
-/// When handling the [`Event::HTLCIntercepted`], we may need to
-/// create a new channel with the recipient of the HTLC. If the
-/// payment is small enough (< 1000 sats), opening the channel will
-/// fail unless we provide more outbound liquidity.
-///
-/// This value defines the maximum channel amount between the coordinator and a user that opens a
-/// channel through an interceptable invoice. Channels that exceed this amount will be rejected.
-/// This value is completely arbitrary.
-///
-/// This constant only applies to the coordinator.
-pub const JUST_IN_TIME_CHANNEL_OUTBOUND_LIQUIDITY_SAT_MAX: u64 = 200_000;
-
 /// The multiplier to be used by the coordinator to define the just in time channel liquidity
 ///
 /// The liquidity provided by the trader will be multiplied with this value to defined the channel

--- a/crates/ln-dlc-node/src/lib.rs
+++ b/crates/ln-dlc-node/src/lib.rs
@@ -43,7 +43,6 @@ pub mod util;
 
 pub use config::CONFIRMATION_TARGET;
 pub use config::CONTRACT_TX_FEE_RATE;
-pub use config::JUST_IN_TIME_CHANNEL_OUTBOUND_LIQUIDITY_SAT_MAX;
 pub use config::LIQUIDITY_MULTIPLIER;
 pub use ldk_node_wallet::WalletSettings;
 pub use ln::AppEventHandler;

--- a/crates/ln-dlc-node/src/ln/app_event_handler.rs
+++ b/crates/ln-dlc-node/src/ln/app_event_handler.rs
@@ -203,23 +203,8 @@ where
                     amount_msat,
                 )?;
             }
-            Event::HTLCIntercepted {
-                intercept_id,
-                requested_next_hop_scid,
-                payment_hash,
-                inbound_amount_msat,
-                expected_outbound_amount_msat,
-            } => {
-                common_handlers::handle_intercepted_htlc(
-                    &self.node,
-                    &self.pending_intercepted_htlcs,
-                    intercept_id,
-                    payment_hash,
-                    requested_next_hop_scid,
-                    inbound_amount_msat,
-                    expected_outbound_amount_msat,
-                )
-                .await?;
+            Event::HTLCIntercepted { .. } => {
+                unimplemented!("App should not intercept htlcs")
             }
         };
 

--- a/crates/ln-dlc-node/src/ln/common_handlers.rs
+++ b/crates/ln-dlc-node/src/ln/common_handlers.rs
@@ -1,11 +1,7 @@
 use super::event_handler::PendingInterceptedHtlcs;
 use crate::channel::Channel;
-use crate::channel::FakeScid;
 use crate::channel::UserChannelId;
 use crate::config::CONFIRMATION_TARGET;
-use crate::config::HTLC_INTERCEPTED_CONNECTION_TIMEOUT;
-use crate::config::LIQUIDITY_MULTIPLIER;
-use crate::ln::event_handler::InterceptionDetails;
 use crate::node::invoice::HTLCStatus;
 use crate::node::ChannelManager;
 use crate::node::Node;
@@ -14,9 +10,7 @@ use crate::util;
 use crate::MillisatAmount;
 use crate::PaymentFlow;
 use crate::PaymentInfo;
-use crate::JUST_IN_TIME_CHANNEL_OUTBOUND_LIQUIDITY_SAT_MAX;
 use anyhow::anyhow;
-use anyhow::ensure;
 use anyhow::Context;
 use anyhow::Result;
 use bitcoin::consensus::encode::serialize_hex;
@@ -409,194 +403,6 @@ pub(crate) async fn handle_funding_generation_ready<S>(
     ) {
         tracing::error!(?err, "Channel went away before we could fund it. The peer disconnected or refused the channel");
     };
-    Ok(())
-}
-
-/// Handle an [`Event::HTLCIntercepted`].
-pub(crate) async fn handle_intercepted_htlc<S>(
-    node: &Arc<Node<S>>,
-    pending_intercepted_htlcs: &PendingInterceptedHtlcs,
-    intercept_id: InterceptId,
-    payment_hash: PaymentHash,
-    requested_next_hop_scid: u64,
-    inbound_amount_msat: u64,
-    expected_outbound_amount_msat: u64,
-) -> Result<()>
-where
-    S: Storage,
-{
-    let res = handle_intercepted_htlc_internal(
-        node,
-        pending_intercepted_htlcs,
-        intercept_id,
-        payment_hash,
-        requested_next_hop_scid,
-        inbound_amount_msat,
-        expected_outbound_amount_msat,
-    )
-    .await;
-
-    if let Err(ref e) = res {
-        tracing::error!("Failed to handle HTLCIntercepted event: {e:#}");
-        fail_intercepted_htlc(&node.channel_manager, &intercept_id);
-    }
-
-    res
-}
-
-pub(crate) async fn handle_intercepted_htlc_internal<S>(
-    node: &Arc<Node<S>>,
-    pending_intercepted_htlcs: &PendingInterceptedHtlcs,
-    intercept_id: InterceptId,
-    payment_hash: PaymentHash,
-    requested_next_hop_scid: u64,
-    inbound_amount_msat: u64,
-    expected_outbound_amount_msat: u64,
-) -> Result<()>
-where
-    S: Storage,
-{
-    let intercept_id_str = intercept_id.0.to_hex();
-    let payment_hash = payment_hash.0.to_hex();
-
-    tracing::info!(
-        intercept_id = %intercept_id_str,
-        requested_next_hop_scid,
-        payment_hash,
-        inbound_amount_msat,
-        expected_outbound_amount_msat,
-        "Intercepted HTLC"
-    );
-
-    let target_node_id = {
-        node.fake_channel_payments
-            .lock()
-            .get(&requested_next_hop_scid)
-            .copied()
-    }
-    .with_context(|| {
-        format!(
-            "Could not forward the intercepted HTLC because we didn't have a node registered \
-                 with fake scid {requested_next_hop_scid}"
-        )
-    })?;
-
-    tokio::time::timeout(HTLC_INTERCEPTED_CONNECTION_TIMEOUT, async {
-        loop {
-            if node
-                .peer_manager
-                .get_peer_node_ids()
-                .iter()
-                .any(|(id, _)| *id == target_node_id)
-            {
-                tracing::info!(
-                    %target_node_id,
-                    %payment_hash,
-                    "Found connection with target of intercepted HTLC"
-                );
-
-                return;
-            }
-
-            tracing::debug!(
-                %target_node_id,
-                %payment_hash,
-                "Waiting for connection with target of intercepted HTLC"
-            );
-            tokio::time::sleep(Duration::from_secs(2)).await;
-        }
-    })
-    .await
-    .context("Timed out waiting to get connection with target of interceptable HTLC")?;
-
-    // We only support one channel between coordinator and app. Also, we are unfortunately using
-    // interceptable HTLCs for regular payments (not just to open JIT channels). With all this
-    // in mind, if the coordinator (the only party that can handle this event) has a channel
-    // with the target of this payment we must treat this interceptable HTLC as a regular
-    // payment.
-    if let Some(channel) = node
-        .channel_manager
-        .list_channels()
-        .iter()
-        .find(|channel_details| channel_details.counterparty.node_id == target_node_id)
-    {
-        node.channel_manager
-            .forward_intercepted_htlc(
-                intercept_id,
-                &channel.channel_id,
-                channel.counterparty.node_id,
-                expected_outbound_amount_msat,
-            )
-            .map_err(|e| anyhow!("Failed to forward intercepted HTLC: {e:?}"))?;
-
-        return Ok(());
-    }
-
-    let opt_max_allowed_fee = node
-        .wallet
-        .inner()
-        .settings()
-        .await
-        .max_allowed_tx_fee_rate_when_opening_channel;
-    if let Some(max_allowed_tx_fee) = opt_max_allowed_fee {
-        let current_fee = node
-            .fee_rate_estimator
-            .get_est_sat_per_1000_weight(CONFIRMATION_TARGET);
-
-        ensure!(
-            max_allowed_tx_fee >= current_fee,
-            "Not opening JIT channel because the fee is too high"
-        );
-    }
-
-    let channel_value = expected_outbound_amount_msat / 1000 * LIQUIDITY_MULTIPLIER;
-    ensure!(
-        channel_value <= JUST_IN_TIME_CHANNEL_OUTBOUND_LIQUIDITY_SAT_MAX,
-        "Failed to open channel because maximum channel value exceeded"
-    );
-
-    let fake_scid = FakeScid::new(requested_next_hop_scid);
-    let mut shadow_channel = node
-        .storage
-        .get_channel_by_fake_scid(fake_scid)
-        .with_context(|| format!("Failed to load channel by fake SCID {fake_scid}"))?
-        .with_context(|| format!("Could not find shadow channel for fake SCID {fake_scid}"))?;
-
-    shadow_channel.outbound = channel_value;
-
-    node.storage
-        .upsert_channel(shadow_channel.clone())
-        .with_context(|| format!("Failed to upsert shadow channel: {shadow_channel}"))?;
-
-    let mut ldk_config = *node.ldk_config.read();
-    ldk_config.channel_handshake_config.announced_channel = false;
-
-    let temp_channel_id = node
-        .channel_manager
-        .create_channel(
-            target_node_id,
-            channel_value,
-            0,
-            shadow_channel.user_channel_id.to_u128(),
-            Some(ldk_config),
-        )
-        .map_err(|e| anyhow!("Failed to open JIT channel: {e:?}"))?;
-
-    tracing::info!(
-        peer = %target_node_id,
-        %payment_hash,
-        temp_channel_id = %temp_channel_id.to_hex(),
-        "Started JIT channel creation for intercepted HTLC"
-    );
-
-    pending_intercepted_htlcs.lock().insert(
-        target_node_id,
-        InterceptionDetails {
-            id: intercept_id,
-            expected_outbound_amount_msat,
-        },
-    );
-
     Ok(())
 }
 

--- a/crates/ln-dlc-node/src/ln/coordinator_event_handler.rs
+++ b/crates/ln-dlc-node/src/ln/coordinator_event_handler.rs
@@ -1,20 +1,32 @@
 use super::common_handlers;
 use super::event_handler::EventSender;
 use super::event_handler::PendingInterceptedHtlcs;
+use crate::channel::FakeScid;
+use crate::config::HTLC_INTERCEPTED_CONNECTION_TIMEOUT;
+use crate::ln::common_handlers::fail_intercepted_htlc;
+use crate::ln::event_handler::InterceptionDetails;
 use crate::node::ChannelManager;
 use crate::node::Node;
 use crate::node::Storage;
 use crate::EventHandlerTrait;
+use crate::CONFIRMATION_TARGET;
+use crate::JUST_IN_TIME_CHANNEL_OUTBOUND_LIQUIDITY_SAT_MAX;
+use crate::LIQUIDITY_MULTIPLIER;
 use anyhow::anyhow;
+use anyhow::ensure;
 use anyhow::Context;
 use anyhow::Result;
 use async_trait::async_trait;
 use bitcoin::hashes::hex::ToHex;
 use bitcoin::secp256k1::PublicKey;
+use lightning::chain::chaininterface::FeeEstimator;
+use lightning::ln::channelmanager::InterceptId;
+use lightning::ln::PaymentHash;
 use lightning::util::events::Event;
 use parking_lot::Mutex;
 use std::collections::HashMap;
 use std::sync::Arc;
+use std::time::Duration;
 
 /// Event handler for the coordinator node.
 // TODO: Move it out of this crate
@@ -210,7 +222,7 @@ where
                 inbound_amount_msat,
                 expected_outbound_amount_msat,
             } => {
-                common_handlers::handle_intercepted_htlc(
+                handle_intercepted_htlc(
                     &self.node,
                     &self.pending_intercepted_htlcs,
                     intercept_id,
@@ -250,5 +262,193 @@ fn handle_open_channel_request(
         )
         .map_err(|e| anyhow!("{e:?}"))
         .context("To be able to accept a 0-conf channel")?;
+    Ok(())
+}
+
+/// Handle an [`Event::HTLCIntercepted`].
+pub(crate) async fn handle_intercepted_htlc<S>(
+    node: &Arc<Node<S>>,
+    pending_intercepted_htlcs: &PendingInterceptedHtlcs,
+    intercept_id: InterceptId,
+    payment_hash: PaymentHash,
+    requested_next_hop_scid: u64,
+    inbound_amount_msat: u64,
+    expected_outbound_amount_msat: u64,
+) -> Result<()>
+where
+    S: Storage,
+{
+    let res = handle_intercepted_htlc_internal(
+        node,
+        pending_intercepted_htlcs,
+        intercept_id,
+        payment_hash,
+        requested_next_hop_scid,
+        inbound_amount_msat,
+        expected_outbound_amount_msat,
+    )
+    .await;
+
+    if let Err(ref e) = res {
+        tracing::error!("Failed to handle HTLCIntercepted event: {e:#}");
+        fail_intercepted_htlc(&node.channel_manager, &intercept_id);
+    }
+
+    res
+}
+
+pub(crate) async fn handle_intercepted_htlc_internal<S>(
+    node: &Arc<Node<S>>,
+    pending_intercepted_htlcs: &PendingInterceptedHtlcs,
+    intercept_id: InterceptId,
+    payment_hash: PaymentHash,
+    requested_next_hop_scid: u64,
+    inbound_amount_msat: u64,
+    expected_outbound_amount_msat: u64,
+) -> Result<()>
+where
+    S: Storage,
+{
+    let intercept_id_str = intercept_id.0.to_hex();
+    let payment_hash = payment_hash.0.to_hex();
+
+    tracing::info!(
+        intercept_id = %intercept_id_str,
+        requested_next_hop_scid,
+        payment_hash,
+        inbound_amount_msat,
+        expected_outbound_amount_msat,
+        "Intercepted HTLC"
+    );
+
+    let target_node_id = {
+        node.fake_channel_payments
+            .lock()
+            .get(&requested_next_hop_scid)
+            .copied()
+    }
+    .with_context(|| {
+        format!(
+            "Could not forward the intercepted HTLC because we didn't have a node registered \
+                 with fake scid {requested_next_hop_scid}"
+        )
+    })?;
+
+    tokio::time::timeout(HTLC_INTERCEPTED_CONNECTION_TIMEOUT, async {
+        loop {
+            if node
+                .peer_manager
+                .get_peer_node_ids()
+                .iter()
+                .any(|(id, _)| *id == target_node_id)
+            {
+                tracing::info!(
+                    %target_node_id,
+                    %payment_hash,
+                    "Found connection with target of intercepted HTLC"
+                );
+
+                return;
+            }
+
+            tracing::debug!(
+                %target_node_id,
+                %payment_hash,
+                "Waiting for connection with target of intercepted HTLC"
+            );
+            tokio::time::sleep(Duration::from_secs(2)).await;
+        }
+    })
+    .await
+    .context("Timed out waiting to get connection with target of interceptable HTLC")?;
+
+    // We only support one channel between coordinator and app. Also, we are unfortunately using
+    // interceptable HTLCs for regular payments (not just to open JIT channels). With all this
+    // in mind, if the coordinator (the only party that can handle this event) has a channel
+    // with the target of this payment we must treat this interceptable HTLC as a regular
+    // payment.
+    if let Some(channel) = node
+        .channel_manager
+        .list_channels()
+        .iter()
+        .find(|channel_details| channel_details.counterparty.node_id == target_node_id)
+    {
+        node.channel_manager
+            .forward_intercepted_htlc(
+                intercept_id,
+                &channel.channel_id,
+                channel.counterparty.node_id,
+                expected_outbound_amount_msat,
+            )
+            .map_err(|e| anyhow!("Failed to forward intercepted HTLC: {e:?}"))?;
+
+        return Ok(());
+    }
+
+    let opt_max_allowed_fee = node
+        .wallet
+        .inner()
+        .settings()
+        .await
+        .max_allowed_tx_fee_rate_when_opening_channel;
+    if let Some(max_allowed_tx_fee) = opt_max_allowed_fee {
+        let current_fee = node
+            .fee_rate_estimator
+            .get_est_sat_per_1000_weight(CONFIRMATION_TARGET);
+
+        ensure!(
+            max_allowed_tx_fee >= current_fee,
+            "Not opening JIT channel because the fee is too high"
+        );
+    }
+
+    let channel_value = expected_outbound_amount_msat / 1000 * LIQUIDITY_MULTIPLIER;
+    ensure!(
+        channel_value <= JUST_IN_TIME_CHANNEL_OUTBOUND_LIQUIDITY_SAT_MAX,
+        "Failed to open channel because maximum channel value exceeded"
+    );
+
+    let fake_scid = FakeScid::new(requested_next_hop_scid);
+    let mut shadow_channel = node
+        .storage
+        .get_channel_by_fake_scid(fake_scid)
+        .with_context(|| format!("Failed to load channel by fake SCID {fake_scid}"))?
+        .with_context(|| format!("Could not find shadow channel for fake SCID {fake_scid}"))?;
+
+    shadow_channel.outbound = channel_value;
+
+    node.storage
+        .upsert_channel(shadow_channel.clone())
+        .with_context(|| format!("Failed to upsert shadow channel: {shadow_channel}"))?;
+
+    let mut ldk_config = *node.ldk_config.read();
+    ldk_config.channel_handshake_config.announced_channel = false;
+
+    let temp_channel_id = node
+        .channel_manager
+        .create_channel(
+            target_node_id,
+            channel_value,
+            0,
+            shadow_channel.user_channel_id.to_u128(),
+            Some(ldk_config),
+        )
+        .map_err(|e| anyhow!("Failed to open JIT channel: {e:?}"))?;
+
+    tracing::info!(
+        peer = %target_node_id,
+        %payment_hash,
+        temp_channel_id = %temp_channel_id.to_hex(),
+        "Started JIT channel creation for intercepted HTLC"
+    );
+
+    pending_intercepted_htlcs.lock().insert(
+        target_node_id,
+        InterceptionDetails {
+            id: intercept_id,
+            expected_outbound_amount_msat,
+        },
+    );
+
     Ok(())
 }

--- a/crates/ln-dlc-node/src/ln/event_handler.rs
+++ b/crates/ln-dlc-node/src/ln/event_handler.rs
@@ -8,8 +8,13 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::watch;
 
-pub type PendingInterceptedHtlcs = Arc<Mutex<HashMap<PublicKey, (InterceptId, u64)>>>;
+pub type PendingInterceptedHtlcs = Arc<Mutex<HashMap<PublicKey, InterceptionDetails>>>;
 pub type EventSender = watch::Sender<Option<Event>>;
+
+pub struct InterceptionDetails {
+    pub id: InterceptId,
+    pub expected_outbound_amount_msat: u64,
+}
 
 #[async_trait]
 pub trait EventHandlerTrait: Send + Sync {

--- a/crates/ln-dlc-node/src/node/mod.rs
+++ b/crates/ln-dlc-node/src/node/mod.rs
@@ -182,6 +182,16 @@ pub struct LnDlcNodeSettings {
     /// Note: This constant and value was copied from ldk_node
     /// XXX: Requires restart of the node to take effect
     pub bdk_client_concurrency: u8,
+
+    /// When handling the [`Event::HTLCIntercepted`], we may need to
+    /// create a new channel with the recipient of the HTLC. If the
+    /// payment is small enough (< 1000 sats), opening the channel will
+    /// fail unless we provide more outbound liquidity.
+    ///
+    /// This value defines the maximum channel amount between the coordinator and a user that opens
+    /// a channel through an interceptable invoice. Channels that exceed this amount will be
+    /// rejected.
+    pub max_app_channel_size_sats: u64,
 }
 
 impl Default for LnDlcNodeSettings {
@@ -196,6 +206,8 @@ impl Default for LnDlcNodeSettings {
             shadow_sync_interval: Duration::from_secs(600),
             bdk_client_stop_gap: 20,
             bdk_client_concurrency: 4,
+            // 200_000 is an arbitrary number we are feeling comfortable with
+            max_app_channel_size_sats: 200_000,
         }
     }
 }

--- a/crates/ln-dlc-node/src/node/mod.rs
+++ b/crates/ln-dlc-node/src/node/mod.rs
@@ -39,6 +39,8 @@ use lightning_transaction_sync::EsploraSyncClient;
 use p2pd_oracle_client::P2PDOracleClient;
 use serde::Deserialize;
 use serde::Serialize;
+use serde_with::serde_as;
+use serde_with::DurationSeconds;
 use std::collections::HashMap;
 use std::fmt;
 use std::fmt::Display;
@@ -145,19 +147,26 @@ pub struct RunningNode {
     _handles: Vec<RemoteHandle<()>>,
 }
 
+#[serde_as]
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct LnDlcNodeSettings {
     /// How often we sync the LDK wallet
+    #[serde_as(as = "DurationSeconds")]
     pub off_chain_sync_interval: Duration,
     /// How often we sync the BDK wallet
+    #[serde_as(as = "DurationSeconds")]
     pub on_chain_sync_interval: Duration,
     /// How often we update the fee rate
+    #[serde_as(as = "DurationSeconds")]
     pub fee_rate_sync_interval: Duration,
     /// How often we run the [`DlcManager`]'s periodic check.
+    #[serde_as(as = "DurationSeconds")]
     pub dlc_manager_periodic_check_interval: Duration,
     /// How often we run the [`SubChannelManager`]'s periodic check.
+    #[serde_as(as = "DurationSeconds")]
     pub sub_channel_manager_periodic_check_interval: Duration,
     /// How often we sync the shadow states
+    #[serde_as(as = "DurationSeconds")]
     pub shadow_sync_interval: Duration,
 
     /// Amount (in millionths of a satoshi) charged per satoshi for payments forwarded outbound

--- a/crates/ln-dlc-node/src/tests/mod.rs
+++ b/crates/ln-dlc-node/src/tests/mod.rs
@@ -125,8 +125,13 @@ impl Node<InMemoryStore> {
         settings: LnDlcNodeSettings,
         ldk_event_sender: Option<watch::Sender<Option<Event>>>,
     ) -> Result<(Arc<Self>, RunningNode)> {
+        let max_app_channel_size_sats = settings.max_app_channel_size_sats;
         let coordinator_event_handler = |node, event_sender| {
-            Arc::new(CoordinatorEventHandler::new(node, event_sender)) as Arc<dyn EventHandlerTrait>
+            Arc::new(CoordinatorEventHandler::new(
+                node,
+                event_sender,
+                max_app_channel_size_sats,
+            )) as Arc<dyn EventHandlerTrait>
         };
 
         Self::start_test(

--- a/mobile/lib/common/amount_text_input_form_field.dart
+++ b/mobile/lib/common/amount_text_input_form_field.dart
@@ -2,8 +2,9 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
 import 'domain/model.dart';
+import 'modal_bottom_sheet_info.dart';
 
-class AmountInputField extends StatelessWidget {
+class AmountInputField extends StatefulWidget {
   const AmountInputField(
       {super.key,
       required this.controller,
@@ -11,47 +12,61 @@ class AmountInputField extends StatelessWidget {
       required this.hint,
       required this.onChanged,
       required this.value,
+      required this.isLoading,
+      this.infoText,
       this.validator});
 
   final Amount value;
   final TextEditingController controller;
   final String label;
   final String hint;
+  final String? infoText;
+  final bool isLoading;
   final Function(String) onChanged;
 
   final String? Function(String?)? validator;
 
   @override
+  State<AmountInputField> createState() => _AmountInputFieldState();
+}
+
+class _AmountInputFieldState extends State<AmountInputField> {
+  @override
   Widget build(BuildContext context) {
-    String value = this.value.sats.toString();
+    String value = widget.value.sats.toString();
 
     if (value.endsWith(".0")) {
       value = value.replaceAll(".0", "");
     }
 
-    int offset = controller.selection.base.offset;
+    int offset = widget.controller.selection.base.offset;
     if (offset > value.length) {
       offset = value.length;
     }
 
-    controller.value = controller.value.copyWith(
+    widget.controller.value = widget.controller.value.copyWith(
       text: value.toString(),
       selection: TextSelection.collapsed(offset: offset),
     );
 
     return TextFormField(
-      controller: controller,
+      controller: widget.controller,
       keyboardType: TextInputType.number,
       decoration: InputDecoration(
         border: const OutlineInputBorder(),
-        hintText: hint,
-        labelText: label,
+        hintText: widget.hint,
+        labelText: widget.label,
+        suffixIcon: widget.isLoading
+            ? const CircularProgressIndicator()
+            : widget.infoText != null
+                ? ModalBottomSheetInfo(closeButtonText: "Back...", child: Text(widget.infoText!))
+                : null,
       ),
       inputFormatters: <TextInputFormatter>[FilteringTextInputFormatter.digitsOnly],
-      onChanged: (value) => onChanged(value),
+      onChanged: (value) => widget.onChanged(value),
       validator: (value) {
-        if (validator != null) {
-          return validator!(value);
+        if (widget.validator != null) {
+          return widget.validator!(value);
         }
 
         return null;

--- a/mobile/lib/common/application/channel_info_service.dart
+++ b/mobile/lib/common/application/channel_info_service.dart
@@ -25,8 +25,8 @@ class ChannelInfoService {
   /// The agreed upon maximum channel capacity for the beta
   ///
   /// This value is an arbitrary number that may be subject to change.
-  Amount getMaxCapacity() {
-    int maxCapacity = rust.api.maxChannelValue();
+  Future<Amount> getMaxCapacity() async {
+    int maxCapacity = await rust.api.maxChannelValue();
     return Amount(maxCapacity);
   }
 

--- a/mobile/lib/features/trade/trade_bottom_sheet_tab.dart
+++ b/mobile/lib/features/trade/trade_bottom_sheet_tab.dart
@@ -191,6 +191,7 @@ class _TradeBottomSheetTabState extends State<TradeBottomSheetTab> {
                           hint: "e.g. 2000 sats",
                           label: "Margin (sats)",
                           controller: marginController,
+                          isLoading: false,
                           onChanged: (value) {
                             if (value.isEmpty) {
                               return;

--- a/mobile/lib/features/trade/trade_bottom_sheet_tab.dart
+++ b/mobile/lib/features/trade/trade_bottom_sheet_tab.dart
@@ -79,19 +79,15 @@ class _TradeBottomSheetTabState extends State<TradeBottomSheetTab> {
 
     Amount minTradeMargin = channelInfoService.getMinTradeMargin();
     Amount tradeFeeReserve = channelInfoService.getTradeFeeReserve();
-    Amount maxChannelCapacity = lspMaxChannelCapacity ?? Amount(0);
+
+    Amount channelCapacity = lspMaxChannelCapacity;
+
     Amount initialReserve = channelInfoService.getInitialReserve();
-
-    Direction direction = widget.direction;
-
-    String label = direction == Direction.long ? "Buy" : "Sell";
-    Color color = direction == Direction.long ? tradeTheme.buy : tradeTheme.sell;
 
     Amount channelReserve = channelInfo?.reserve ?? initialReserve;
     int totalReserve = channelReserve.sats + tradeFeeReserve.sats;
 
     int usableBalance = max(walletInfo.balances.lightning.sats - totalReserve, 0);
-    Amount channelCapacity = channelInfo?.channelCapacity ?? maxChannelCapacity;
     // the assumed balance of the counterparty based on the channel and our balance
     // this is needed to make sure that the counterparty can fulfil the trade
     int counterpartyUsableBalance =
@@ -103,6 +99,11 @@ class _TradeBottomSheetTabState extends State<TradeBottomSheetTab> {
         channelCapacity.sats - totalReserve - (provider.counterpartyMargin(widget.direction) ?? 0);
 
     int coordinatorLiquidityMultiplier = channelInfoService.getCoordinatorLiquidityMultiplier();
+
+
+    Direction direction = widget.direction;
+    String label = direction == Direction.long ? "Buy" : "Sell";
+    Color color = direction == Direction.long ? tradeTheme.buy : tradeTheme.sell;
 
     return Form(
       key: _formKey,

--- a/mobile/lib/features/trade/trade_bottom_sheet_tab.dart
+++ b/mobile/lib/features/trade/trade_bottom_sheet_tab.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:math';
 
 import 'package:flutter/material.dart';
@@ -44,22 +45,23 @@ class _TradeBottomSheetTabState extends State<TradeBottomSheetTab> {
 
   bool showCapacityInfo = false;
 
-  ChannelInfo? channelInfo;
-
-  /// The max channel capacity as received by the LSP or if there is an existing channel
-  Amount? lspMaxChannelCapacity;
-
   @override
   void initState() {
     provider = context.read<TradeValuesChangeNotifier>();
     channelInfoService = provider.channelInfoService;
-    initChannelInfo(channelInfoService);
     super.initState();
   }
 
-  Future<void> initChannelInfo(ChannelInfoService channelInfoService) async {
-    channelInfo = await channelInfoService.getChannelInfo();
-    lspMaxChannelCapacity = await channelInfoService.getMaxCapacity();
+  Future<(ChannelInfo?, Amount)> _getChannelInfo(ChannelInfoService channelInfoService) async {
+    var channelInfo = await channelInfoService.getChannelInfo();
+
+    /// The max channel capacity as received by the LSP or if there is an existing channel
+    var lspMaxChannelCapacity = await channelInfoService.getMaxCapacity();
+
+    var completer = Completer<(ChannelInfo?, Amount)>();
+    completer.complete((channelInfo, lspMaxChannelCapacity));
+
+    return completer.future;
   }
 
   @override
@@ -77,30 +79,6 @@ class _TradeBottomSheetTabState extends State<TradeBottomSheetTab> {
 
     WalletInfo walletInfo = context.watch<WalletChangeNotifier>().walletInfo;
 
-    Amount minTradeMargin = channelInfoService.getMinTradeMargin();
-    Amount tradeFeeReserve = channelInfoService.getTradeFeeReserve();
-
-    Amount channelCapacity = lspMaxChannelCapacity;
-
-    Amount initialReserve = channelInfoService.getInitialReserve();
-
-    Amount channelReserve = channelInfo?.reserve ?? initialReserve;
-    int totalReserve = channelReserve.sats + tradeFeeReserve.sats;
-
-    int usableBalance = max(walletInfo.balances.lightning.sats - totalReserve, 0);
-    // the assumed balance of the counterparty based on the channel and our balance
-    // this is needed to make sure that the counterparty can fulfil the trade
-    int counterpartyUsableBalance =
-        max(channelCapacity.sats - (walletInfo.balances.lightning.sats + totalReserve), 0);
-    int maxMargin = usableBalance;
-
-    // the trading capacity does not take into account if the channel is balanced or not
-    int tradingCapacity =
-        channelCapacity.sats - totalReserve - (provider.counterpartyMargin(widget.direction) ?? 0);
-
-    int coordinatorLiquidityMultiplier = channelInfoService.getCoordinatorLiquidityMultiplier();
-
-
     Direction direction = widget.direction;
     String label = direction == Direction.long ? "Buy" : "Sell";
     Color color = direction == Direction.long ? tradeTheme.buy : tradeTheme.sell;
@@ -112,195 +90,87 @@ class _TradeBottomSheetTabState extends State<TradeBottomSheetTab> {
         crossAxisAlignment: CrossAxisAlignment.center,
         mainAxisSize: MainAxisSize.min,
         children: [
-          Wrap(
-            runSpacing: 15,
-            children: [
-              Padding(
-                padding: const EdgeInsets.only(bottom: 10),
-                child: Row(
-                  children: [
-                    const Flexible(child: Text("Usable Balance:")),
-                    const SizedBox(width: 5),
-                    Flexible(child: AmountText(amount: Amount(usableBalance))),
-                    const SizedBox(
-                      width: 5,
-                    ),
-                    ModalBottomSheetInfo(
-                      closeButtonText: "Back to order...",
-                      infoButtonPadding: const EdgeInsets.symmetric(horizontal: 8.0),
-                      child: Text(
-                          "Your usable balance of $usableBalance sats takes a fixed reserve of $totalReserve sats into account. "
-                          "\n${channelReserve.sats} is the minimum amount that has to stay in the Lightning channel. "
-                          "\n${tradeFeeReserve.sats} is reserved for fees per trade that is needed for publishing on-chain transactions in a worst case scenario. This is needed for the self-custodial setup"
-                          "\n\nWe are working on optimizing the reserve and it might be subject to change after the beta."),
-                    )
-                  ],
+          FutureBuilder<(ChannelInfo?, Amount)>(
+            future:
+                _getChannelInfo(channelInfoService), // a previously-obtained Future<String> or null
+            builder: (BuildContext context, AsyncSnapshot<(ChannelInfo?, Amount)> snapshot) {
+              List<Widget> children;
+              if (snapshot.hasData) {
+                var (channelInfo, lspMaxChannelCapacity) = snapshot.data!;
+                Amount minTradeMargin = channelInfoService.getMinTradeMargin();
+                Amount tradeFeeReserve = channelInfoService.getTradeFeeReserve();
+
+                Amount channelCapacity = lspMaxChannelCapacity;
+
+                Amount initialReserve = channelInfoService.getInitialReserve();
+
+                Amount channelReserve = channelInfo?.reserve ?? initialReserve;
+                int totalReserve = channelReserve.sats + tradeFeeReserve.sats;
+
+                int usableBalance = max(walletInfo.balances.lightning.sats - totalReserve, 0);
+                // the assumed balance of the counterparty based on the channel and our balance
+                // this is needed to make sure that the counterparty can fulfil the trade
+                int counterpartyUsableBalance = max(
+                    channelCapacity.sats - (walletInfo.balances.lightning.sats + totalReserve), 0);
+                int maxMargin = usableBalance;
+
+                // the trading capacity does not take into account if the channel is balanced or not
+                int tradingCapacity = channelCapacity.sats -
+                    totalReserve -
+                    (provider.counterpartyMargin(widget.direction) ?? 0);
+
+                int coordinatorLiquidityMultiplier =
+                    channelInfoService.getCoordinatorLiquidityMultiplier();
+
+                children = <Widget>[
+                  buildChildren(
+                      usableBalance,
+                      totalReserve,
+                      channelReserve,
+                      tradeFeeReserve,
+                      direction,
+                      tradingCapacity,
+                      counterpartyUsableBalance,
+                      maxMargin,
+                      minTradeMargin,
+                      channelCapacity,
+                      coordinatorLiquidityMultiplier,
+                      context,
+                      channelInfoService),
+                ];
+              } else if (snapshot.hasError) {
+                children = <Widget>[
+                  const Icon(
+                    Icons.error_outline,
+                    color: Colors.red,
+                    size: 60,
+                  ),
+                  Padding(
+                    padding: const EdgeInsets.only(top: 16),
+                    child:
+                        Text('Error: Could not load confirmation screen due to ${snapshot.error}'),
+                  ),
+                ];
+              } else {
+                children = const <Widget>[
+                  SizedBox(
+                    width: 60,
+                    height: 60,
+                    child: CircularProgressIndicator(),
+                  ),
+                  Padding(
+                    padding: EdgeInsets.only(top: 16),
+                    child: Text('Loading confirmation screen...'),
+                  ),
+                ];
+              }
+              return Center(
+                child: Column(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: children,
                 ),
-              ),
-              Selector<TradeValuesChangeNotifier, double>(
-                  selector: (_, provider) => provider.fromDirection(direction).price ?? 0,
-                  builder: (context, price, child) {
-                    return DoubleTextInputFormField(
-                      value: price,
-                      controller: priceController,
-                      enabled: false,
-                      label: "Market Price",
-                    );
-                  }),
-              Row(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Flexible(
-                    child: Selector<TradeValuesChangeNotifier, double>(
-                      selector: (_, provider) => provider.fromDirection(direction).quantity ?? 0.0,
-                      builder: (context, quantity, child) {
-                        return DoubleTextInputFormField(
-                          value: quantity,
-                          hint: "e.g. 100 USD",
-                          label: "Quantity (USD)",
-                          controller: quantityController,
-                          onChanged: (value) {
-                            if (value.isEmpty) {
-                              return;
-                            }
-
-                            try {
-                              double quantity = double.parse(value);
-                              context
-                                  .read<TradeValuesChangeNotifier>()
-                                  .updateQuantity(direction, quantity);
-                            } on Exception {
-                              context
-                                  .read<TradeValuesChangeNotifier>()
-                                  .updateQuantity(direction, 0);
-                            }
-                          },
-                        );
-                      },
-                    ),
-                  ),
-                  const SizedBox(
-                    width: 10,
-                  ),
-                  Flexible(
-                    child: Selector<TradeValuesChangeNotifier, Amount>(
-                      selector: (_, provider) =>
-                          provider.fromDirection(direction).margin ?? Amount(0),
-                      builder: (context, margin, child) {
-                        return AmountInputField(
-                          value: margin,
-                          hint: "e.g. 2000 sats",
-                          label: "Margin (sats)",
-                          controller: marginController,
-                          isLoading: false,
-                          onChanged: (value) {
-                            if (value.isEmpty) {
-                              return;
-                            }
-
-                            try {
-                              Amount margin = Amount.parse(value);
-                              context
-                                  .read<TradeValuesChangeNotifier>()
-                                  .updateMargin(direction, margin);
-                            } on Exception {
-                              context
-                                  .read<TradeValuesChangeNotifier>()
-                                  .updateMargin(direction, Amount.zero());
-                            }
-                          },
-                          validator: (value) {
-                            if (value == null) {
-                              return "Enter margin";
-                            }
-
-                            try {
-                              int margin = int.parse(value);
-
-                              int? optCounterPartyMargin = provider.counterpartyMargin(direction);
-                              if (optCounterPartyMargin == null) {
-                                return "Counterparty margin not available";
-                              }
-                              int counterpartyMargin = optCounterPartyMargin;
-
-                              // This condition has to stay as the first thing to check, so we reset showing the info
-                              if (margin > tradingCapacity ||
-                                  counterpartyMargin > counterpartyUsableBalance) {
-                                setState(() {
-                                  showCapacityInfo = true;
-                                });
-
-                                return "Insufficient capacity";
-                              } else if (showCapacityInfo) {
-                                setState(() {
-                                  showCapacityInfo = false;
-                                });
-                              }
-
-                              Amount fee = provider.orderMatchingFee(direction) ?? Amount.zero();
-                              if (usableBalance < margin + fee.sats) {
-                                return "Insufficient balance";
-                              }
-
-                              if (margin > maxMargin) {
-                                return "Max margin is $maxMargin";
-                              }
-                              if (margin < minTradeMargin.sats) {
-                                return "Min margin is ${minTradeMargin.sats}";
-                              }
-                            } on Exception {
-                              return "Enter a number";
-                            }
-
-                            return null;
-                          },
-                        );
-                      },
-                    ),
-                  ),
-                  if (showCapacityInfo)
-                    ModalBottomSheetInfo(
-                        closeButtonText: "Back to order...",
-                        child: Text(
-                            "Your channel capacity is limited to $channelCapacity sats. During the beta channel resize is not available yet"
-                            "In order to trade with higher margin you have to reduce your balance"
-                            "\n\nYour current usable balance is $usableBalance."
-                            "Please send ${usableBalance - (channelCapacity.sats / coordinatorLiquidityMultiplier)} sats out of your wallet to free up capacity."))
-                ],
-              ),
-              LeverageSlider(
-                  initialValue: context
-                      .read<TradeValuesChangeNotifier>()
-                      .fromDirection(direction)
-                      .leverage
-                      .leverage,
-                  onLeverageChanged: (value) {
-                    context
-                        .read<TradeValuesChangeNotifier>()
-                        .updateLeverage(direction, Leverage(value));
-                  }),
-              Row(
-                children: [
-                  const Flexible(child: Text("Liquidation Price:")),
-                  const SizedBox(width: 5),
-                  Selector<TradeValuesChangeNotifier, double>(
-                      selector: (_, provider) =>
-                          provider.fromDirection(direction).liquidationPrice ?? 0.0,
-                      builder: (context, liquidationPrice, child) {
-                        return Flexible(child: FiatText(amount: liquidationPrice));
-                      }),
-                  const SizedBox(width: 20),
-                  const Flexible(child: Text("Estimated fee:")),
-                  const SizedBox(width: 5),
-                  Selector<TradeValuesChangeNotifier, Amount>(
-                      selector: (_, provider) =>
-                          provider.orderMatchingFee(direction) ?? Amount.zero(),
-                      builder: (context, fee, child) {
-                        return Flexible(child: AmountText(amount: fee));
-                      }),
-                ],
-              )
-            ],
+              );
+            },
           ),
           Column(
             crossAxisAlignment: CrossAxisAlignment.stretch,
@@ -333,6 +203,204 @@ class _TradeBottomSheetTabState extends State<TradeBottomSheetTab> {
           )
         ],
       ),
+    );
+  }
+
+  Wrap buildChildren(
+      int usableBalance,
+      int totalReserve,
+      Amount channelReserve,
+      Amount tradeFeeReserve,
+      Direction direction,
+      int tradingCapacity,
+      int counterpartyUsableBalance,
+      int maxMargin,
+      Amount minTradeMargin,
+      Amount channelCapacity,
+      int coordinatorLiquidityMultiplier,
+      BuildContext context,
+      ChannelInfoService channelInfoService) {
+    return Wrap(
+      runSpacing: 15,
+      children: [
+        Padding(
+          padding: const EdgeInsets.only(bottom: 10),
+          child: Row(
+            children: [
+              const Flexible(child: Text("Usable Balance:")),
+              const SizedBox(width: 5),
+              Flexible(child: AmountText(amount: Amount(usableBalance))),
+              const SizedBox(
+                width: 5,
+              ),
+              ModalBottomSheetInfo(
+                closeButtonText: "Back to order...",
+                infoButtonPadding: const EdgeInsets.symmetric(horizontal: 8.0),
+                child: Text(
+                    "Your usable balance of $usableBalance sats takes a fixed reserve of $totalReserve sats into account. "
+                    "\n${channelReserve.sats} is the minimum amount that has to stay in the Lightning channel. "
+                    "\n${tradeFeeReserve.sats} is reserved for fees per trade that is needed for publishing on-chain transactions in a worst case scenario. This is needed for the self-custodial setup"
+                    "\n\nWe are working on optimizing the reserve and it might be subject to change after the beta."),
+              )
+            ],
+          ),
+        ),
+        Selector<TradeValuesChangeNotifier, double>(
+            selector: (_, provider) => provider.fromDirection(direction).price ?? 0,
+            builder: (context, price, child) {
+              return DoubleTextInputFormField(
+                value: price,
+                controller: priceController,
+                enabled: false,
+                label: "Market Price",
+              );
+            }),
+        Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Flexible(
+              child: Selector<TradeValuesChangeNotifier, double>(
+                selector: (_, provider) => provider.fromDirection(direction).quantity ?? 0.0,
+                builder: (context, quantity, child) {
+                  return DoubleTextInputFormField(
+                    value: quantity,
+                    hint: "e.g. 100 USD",
+                    label: "Quantity (USD)",
+                    controller: quantityController,
+                    onChanged: (value) {
+                      if (value.isEmpty) {
+                        return;
+                      }
+
+                      try {
+                        double quantity = double.parse(value);
+                        context
+                            .read<TradeValuesChangeNotifier>()
+                            .updateQuantity(direction, quantity);
+                      } on Exception {
+                        context.read<TradeValuesChangeNotifier>().updateQuantity(direction, 0);
+                      }
+                    },
+                  );
+                },
+              ),
+            ),
+            const SizedBox(
+              width: 10,
+            ),
+            Flexible(
+              child: Selector<TradeValuesChangeNotifier, Amount>(
+                selector: (_, provider) => provider.fromDirection(direction).margin ?? Amount(0),
+                builder: (context, margin, child) {
+                  return AmountInputField(
+                    value: margin,
+                    hint: "e.g. 2000 sats",
+                    label: "Margin (sats)",
+                    controller: marginController,
+                    isLoading: false,
+                    onChanged: (value) {
+                      if (value.isEmpty) {
+                        return;
+                      }
+
+                      try {
+                        Amount margin = Amount.parse(value);
+                        context.read<TradeValuesChangeNotifier>().updateMargin(direction, margin);
+                      } on Exception {
+                        context
+                            .read<TradeValuesChangeNotifier>()
+                            .updateMargin(direction, Amount.zero());
+                      }
+                    },
+                    validator: (value) {
+                      if (value == null) {
+                        return "Enter margin";
+                      }
+
+                      try {
+                        int margin = int.parse(value);
+
+                        int? optCounterPartyMargin = provider.counterpartyMargin(direction);
+                        if (optCounterPartyMargin == null) {
+                          return "Counterparty margin not available";
+                        }
+                        int counterpartyMargin = optCounterPartyMargin;
+
+                        // This condition has to stay as the first thing to check, so we reset showing the info
+                        if (margin > tradingCapacity ||
+                            counterpartyMargin > counterpartyUsableBalance) {
+                          setState(() {
+                            showCapacityInfo = true;
+                          });
+
+                          return "Insufficient capacity";
+                        } else if (showCapacityInfo) {
+                          setState(() {
+                            showCapacityInfo = false;
+                          });
+                        }
+
+                        Amount fee = provider.orderMatchingFee(direction) ?? Amount.zero();
+                        if (usableBalance < margin + fee.sats) {
+                          return "Insufficient balance";
+                        }
+
+                        if (margin > maxMargin) {
+                          return "Max margin is $maxMargin";
+                        }
+                        if (margin < minTradeMargin.sats) {
+                          return "Min margin is ${minTradeMargin.sats}";
+                        }
+                      } on Exception {
+                        return "Enter a number";
+                      }
+
+                      return null;
+                    },
+                  );
+                },
+              ),
+            ),
+            if (showCapacityInfo)
+              ModalBottomSheetInfo(
+                  closeButtonText: "Back to order...",
+                  child: Text(
+                      "Your channel capacity is limited to $channelCapacity sats. During the beta channel resize is not available yet"
+                      "In order to trade with higher margin you have to reduce your balance"
+                      "\n\nYour current usable balance is $usableBalance."
+                      "Please send ${usableBalance - (channelCapacity.sats / coordinatorLiquidityMultiplier)} sats out of your wallet to free up capacity."))
+          ],
+        ),
+        LeverageSlider(
+            initialValue: context
+                .read<TradeValuesChangeNotifier>()
+                .fromDirection(direction)
+                .leverage
+                .leverage,
+            onLeverageChanged: (value) {
+              context.read<TradeValuesChangeNotifier>().updateLeverage(direction, Leverage(value));
+            }),
+        Row(
+          children: [
+            const Flexible(child: Text("Liquidation Price:")),
+            const SizedBox(width: 5),
+            Selector<TradeValuesChangeNotifier, double>(
+                selector: (_, provider) =>
+                    provider.fromDirection(direction).liquidationPrice ?? 0.0,
+                builder: (context, liquidationPrice, child) {
+                  return Flexible(child: FiatText(amount: liquidationPrice));
+                }),
+            const SizedBox(width: 20),
+            const Flexible(child: Text("Estimated fee:")),
+            const SizedBox(width: 5),
+            Selector<TradeValuesChangeNotifier, Amount>(
+                selector: (_, provider) => provider.orderMatchingFee(direction) ?? Amount.zero(),
+                builder: (context, fee, child) {
+                  return Flexible(child: AmountText(amount: fee));
+                }),
+          ],
+        )
+      ],
     );
   }
 }

--- a/mobile/lib/features/trade/trade_bottom_sheet_tab.dart
+++ b/mobile/lib/features/trade/trade_bottom_sheet_tab.dart
@@ -46,6 +46,9 @@ class _TradeBottomSheetTabState extends State<TradeBottomSheetTab> {
 
   ChannelInfo? channelInfo;
 
+  /// The max channel capacity as received by the LSP or if there is an existing channel
+  Amount? lspMaxChannelCapacity;
+
   @override
   void initState() {
     provider = context.read<TradeValuesChangeNotifier>();
@@ -56,6 +59,7 @@ class _TradeBottomSheetTabState extends State<TradeBottomSheetTab> {
 
   Future<void> initChannelInfo(ChannelInfoService channelInfoService) async {
     channelInfo = await channelInfoService.getChannelInfo();
+    lspMaxChannelCapacity = await channelInfoService.getMaxCapacity();
   }
 
   @override
@@ -75,7 +79,7 @@ class _TradeBottomSheetTabState extends State<TradeBottomSheetTab> {
 
     Amount minTradeMargin = channelInfoService.getMinTradeMargin();
     Amount tradeFeeReserve = channelInfoService.getTradeFeeReserve();
-    Amount maxChannelCapacity = channelInfoService.getMaxCapacity();
+    Amount maxChannelCapacity = lspMaxChannelCapacity ?? Amount(0);
     Amount initialReserve = channelInfoService.getInitialReserve();
 
     Direction direction = widget.direction;

--- a/mobile/lib/features/wallet/create_invoice_screen.dart
+++ b/mobile/lib/features/wallet/create_invoice_screen.dart
@@ -37,6 +37,9 @@ class _CreateInvoiceScreenState extends State<CreateInvoiceScreen> {
   /// If no channel exists yet this field will be null.
   ChannelInfo? channelInfo;
 
+  /// The max channel capacity as received by the LSP or if there is an existing channel
+  Amount? lspMaxChannelCapacity;
+
   /// Estimated fees for receiving
   ///
   /// These fees have to be added on top of the receive amount because they are collected after receiving the funds.
@@ -57,6 +60,7 @@ class _CreateInvoiceScreenState extends State<CreateInvoiceScreen> {
 
   Future<void> initChannelInfo(ChannelInfoService channelInfoService) async {
     channelInfo = await channelInfoService.getChannelInfo();
+    lspMaxChannelCapacity = await channelInfoService.getMaxCapacity();
 
     // initial channel opening
     if (channelInfo == null) {
@@ -72,7 +76,7 @@ class _CreateInvoiceScreenState extends State<CreateInvoiceScreen> {
 
     Amount minTradeMargin = channelInfoService.getMinTradeMargin();
     Amount tradeFeeReserve = channelInfoService.getTradeFeeReserve();
-    Amount maxChannelCapacity = channelInfoService.getMaxCapacity();
+    Amount maxChannelCapacity = lspMaxChannelCapacity ?? Amount(0);
     Amount initialReserve = channelInfoService.getInitialReserve();
 
     int coordinatorLiquidityMultiplier = channelInfoService.getCoordinatorLiquidityMultiplier();

--- a/mobile/lib/features/wallet/create_invoice_screen.dart
+++ b/mobile/lib/features/wallet/create_invoice_screen.dart
@@ -11,7 +11,6 @@ import 'package:get_10101/features/wallet/wallet_change_notifier.dart';
 import 'package:get_10101/features/wallet/wallet_screen.dart';
 import 'package:go_router/go_router.dart';
 import 'package:provider/provider.dart';
-import 'package:get_10101/common/modal_bottom_sheet_info.dart';
 import 'package:get_10101/common/domain/channel.dart';
 import 'package:get_10101/common/scrollable_safe_area.dart';
 
@@ -127,6 +126,12 @@ class _CreateInvoiceScreenState extends State<CreateInvoiceScreen> {
                         hint: "e.g. ${formatSats(Amount(5000))}",
                         label: "Amount",
                         controller: _amountController,
+                        isLoading: lspMaxChannelCapacity == null,
+                        infoText:
+                            "While in beta, maximum channel capacity is limited to ${formatSats(maxChannelCapacity)}; channels above this capacity might get rejected."
+                            "\nThe maximum is enforced initially to ensure users only trade with small stakes until the software has proven to be stable."
+                            "\n\nYour current balance is ${formatSats(balance)}, so you can receive up to ${formatSats(maxReceiveAmount)}."
+                            "\nIf you hold less than ${formatSats(minAmountToBeAbleToTrade)} or more than ${formatSats(maxAllowedOutboundCapacity)} in your wallet you might not be able to trade.",
                         onChanged: (value) {
                           if (value.isEmpty) {
                             return;
@@ -161,25 +166,9 @@ class _CreateInvoiceScreenState extends State<CreateInvoiceScreen> {
                         },
                       ),
                     ),
-                    if (showValidationHint)
-                      ModalBottomSheetInfo(
-                          closeButtonText: "Back to Receive...",
-                          child: Text(
-                              "While in beta, maximum channel capacity is limited to ${formatSats(maxChannelCapacity)}; channels above this capacity might get rejected."
-                              "\nThe maximum is enforced initially to ensure users only trade with small stakes until the software has proven to be stable."
-                              "\n\nYour current balance is ${formatSats(balance)}, so you can receive up to ${formatSats(maxReceiveAmount)}."
-                              "\nIf you hold less than ${formatSats(minAmountToBeAbleToTrade)} or more than ${formatSats(maxAllowedOutboundCapacity)} in your wallet you might not be able to trade.")),
                   ],
                 ),
               ),
-              Center(
-                  child: Padding(
-                padding: const EdgeInsets.only(bottom: 10.0, left: 32.0, right: 32.0),
-                child: Text(
-                  "Your wallet balance is ${formatSats(balance)} so you should only receive up to ${formatSats(maxReceiveAmount)}.",
-                  style: const TextStyle(color: Colors.black),
-                ),
-              )),
               Expanded(
                 child: Padding(
                   padding: const EdgeInsets.all(32.0),

--- a/mobile/native/src/api.rs
+++ b/mobile/native/src/api.rs
@@ -257,9 +257,8 @@ pub fn coordinator_liquidity_multiplier() -> SyncReturn<u64> {
     SyncReturn(ln_dlc_node::LIQUIDITY_MULTIPLIER)
 }
 
-pub fn max_channel_value() -> SyncReturn<u64> {
-    // TODO: FIXME: this should not be hardcoded anymore
-    SyncReturn(200_000)
+pub fn max_channel_value() -> Result<u64> {
+    ln_dlc::max_channel_value().map(|amount| amount.to_sat())
 }
 
 pub fn contract_tx_fee_rate() -> SyncReturn<u64> {

--- a/mobile/native/src/api.rs
+++ b/mobile/native/src/api.rs
@@ -258,7 +258,8 @@ pub fn coordinator_liquidity_multiplier() -> SyncReturn<u64> {
 }
 
 pub fn max_channel_value() -> SyncReturn<u64> {
-    SyncReturn(ln_dlc_node::JUST_IN_TIME_CHANNEL_OUTBOUND_LIQUIDITY_SAT_MAX)
+    // TODO: FIXME: this should not be hardcoded anymore
+    SyncReturn(200_000)
 }
 
 pub fn contract_tx_fee_rate() -> SyncReturn<u64> {

--- a/mobile/test/trade_test.dart
+++ b/mobile/test/trade_test.dart
@@ -104,7 +104,9 @@ void main() {
       return null;
     });
 
-    when(channelConstraintsService.getMaxCapacity()).thenReturn(Amount(20000));
+    when(channelConstraintsService.getMaxCapacity()).thenAnswer((_) async {
+      return Amount(20000);
+    });
 
     when(channelConstraintsService.getMinTradeMargin()).thenReturn(Amount(1000));
 


### PR DESCRIPTION
With this change we can configure the max channel size aka, we can enable wumbo trades.

I've also made a small frontend change: the info text is gone and replaced with an info icon. This solved the problem that the `maxChannelSize` is not immediately available .

https://github.com/get10101/10101/assets/224613/293eaa2b-dd3c-44a5-bdaa-3cd476d599a0

This will help us with running the increased-channel-size experiment.

resolves https://github.com/get10101/10101/issues/983
