### PR TITLE
chore: bump DLC fee rate

### DIFF
--- a/crates/ln-dlc-node/src/config.rs
+++ b/crates/ln-dlc-node/src/config.rs
@@ -16,7 +16,7 @@ pub const LIQUIDITY_MULTIPLIER: u64 = 2;
 /// Sats/vbyte rate for position
 ///
 /// The coordinator and the app have to align on this to agree on the fees.
-pub const CONTRACT_TX_FEE_RATE: u64 = 4;
+pub const CONTRACT_TX_FEE_RATE: u64 = 7;
 
 /// The speed at which we want a transaction to confirm used for feerate estimation.
 ///


### PR DESCRIPTION
A fix fee rate of 4 is not safe anymore as the mempool has been congested since a long time purging transactions with a low fee. We clearly need anchor outputs, but this is an attempt to at least be able to force close positions

