### PR TITLE
fix: actually run native tests with `just native-test`

### DIFF
--- a/justfile
+++ b/justfile
@@ -199,8 +199,9 @@ maker args="":
 flutter-test:
     cd mobile && flutter pub run build_runner build && flutter test
 
+# Tests for the `native` crate
 native-test:
-    cd mobile/native
+    cd mobile/native && cargo test
 
 test: flutter-test native-test
 


### PR DESCRIPTION
Seems like an accidental omission