### PR TITLE
Check for new DLC-related messages 25 times more often

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Add support for push notifications
-- Added new setting to coordinator to configure max channel size to traders
+- Add support for push notifications.
+- Added new setting to coordinator to configure max channel size to traders.
+- Speed up DLC channel setup and settlement by checking for messages more often.
 
 ## [1.2.0] - 2023-08-04
 
-- Automatically retry spendable outputs if not successfully published
+- Automatically retry spendable outputs if not successfully published.
 - Permit the closure of the LN-DLC channel in any intermediate state.
 
 ## [1.1.0] - 2023-07-27

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -952,7 +952,7 @@ dependencies = [
 [[package]]
 name = "dlc"
 version = "0.4.0"
-source = "git+https://github.com/p2pderivatives/rust-dlc?rev=78a8b46#78a8b46582ce193bc2dcacbc246338563ebc0ab7"
+source = "git+https://github.com/p2pderivatives/rust-dlc?rev=22b7052#22b70527f5d499153710c3aaac1a7a7315be32f3"
 dependencies = [
  "bitcoin",
  "miniscript 8.0.0",
@@ -964,7 +964,7 @@ dependencies = [
 [[package]]
 name = "dlc-manager"
 version = "0.4.0"
-source = "git+https://github.com/p2pderivatives/rust-dlc?rev=78a8b46#78a8b46582ce193bc2dcacbc246338563ebc0ab7"
+source = "git+https://github.com/p2pderivatives/rust-dlc?rev=22b7052#22b70527f5d499153710c3aaac1a7a7315be32f3"
 dependencies = [
  "async-trait",
  "bitcoin",
@@ -980,7 +980,7 @@ dependencies = [
 [[package]]
 name = "dlc-messages"
 version = "0.4.0"
-source = "git+https://github.com/p2pderivatives/rust-dlc?rev=78a8b46#78a8b46582ce193bc2dcacbc246338563ebc0ab7"
+source = "git+https://github.com/p2pderivatives/rust-dlc?rev=22b7052#22b70527f5d499153710c3aaac1a7a7315be32f3"
 dependencies = [
  "bitcoin",
  "dlc",
@@ -993,7 +993,7 @@ dependencies = [
 [[package]]
 name = "dlc-sled-storage-provider"
 version = "0.1.0"
-source = "git+https://github.com/p2pderivatives/rust-dlc?rev=78a8b46#78a8b46582ce193bc2dcacbc246338563ebc0ab7"
+source = "git+https://github.com/p2pderivatives/rust-dlc?rev=22b7052#22b70527f5d499153710c3aaac1a7a7315be32f3"
 dependencies = [
  "bitcoin",
  "dlc-manager",
@@ -1007,7 +1007,7 @@ dependencies = [
 [[package]]
 name = "dlc-trie"
 version = "0.4.0"
-source = "git+https://github.com/p2pderivatives/rust-dlc?rev=78a8b46#78a8b46582ce193bc2dcacbc246338563ebc0ab7"
+source = "git+https://github.com/p2pderivatives/rust-dlc?rev=22b7052#22b70527f5d499153710c3aaac1a7a7315be32f3"
 dependencies = [
  "bitcoin",
  "dlc",
@@ -1678,7 +1678,7 @@ dependencies = [
 [[package]]
 name = "lightning"
 version = "0.0.114"
-source = "git+https://github.com/p2pderivatives/rust-lightning/?rev=26db9546#26db954698bfe2871fa267f63fa85374bb74c4a0"
+source = "git+https://github.com/p2pderivatives/rust-lightning/?rev=420d961d#420d961d2675ecf0aef90d756bcab9fff65550ac"
 dependencies = [
  "bitcoin",
 ]
@@ -1686,7 +1686,7 @@ dependencies = [
 [[package]]
 name = "lightning-background-processor"
 version = "0.0.114"
-source = "git+https://github.com/p2pderivatives/rust-lightning/?rev=26db9546#26db954698bfe2871fa267f63fa85374bb74c4a0"
+source = "git+https://github.com/p2pderivatives/rust-lightning/?rev=420d961d#420d961d2675ecf0aef90d756bcab9fff65550ac"
 dependencies = [
  "bitcoin",
  "futures-util",
@@ -1710,7 +1710,7 @@ dependencies = [
 [[package]]
 name = "lightning-net-tokio"
 version = "0.0.114"
-source = "git+https://github.com/p2pderivatives/rust-lightning/?rev=26db9546#26db954698bfe2871fa267f63fa85374bb74c4a0"
+source = "git+https://github.com/p2pderivatives/rust-lightning/?rev=420d961d#420d961d2675ecf0aef90d756bcab9fff65550ac"
 dependencies = [
  "bitcoin",
  "lightning",
@@ -1720,7 +1720,7 @@ dependencies = [
 [[package]]
 name = "lightning-persister"
 version = "0.0.114"
-source = "git+https://github.com/p2pderivatives/rust-lightning/?rev=26db9546#26db954698bfe2871fa267f63fa85374bb74c4a0"
+source = "git+https://github.com/p2pderivatives/rust-lightning/?rev=420d961d#420d961d2675ecf0aef90d756bcab9fff65550ac"
 dependencies = [
  "bitcoin",
  "libc",
@@ -1731,7 +1731,7 @@ dependencies = [
 [[package]]
 name = "lightning-rapid-gossip-sync"
 version = "0.0.114"
-source = "git+https://github.com/p2pderivatives/rust-lightning/?rev=26db9546#26db954698bfe2871fa267f63fa85374bb74c4a0"
+source = "git+https://github.com/p2pderivatives/rust-lightning/?rev=420d961d#420d961d2675ecf0aef90d756bcab9fff65550ac"
 dependencies = [
  "bitcoin",
  "lightning",
@@ -1740,7 +1740,7 @@ dependencies = [
 [[package]]
 name = "lightning-transaction-sync"
 version = "0.0.114"
-source = "git+https://github.com/p2pderivatives/rust-lightning/?rev=26db9546#26db954698bfe2871fa267f63fa85374bb74c4a0"
+source = "git+https://github.com/p2pderivatives/rust-lightning/?rev=420d961d#420d961d2675ecf0aef90d756bcab9fff65550ac"
 dependencies = [
  "bdk-macros",
  "bitcoin",
@@ -2374,7 +2374,7 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 [[package]]
 name = "p2pd-oracle-client"
 version = "0.1.0"
-source = "git+https://github.com/p2pderivatives/rust-dlc?rev=78a8b46#78a8b46582ce193bc2dcacbc246338563ebc0ab7"
+source = "git+https://github.com/p2pderivatives/rust-dlc?rev=22b7052#22b70527f5d499153710c3aaac1a7a7315be32f3"
 dependencies = [
  "chrono",
  "dlc-manager",
@@ -3218,7 +3218,7 @@ dependencies = [
 [[package]]
 name = "simple-wallet"
 version = "0.1.0"
-source = "git+https://github.com/p2pderivatives/rust-dlc?rev=78a8b46#78a8b46582ce193bc2dcacbc246338563ebc0ab7"
+source = "git+https://github.com/p2pderivatives/rust-dlc?rev=22b7052#22b70527f5d499153710c3aaac1a7a7315be32f3"
 dependencies = [
  "bitcoin",
  "dlc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,19 +4,19 @@ resolver = "2"
 
 [patch.crates-io]
 # We should usually track the `feature/ln-dlc-channels[-10101]` branch
-dlc-manager = { git = "https://github.com/p2pderivatives/rust-dlc", rev = "78a8b46" }
-dlc-messages = { git = "https://github.com/p2pderivatives/rust-dlc", rev = "78a8b46" }
-dlc = { git = "https://github.com/p2pderivatives/rust-dlc", rev = "78a8b46" }
-dlc-sled-storage-provider = { git = "https://github.com/p2pderivatives/rust-dlc", rev = "78a8b46" }
-p2pd-oracle-client = { git = "https://github.com/p2pderivatives/rust-dlc", rev = "78a8b46" }
-dlc-trie = { git = "https://github.com/p2pderivatives/rust-dlc", rev = "78a8b46" }
-simple-wallet = { git = "https://github.com/p2pderivatives/rust-dlc", rev = "78a8b46" }
+dlc-manager = { git = "https://github.com/p2pderivatives/rust-dlc", rev = "22b7052" }
+dlc-messages = { git = "https://github.com/p2pderivatives/rust-dlc", rev = "22b7052" }
+dlc = { git = "https://github.com/p2pderivatives/rust-dlc", rev = "22b7052" }
+dlc-sled-storage-provider = { git = "https://github.com/p2pderivatives/rust-dlc", rev = "22b7052" }
+p2pd-oracle-client = { git = "https://github.com/p2pderivatives/rust-dlc", rev = "22b7052" }
+dlc-trie = { git = "https://github.com/p2pderivatives/rust-dlc", rev = "22b7052" }
+simple-wallet = { git = "https://github.com/p2pderivatives/rust-dlc", rev = "22b7052" }
 
 # We should usually track the `split-tx-experiment[-10101]` branch
-lightning = { git = "https://github.com/p2pderivatives/rust-lightning/", rev = "26db9546" }
-lightning-background-processor = { git = "https://github.com/p2pderivatives/rust-lightning/", rev = "26db9546" }
-lightning-transaction-sync = { git = "https://github.com/p2pderivatives/rust-lightning/", rev = "26db9546" }
-lightning-net-tokio = { git = "https://github.com/p2pderivatives/rust-lightning/", rev = "26db9546" }
-lightning-persister = { git = "https://github.com/p2pderivatives/rust-lightning/", rev = "26db9546" }
+lightning = { git = "https://github.com/p2pderivatives/rust-lightning/", rev = "420d961d" }
+lightning-background-processor = { git = "https://github.com/p2pderivatives/rust-lightning/", rev = "420d961d" }
+lightning-transaction-sync = { git = "https://github.com/p2pderivatives/rust-lightning/", rev = "420d961d" }
+lightning-net-tokio = { git = "https://github.com/p2pderivatives/rust-lightning/", rev = "420d961d" }
+lightning-persister = { git = "https://github.com/p2pderivatives/rust-lightning/", rev = "420d961d" }
 
 rust-bitcoin-coin-selection = { git = "https://github.com/p2pderivatives/rust-bitcoin-coin-selection" }

--- a/coordinator/src/bin/coordinator.rs
+++ b/coordinator/src/bin/coordinator.rs
@@ -34,7 +34,7 @@ use tokio::task::spawn_blocking;
 use tracing::metadata::LevelFilter;
 
 const PROCESS_PROMETHEUS_METRICS: Duration = Duration::from_secs(10);
-const PROCESS_INCOMING_DLC_MESSAGES_INTERVAL: Duration = Duration::from_secs(5);
+const PROCESS_INCOMING_DLC_MESSAGES_INTERVAL: Duration = Duration::from_millis(200);
 const EXPIRED_POSITION_SYNC_INTERVAL: Duration = Duration::from_secs(300);
 const CLOSED_POSITION_SYNC_INTERVAL: Duration = Duration::from_secs(30);
 const UNREALIZED_PNL_SYNC_INTERVAL: Duration = Duration::from_secs(600);

--- a/coordinator/src/node.rs
+++ b/coordinator/src/node.rs
@@ -387,6 +387,14 @@ impl Node {
 
     #[autometrics]
     pub fn process_incoming_dlc_messages(&self) {
+        if !self
+            .inner
+            .dlc_message_handler
+            .has_pending_messages_to_process()
+        {
+            return;
+        }
+
         let messages = self
             .inner
             .dlc_message_handler
@@ -398,7 +406,7 @@ impl Node {
                 tracing::error!(
                     from = %node_id,
                     kind = %msg_name,
-                    "Failed to process message: {e:#}"
+                    "Failed to process DLC message: {e:#}"
                 );
             }
         }

--- a/mobile/native/src/ln_dlc/mod.rs
+++ b/mobile/native/src/ln_dlc/mod.rs
@@ -65,9 +65,7 @@ pub mod channel_status;
 
 pub use channel_status::ChannelStatus;
 
-static NODE: Storage<Arc<Node>> = Storage::new();
-
-const PROCESS_INCOMING_DLC_MESSAGES_INTERVAL: Duration = Duration::from_secs(5);
+const PROCESS_INCOMING_DLC_MESSAGES_INTERVAL: Duration = Duration::from_millis(200);
 const UPDATE_WALLET_HISTORY_INTERVAL: Duration = Duration::from_secs(5);
 const CHECK_OPEN_ORDERS_INTERVAL: Duration = Duration::from_secs(60);
 
@@ -79,6 +77,8 @@ const CHECK_OPEN_ORDERS_INTERVAL: Duration = Duration::from_secs(60);
 /// coordinator will use for the channel opening transaction. Only once the transaction is know the
 /// exact fee will be know.
 pub const FUNDING_TX_WEIGHT_ESTIMATE: u64 = 220;
+
+static NODE: Storage<Arc<Node>> = Storage::new();
 
 pub async fn refresh_wallet_info() -> Result<()> {
     let node = NODE.get();

--- a/mobile/native/src/ln_dlc/mod.rs
+++ b/mobile/native/src/ln_dlc/mod.rs
@@ -67,7 +67,7 @@ pub use channel_status::ChannelStatus;
 
 static NODE: Storage<Arc<Node>> = Storage::new();
 
-const PROCESS_INCOMING_MESSAGES_INTERVAL: Duration = Duration::from_secs(5);
+const PROCESS_INCOMING_DLC_MESSAGES_INTERVAL: Duration = Duration::from_secs(5);
 const UPDATE_WALLET_HISTORY_INTERVAL: Duration = Duration::from_secs(5);
 const CHECK_OPEN_ORDERS_INTERVAL: Duration = Duration::from_secs(60);
 
@@ -226,7 +226,7 @@ pub fn run(data_dir: String, seed_dir: String, runtime: &Runtime) -> Result<()> 
                     spawn_blocking(move || node.process_incoming_dlc_messages())
                         .await
                         .expect("To spawn blocking thread");
-                    tokio::time::sleep(PROCESS_INCOMING_MESSAGES_INTERVAL).await;
+                    tokio::time::sleep(PROCESS_INCOMING_DLC_MESSAGES_INTERVAL).await;
                 }
             }
         });

--- a/mobile/native/src/ln_dlc/node.rs
+++ b/mobile/native/src/ln_dlc/node.rs
@@ -103,6 +103,14 @@ impl Node {
     }
 
     pub fn process_incoming_dlc_messages(&self) {
+        if !self
+            .inner
+            .dlc_message_handler
+            .has_pending_messages_to_process()
+        {
+            return;
+        }
+
         let messages = self
             .inner
             .dlc_message_handler
@@ -114,7 +122,7 @@ impl Node {
                 tracing::error!(
                     from = %node_id,
                     kind = %msg_name,
-                    "Failed to process message: {e:#}"
+                    "Failed to process DLC message: {e:#}"
                 );
             }
         }


### PR DESCRIPTION
Fixes #1107.

I think this could be very, very helpful in preventing disconnection-related issues in production. In theory this could improve the speed of the worst-case scenario for the current version of the subchannel open/close protocol by ~25 seconds!