### PR TITLE
fix(justfile): Remove skipping funding

### DIFF
--- a/justfile
+++ b/justfile
@@ -106,15 +106,7 @@ run-local-android args="":
     --dart-define="REGTEST_FAUCET=http://${LOCAL_IP}:8080" --dart-define="COORDINATOR_PORT_HTTP=8000" --flavor local
 
 fund args="":
-    #!/usr/bin/env bash
-    BALANCE=$(curl -s localhost:8080/lnd/v1/balance/channels | sed 's/.*"balance":"\{0,1\}\([^,"]*\)"\{0,1\}.*/\1/')
-    if [ $BALANCE -lt 10000000 ] || [ "{{args}}" = "--force" ] || [ "{{args}}" = "-f" ]
-    then
-      echo "Lightning faucet balance is $BALANCE; funding..."
       cargo run --example fund
-    else
-      echo "Lightning faucet balance is $BALANCE; skipping funding. Pass -f or --force to force."
-    fi
 
 # Fund remote regtest instance
 fund-regtest:


### PR DESCRIPTION
At times, the script would pass with a non-functioning faucet.
The few seconds saved on skipping funding is not worth the extra debugging
    effort, as `just fund` catches these occurrences.