### PR TITLE
Drop pending `SubChannelFinalize` message after reconnect

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -953,7 +953,7 @@ dependencies = [
 [[package]]
 name = "dlc"
 version = "0.4.0"
-source = "git+https://github.com/p2pderivatives/rust-dlc?rev=22b7052#22b70527f5d499153710c3aaac1a7a7315be32f3"
+source = "git+https://github.com/p2pderivatives/rust-dlc?rev=b76802c#b76802c99e060c7e55705dd5ec5ee3775ed29936"
 dependencies = [
  "bitcoin",
  "miniscript 8.0.0",
@@ -965,7 +965,7 @@ dependencies = [
 [[package]]
 name = "dlc-manager"
 version = "0.4.0"
-source = "git+https://github.com/p2pderivatives/rust-dlc?rev=22b7052#22b70527f5d499153710c3aaac1a7a7315be32f3"
+source = "git+https://github.com/p2pderivatives/rust-dlc?rev=b76802c#b76802c99e060c7e55705dd5ec5ee3775ed29936"
 dependencies = [
  "async-trait",
  "bitcoin",
@@ -981,7 +981,7 @@ dependencies = [
 [[package]]
 name = "dlc-messages"
 version = "0.4.0"
-source = "git+https://github.com/p2pderivatives/rust-dlc?rev=22b7052#22b70527f5d499153710c3aaac1a7a7315be32f3"
+source = "git+https://github.com/p2pderivatives/rust-dlc?rev=b76802c#b76802c99e060c7e55705dd5ec5ee3775ed29936"
 dependencies = [
  "bitcoin",
  "dlc",
@@ -994,7 +994,7 @@ dependencies = [
 [[package]]
 name = "dlc-sled-storage-provider"
 version = "0.1.0"
-source = "git+https://github.com/p2pderivatives/rust-dlc?rev=22b7052#22b70527f5d499153710c3aaac1a7a7315be32f3"
+source = "git+https://github.com/p2pderivatives/rust-dlc?rev=b76802c#b76802c99e060c7e55705dd5ec5ee3775ed29936"
 dependencies = [
  "bitcoin",
  "dlc-manager",
@@ -1008,7 +1008,7 @@ dependencies = [
 [[package]]
 name = "dlc-trie"
 version = "0.4.0"
-source = "git+https://github.com/p2pderivatives/rust-dlc?rev=22b7052#22b70527f5d499153710c3aaac1a7a7315be32f3"
+source = "git+https://github.com/p2pderivatives/rust-dlc?rev=b76802c#b76802c99e060c7e55705dd5ec5ee3775ed29936"
 dependencies = [
  "bitcoin",
  "dlc",
@@ -2375,7 +2375,7 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 [[package]]
 name = "p2pd-oracle-client"
 version = "0.1.0"
-source = "git+https://github.com/p2pderivatives/rust-dlc?rev=22b7052#22b70527f5d499153710c3aaac1a7a7315be32f3"
+source = "git+https://github.com/p2pderivatives/rust-dlc?rev=b76802c#b76802c99e060c7e55705dd5ec5ee3775ed29936"
 dependencies = [
  "chrono",
  "dlc-manager",
@@ -3219,7 +3219,7 @@ dependencies = [
 [[package]]
 name = "simple-wallet"
 version = "0.1.0"
-source = "git+https://github.com/p2pderivatives/rust-dlc?rev=22b7052#22b70527f5d499153710c3aaac1a7a7315be32f3"
+source = "git+https://github.com/p2pderivatives/rust-dlc?rev=b76802c#b76802c99e060c7e55705dd5ec5ee3775ed29936"
 dependencies = [
  "bitcoin",
  "dlc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,13 +4,13 @@ resolver = "2"
 
 [patch.crates-io]
 # We should usually track the `feature/ln-dlc-channels[-10101]` branch
-dlc-manager = { git = "https://github.com/p2pderivatives/rust-dlc", rev = "22b7052" }
-dlc-messages = { git = "https://github.com/p2pderivatives/rust-dlc", rev = "22b7052" }
-dlc = { git = "https://github.com/p2pderivatives/rust-dlc", rev = "22b7052" }
-dlc-sled-storage-provider = { git = "https://github.com/p2pderivatives/rust-dlc", rev = "22b7052" }
-p2pd-oracle-client = { git = "https://github.com/p2pderivatives/rust-dlc", rev = "22b7052" }
-dlc-trie = { git = "https://github.com/p2pderivatives/rust-dlc", rev = "22b7052" }
-simple-wallet = { git = "https://github.com/p2pderivatives/rust-dlc", rev = "22b7052" }
+dlc-manager = { git = "https://github.com/p2pderivatives/rust-dlc", rev = "b76802c" }
+dlc-messages = { git = "https://github.com/p2pderivatives/rust-dlc", rev = "b76802c" }
+dlc = { git = "https://github.com/p2pderivatives/rust-dlc", rev = "b76802c" }
+dlc-sled-storage-provider = { git = "https://github.com/p2pderivatives/rust-dlc", rev = "b76802c" }
+p2pd-oracle-client = { git = "https://github.com/p2pderivatives/rust-dlc", rev = "b76802c" }
+dlc-trie = { git = "https://github.com/p2pderivatives/rust-dlc", rev = "b76802c" }
+simple-wallet = { git = "https://github.com/p2pderivatives/rust-dlc", rev = "b76802c" }
 
 # We should usually track the `split-tx-experiment[-10101]` branch
 lightning = { git = "https://github.com/p2pderivatives/rust-lightning/", rev = "420d961d" }

--- a/crates/ln-dlc-node/src/tests/dlc/dlc_setup_with_reconnects.rs
+++ b/crates/ln-dlc-node/src/tests/dlc/dlc_setup_with_reconnects.rs
@@ -319,7 +319,6 @@ async fn can_lose_connection_before_processing_subchannel_close_finalize() {
     .unwrap();
 
     tokio::time::sleep(Duration::from_secs(5)).await;
-
     app.reconnect(coordinator.info).await.unwrap();
 
     coordinator.process_incoming_messages().unwrap();
@@ -557,21 +556,9 @@ async fn can_lose_connection_before_processing_subchannel_finalize() {
     // Give time to deliver the `Finalize` message to the coordinator
     tokio::time::sleep(Duration::from_secs(5)).await;
 
-    // Lose the connection, triggering the coordinator's rollback to the Offered state
+    // Lose the connection, triggering the coordinator's rollback to the `Offered` state. The
+    // `Finalize` message is dropped during the reconnect
     coordinator.reconnect(app.info).await.unwrap();
-
-    // Process the app's `Finalize`, expecting an error
-    wait_until_dlc_channel_state(
-        Duration::from_secs(30),
-        &coordinator,
-        app.info.pubkey,
-        SubChannelStateName::Signed,
-    )
-    .await
-    .expect_err("Invalid state: Expected Confirmed state but got Offered");
-
-    // Lose the connection, triggering the coordinator's rollback to the Offered state
-    app.reconnect(coordinator.info).await.unwrap();
 
     // Process the app's resent `Accept` and send `Confirm`
     wait_until_dlc_channel_state(

--- a/crates/ln-dlc-node/src/tests/dlc/dlc_setup_with_reconnects.rs
+++ b/crates/ln-dlc-node/src/tests/dlc/dlc_setup_with_reconnects.rs
@@ -559,19 +559,7 @@ async fn can_lose_connection_before_processing_subchannel_finalize() {
     // Lose the connection, triggering the coordinator's rollback to the `Offered` state.
     app.reconnect(coordinator.info).await.unwrap();
 
-    // Process the pending `Finalize` which will fail, as the coordinator rolled back to the
-    // `Offered` state.
-    let result = wait_until_dlc_channel_state(
-        Duration::from_secs(30),
-        &coordinator,
-        app.info.pubkey,
-        SubChannelStateName::Signed,
-    )
-    .await;
-
-    // Invalid state: Expected Confirmed state but got Offered
-    tracing::error!("{:#}", result.err().unwrap());
-
+    // Create `Accept` message from pending `ReAccept` Action
     sub_channel_manager_periodic_check(app.sub_channel_manager.clone(), &app.dlc_message_handler)
         .await
         .unwrap();


### PR DESCRIPTION
For now we have decided not to merge the `rust-dlc` changes into the `feature/ln-dlc-channels` branch, because we have not been able to prove that they fix the bugs listed in https://github.com/get10101/10101/issues/1141 and https://github.com/get10101/10101/issues/1074. We instead now depend on an updated version of `feature/ln-dlc-channels-10101`.

We propose to merge this hoping that it does fix those problems and knowing that it should not have a negative effect regardless. At the very least we will not process stale messages unnecessarily and we will emit fewer error logs.