### PR TITLE
fix: wrong provisioning profile

### DIFF
--- a/mobile/ios/Runner.xcodeproj/project.pbxproj
+++ b/mobile/ios/Runner.xcodeproj/project.pbxproj
@@ -466,7 +466,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = finance.get10101.app;
 				PRODUCT_NAME = 10101;
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "match AppStore finance.get10101.app 1691412333";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "match AppStore finance.get10101.app 1692208014";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
 				VERSIONING_SYSTEM = "apple-generic";
@@ -614,7 +614,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = finance.get10101.app;
 				PRODUCT_NAME = 10101;
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "match AppStore finance.get10101.app 1691412333";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "match AppStore finance.get10101.app 1692208014";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
@@ -652,7 +652,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = finance.get10101.app;
 				PRODUCT_NAME = 10101;
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "match AppStore finance.get10101.app 1691412333";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "match AppStore finance.get10101.app 1692208014";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
 				VERSIONING_SYSTEM = "apple-generic";


### PR DESCRIPTION
Release [1.2.1 failed](https://github.com/get10101/10101/actions/runs/5928785922/job/16075130621)

Did not test it on the fork but locally. The problem was that when I've provided the [last fix ](https://github.com/get10101/10101/pull/1112/commits/005fd65f29d8375e61722069fceb301f147272b7) for fastlane I forgot to change the provisioning profile in the xcode config.

Uploading version 1.2.1 from local setup as this is being created
