### PR TITLE
Model more transaction history details 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1097,12 +1097,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fixedbitset"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
-
-[[package]]
 name = "flate2"
 version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2431,13 +2425,10 @@ version = "0.9.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9069cbb9f99e3a5083476ccb29ceb1de18b9118cafa53e90c9551235de2b9521"
 dependencies = [
- "backtrace",
  "cfg-if",
  "libc",
- "petgraph",
  "redox_syscall 0.2.16",
  "smallvec",
- "thread-id",
  "windows-sys 0.45.0",
 ]
 
@@ -2446,16 +2437,6 @@ name = "percent-encoding"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
-
-[[package]]
-name = "petgraph"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dd7d28ee937e54fe3080c91faa1c3a46c06de6252988a7f4592ba2310ef22a4"
-dependencies = [
- "fixedbitset",
- "indexmap 1.9.2",
-]
 
 [[package]]
 name = "pin-project"
@@ -3464,17 +3445,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
-]
-
-[[package]]
-name = "thread-id"
-version = "4.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ee93aa2b8331c0fec9091548843f2c90019571814057da3b783f9de09349d73"
-dependencies = [
- "libc",
- "redox_syscall 0.2.16",
- "winapi",
 ]
 
 [[package]]

--- a/coordinator/migrations/2023-08-23-152802_add_invoice_to_payments/down.sql
+++ b/coordinator/migrations/2023-08-23-152802_add_invoice_to_payments/down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE
+    payments DROP COLUMN invoice;

--- a/coordinator/migrations/2023-08-23-152802_add_invoice_to_payments/up.sql
+++ b/coordinator/migrations/2023-08-23-152802_add_invoice_to_payments/up.sql
@@ -1,0 +1,4 @@
+ALTER TABLE
+    payments
+ADD
+    COLUMN invoice TEXT DEFAULT null;

--- a/coordinator/src/db/payments.rs
+++ b/coordinator/src/db/payments.rs
@@ -29,6 +29,7 @@ pub struct Payment {
     pub created_at: OffsetDateTime,
     pub updated_at: OffsetDateTime,
     pub description: String,
+    pub invoice: Option<String>,
 }
 
 pub fn get(
@@ -81,6 +82,7 @@ impl From<(lightning::ln::PaymentHash, ln_dlc_node::PaymentInfo)> for NewPayment
             flow: info.flow.into(),
             payment_timestamp: info.timestamp,
             description: info.description,
+            invoice: info.invoice,
         }
     }
 }
@@ -123,6 +125,7 @@ impl TryFrom<Payment> for (lightning::ln::PaymentHash, ln_dlc_node::PaymentInfo)
                 flow: value.flow.into(),
                 timestamp: value.payment_timestamp,
                 description: value.description,
+                invoice: value.invoice,
             },
         ))
     }
@@ -172,6 +175,8 @@ pub(crate) struct NewPayment {
     pub payment_timestamp: OffsetDateTime,
     #[diesel(sql_type = Text)]
     pub description: String,
+    #[diesel(sql_type = Nullable<Text>)]
+    pub invoice: Option<String>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, FromSqlRow, AsExpression)]

--- a/coordinator/src/node/storage.rs
+++ b/coordinator/src/node/storage.rs
@@ -73,6 +73,7 @@ impl node::Storage for NodeStorage {
                             flow,
                             timestamp: OffsetDateTime::now_utc(),
                             description: "".to_string(),
+                            invoice: None,
                         },
                     ),
                     &mut conn,

--- a/coordinator/src/schema.rs
+++ b/coordinator/src/schema.rs
@@ -85,6 +85,7 @@ diesel::table! {
         created_at -> Timestamptz,
         updated_at -> Timestamptz,
         description -> Text,
+        invoice -> Nullable<Text>,
     }
 }
 

--- a/crates/ln-dlc-node/src/lib.rs
+++ b/crates/ln-dlc-node/src/lib.rs
@@ -99,6 +99,7 @@ pub struct PaymentInfo {
     pub flow: PaymentFlow,
     pub timestamp: OffsetDateTime,
     pub description: String,
+    pub invoice: Option<String>,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -142,6 +143,7 @@ impl From<Invoice> for PaymentInfo {
                 InvoiceDescription::Direct(direct) => direct.to_string(),
                 InvoiceDescription::Hash(hash) => hash.0.to_hex(),
             },
+            invoice: Some(value.to_string()),
         }
     }
 }

--- a/crates/ln-dlc-node/src/ln/common_handlers.rs
+++ b/crates/ln-dlc-node/src/ln/common_handlers.rs
@@ -189,6 +189,7 @@ where
                     flow: PaymentFlow::Outbound,
                     timestamp: OffsetDateTime::now_utc(),
                     description: "".to_string(),
+                    invoice: None,
                 },
             ) {
                 tracing::error!(

--- a/crates/ln-dlc-node/src/node/invoice.rs
+++ b/crates/ln-dlc-node/src/node/invoice.rs
@@ -101,6 +101,12 @@ where
             })
             .map_err(|_| anyhow!("Failed to sign invoice"))?;
         let invoice = Invoice::from_signed(signed_invoice)?;
+
+        self.storage.insert_payment(
+            payment_hash,
+            invoice.clone().into(),
+        )?;
+
         Ok(invoice)
     }
 

--- a/crates/ln-dlc-node/src/node/invoice.rs
+++ b/crates/ln-dlc-node/src/node/invoice.rs
@@ -102,10 +102,8 @@ where
             .map_err(|_| anyhow!("Failed to sign invoice"))?;
         let invoice = Invoice::from_signed(signed_invoice)?;
 
-        self.storage.insert_payment(
-            payment_hash,
-            invoice.clone().into(),
-        )?;
+        self.storage
+            .insert_payment(payment_hash, invoice.clone().into())?;
 
         Ok(invoice)
     }
@@ -227,6 +225,7 @@ where
                 flow: PaymentFlow::Outbound,
                 timestamp: OffsetDateTime::now_utc(),
                 description,
+                invoice: Some(format!("{invoice}")),
             },
         )?;
 

--- a/crates/ln-dlc-node/src/node/storage.rs
+++ b/crates/ln-dlc-node/src/node/storage.rs
@@ -148,6 +148,7 @@ impl Storage for InMemoryStore {
                         flow,
                         timestamp: OffsetDateTime::now_utc(),
                         description: "".to_string(),
+                        invoice: None,
                     },
                 );
             }

--- a/crates/ln-dlc-node/src/node/wallet.rs
+++ b/crates/ln-dlc-node/src/node/wallet.rs
@@ -154,6 +154,7 @@ where
                 timestamp: info.timestamp,
                 description: info.description.clone(),
                 preimage: info.preimage.map(|preimage| preimage.0.to_hex()),
+                invoice: info.invoice.clone(),
             })
             .collect::<Vec<_>>();
 
@@ -172,6 +173,7 @@ pub struct PaymentDetails {
     pub timestamp: OffsetDateTime,
     pub description: String,
     pub preimage: Option<String>,
+    pub invoice: Option<String>,
 }
 
 impl fmt::Display for PaymentDetails {
@@ -182,11 +184,12 @@ impl fmt::Display for PaymentDetails {
         let amount_msat = self.amount_msat.unwrap_or_default();
         let timestamp = self.timestamp.to_string();
         let description = self.description.clone();
+        let invoice = self.invoice.clone();
 
         write!(
             f,
-            "payment_hash {}, status {}, flow {}, amount_msat {}, timestamp {}, description {}",
-            payment_hash, status, flow, amount_msat, timestamp, description,
+            "payment_hash {}, status {}, flow {}, amount_msat {}, timestamp {}, description {} invoice {:?}",
+            payment_hash, status, flow, amount_msat, timestamp, description, invoice
         )
     }
 }

--- a/crates/ln-dlc-node/src/node/wallet.rs
+++ b/crates/ln-dlc-node/src/node/wallet.rs
@@ -4,6 +4,7 @@ use crate::node::HTLCStatus;
 use crate::node::Node;
 use crate::node::Storage;
 use crate::PaymentFlow;
+use crate::ToHex;
 use anyhow::Context;
 use anyhow::Result;
 use bdk::blockchain::EsploraBlockchain;
@@ -152,6 +153,7 @@ where
                 amount_msat: info.amt_msat.0,
                 timestamp: info.timestamp,
                 description: info.description.clone(),
+                preimage: info.preimage.map(|preimage| preimage.0.to_hex()),
             })
             .collect::<Vec<_>>();
 
@@ -169,6 +171,7 @@ pub struct PaymentDetails {
     pub amount_msat: Option<u64>,
     pub timestamp: OffsetDateTime,
     pub description: String,
+    pub preimage: Option<String>,
 }
 
 impl fmt::Display for PaymentDetails {
@@ -179,6 +182,7 @@ impl fmt::Display for PaymentDetails {
         let amount_msat = self.amount_msat.unwrap_or_default();
         let timestamp = self.timestamp.to_string();
         let description = self.description.clone();
+
         write!(
             f,
             "payment_hash {}, status {}, flow {}, amount_msat {}, timestamp {}, description {}",

--- a/crates/ln-dlc-node/src/node/wallet.rs
+++ b/crates/ln-dlc-node/src/node/wallet.rs
@@ -10,6 +10,7 @@ use bdk::blockchain::EsploraBlockchain;
 use bdk::sled;
 use bitcoin::secp256k1::SecretKey;
 use bitcoin::Address;
+use dlc_manager::Blockchain;
 use lightning::ln::PaymentHash;
 use std::fmt;
 use std::sync::Arc;
@@ -58,6 +59,12 @@ where
 
     pub fn get_unused_address(&self) -> Address {
         self.wallet.unused_address()
+    }
+
+    pub fn get_blockchain_height(&self) -> Result<u64> {
+        self.wallet
+            .get_blockchain_height()
+            .context("Failed to get blockchain height")
     }
 
     pub fn get_on_chain_balance(&self) -> Result<bdk::Balance> {

--- a/crates/ln-dlc-node/src/tests/just_in_time_channel/create.rs
+++ b/crates/ln-dlc-node/src/tests/just_in_time_channel/create.rs
@@ -136,7 +136,7 @@ async fn fail_to_open_jit_channel_with_fee_rate_over_max() {
     let invoice = payee
         .create_interceptable_invoice(
             Some(payer_to_payee_invoice_amount),
-            0,
+            None,
             "interceptable-invoice".to_string(),
             final_route_hint_hop,
         )
@@ -181,7 +181,7 @@ async fn open_jit_channel_with_disconnected_payee() {
     let invoice = payee
         .create_interceptable_invoice(
             Some(payer_to_payee_invoice_amount),
-            0,
+            None,
             "interceptable-invoice".to_string(),
             final_route_hint_hop,
         )
@@ -238,10 +238,9 @@ pub(crate) async fn send_interceptable_payment(
     let interceptable_route_hint_hop =
         coordinator.prepare_interceptable_payment(payee.info.pubkey)?;
 
-    let invoice_expiry = 0; // an expiry of 0 means the invoice never expires
     let invoice = payee.create_interceptable_invoice(
         Some(invoice_amount_sat),
-        invoice_expiry,
+        None,
         "interceptable-invoice".to_string(),
         interceptable_route_hint_hop,
     )?;

--- a/crates/ln-dlc-node/src/tests/just_in_time_channel/fail_intercepted_htlc.rs
+++ b/crates/ln-dlc-node/src/tests/just_in_time_channel/fail_intercepted_htlc.rs
@@ -35,7 +35,7 @@ async fn fail_intercepted_htlc_if_coordinator_cannot_reconnect_to_payee() {
     let invoice = payee
         .create_interceptable_invoice(
             Some(invoice_amount),
-            0,
+            None,
             "interceptable-invoice".to_string(),
             interceptable_route_hint_hop,
         )
@@ -100,7 +100,7 @@ async fn fail_intercepted_htlc_if_connection_lost_after_funding_tx_generated() {
     let invoice = payee
         .create_interceptable_invoice(
             Some(invoice_amount),
-            0,
+            None,
             "interceptable-invoice".to_string(),
             interceptable_route_hint_hop,
         )
@@ -169,7 +169,7 @@ async fn fail_intercepted_htlc_if_coordinator_cannot_pay_to_open_jit_channel() {
     let invoice = payee
         .create_interceptable_invoice(
             Some(invoice_amount),
-            0,
+            None,
             "interceptable-invoice".to_string(),
             interceptable_route_hint_hop,
         )

--- a/crates/tests-e2e/tests/open_position.rs
+++ b/crates/tests-e2e/tests/open_position.rs
@@ -1,6 +1,6 @@
 use native::api;
 use native::api::ContractSymbol;
-use native::api::WalletType;
+use native::api::WalletHistoryItemType;
 use native::health::Service;
 use native::health::ServiceStatus;
 use native::trade::order::api::NewOrder;
@@ -72,5 +72,5 @@ async fn can_open_position() {
         .expect("to retrieve wallet info")
         .history
         .iter()
-        .any(|item| matches!(item.wallet_type, WalletType::OrderMatchingFee { ref order_id } if order_id == &order_id_original)));
+        .any(|item| matches!(item.wallet_type, WalletHistoryItemType::OrderMatchingFee { ref order_id, .. } if order_id == &order_id_original)));
 }

--- a/mobile/lib/features/trade/order_list_item.dart
+++ b/mobile/lib/features/trade/order_list_item.dart
@@ -20,19 +20,14 @@ class OrderListItem extends StatelessWidget {
     formatter.maximumFractionDigits = 2;
 
     const double iconSize = 18;
-    Icon statusIcon = () {
-      switch (order.state) {
-        case OrderState.open:
-          return const Icon(
-            Icons.pending,
-            size: iconSize,
-          );
-        case OrderState.filled:
-          return const Icon(Icons.check_circle, color: Colors.green, size: iconSize);
-        case OrderState.failed:
-          return const Icon(Icons.error, color: Colors.red, size: iconSize);
-      }
-    }();
+    Icon statusIcon = switch (order.state) {
+      OrderState.open => const Icon(
+          Icons.pending,
+          size: iconSize,
+        ),
+      OrderState.filled => const Icon(Icons.check_circle, color: Colors.green, size: iconSize),
+      OrderState.failed => const Icon(Icons.error, color: Colors.red, size: iconSize),
+    };
 
     return Card(
       child: ListTile(

--- a/mobile/lib/features/wallet/balance_row.dart
+++ b/mobile/lib/features/wallet/balance_row.dart
@@ -6,7 +6,7 @@ import 'package:get_10101/common/fiat_text.dart';
 import 'package:get_10101/features/stable/stable_screen.dart';
 import 'package:get_10101/features/trade/position_change_notifier.dart';
 import 'package:get_10101/features/wallet/create_invoice_screen.dart';
-import 'package:get_10101/features/wallet/domain/wallet_history.dart';
+import 'package:get_10101/features/wallet/domain/wallet_type.dart';
 import 'package:get_10101/features/wallet/send_screen.dart';
 import 'package:get_10101/features/wallet/wallet_change_notifier.dart';
 import 'package:get_10101/features/wallet/wallet_theme.dart';
@@ -16,7 +16,7 @@ import 'package:provider/provider.dart';
 import 'domain/payment_flow.dart';
 
 class BalanceRow extends StatefulWidget {
-  final WalletHistoryItemDataType walletType;
+  final WalletType walletType;
   final double iconSize;
 
   const BalanceRow({required this.walletType, this.iconSize = 30, super.key});
@@ -53,12 +53,12 @@ class _BalanceRowState extends State<BalanceRow> with SingleTickerProviderStateM
     Color rowBgColor;
     SvgPicture icon;
 
-    if (widget.walletType == WalletHistoryItemDataType.lightning) {
+    if (widget.walletType == WalletType.lightning) {
       name = "Lightning";
       rowBgColor = theme.lightning;
       icon = SvgPicture.asset("assets/Lightning_logo.svg");
       amount = walletChangeNotifier.lightning();
-    } else if (widget.walletType == WalletHistoryItemDataType.stable) {
+    } else if (widget.walletType == WalletType.stable) {
       name = "Synthetic-USD";
       rowBgColor = theme.lightning;
       icon = SvgPicture.asset("assets/USD_logo.svg");
@@ -142,7 +142,7 @@ class _BalanceRowState extends State<BalanceRow> with SingleTickerProviderStateM
                       child: SizedBox(height: widget.iconSize, width: widget.iconSize, child: icon),
                     ),
                     Expanded(child: Text(name, style: normal)),
-                    if (widget.walletType == WalletHistoryItemDataType.stable)
+                    if (widget.walletType == WalletType.stable)
                       // we need to use different widget as we display the value in dollar terms
                       FiatText(
                         amount: positionChangeNotifier.getStableUSDAmountInFiat(),
@@ -162,7 +162,7 @@ class _BalanceRowState extends State<BalanceRow> with SingleTickerProviderStateM
 }
 
 class BalanceRowButton extends StatelessWidget {
-  final WalletHistoryItemDataType type;
+  final WalletType type;
   final PaymentFlow flow;
   final bool enabled;
   final double buttonSize;
@@ -196,7 +196,7 @@ class BalanceRowButton extends StatelessWidget {
         onPressed: !enabled
             ? null
             : () {
-                if (type == WalletHistoryItemDataType.stable) {
+                if (type == WalletType.stable) {
                   if (flow == PaymentFlow.outbound) {
                     // eventually there should be a way to send stable sats directly
                     context.go(StableScreen.route);

--- a/mobile/lib/features/wallet/domain/wallet_history.dart
+++ b/mobile/lib/features/wallet/domain/wallet_history.dart
@@ -30,7 +30,14 @@ abstract class WalletHistoryItemData {
       rust.WalletType_OnChain type = item.walletType as rust.WalletType_OnChain;
 
       return OnChainPaymentData(
-          flow: flow, amount: amount, status: status, timestamp: timestamp, txid: type.txid);
+        flow: flow,
+        amount: amount,
+        status: status,
+        timestamp: timestamp,
+        txid: type.txid,
+        confirmations: type.confirmations,
+        fee: type.feeSats != null ? Amount(type.feeSats!) : null,
+      );
     }
 
     if (item.walletType is rust.WalletType_Trade) {
@@ -86,12 +93,16 @@ class LightningPaymentData extends WalletHistoryItemData {
 
 class OnChainPaymentData extends WalletHistoryItemData {
   final String txid;
+  final int confirmations;
+  final Amount? fee;
 
   OnChainPaymentData(
       {required super.flow,
       required super.amount,
       required super.status,
       required super.timestamp,
+      required this.confirmations,
+      required this.fee,
       required this.txid});
 
   @override

--- a/mobile/lib/features/wallet/domain/wallet_history.dart
+++ b/mobile/lib/features/wallet/domain/wallet_history.dart
@@ -80,6 +80,10 @@ abstract class WalletHistoryItemData {
     rust.WalletHistoryItemType_Lightning type =
         item.walletType as rust.WalletHistoryItemType_Lightning;
 
+    DateTime? expiry = type.expiryTimestamp != null
+        ? DateTime.fromMillisecondsSinceEpoch(type.expiryTimestamp! * 1000)
+        : null;
+
     return LightningPaymentData(
         flow: flow,
         amount: amount,
@@ -88,6 +92,7 @@ abstract class WalletHistoryItemData {
         preimage: type.paymentPreimage,
         description: type.description,
         paymentHash: type.paymentHash,
+        expiry: expiry,
         invoice: type.invoice);
   }
 }
@@ -97,6 +102,7 @@ class LightningPaymentData extends WalletHistoryItemData {
   final String? preimage;
   final String description;
   final String? invoice;
+  final DateTime? expiry;
 
   LightningPaymentData(
       {required super.flow,
@@ -106,6 +112,7 @@ class LightningPaymentData extends WalletHistoryItemData {
       required this.preimage,
       required this.description,
       required this.invoice,
+      required this.expiry,
       required this.paymentHash});
 
   @override

--- a/mobile/lib/features/wallet/domain/wallet_history.dart
+++ b/mobile/lib/features/wallet/domain/wallet_history.dart
@@ -66,23 +66,31 @@ abstract class WalletHistoryItemData {
       );
     }
 
+    rust.WalletType_Lightning type = item.walletType as rust.WalletType_Lightning;
+
     return LightningPaymentData(
         flow: flow,
         amount: amount,
         status: status,
         timestamp: timestamp,
-        paymentHash: (item.walletType as rust.WalletType_Lightning).paymentHash);
+        preimage: type.paymentPreimage,
+        description: type.description,
+        paymentHash: type.paymentHash);
   }
 }
 
 class LightningPaymentData extends WalletHistoryItemData {
   final String paymentHash;
+  final String? preimage;
+  final String description;
 
   LightningPaymentData(
       {required super.flow,
       required super.amount,
       required super.status,
       required super.timestamp,
+      required this.preimage,
+      required this.description,
       required this.paymentHash});
 
   @override

--- a/mobile/lib/features/wallet/domain/wallet_history.dart
+++ b/mobile/lib/features/wallet/domain/wallet_history.dart
@@ -3,7 +3,7 @@ import 'package:get_10101/features/wallet/wallet_history_item.dart';
 import 'payment_flow.dart';
 import 'package:get_10101/bridge_generated/bridge_definitions.dart' as rust;
 
-enum WalletHistoryStatus { pending, expired, confirmed }
+enum WalletHistoryStatus { pending, expired, confirmed, failed }
 
 abstract class WalletHistoryItemData {
   final PaymentFlow flow;
@@ -24,6 +24,7 @@ abstract class WalletHistoryItemData {
       rust.Status.Pending => WalletHistoryStatus.pending,
       rust.Status.Expired => WalletHistoryStatus.expired,
       rust.Status.Confirmed => WalletHistoryStatus.confirmed,
+      rust.Status.Failed => WalletHistoryStatus.failed,
     };
 
     DateTime timestamp = DateTime.fromMillisecondsSinceEpoch(item.timestamp * 1000);

--- a/mobile/lib/features/wallet/domain/wallet_history.dart
+++ b/mobile/lib/features/wallet/domain/wallet_history.dart
@@ -26,8 +26,9 @@ abstract class WalletHistoryItemData {
 
     DateTime timestamp = DateTime.fromMillisecondsSinceEpoch(item.timestamp * 1000);
 
-    if (item.walletType is rust.WalletType_OnChain) {
-      rust.WalletType_OnChain type = item.walletType as rust.WalletType_OnChain;
+    if (item.walletType is rust.WalletHistoryItemType_OnChain) {
+      rust.WalletHistoryItemType_OnChain type =
+          item.walletType as rust.WalletHistoryItemType_OnChain;
 
       return OnChainPaymentData(
         flow: flow,
@@ -40,22 +41,24 @@ abstract class WalletHistoryItemData {
       );
     }
 
-    if (item.walletType is rust.WalletType_Trade) {
-      rust.WalletType_Trade type = item.walletType as rust.WalletType_Trade;
+    if (item.walletType is rust.WalletHistoryItemType_Trade) {
+      rust.WalletHistoryItemType_Trade type = item.walletType as rust.WalletHistoryItemType_Trade;
 
       return TradeData(
           flow: flow, amount: amount, status: status, timestamp: timestamp, orderId: type.orderId);
     }
 
-    if (item.walletType is rust.WalletType_OrderMatchingFee) {
-      rust.WalletType_OrderMatchingFee type = item.walletType as rust.WalletType_OrderMatchingFee;
+    if (item.walletType is rust.WalletHistoryItemType_OrderMatchingFee) {
+      rust.WalletHistoryItemType_OrderMatchingFee type =
+          item.walletType as rust.WalletHistoryItemType_OrderMatchingFee;
 
       return OrderMatchingFeeData(
           flow: flow, amount: amount, status: status, timestamp: timestamp, orderId: type.orderId);
     }
 
-    if (item.walletType is rust.WalletType_JitChannelFee) {
-      rust.WalletType_JitChannelFee type = item.walletType as rust.WalletType_JitChannelFee;
+    if (item.walletType is rust.WalletHistoryItemType_JitChannelFee) {
+      rust.WalletHistoryItemType_JitChannelFee type =
+          item.walletType as rust.WalletHistoryItemType_JitChannelFee;
 
       return JitChannelOpenFeeData(
         flow: flow,
@@ -66,7 +69,8 @@ abstract class WalletHistoryItemData {
       );
     }
 
-    rust.WalletType_Lightning type = item.walletType as rust.WalletType_Lightning;
+    rust.WalletHistoryItemType_Lightning type =
+        item.walletType as rust.WalletHistoryItemType_Lightning;
 
     return LightningPaymentData(
         flow: flow,

--- a/mobile/lib/features/wallet/domain/wallet_history.dart
+++ b/mobile/lib/features/wallet/domain/wallet_history.dart
@@ -53,7 +53,12 @@ abstract class WalletHistoryItemData {
           item.walletType as rust.WalletHistoryItemType_OrderMatchingFee;
 
       return OrderMatchingFeeData(
-          flow: flow, amount: amount, status: status, timestamp: timestamp, orderId: type.orderId);
+          flow: flow,
+          amount: amount,
+          status: status,
+          timestamp: timestamp,
+          orderId: type.orderId,
+          paymentHash: type.paymentHash);
     }
 
     if (item.walletType is rust.WalletHistoryItemType_JitChannelFee) {
@@ -128,13 +133,15 @@ class OnChainPaymentData extends WalletHistoryItemData {
 
 class OrderMatchingFeeData extends WalletHistoryItemData {
   final String orderId;
+  final String paymentHash;
 
   OrderMatchingFeeData(
       {required super.flow,
       required super.amount,
       required super.status,
       required super.timestamp,
-      required this.orderId});
+      required this.orderId,
+      required this.paymentHash});
 
   @override
   WalletHistoryItem toWidget() {

--- a/mobile/lib/features/wallet/domain/wallet_history.dart
+++ b/mobile/lib/features/wallet/domain/wallet_history.dart
@@ -75,7 +75,8 @@ abstract class WalletHistoryItemData {
         timestamp: timestamp,
         preimage: type.paymentPreimage,
         description: type.description,
-        paymentHash: type.paymentHash);
+        paymentHash: type.paymentHash,
+        invoice: type.invoice);
   }
 }
 
@@ -83,6 +84,7 @@ class LightningPaymentData extends WalletHistoryItemData {
   final String paymentHash;
   final String? preimage;
   final String description;
+  final String? invoice;
 
   LightningPaymentData(
       {required super.flow,
@@ -91,6 +93,7 @@ class LightningPaymentData extends WalletHistoryItemData {
       required super.timestamp,
       required this.preimage,
       required this.description,
+      required this.invoice,
       required this.paymentHash});
 
   @override

--- a/mobile/lib/features/wallet/domain/wallet_history.dart
+++ b/mobile/lib/features/wallet/domain/wallet_history.dart
@@ -3,7 +3,7 @@ import 'package:get_10101/features/wallet/wallet_history_item.dart';
 import 'payment_flow.dart';
 import 'package:get_10101/bridge_generated/bridge_definitions.dart' as rust;
 
-enum WalletHistoryStatus { pending, confirmed }
+enum WalletHistoryStatus { pending, expired, confirmed }
 
 abstract class WalletHistoryItemData {
   final PaymentFlow flow;
@@ -20,9 +20,11 @@ abstract class WalletHistoryItemData {
     PaymentFlow flow =
         item.flow == rust.PaymentFlow.Outbound ? PaymentFlow.outbound : PaymentFlow.inbound;
     Amount amount = Amount(item.amountSats);
-    WalletHistoryStatus status = item.status == rust.Status.Pending
-        ? WalletHistoryStatus.pending
-        : WalletHistoryStatus.confirmed;
+    WalletHistoryStatus status = switch (item.status) {
+      rust.Status.Pending => WalletHistoryStatus.pending,
+      rust.Status.Expired => WalletHistoryStatus.expired,
+      rust.Status.Confirmed => WalletHistoryStatus.confirmed,
+    };
 
     DateTime timestamp = DateTime.fromMillisecondsSinceEpoch(item.timestamp * 1000);
 

--- a/mobile/lib/features/wallet/domain/wallet_type.dart
+++ b/mobile/lib/features/wallet/domain/wallet_type.dart
@@ -1,0 +1,1 @@
+enum WalletType { lightning, onChain, stable }

--- a/mobile/lib/features/wallet/wallet_history_item.dart
+++ b/mobile/lib/features/wallet/wallet_history_item.dart
@@ -167,6 +167,12 @@ class LightningPaymentHistoryItem extends WalletHistoryItem {
   @override
   List<Widget> getDetails() {
     return [
+      Visibility(
+        visible: data.expiry != null,
+        child: HistoryDetail(
+            label: "Expiry time",
+            value: WalletHistoryItem.dateFormat.format(data.expiry ?? DateTime.utc(0))),
+      ),
       HistoryDetail(label: "Invoice description", value: data.description),
       Visibility(
         visible: data.invoice != null,

--- a/mobile/lib/features/wallet/wallet_history_item.dart
+++ b/mobile/lib/features/wallet/wallet_history_item.dart
@@ -177,7 +177,14 @@ class LightningPaymentHistoryItem extends WalletHistoryItem {
 
   @override
   List<Widget> getDetails() {
-    return [HistoryDetail(label: "Payment hash", value: data.paymentHash)];
+    return [
+      HistoryDetail(label: "Invoice description", value: data.description),
+      HistoryDetail(label: "Payment hash", value: data.paymentHash),
+      Visibility(
+        visible: data.preimage != null,
+        child: HistoryDetail(label: "Payment preimage", value: data.preimage ?? ''),
+      ),
+    ];
   }
 
   @override

--- a/mobile/lib/features/wallet/wallet_history_item.dart
+++ b/mobile/lib/features/wallet/wallet_history_item.dart
@@ -245,7 +245,10 @@ class OrderMatchingFeeHistoryItem extends WalletHistoryItem {
 
   @override
   List<Widget> getDetails() {
-    return [HistoryDetail(label: "Order", value: data.orderId)];
+    return [
+      HistoryDetail(label: "Order", value: data.orderId),
+      HistoryDetail(label: "Payment hash", value: data.paymentHash)
+    ];
   }
 
   @override

--- a/mobile/lib/features/wallet/wallet_history_item.dart
+++ b/mobile/lib/features/wallet/wallet_history_item.dart
@@ -28,7 +28,9 @@ abstract class WalletHistoryItem extends StatelessWidget {
       WalletHistoryStatus.confirmed =>
         const Icon(Icons.check_circle, color: Colors.green, size: statusIconSize),
       WalletHistoryStatus.expired =>
-        const Icon(Icons.timer_off, color: Colors.red, size: statusIconSize)
+        const Icon(Icons.timer_off, color: Colors.red, size: statusIconSize),
+      WalletHistoryStatus.failed =>
+        const Icon(Icons.error, color: Colors.red, size: statusIconSize),
     };
 
     const double flowIconSize = 30;

--- a/mobile/lib/features/wallet/wallet_history_item.dart
+++ b/mobile/lib/features/wallet/wallet_history_item.dart
@@ -179,6 +179,10 @@ class LightningPaymentHistoryItem extends WalletHistoryItem {
   List<Widget> getDetails() {
     return [
       HistoryDetail(label: "Invoice description", value: data.description),
+      Visibility(
+        visible: data.invoice != null,
+        child: HistoryDetail(label: "Invoice", value: data.invoice ?? ''),
+      ),
       HistoryDetail(label: "Payment hash", value: data.paymentHash),
       Visibility(
         visible: data.preimage != null,
@@ -296,11 +300,11 @@ class OnChainPaymentHistoryItem extends WalletHistoryItem {
     final details = [
       HistoryDetail(label: "Transaction ID", value: data.txid),
       HistoryDetail(label: "Confirmations", value: data.confirmations.toString()),
+      Visibility(
+        visible: data.fee != null,
+        child: HistoryDetail(label: "Fee", value: formatSats(data.fee ?? Amount(0))),
+      ),
     ];
-
-    if (data.fee != null) {
-      details.add(HistoryDetail(label: "Fee", value: formatSats(data.fee!)));
-    }
 
     return details;
   }

--- a/mobile/lib/features/wallet/wallet_history_item.dart
+++ b/mobile/lib/features/wallet/wallet_history_item.dart
@@ -20,17 +20,16 @@ abstract class WalletHistoryItem extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     const double statusIconSize = 18;
-    Icon statusIcon = () {
-      switch (data.status) {
-        case WalletHistoryStatus.pending:
-          return const Icon(
-            Icons.pending,
-            size: statusIconSize,
-          );
-        case WalletHistoryStatus.confirmed:
-          return const Icon(Icons.check_circle, color: Colors.green, size: statusIconSize);
-      }
-    }();
+    Icon statusIcon = switch (data.status) {
+      WalletHistoryStatus.pending => const Icon(
+          Icons.pending,
+          size: statusIconSize,
+        ),
+      WalletHistoryStatus.confirmed =>
+        const Icon(Icons.check_circle, color: Colors.green, size: statusIconSize),
+      WalletHistoryStatus.expired =>
+        const Icon(Icons.timer_off, color: Colors.red, size: statusIconSize)
+    };
 
     const double flowIconSize = 30;
     Icon flowIcon = Icon(getFlowIcon(), size: flowIconSize);

--- a/mobile/lib/features/wallet/wallet_history_item.dart
+++ b/mobile/lib/features/wallet/wallet_history_item.dart
@@ -39,23 +39,15 @@ abstract class WalletHistoryItem extends StatelessWidget {
     String title = getTitle();
     String onOrOff = isOnChain() ? "on-chain" : "off-chain";
 
-    String sign = () {
-      switch (data.flow) {
-        case PaymentFlow.inbound:
-          return "+";
-        case PaymentFlow.outbound:
-          return "-";
-      }
-    }();
+    String sign = switch (data.flow) {
+      PaymentFlow.inbound => "+",
+      PaymentFlow.outbound => "-",
+    };
 
-    Color color = () {
-      switch (data.flow) {
-        case PaymentFlow.inbound:
-          return Colors.green.shade600;
-        case PaymentFlow.outbound:
-          return Colors.red.shade600;
-      }
-    }();
+    Color color = switch (data.flow) {
+      PaymentFlow.inbound => Colors.green.shade600,
+      PaymentFlow.outbound => Colors.red.shade600,
+    };
 
     var amountFormatter = NumberFormat.compact(locale: "en_UK");
 
@@ -117,14 +109,10 @@ abstract class WalletHistoryItem extends StatelessWidget {
   }
 
   Widget showItemDetails(String title, BuildContext context) {
-    int directionMultiplier = () {
-      switch (data.flow) {
-        case PaymentFlow.inbound:
-          return 1;
-        case PaymentFlow.outbound:
-          return -1;
-      }
-    }();
+    int directionMultiplier = switch (data.flow) {
+      PaymentFlow.inbound => 1,
+      PaymentFlow.outbound => -1,
+    };
 
     return AlertDialog(
       title: Text(title),

--- a/mobile/lib/features/wallet/wallet_history_item.dart
+++ b/mobile/lib/features/wallet/wallet_history_item.dart
@@ -286,7 +286,16 @@ class OnChainPaymentHistoryItem extends WalletHistoryItem {
 
   @override
   List<Widget> getDetails() {
-    return [HistoryDetail(label: "Transaction ID", value: data.txid)];
+    final details = [
+      HistoryDetail(label: "Transaction ID", value: data.txid),
+      HistoryDetail(label: "Confirmations", value: data.confirmations.toString()),
+    ];
+
+    if (data.fee != null) {
+      details.add(HistoryDetail(label: "Fee", value: formatSats(data.fee!)));
+    }
+
+    return details;
   }
 
   @override

--- a/mobile/lib/features/wallet/wallet_screen.dart
+++ b/mobile/lib/features/wallet/wallet_screen.dart
@@ -4,6 +4,7 @@ import 'package:get_10101/common/amount_text.dart';
 import 'package:get_10101/common/fiat_text.dart';
 import 'package:get_10101/common/submission_status_dialog.dart';
 import 'package:get_10101/common/value_data_row.dart';
+import 'package:get_10101/features/wallet/domain/wallet_type.dart';
 import 'package:get_10101/features/trade/position_change_notifier.dart';
 import 'package:get_10101/features/wallet/seed_screen.dart';
 import 'package:get_10101/features/wallet/send_payment_change_notifier.dart';
@@ -11,7 +12,6 @@ import 'package:get_10101/util/preferences.dart';
 import 'package:get_10101/features/wallet/balance_row.dart';
 import 'package:get_10101/features/wallet/create_invoice_screen.dart';
 import 'package:get_10101/features/wallet/domain/wallet_history.dart';
-import 'package:get_10101/features/wallet/wallet_history_item.dart';
 import 'package:get_10101/features/wallet/wallet_theme.dart';
 import 'package:get_10101/features/wallet/send_screen.dart';
 import 'package:get_10101/features/wallet/wallet_change_notifier.dart';
@@ -174,9 +174,9 @@ class _WalletScreenState extends State<WalletScreen> {
                       margin: const EdgeInsets.only(left: 20.0, right: 20.0, bottom: 8.0),
                       child: const Column(
                         children: [
-                          BalanceRow(walletType: WalletHistoryItemDataType.lightning),
-                          BalanceRow(walletType: WalletHistoryItemDataType.onChain),
-                          BalanceRow(walletType: WalletHistoryItemDataType.stable),
+                          BalanceRow(walletType: WalletType.lightning),
+                          BalanceRow(walletType: WalletType.onChain),
+                          BalanceRow(walletType: WalletType.stable),
                         ],
                       ),
                     ),
@@ -236,9 +236,7 @@ class _WalletScreenState extends State<WalletScreen> {
 
                     WalletHistoryItemData itemData = walletChangeNotifier.walletInfo.history[index];
 
-                    return WalletHistoryItem(
-                      data: itemData,
-                    );
+                    return itemData.toWidget();
                   },
                 ),
               ),

--- a/mobile/native/migrations/2023-08-23-152633_add_invoice_to_payments/down.sql
+++ b/mobile/native/migrations/2023-08-23-152633_add_invoice_to_payments/down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE
+    payments DROP COLUMN invoice;

--- a/mobile/native/migrations/2023-08-23-152633_add_invoice_to_payments/up.sql
+++ b/mobile/native/migrations/2023-08-23-152633_add_invoice_to_payments/up.sql
@@ -1,0 +1,4 @@
+ALTER TABLE
+    payments
+ADD
+    COLUMN invoice TEXT DEFAULT null;

--- a/mobile/native/src/api.rs
+++ b/mobile/native/src/api.rs
@@ -82,6 +82,8 @@ pub enum WalletType {
     },
     Lightning {
         payment_hash: String,
+        description: String,
+        payment_preimage: Option<String>,
     },
     Trade {
         order_id: String,

--- a/mobile/native/src/api.rs
+++ b/mobile/native/src/api.rs
@@ -91,6 +91,7 @@ pub enum WalletHistoryItemType {
     },
     OrderMatchingFee {
         order_id: String,
+        payment_hash: String,
     },
     JitChannelFee {
         funding_txid: String,

--- a/mobile/native/src/api.rs
+++ b/mobile/native/src/api.rs
@@ -84,6 +84,7 @@ pub enum WalletType {
         payment_hash: String,
         description: String,
         payment_preimage: Option<String>,
+        invoice: Option<String>,
     },
     Trade {
         order_id: String,

--- a/mobile/native/src/api.rs
+++ b/mobile/native/src/api.rs
@@ -77,6 +77,8 @@ pub struct WalletHistoryItem {
 pub enum WalletType {
     OnChain {
         txid: String,
+        fee_sats: Option<u64>,
+        confirmations: u64,
     },
     Lightning {
         payment_hash: String,

--- a/mobile/native/src/api.rs
+++ b/mobile/native/src/api.rs
@@ -85,6 +85,7 @@ pub enum WalletHistoryItemType {
         description: String,
         payment_preimage: Option<String>,
         invoice: Option<String>,
+        expiry_timestamp: Option<u64>,
     },
     Trade {
         order_id: String,

--- a/mobile/native/src/api.rs
+++ b/mobile/native/src/api.rs
@@ -111,6 +111,7 @@ pub enum Status {
     #[default]
     Pending,
     Confirmed,
+    Expired,
 }
 
 pub fn calculate_margin(price: f32, quantity: f32, leverage: f32) -> SyncReturn<u64> {

--- a/mobile/native/src/api.rs
+++ b/mobile/native/src/api.rs
@@ -70,11 +70,11 @@ pub struct WalletHistoryItem {
     pub amount_sats: u64,
     pub timestamp: u64,
     pub status: Status,
-    pub wallet_type: WalletType,
+    pub wallet_type: WalletHistoryItemType,
 }
 
 #[derive(Clone, Debug)]
-pub enum WalletType {
+pub enum WalletHistoryItemType {
     OnChain {
         txid: String,
         fee_sats: Option<u64>,

--- a/mobile/native/src/api.rs
+++ b/mobile/native/src/api.rs
@@ -112,6 +112,7 @@ pub enum Status {
     Pending,
     Confirmed,
     Expired,
+    Failed,
 }
 
 pub fn calculate_margin(price: f32, quantity: f32, leverage: f32) -> SyncReturn<u64> {

--- a/mobile/native/src/ln_dlc/mod.rs
+++ b/mobile/native/src/ln_dlc/mod.rs
@@ -609,7 +609,7 @@ pub fn create_invoice(amount_sats: Option<u64>) -> Result<Invoice> {
 
         node.inner.create_interceptable_invoice(
             amount_sats,
-            0,
+            None,
             "Fund your 10101 wallet".to_string(),
             final_route_hint_hop,
         )

--- a/mobile/native/src/ln_dlc/mod.rs
+++ b/mobile/native/src/ln_dlc/mod.rs
@@ -322,7 +322,7 @@ fn keep_wallet_balance_and_history_up_to_date(node: &Node) -> Result<()> {
             }
         };
 
-        let wallet_type = api::WalletType::OnChain {
+        let wallet_type = api::WalletHistoryItemType::OnChain {
             txid: details.txid.to_string(),
             fee_sats: details.fee,
             confirmations: n_confirmations,
@@ -366,18 +366,18 @@ fn keep_wallet_balance_and_history_up_to_date(node: &Node) -> Result<()> {
         let wallet_type = if let Some(order_id) =
             description.strip_prefix(FEE_INVOICE_DESCRIPTION_PREFIX_TAKER)
         {
-            api::WalletType::OrderMatchingFee {
+            api::WalletHistoryItemType::OrderMatchingFee {
                 order_id: order_id.to_string(),
             }
         } else if let Some(funding_txid) =
             description.strip_prefix(JIT_FEE_INVOICE_DESCRIPTION_PREFIX)
         {
-            api::WalletType::JitChannelFee {
+            api::WalletHistoryItemType::JitChannelFee {
                 funding_txid: funding_txid.to_string(),
                 payment_hash,
             }
         } else {
-            api::WalletType::Lightning {
+            api::WalletHistoryItemType::Lightning {
                 payment_hash,
                 description: details.description.clone(),
                 payment_preimage: details.preimage.clone(),
@@ -443,7 +443,7 @@ fn keep_wallet_balance_and_history_up_to_date(node: &Node) -> Result<()> {
 
         let timestamp = order.creation_timestamp.unix_timestamp() as u64;
 
-        let wallet_type = api::WalletType::Trade {
+        let wallet_type = api::WalletHistoryItemType::Trade {
             order_id: order.id.to_string(),
         };
 

--- a/mobile/native/src/ln_dlc/mod.rs
+++ b/mobile/native/src/ln_dlc/mod.rs
@@ -295,9 +295,9 @@ fn keep_wallet_balance_and_history_up_to_date(node: &Node) -> Result<()> {
         let net_sats = details.received as i64 - details.sent as i64;
 
         let (flow, amount_sats) = if net_sats >= 0 {
-            (api::PaymentFlow::Outbound, net_sats as u64)
+            (api::PaymentFlow::Inbound, net_sats as u64)
         } else {
-            (api::PaymentFlow::Inbound, net_sats.unsigned_abs())
+            (api::PaymentFlow::Outbound, net_sats.unsigned_abs())
         };
 
         let (status, timestamp, n_confirmations) = match details.confirmation_time {

--- a/mobile/native/src/ln_dlc/mod.rs
+++ b/mobile/native/src/ln_dlc/mod.rs
@@ -307,7 +307,9 @@ fn keep_wallet_balance_and_history_up_to_date(node: &Node) -> Result<()> {
                 // This is calculated manually to avoid wasteful requests to esplora,
                 // since we can just cache the blockchain height as opposed to fetching it for each
                 // block as with `LnDlcWallet::get_transaction_confirmations`
-                blockchain_height.checked_sub(height as u64).unwrap_or_default(),
+                blockchain_height
+                    .checked_sub(height as u64)
+                    .unwrap_or_default(),
             ),
 
             None => {
@@ -375,7 +377,11 @@ fn keep_wallet_balance_and_history_up_to_date(node: &Node) -> Result<()> {
                 payment_hash,
             }
         } else {
-            api::WalletType::Lightning { payment_hash }
+            api::WalletType::Lightning {
+                payment_hash,
+                description: details.description.clone(),
+                payment_preimage: details.preimage.clone(),
+            }
         };
 
         Some(api::WalletHistoryItem {

--- a/mobile/native/src/ln_dlc/mod.rs
+++ b/mobile/native/src/ln_dlc/mod.rs
@@ -363,8 +363,7 @@ fn keep_wallet_balance_and_history_up_to_date(node: &Node) -> Result<()> {
             HTLCStatus::Pending if expired => api::Status::Expired,
             HTLCStatus::Pending => api::Status::Pending,
             HTLCStatus::Succeeded => api::Status::Confirmed,
-            // TODO: Handle failed payments
-            HTLCStatus::Failed => return None,
+            HTLCStatus::Failed => api::Status::Failed,
         };
 
         let flow = match details.flow {

--- a/mobile/native/src/ln_dlc/mod.rs
+++ b/mobile/native/src/ln_dlc/mod.rs
@@ -381,6 +381,7 @@ fn keep_wallet_balance_and_history_up_to_date(node: &Node) -> Result<()> {
                 payment_hash,
                 description: details.description.clone(),
                 payment_preimage: details.preimage.clone(),
+                invoice: details.invoice.clone(),
             }
         };
 

--- a/mobile/native/src/ln_dlc/mod.rs
+++ b/mobile/native/src/ln_dlc/mod.rs
@@ -368,6 +368,7 @@ fn keep_wallet_balance_and_history_up_to_date(node: &Node) -> Result<()> {
         {
             api::WalletHistoryItemType::OrderMatchingFee {
                 order_id: order_id.to_string(),
+                payment_hash,
             }
         } else if let Some(funding_txid) =
             description.strip_prefix(JIT_FEE_INVOICE_DESCRIPTION_PREFIX)

--- a/mobile/native/src/ln_dlc/node.rs
+++ b/mobile/native/src/ln_dlc/node.rs
@@ -417,6 +417,7 @@ impl node::Storage for NodeStorage {
                         flow,
                         timestamp: OffsetDateTime::now_utc(),
                         description: "".to_string(),
+                        invoice: None,
                     },
                 )?;
             }

--- a/mobile/native/src/ln_dlc/node.rs
+++ b/mobile/native/src/ln_dlc/node.rs
@@ -85,6 +85,10 @@ impl Node {
         self.inner.get_seed_phrase()
     }
 
+    pub fn get_blockchain_height(&self) -> Result<u64> {
+        self.inner.get_blockchain_height()
+    }
+
     pub fn get_wallet_balances(&self) -> Result<Balances> {
         let on_chain = self.inner.get_on_chain_balance()?.confirmed;
         let off_chain = self.inner.get_ldk_balance().available();

--- a/mobile/native/src/schema.rs
+++ b/mobile/native/src/schema.rs
@@ -50,6 +50,7 @@ diesel::table! {
         created_at -> BigInt,
         updated_at -> BigInt,
         description -> Text,
+        invoice -> Nullable<Text>,
     }
 }
 

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -181,10 +181,10 @@ packages:
     dependency: transitive
     description:
       name: collection
-      sha256: "4a07be6cb69c84d677a6c3096fcf960cc3285a8330b4603e0d463d15d9bd934c"
+      sha256: f092b211a4319e98e5ff58223576de6c2803db36221657b46c82574721240687
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.1"
+    version: "1.17.2"
   colorize:
     dependency: transitive
     description:
@@ -604,18 +604,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "6501fbd55da300384b768785b83e5ce66991266cec21af89ab9ae7f5ce1c4cbb"
+      sha256: "1803e76e6653768d64ed8ff2e1e67bea3ad4b923eb5c56a295c3e634bad5960e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.15"
+    version: "0.12.16"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: d92141dc6fe1dad30722f9aa826c7fbc896d021d792f80678280601aff8cf724
+      sha256: "9528f2f296073ff54cb9fee677df673ace1218163c3bc7628093e7eed5203d41"
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.0"
+    version: "0.5.0"
   meta:
     dependency: "direct main"
     description:
@@ -1017,10 +1017,10 @@ packages:
     dependency: transitive
     description:
       name: source_span
-      sha256: dd904f795d4b4f3b870833847c461801f6750a9fa8e61ea5ac53f9422b31f250
+      sha256: "53e943d4206a5e30df338fd4c6e7a077e02254531b138a15aec3bd143c1a8b3c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.1"
+    version: "1.10.0"
   stack_trace:
     dependency: transitive
     description:
@@ -1073,26 +1073,26 @@ packages:
     dependency: "direct main"
     description:
       name: test
-      sha256: "3dac9aecf2c3991d09b9cdde4f98ded7b30804a88a0d7e4e7e1678e78d6b97f4"
+      sha256: "13b41f318e2a5751c3169137103b60c584297353d4b1761b66029bae6411fe46"
       url: "https://pub.dev"
     source: hosted
-    version: "1.24.1"
+    version: "1.24.3"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: eb6ac1540b26de412b3403a163d919ba86f6a973fe6cc50ae3541b80092fdcfb
+      sha256: "75760ffd7786fffdfb9597c35c5b27eaeec82be8edfb6d71d32651128ed7aab8"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.1"
+    version: "0.6.0"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "5138dbffb77b2289ecb12b81c11ba46036590b72a64a7a90d6ffb880f1a29e93"
+      sha256: "99806e9e6d95c7b059b7a0fc08f07fc53fabe54a829497f0d9676299f1e8637e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.1"
+    version: "0.5.3"
   timeago:
     dependency: "direct main"
     description:
@@ -1237,6 +1237,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.0"
+  web:
+    dependency: transitive
+    description:
+      name: web
+      sha256: dc8ccd225a2005c1be616fe02951e2e342092edf968cf0844220383757ef8f10
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.4-beta"
   web_socket_channel:
     dependency: transitive
     description:
@@ -1302,5 +1310,5 @@ packages:
     source: hosted
     version: "2.1.1"
 sdks:
-  dart: ">=3.0.0 <4.0.0"
+  dart: ">=3.1.0-185.0.dev <4.0.0"
   flutter: ">=3.7.0"


### PR DESCRIPTION
Addresses #872 by modelling more history details for different kinds of events (transactions, trades, fees, etc).

I don't think this PR should address the Figma mock beyond adding all the info that it has to the display and that should rather be done in a followup, but happy to change this if desired.

- [x] Model on-chain payment data
  - [x] Confirmations
  - [x] Fee
      - [x] Check if the fee reported is correct   
- [x] Model lightning payment data
    - ~~[ ] From node~~ I do not believe this to be possible without an explicit proof-of-payment protocol: https://bitcoin.stackexchange.com/a/85555
    - [x] Invoice description
    - [x] Payment preimage
    - [x] Invoice itself
    - [x] Show expiry time 
    - [x] Show expired payments
        - [x]  Test
    - [x] Handle failed payments (fixes #1140)
        - [x] Test
- [x] JIT fee - blocked on #1103
- [x] Order matching fee
    - [x] Order ID

Questions:
- [x] What should we do about unpaid invoices in the database?

Related: #1103 