### PR TITLE
Ensure that broadcast TXs are always stored

### DIFF
--- a/coordinator/src/db/transactions.rs
+++ b/coordinator/src/db/transactions.rs
@@ -54,21 +54,21 @@ pub(crate) fn upsert(tx: Transaction, conn: &mut PgConnection) -> Result<()> {
 impl From<ln_dlc_node::transaction::Transaction> for Transaction {
     fn from(value: ln_dlc_node::transaction::Transaction) -> Self {
         Transaction {
-            txid: value.txid.to_string(),
-            fee: value.fee as i64,
-            created_at: value.created_at,
-            updated_at: value.updated_at,
+            txid: value.txid().to_string(),
+            fee: value.fee() as i64,
+            created_at: value.created_at(),
+            updated_at: value.updated_at(),
         }
     }
 }
 
 impl From<Transaction> for ln_dlc_node::transaction::Transaction {
     fn from(value: Transaction) -> Self {
-        ln_dlc_node::transaction::Transaction {
-            txid: Txid::from_str(&value.txid).expect("valid txid"),
-            fee: value.fee as u64,
-            created_at: value.created_at,
-            updated_at: value.updated_at,
-        }
+        ln_dlc_node::transaction::Transaction::new(
+            Txid::from_str(&value.txid).expect("valid txid"),
+            value.fee as u64,
+            value.created_at,
+            value.updated_at,
+        )
     }
 }

--- a/crates/ln-dlc-node/src/node/storage.rs
+++ b/crates/ln-dlc-node/src/node/storage.rs
@@ -243,7 +243,7 @@ impl Storage for InMemoryStore {
     // Transaction
 
     fn upsert_transaction(&self, transaction: Transaction) -> Result<()> {
-        let txid = transaction.txid.to_string();
+        let txid = transaction.txid().to_string();
         self.transactions_lock().insert(txid, transaction);
         Ok(())
     }
@@ -257,7 +257,7 @@ impl Storage for InMemoryStore {
         Ok(self
             .transactions_lock()
             .values()
-            .filter(|t| t.fee == 0)
+            .filter(|t| t.fee() == 0)
             .cloned()
             .collect())
     }

--- a/crates/ln-dlc-node/src/tests/just_in_time_channel/create.rs
+++ b/crates/ln-dlc-node/src/tests/just_in_time_channel/create.rs
@@ -95,7 +95,7 @@ async fn open_jit_channel() {
         .get_transaction(&channel.funding_txid.unwrap().to_string())
         .unwrap()
         .unwrap();
-    assert!(transaction.fee > 0);
+    assert!(transaction.fee() > 0);
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/ln-dlc-node/src/transaction.rs
+++ b/crates/ln-dlc-node/src/transaction.rs
@@ -4,12 +4,60 @@ use std::fmt::Display;
 use std::fmt::Formatter;
 use time::OffsetDateTime;
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct Transaction {
-    pub txid: Txid,
-    pub fee: u64,
-    pub created_at: OffsetDateTime,
-    pub updated_at: OffsetDateTime,
+    txid: Txid,
+    fee: u64,
+    created_at: OffsetDateTime,
+    updated_at: OffsetDateTime,
+}
+
+impl Transaction {
+    pub fn new(
+        txid: Txid,
+        fee: u64,
+        created_at: OffsetDateTime,
+        updated_at: OffsetDateTime,
+    ) -> Self {
+        Self {
+            txid,
+            fee,
+            created_at,
+            updated_at,
+        }
+    }
+
+    pub fn txid(&self) -> Txid {
+        self.txid
+    }
+
+    pub fn fee(&self) -> u64 {
+        self.fee
+    }
+
+    pub fn with_fee(self, fee: u64) -> Self {
+        Self {
+            fee,
+            updated_at: OffsetDateTime::now_utc(),
+            ..self
+        }
+    }
+
+    pub fn created_at(&self) -> OffsetDateTime {
+        self.created_at
+    }
+
+    pub fn updated_at(&self) -> OffsetDateTime {
+        self.updated_at
+    }
+}
+
+impl From<&bitcoin::Transaction> for Transaction {
+    fn from(value: &bitcoin::Transaction) -> Self {
+        let now = OffsetDateTime::now_utc();
+
+        Self::new(value.txid(), 0, now, now)
+    }
 }
 
 impl Display for Transaction {


### PR DESCRIPTION
Fixes #1101.

We needed to align the implementations of the two traits where we broadcast transactions. There were several places where we were not storing broadcast transactions because of this.