### PR TITLE
fix: Adjust navigator usage within Flutter

### DIFF
--- a/mobile/lib/common/global_keys.dart
+++ b/mobile/lib/common/global_keys.dart
@@ -1,0 +1,4 @@
+import 'package:flutter/material.dart';
+
+final GlobalKey<NavigatorState> rootNavigatorKey = GlobalKey<NavigatorState>(debugLabel: 'root');
+final GlobalKey<NavigatorState> shellNavigatorKey = GlobalKey<NavigatorState>(debugLabel: 'shell');

--- a/mobile/lib/common/modal_bottom_sheet_info.dart
+++ b/mobile/lib/common/modal_bottom_sheet_info.dart
@@ -16,7 +16,6 @@ class ModalBottomSheetInfo extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    // TODO: implement build
     return IconButton(
         onPressed: () {
           showModalBottomSheet<void>(
@@ -26,7 +25,7 @@ class ModalBottomSheetInfo extends StatelessWidget {
               ),
             ),
             clipBehavior: Clip.antiAliasWithSaveLayer,
-            useRootNavigator: true,
+            useRootNavigator: false,
             context: context,
             builder: (BuildContext context) {
               return Container(

--- a/mobile/lib/features/trade/trade_bottom_sheet.dart
+++ b/mobile/lib/features/trade/trade_bottom_sheet.dart
@@ -14,7 +14,7 @@ tradeBottomSheet({required BuildContext context, required Direction direction}) 
     ),
     clipBehavior: Clip.antiAlias,
     isScrollControlled: true,
-    useRootNavigator: true,
+    useRootNavigator: false,
     context: context,
     builder: (BuildContext context) {
       return SafeArea(

--- a/mobile/lib/features/trade/trade_bottom_sheet_confirmation.dart
+++ b/mobile/lib/features/trade/trade_bottom_sheet_confirmation.dart
@@ -34,7 +34,7 @@ tradeBottomSheetConfirmation(
     ),
     clipBehavior: Clip.antiAlias,
     isScrollControlled: true,
-    useRootNavigator: true,
+    useRootNavigator: false,
     context: context,
     builder: (BuildContext context) {
       return SafeArea(

--- a/mobile/lib/features/trade/trade_screen.dart
+++ b/mobile/lib/features/trade/trade_screen.dart
@@ -62,7 +62,7 @@ class TradeScreen extends StatelessWidget {
       WidgetsBinding.instance.addPostFrameCallback((_) async {
         return await showDialog(
             context: context,
-            useRootNavigator: true,
+            useRootNavigator: false,
             barrierDismissible: false, // Prevent user from leaving
             builder: (BuildContext context) {
               return Selector<SubmitOrderChangeNotifier, PendingOrderState>(

--- a/mobile/lib/features/wallet/wallet_screen.dart
+++ b/mobile/lib/features/wallet/wallet_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_speed_dial/flutter_speed_dial.dart';
 import 'package:get_10101/common/amount_text.dart';
+import 'package:get_10101/common/global_keys.dart';
 import 'package:get_10101/common/submission_status_dialog.dart';
 import 'package:get_10101/common/value_data_row.dart';
 import 'package:get_10101/features/wallet/seed_screen.dart';
@@ -48,8 +49,8 @@ class _WalletScreenState extends State<WalletScreen> {
       sendPaymentChangeNotifier.pendingPayment!.displayed = true;
       WidgetsBinding.instance.addPostFrameCallback((_) async {
         return await showDialog(
-            context: context,
-            useRootNavigator: true,
+            context: shellNavigatorKey.currentContext!, // Use the context from the navigatorKey
+            useRootNavigator: false,
             builder: (BuildContext context) {
               return Selector<SendPaymentChangeNotifier, PendingPaymentState>(
                 selector: (_, provider) => provider.pendingPayment!.state,

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -5,6 +5,7 @@ import 'package:firebase_core/firebase_core.dart';
 import 'package:firebase_messaging/firebase_messaging.dart';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import 'package:flutter/material.dart';
+import 'package:get_10101/common/global_keys.dart';
 import 'package:get_10101/firebase_options.dart';
 import 'package:get_10101/common/channel_status_notifier.dart';
 import 'dart:io';
@@ -55,9 +56,6 @@ import 'package:get_10101/features/trade/domain/price.dart';
 import 'package:get_10101/features/wallet/domain/wallet_info.dart';
 import 'package:get_10101/ffi.dart' as rust;
 import 'package:version/version.dart';
-
-final GlobalKey<NavigatorState> _rootNavigatorKey = GlobalKey<NavigatorState>(debugLabel: 'root');
-final GlobalKey<NavigatorState> _shellNavigatorKey = GlobalKey<NavigatorState>(debugLabel: 'shell');
 
 final GlobalKey<NavigatorState> _feedbackNavigatorKey =
     GlobalKey<NavigatorState>(debugLabel: 'feedback');
@@ -117,11 +115,11 @@ class _TenTenOneAppState extends State<TenTenOneApp> {
       GlobalKey<ScaffoldMessengerState>();
 
   final GoRouter _router = GoRouter(
-      navigatorKey: _rootNavigatorKey,
+      navigatorKey: rootNavigatorKey,
       initialLocation: WalletScreen.route,
       routes: <RouteBase>[
         ShellRoute(
-          navigatorKey: _shellNavigatorKey,
+          navigatorKey: shellNavigatorKey,
           builder: (BuildContext context, GoRouterState state, Widget child) {
             return ScaffoldWithNavBar(
               child: child,
@@ -137,7 +135,7 @@ class _TenTenOneAppState extends State<TenTenOneApp> {
                 GoRoute(
                   path: SendScreen.subRouteName,
                   // Use root navigator so the screen overlays the application shell
-                  parentNavigatorKey: _rootNavigatorKey,
+                  parentNavigatorKey: rootNavigatorKey,
                   builder: (BuildContext context, GoRouterState state) {
                     return const SendScreen();
                   },
@@ -145,7 +143,7 @@ class _TenTenOneAppState extends State<TenTenOneApp> {
                 GoRoute(
                   path: SeedScreen.subRouteName,
                   // Use root navigator so the screen overlays the application shell
-                  parentNavigatorKey: _rootNavigatorKey,
+                  parentNavigatorKey: rootNavigatorKey,
                   builder: (BuildContext context, GoRouterState state) {
                     return const SeedScreen();
                   },
@@ -153,7 +151,7 @@ class _TenTenOneAppState extends State<TenTenOneApp> {
                 GoRoute(
                     path: CreateInvoiceScreen.subRouteName,
                     // Use root navigator so the screen overlays the application shell
-                    parentNavigatorKey: _rootNavigatorKey,
+                    parentNavigatorKey: rootNavigatorKey,
                     builder: (BuildContext context, GoRouterState state) {
                       return const CreateInvoiceScreen();
                     },
@@ -161,7 +159,7 @@ class _TenTenOneAppState extends State<TenTenOneApp> {
                       GoRoute(
                         path: ShareInvoiceScreen.subRouteName,
                         // Use root navigator so the screen overlays the application shell
-                        parentNavigatorKey: _rootNavigatorKey,
+                        parentNavigatorKey: rootNavigatorKey,
                         builder: (BuildContext context, GoRouterState state) {
                           return ShareInvoiceScreen(invoice: state.extra as ShareInvoice);
                         },
@@ -169,7 +167,7 @@ class _TenTenOneAppState extends State<TenTenOneApp> {
                     ]),
                 GoRoute(
                   path: ScannerScreen.subRouteName,
-                  parentNavigatorKey: _rootNavigatorKey,
+                  parentNavigatorKey: rootNavigatorKey,
                   builder: (BuildContext context, GoRouterState state) {
                     return const ScannerScreen();
                   },
@@ -187,7 +185,7 @@ class _TenTenOneAppState extends State<TenTenOneApp> {
         ),
         GoRoute(
             path: WelcomeScreen.route,
-            parentNavigatorKey: _rootNavigatorKey,
+            parentNavigatorKey: rootNavigatorKey,
             builder: (BuildContext context, GoRouterState state) {
               return const WelcomeScreen();
             },
@@ -234,7 +232,7 @@ class _TenTenOneAppState extends State<TenTenOneApp> {
         if (coordinatorVersion > clientVersion) {
           FLog.warning(text: "Client out of date. Current version: ${clientVersion.toString()}");
           showDialog(
-              context: _shellNavigatorKey.currentContext!,
+              context: shellNavigatorKey.currentContext!,
               builder: (context) => AlertDialog(
                       title: const Text("Update available"),
                       content: Text("A new version of 10101 is available: "


### PR DESCRIPTION
Using `useRootNavigator` flag was fragile, because it assumed that
GoRouter will *always* remain be the top navigator.
This has changed with introducing `BetterFeedback` (similar issue would have
    been observed with Firebase Analytics, if we merged that already).

By selecting a navigator in dialog windows that was above GoRouter we could not access it as we only had access to the parent context.

Allow specifying global navigators directly if needed (e.g. when they need to be
    on top of the widget stack) by referring to their keys.