### PR TITLE
Allow switching between mainnet and regtest networks.

### DIFF
--- a/justfile
+++ b/justfile
@@ -87,14 +87,13 @@ ios-release:
 run args="":
     #!/usr/bin/env bash
     cd mobile && flutter run {{args}} --dart-define="COMMIT=$(git rev-parse HEAD)" --dart-define="BRANCH=$(git rev-parse --abbrev-ref HEAD)" \
-    --dart-define="REGTEST_FAUCET=http://localhost:8080" --dart-define="HEALTH_CHECK_INTERVAL_SECONDS=2" \
+    --dart-define="REGTEST_FAUCET=http://localhost:8080" \
+    --dart-define="DEV_MODE=true"
 
 # Run against our public regtest server
 run-regtest args="":
     #!/usr/bin/env bash
     cd mobile && flutter run {{args}} --dart-define="COMMIT=$(git rev-parse HEAD)" --dart-define="BRANCH=$(git rev-parse --abbrev-ref HEAD)" \
-    --dart-define="ESPLORA_ENDPOINT={{public_regtest_esplora}}" --dart-define="COORDINATOR_P2P_ENDPOINT={{public_regtest_coordinator}}" \
-    --dart-define="COORDINATOR_PORT_HTTP={{public_coordinator_http_port}}"
 
 [unix]
 run-local-android args="":
@@ -102,6 +101,7 @@ run-local-android args="":
     LOCAL_IP=$({{get_local_ip}})
     echo "Android app will connect to $LOCAL_IP for 10101 services"
     cd mobile && flutter run {{args}} --dart-define="COMMIT=$(git rev-parse HEAD)" --dart-define="BRANCH=$(git rev-parse --abbrev-ref HEAD)" \
+    --dart-define="DEV_MODE=true" \
     --dart-define="ESPLORA_ENDPOINT=http://${LOCAL_IP}:3000" --dart-define="COORDINATOR_P2P_ENDPOINT=02dd6abec97f9a748bf76ad502b004ce05d1b2d1f43a9e76bd7d85e767ffb022c9@${LOCAL_IP}:9045" \
     --dart-define="REGTEST_FAUCET=http://${LOCAL_IP}:8080" --dart-define="COORDINATOR_PORT_HTTP=8000" --flavor local
 
@@ -335,12 +335,8 @@ build-ipa args="":
     fi
 
     cd mobile && flutter build ipa "${args[@]}" \
-           --dart-define="ESPLORA_ENDPOINT=${ESPLORA_ENDPOINT}" \
-           --dart-define="COORDINATOR_P2P_ENDPOINT=${COORDINATOR_P2P_ENDPOINT}" \
-           --dart-define="NETWORK=${NETWORK}" \
            --dart-define="COMMIT=$(git rev-parse HEAD)" \
            --dart-define="BRANCH=$(git rev-parse --abbrev-ref HEAD)" \
-           --dart-define="COORDINATOR_PORT_HTTP=${COORDINATOR_PORT_HTTP}" \
            --build-number=${BUILD_NUMBER} \
            {{args}}
 
@@ -364,8 +360,7 @@ build-apk-regtest:
     echo "build name: ${BUILD_NAME}"
     echo "build number: ${BUILD_NUMBER}"
     cd mobile && flutter build apk  --build-name=${BUILD_NAME} --build-number=${BUILD_NUMBER} --release --dart-define="COMMIT=$(git rev-parse HEAD)" --dart-define="BRANCH=$(git rev-parse --abbrev-ref HEAD)" \
-                                       --dart-define="ESPLORA_ENDPOINT={{public_regtest_esplora}}" --dart-define="COORDINATOR_P2P_ENDPOINT={{public_regtest_coordinator}}" \
-                                       --dart-define="COORDINATOR_PORT_HTTP={{public_coordinator_http_port}}" --flavor demo
+    --flavor demo
 
 release-apk-regtest: gen android-release build-apk-regtest
 

--- a/mobile/lib/common/application/config_service.dart
+++ b/mobile/lib/common/application/config_service.dart
@@ -2,6 +2,7 @@ import 'package:f_logs/model/flog/flog.dart';
 import 'package:get_10101/ffi.dart' as rust;
 import 'package:get_10101/util/environment.dart';
 import 'package:get_10101/util/preferences.dart';
+import 'package:package_info_plus/package_info_plus.dart';
 
 class ConfigService {
   rust.Config _config = Environment.parse();
@@ -17,6 +18,11 @@ class ConfigService {
   ConfigService() {
     determineConfig(_config).then((config) {
       _config = config;
+    });
+
+    PackageInfo.fromPlatform().then((packageInfo) {
+      buildNumber = packageInfo.buildNumber;
+      version = packageInfo.version;
     });
   }
 

--- a/mobile/lib/common/application/config_service.dart
+++ b/mobile/lib/common/application/config_service.dart
@@ -1,0 +1,43 @@
+import 'package:f_logs/model/flog/flog.dart';
+import 'package:get_10101/ffi.dart' as rust;
+import 'package:get_10101/util/environment.dart';
+import 'package:get_10101/util/preferences.dart';
+
+class ConfigService {
+  rust.Config _config = Environment.parse();
+
+  String commit = const String.fromEnvironment('COMMIT', defaultValue: 'not available');
+  String branch = const String.fromEnvironment('BRANCH', defaultValue: 'not available');
+
+  String buildNumber = "";
+  String version = "";
+
+  bool devMode = (const String.fromEnvironment('DEV_MODE', defaultValue: 'false')) == 'true';
+
+  ConfigService() {
+    determineConfig(_config).then((config) {
+      _config = config;
+    });
+  }
+
+  rust.Config getConfig() {
+    return _config;
+  }
+
+  Future<rust.Config> determineConfig(rust.Config parsedConfig) async {
+    final network = await Preferences.instance.getNetwork();
+    switch (network) {
+      case Network.regtest:
+        if (devMode) {
+          FLog.info(
+              text:
+                  "Dev mode enabled: using provided `--dart-define` variables instead of public regtest node config");
+          return parsedConfig;
+        } else {
+          return rust.api.regtestConfig();
+        }
+      case Network.mainnet:
+        return rust.api.mainnetConfig();
+    }
+  }
+}

--- a/mobile/lib/common/network_toggle_button.dart
+++ b/mobile/lib/common/network_toggle_button.dart
@@ -1,0 +1,65 @@
+import 'package:flutter/material.dart';
+import 'package:get_10101/util/preferences.dart';
+
+/// Widget to toggle between mainnet and regtest (requires app restart).
+class NetworkToggleButton extends StatefulWidget {
+  const NetworkToggleButton({super.key});
+
+  @override
+  NetworkToggleButtonState createState() => NetworkToggleButtonState();
+}
+
+class NetworkToggleButtonState extends State<NetworkToggleButton> {
+  @override
+  void initState() {
+    Preferences.instance.getNetwork().then((network) {
+      setState(() {
+        _currentNetwork = network;
+      });
+    });
+    super.initState();
+  }
+
+  Network _currentNetwork = Network.mainnet;
+
+  void _toggleNetwork() {
+    setState(() {
+      if (_currentNetwork == Network.mainnet) {
+        _currentNetwork = Network.regtest;
+      } else {
+        _currentNetwork = Network.mainnet;
+      }
+    });
+
+    Preferences.instance.setNetwork(_currentNetwork);
+
+    // Show a dialog after updating the state
+    showDialog(
+      context: context,
+      builder: (BuildContext context) {
+        return AlertDialog(
+          title: const Text('Network Changed'),
+          content: const Text('The new setting will be applied after app restart.'),
+          actions: <Widget>[
+            TextButton(
+              child: const Text('OK'),
+              onPressed: () {
+                Navigator.of(context).pop();
+              },
+            ),
+          ],
+        );
+      },
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return ElevatedButton(
+      onPressed: _toggleNetwork,
+      child: Text(
+        'Change to ${_currentNetwork == Network.mainnet ? 'regtest' : 'mainnet'}',
+      ),
+    );
+  }
+}

--- a/mobile/lib/common/settings_screen.dart
+++ b/mobile/lib/common/settings_screen.dart
@@ -12,7 +12,6 @@ import 'package:intl/intl.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:provider/provider.dart';
 import 'package:share_plus/share_plus.dart';
-import 'package:package_info_plus/package_info_plus.dart';
 import 'package:get_10101/ffi.dart' as rust;
 
 class SettingsScreen extends StatefulWidget {
@@ -25,26 +24,13 @@ class SettingsScreen extends StatefulWidget {
 }
 
 class _SettingsScreenState extends State<SettingsScreen> {
-  String _buildNumber = '';
-  String _version = '';
   String _nodeId = "";
 
   @override
   void initState() {
     var nodeId = rust.api.getNodeId();
     _nodeId = nodeId;
-    loadValues();
     super.initState();
-  }
-
-  Future<void> loadValues() async {
-    var value = await PackageInfo.fromPlatform();
-
-    FLog.info(text: "All values $value");
-    setState(() {
-      _buildNumber = value.buildNumber;
-      _version = value.version;
-    });
   }
 
   @override
@@ -136,7 +122,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
                   child: Text('Build Number'),
                 ),
                 Center(
-                  child: SelectableText(_buildNumber),
+                  child: SelectableText(configService.buildNumber),
                 ),
               ],
             ),
@@ -146,7 +132,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
                   child: Text('Build Version'),
                 ),
                 Center(
-                  child: SelectableText(_version),
+                  child: SelectableText(configService.version),
                 ),
               ],
             ),

--- a/mobile/lib/common/settings_screen.dart
+++ b/mobile/lib/common/settings_screen.dart
@@ -4,9 +4,10 @@ import 'dart:io';
 import 'package:f_logs/f_logs.dart';
 import 'package:feedback/feedback.dart';
 import 'package:flutter/material.dart';
+import 'package:get_10101/common/application/config_service.dart';
 import 'package:get_10101/common/feedback.dart';
+import 'package:get_10101/common/network_toggle_button.dart';
 import 'package:get_10101/common/scrollable_safe_area.dart';
-import 'package:get_10101/bridge_generated/bridge_definitions.dart' as bridge;
 import 'package:intl/intl.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:provider/provider.dart';
@@ -48,10 +49,9 @@ class _SettingsScreenState extends State<SettingsScreen> {
 
   @override
   Widget build(BuildContext context) {
-    final bridge.Config config = context.read<bridge.Config>();
-
-    String commit = const String.fromEnvironment('COMMIT', defaultValue: 'not available');
-    String branch = const String.fromEnvironment('BRANCH', defaultValue: 'not available');
+    final configService = context.watch<ConfigService>();
+    final config = configService.getConfig();
+    final devMode = configService.devMode;
 
     return Scaffold(
       appBar: AppBar(title: const Text("Settings")),
@@ -95,7 +95,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
                   child: Text('Network'),
                 ),
                 Center(
-                  child: SelectableText(config.network),
+                  child: SelectableText(config.network + (devMode ? " (dev)" : "")),
                 ),
               ],
             ),
@@ -116,7 +116,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
                   child: Text('Branch'),
                 ),
                 Center(
-                  child: SelectableText(branch),
+                  child: SelectableText(configService.branch),
                 ),
               ],
             ),
@@ -126,7 +126,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
                   child: Text('Commit'),
                 ),
                 Center(
-                  child: SelectableText(commit),
+                  child: SelectableText(configService.commit),
                 ),
               ],
             ),
@@ -175,7 +175,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
               Share.shareXFiles([logFile], text: 'Logs from $now');
             },
             child: const Text("Share logs")),
-        const SizedBox(height: 20),
+        const SizedBox(height: 10),
         ElevatedButton(
           child: const Text('Provide feedback'),
           onPressed: () {
@@ -187,6 +187,8 @@ class _SettingsScreenState extends State<SettingsScreen> {
             }
           },
         ),
+        const SizedBox(height: 10),
+        const NetworkToggleButton(),
       ])),
     );
   }

--- a/mobile/lib/features/wallet/share_invoice_screen.dart
+++ b/mobile/lib/features/wallet/share_invoice_screen.dart
@@ -3,13 +3,13 @@ import 'package:f_logs/f_logs.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:get_10101/common/amount_text.dart';
+import 'package:get_10101/common/application/config_service.dart';
 import 'package:get_10101/common/modal_bottom_sheet_info.dart';
 import 'package:get_10101/common/snack_bar.dart';
 import 'package:get_10101/common/value_data_row.dart';
 import 'package:get_10101/features/wallet/create_invoice_screen.dart';
 import 'package:get_10101/features/wallet/domain/wallet_info.dart';
 import 'package:get_10101/features/wallet/wallet_change_notifier.dart';
-import 'package:get_10101/bridge_generated/bridge_definitions.dart' as bridge;
 import 'package:get_10101/features/wallet/wallet_screen.dart';
 import 'package:http/http.dart' as http;
 import 'package:go_router/go_router.dart';
@@ -35,7 +35,7 @@ class _ShareInvoiceScreenState extends State<ShareInvoiceScreen> {
   @override
   Widget build(BuildContext context) {
     WalletInfo info = context.watch<WalletChangeNotifier>().walletInfo;
-    final bridge.Config config = context.read<bridge.Config>();
+    final config = context.read<ConfigService>().getConfig();
 
     FLog.debug(text: "Refresh receive screen: ${formatSats(info.balances.onChain)}");
 

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -47,7 +47,6 @@ import 'package:get_10101/features/welcome/welcome_screen.dart';
 import 'package:get_10101/util/constants.dart';
 import 'package:get_10101/util/preferences.dart';
 import 'package:go_router/go_router.dart';
-import 'package:package_info_plus/package_info_plus.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:provider/provider.dart';
 import 'package:get_10101/common/amount_denomination_change_notifier.dart';
@@ -237,13 +236,12 @@ class _TenTenOneAppState extends State<TenTenOneApp> {
     init();
 
     WidgetsBinding.instance.addPostFrameCallback((_) async {
-      final config = context.read<ConfigService>().getConfig();
+      final configService = context.read<ConfigService>();
+      final config = configService.getConfig();
       await initFirebase();
       await requestNotificationPermission();
       final flutterLocalNotificationsPlugin = initLocalNotifications();
       await configureFirebase(flutterLocalNotificationsPlugin);
-
-      PackageInfo packageInfo = await PackageInfo.fromPlatform();
 
       final messenger = scaffoldMessengerKey.currentState!;
 
@@ -252,7 +250,7 @@ class _TenTenOneAppState extends State<TenTenOneApp> {
           Uri.parse('http://${config.host}:${config.httpPort}/api/version'),
         );
 
-        final clientVersion = Version.parse(packageInfo.version);
+        final clientVersion = Version.parse(configService.version);
         final coordinatorVersion = Version.parse(jsonDecode(response.body));
         FLog.info(text: "Coordinator version: ${coordinatorVersion.toString()}");
 
@@ -432,9 +430,8 @@ Future<void> logAppSettings(ConfigService configService) async {
 
   final config = configService.getConfig();
 
-  PackageInfo packageInfo = await PackageInfo.fromPlatform();
-  FLog.info(text: "Build number: ${packageInfo.buildNumber}");
-  FLog.info(text: "Build version: ${packageInfo.version}");
+  FLog.info(text: "Build number: ${configService.buildNumber}");
+  FLog.info(text: "Build version: ${configService.version}");
 
   FLog.info(text: "Network: ${config.network}");
   FLog.info(text: "Esplora endpoint: ${config.esploraEndpoint}");

--- a/mobile/lib/util/preferences.dart
+++ b/mobile/lib/util/preferences.dart
@@ -1,5 +1,7 @@
 import 'package:shared_preferences/shared_preferences.dart';
 
+enum Network { regtest, mainnet }
+
 class Preferences {
   Preferences._privateConstructor();
 
@@ -7,6 +9,7 @@ class Preferences {
 
   static const userSeedBackupConfirmed = "userSeedBackupConfirmed";
   static const emailAddress = "emailAddress";
+  static const network = "network";
 
   setUserSeedBackupConfirmed() async {
     SharedPreferences preferences = await SharedPreferences.getInstance();
@@ -26,6 +29,21 @@ class Preferences {
   Future<String> getEmailAddress() async {
     SharedPreferences preferences = await SharedPreferences.getInstance();
     return preferences.getString(emailAddress) ?? "";
+  }
+
+  setNetwork(Network value) async {
+    SharedPreferences preferences = await SharedPreferences.getInstance();
+    preferences.setString(network, value.toString());
+  }
+
+  Future<Network> getNetwork() async {
+    SharedPreferences preferences = await SharedPreferences.getInstance();
+    final networkString = preferences.getString(network) ?? "";
+    if (networkString == Network.mainnet.toString()) {
+      return Network.mainnet;
+    } else {
+      return Network.regtest;
+    }
   }
 
   Future<bool> hasEmailAddress() async {

--- a/mobile/macos/Podfile.lock
+++ b/mobile/macos/Podfile.lock
@@ -1,4 +1,6 @@
 PODS:
+  - device_info_plus (0.0.1):
+    - FlutterMacOS
   - Firebase/CoreOnly (10.12.0):
     - FirebaseCore (= 10.12.0)
   - Firebase/Messaging (10.12.0):
@@ -72,8 +74,11 @@ PODS:
   - shared_preferences_foundation (0.0.1):
     - Flutter
     - FlutterMacOS
+  - url_launcher_macos (0.0.1):
+    - FlutterMacOS
 
 DEPENDENCIES:
+  - device_info_plus (from `Flutter/ephemeral/.symlinks/plugins/device_info_plus/macos`)
   - firebase_core (from `Flutter/ephemeral/.symlinks/plugins/firebase_core/macos`)
   - firebase_messaging (from `Flutter/ephemeral/.symlinks/plugins/firebase_messaging/macos`)
   - flutter_local_notifications (from `Flutter/ephemeral/.symlinks/plugins/flutter_local_notifications/macos`)
@@ -82,6 +87,7 @@ DEPENDENCIES:
   - path_provider_foundation (from `Flutter/ephemeral/.symlinks/plugins/path_provider_foundation/darwin`)
   - share_plus (from `Flutter/ephemeral/.symlinks/plugins/share_plus/macos`)
   - shared_preferences_foundation (from `Flutter/ephemeral/.symlinks/plugins/shared_preferences_foundation/darwin`)
+  - url_launcher_macos (from `Flutter/ephemeral/.symlinks/plugins/url_launcher_macos/macos`)
 
 SPEC REPOS:
   trunk:
@@ -96,6 +102,8 @@ SPEC REPOS:
     - PromisesObjC
 
 EXTERNAL SOURCES:
+  device_info_plus:
+    :path: Flutter/ephemeral/.symlinks/plugins/device_info_plus/macos
   firebase_core:
     :path: Flutter/ephemeral/.symlinks/plugins/firebase_core/macos
   firebase_messaging:
@@ -112,8 +120,11 @@ EXTERNAL SOURCES:
     :path: Flutter/ephemeral/.symlinks/plugins/share_plus/macos
   shared_preferences_foundation:
     :path: Flutter/ephemeral/.symlinks/plugins/shared_preferences_foundation/darwin
+  url_launcher_macos:
+    :path: Flutter/ephemeral/.symlinks/plugins/url_launcher_macos/macos
 
 SPEC CHECKSUMS:
+  device_info_plus: 5401765fde0b8d062a2f8eb65510fb17e77cf07f
   Firebase: 07150e75d142fb9399f6777fa56a187b17f833a0
   firebase_core: ff59797157ca9adda4440071643761b41fcd03b3
   firebase_messaging: d489df2f5cf5eb4b1ffb0b920f1d8c6b911f6166
@@ -131,6 +142,7 @@ SPEC CHECKSUMS:
   PromisesObjC: c50d2056b5253dadbd6c2bea79b0674bd5a52fa4
   share_plus: 76dd39142738f7a68dd57b05093b5e8193f220f7
   shared_preferences_foundation: 5b919d13b803cadd15ed2dc053125c68730e5126
+  url_launcher_macos: d2691c7dd33ed713bf3544850a623080ec693d95
 
 PODFILE CHECKSUM: f429f80f5470aff39540e8333365097246b857cb
 

--- a/mobile/native/src/api.rs
+++ b/mobile/native/src/api.rs
@@ -348,3 +348,13 @@ pub fn get_channel_open_fee_estimate_sat() -> Result<u64> {
 
     Ok(estimate.ceil() as u64)
 }
+
+/// Mainnet config for the app
+pub fn mainnet_config() -> SyncReturn<Config> {
+    SyncReturn(config::api::mainnet_config())
+}
+
+/// Regtest config for the app
+pub fn regtest_config() -> SyncReturn<Config> {
+    SyncReturn(config::api::regtest_config())
+}

--- a/mobile/native/src/config/api.rs
+++ b/mobile/native/src/config/api.rs
@@ -10,13 +10,35 @@ use url::Url;
 pub struct Config {
     pub coordinator_pubkey: String,
     pub esplora_endpoint: String,
+    // Coordinator host
     pub host: String,
+    // Coordinator p2p port
     pub p2p_port: u16,
+    // Coordinator http port
     pub http_port: u16,
     pub network: String,
     pub oracle_endpoint: String,
     pub oracle_pubkey: String,
     pub health_check_interval_secs: u64,
+}
+
+impl Default for Config {
+    /// Default config for the app connects to the public regtest network
+    fn default() -> Self {
+        Self {
+            coordinator_pubkey:
+                "03507b924dae6595cfb78492489978127c5f1e3877848564de2015cd6d41375802".to_string(),
+            esplora_endpoint: "http://35.189.57.114:3000".to_string(),
+            host: "35.189.57.114".to_string(),
+            p2p_port: 9045,
+            http_port: 80,
+            network: "regtest".to_string(),
+            oracle_endpoint: "http://35.189.57.114:8081".to_string(),
+            oracle_pubkey: "5d12d79f575b8d99523797c46441c0549eb0defb6195fe8a080000cbe3ab3859"
+                .to_string(),
+            health_check_interval_secs: 10,
+        }
+    }
 }
 
 impl From<Config> for ConfigInternal {
@@ -49,5 +71,27 @@ fn parse_network(network: &str) -> Network {
         "testnet" => Network::Testnet,
         "mainnet" => Network::Bitcoin,
         _ => Network::Regtest,
+    }
+}
+
+/// Regtest config for the app
+pub fn regtest_config() -> Config {
+    Config::default()
+}
+
+/// Mainnet config for the app
+pub fn mainnet_config() -> Config {
+    Config {
+        coordinator_pubkey: "022ae8dbec1caa4dac93f07f2ebf5ad7a5dd08d375b79f11095e81b065c2155156"
+            .to_string(),
+        esplora_endpoint: "https://blockstream.info/api".to_string(),
+        host: "46.17.98.29".to_string(),
+        p2p_port: 9045,
+        http_port: 8000,
+        network: "mainnet".to_string(),
+        oracle_endpoint: "https://oracle.holzeis.me".to_string(),
+        oracle_pubkey: "16f88cf7d21e6c0f46bcbc983a4e3b19726c6c98858cc31c83551a88fde171c0"
+            .to_string(),
+        ..Default::default()
     }
 }


### PR DESCRIPTION
It needs a restart, which is clearly communicated in the app.
Eventually we might have "expert" mode that gets unlocked with a toggle or something, so it can't be accidentally clicked.

Removes the need of deploying two versions and mostly removes the need for
dart_define from the release process.

(I almost finished vergen support that would remove other dart_define, will add it in the morning!). This would unblock us to proper continuous delivery for iOS.

note: I've aligned the distance between the buttons to be consistent (10px) after running the screenshot tool.

<img width="799" alt="Screenshot 2023-08-17 at 10 31 50 pm" src="https://github.com/get10101/10101/assets/8319440/0a3ec739-3cc9-46d8-94bd-2795b492671b">

<img width="799" alt="Screenshot 2023-08-17 at 10 31 42 pm" src="https://github.com/get10101/10101/assets/8319440/cc6e5a25-d0a9-48af-aa84-fa8eb8a6bf98">
