### PR TITLE
chore: change contract duration to 7 days

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add synthetic usd feature.
 - Fix delayed position update.
+- Change contract duration to 7 days.
 
 ## [1.2.2] - 2023-08-22
 

--- a/coordinator/src/orderbook/trading.rs
+++ b/coordinator/src/orderbook/trading.rs
@@ -65,7 +65,7 @@ pub fn match_order(
         return Ok(None);
     }
 
-    let tomorrow = OffsetDateTime::now_utc().date() + Duration::days(2);
+    let tomorrow = OffsetDateTime::now_utc().date() + Duration::days(7);
     let expiry_timestamp = tomorrow.midnight().assume_utc();
 
     // For now we hardcode the oracle pubkey here

--- a/coordinator/src/rollover.rs
+++ b/coordinator/src/rollover.rs
@@ -81,7 +81,7 @@ impl Rollover {
     ///
     /// todo(holzeis): this should come from a configuration https://github.com/get10101/10101/issues/1029
     pub fn maturity_time(&self) -> OffsetDateTime {
-        let tomorrow = self.expiry_timestamp.date() + Duration::days(2);
+        let tomorrow = self.expiry_timestamp.date() + Duration::days(7);
         tomorrow.midnight().assume_utc()
     }
 }
@@ -204,9 +204,9 @@ pub mod tests {
         };
         let event_id = rollover.event_id();
 
-        // expect expiry in two days at midnight.
-        // Sat Aug 19 2023 00:00:00 GMT+0000
-        assert_eq!(event_id, format!("btcusd1692403200"))
+        // expect expiry in seven days at midnight.
+        // Thu Aug 24 2023 00:00:00 GMT+0000
+        assert_eq!(event_id, format!("btcusd1692835200"))
     }
 
     #[test]

--- a/crates/tests-e2e/tests/rollover_position.rs
+++ b/crates/tests-e2e/tests/rollover_position.rs
@@ -23,7 +23,7 @@ async fn can_rollover_position() {
         .unwrap();
 
     let position = test.app.rx.position().expect("position to exist");
-    let tomorrow = position.expiry.date() + Duration::days(2);
+    let tomorrow = position.expiry.date() + Duration::days(7);
     let new_expiry = tomorrow.midnight().assume_utc();
 
     coordinator

--- a/mobile/lib/features/trade/trade_bottom_sheet_confirmation.dart
+++ b/mobile/lib/features/trade/trade_bottom_sheet_confirmation.dart
@@ -122,7 +122,7 @@ class TradeBottomSheetConfirmation extends StatelessWidget {
                         if (!close)
                           ValueDataRow(
                               type: ValueType.date,
-                              value: DateTime.utc(now.year, now.month, now.day + 2).toLocal(),
+                              value: DateTime.utc(now.year, now.month, now.day + 7).toLocal(),
                               label: 'Expiry'),
                         close
                             ? ValueDataRow(

--- a/mobile/native/src/trade/position/handler.rs
+++ b/mobile/native/src/trade/position/handler.rs
@@ -127,7 +127,7 @@ pub fn update_position_after_dlc_creation(filled_order: Order, collateral: u64) 
 
     let average_entry_price = filled_order.execution_price().unwrap_or(0.0);
 
-    let tomorrow = OffsetDateTime::now_utc().date() + Duration::days(2);
+    let tomorrow = OffsetDateTime::now_utc().date() + Duration::days(7);
     let expiry = tomorrow.midnight().assume_utc();
 
     let have_a_position = Position {


### PR DESCRIPTION
This is also a good reference for implementing #1029. The expiry is currently scattered through the code and would be ideally only configured at one place.

resolves #1154 