### PR TITLE
feat: store raw transaction in db

### DIFF
--- a/coordinator/migrations/2023-08-28-082948_add_raw_tx_field/down.sql
+++ b/coordinator/migrations/2023-08-28-082948_add_raw_tx_field/down.sql
@@ -1,0 +1,3 @@
+-- This file should undo anything in `up.sql`
+ALTER TABLE
+    transactions DROP COLUMN "raw";

--- a/coordinator/migrations/2023-08-28-082948_add_raw_tx_field/up.sql
+++ b/coordinator/migrations/2023-08-28-082948_add_raw_tx_field/up.sql
@@ -1,0 +1,5 @@
+-- Your SQL goes here
+ALTER TABLE
+    transactions
+    ADD
+        COLUMN "raw" TEXT NOT NULL DEFAULT 'undefined';

--- a/coordinator/src/db/transactions.rs
+++ b/coordinator/src/db/transactions.rs
@@ -23,6 +23,7 @@ pub(crate) struct Transaction {
     pub fee: i64,
     pub created_at: OffsetDateTime,
     pub updated_at: OffsetDateTime,
+    pub raw: String,
 }
 
 pub(crate) fn get(txid: &str, conn: &mut PgConnection) -> QueryResult<Option<Transaction>> {
@@ -58,6 +59,7 @@ impl From<ln_dlc_node::transaction::Transaction> for Transaction {
             fee: value.fee() as i64,
             created_at: value.created_at(),
             updated_at: value.updated_at(),
+            raw: value.raw(),
         }
     }
 }
@@ -69,6 +71,7 @@ impl From<Transaction> for ln_dlc_node::transaction::Transaction {
             value.fee as u64,
             value.created_at,
             value.updated_at,
+            value.raw,
         )
     }
 }

--- a/coordinator/src/schema.rs
+++ b/coordinator/src/schema.rs
@@ -160,6 +160,7 @@ diesel::table! {
         fee -> Int8,
         created_at -> Timestamptz,
         updated_at -> Timestamptz,
+        raw -> Text,
     }
 }
 

--- a/crates/ln-dlc-node/src/shadow.rs
+++ b/crates/ln-dlc-node/src/shadow.rs
@@ -55,7 +55,8 @@ where
             let txid = transaction.txid();
             match self.ln_dlc_wallet.inner().get_transaction(&txid) {
                 Ok(Some(TransactionDetails { fee: Some(fee), .. })) => {
-                    self.storage.upsert_transaction(transaction.with_fee(fee))?;
+                    self.storage
+                        .upsert_transaction(transaction.clone().with_fee(fee))?;
                 }
                 Ok(_) => {}
                 Err(e) => {

--- a/crates/ln-dlc-node/src/transaction.rs
+++ b/crates/ln-dlc-node/src/transaction.rs
@@ -1,15 +1,18 @@
+use bitcoin::hashes::hex::ToHex;
+use bitcoin::psbt::serialize::Serialize;
 use bitcoin::Txid;
 use std::fmt;
 use std::fmt::Display;
 use std::fmt::Formatter;
 use time::OffsetDateTime;
 
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct Transaction {
     txid: Txid,
     fee: u64,
     created_at: OffsetDateTime,
     updated_at: OffsetDateTime,
+    raw: String,
 }
 
 impl Transaction {
@@ -18,12 +21,14 @@ impl Transaction {
         fee: u64,
         created_at: OffsetDateTime,
         updated_at: OffsetDateTime,
+        raw: String,
     ) -> Self {
         Self {
             txid,
             fee,
             created_at,
             updated_at,
+            raw,
         }
     }
 
@@ -50,13 +55,17 @@ impl Transaction {
     pub fn updated_at(&self) -> OffsetDateTime {
         self.updated_at
     }
+
+    pub fn raw(&self) -> String {
+        self.raw.clone()
+    }
 }
 
 impl From<&bitcoin::Transaction> for Transaction {
     fn from(value: &bitcoin::Transaction) -> Self {
         let now = OffsetDateTime::now_utc();
 
-        Self::new(value.txid(), 0, now, now)
+        Self::new(value.txid(), 0, now, now, value.serialize().to_hex())
     }
 }
 

--- a/mobile/native/migrations/2023-08-28-083813_add_raw_field_to_transactions/down.sql
+++ b/mobile/native/migrations/2023-08-28-083813_add_raw_field_to_transactions/down.sql
@@ -1,0 +1,4 @@
+-- This file should undo anything in `up.sql`
+-- Note: There is no down migration for removing the `Announced variant that was added to `ChannelState_Type` because it is not feasible to remove enum variants in the db!
+ALTER TABLE
+    transactions DROP COLUMN "raw";

--- a/mobile/native/migrations/2023-08-28-083813_add_raw_field_to_transactions/up.sql
+++ b/mobile/native/migrations/2023-08-28-083813_add_raw_field_to_transactions/up.sql
@@ -1,0 +1,5 @@
+-- Your SQL goes here
+ALTER TABLE
+    transactions
+    ADD
+        COLUMN "raw" TEXT NOT NULL DEFAULT 'undefined';

--- a/mobile/native/src/db/models.rs
+++ b/mobile/native/src/db/models.rs
@@ -1093,6 +1093,7 @@ pub(crate) struct Transaction {
     pub fee: i64,
     pub created_at: i64,
     pub updated_at: i64,
+    pub raw: String,
 }
 
 impl Transaction {
@@ -1130,6 +1131,7 @@ impl From<ln_dlc_node::transaction::Transaction> for Transaction {
             fee: value.fee() as i64,
             created_at: value.created_at().unix_timestamp(),
             updated_at: value.updated_at().unix_timestamp(),
+            raw: value.raw(),
         }
     }
 }
@@ -1141,6 +1143,7 @@ impl From<Transaction> for ln_dlc_node::transaction::Transaction {
             value.fee as u64,
             OffsetDateTime::from_unix_timestamp(value.created_at).expect("valid timestamp"),
             OffsetDateTime::from_unix_timestamp(value.updated_at).expect("valid timestamp"),
+            value.raw,
         )
     }
 }
@@ -1696,9 +1699,10 @@ pub mod test {
             // we need to set the time manually as the nano seconds are not stored in sql.
             OffsetDateTime::now_utc().replace_time(Time::from_hms(0, 0, 0).unwrap()),
             OffsetDateTime::now_utc().replace_time(Time::from_hms(0, 0, 0).unwrap()),
+            "0200...doesntmattermuch".to_string(),
         );
 
-        Transaction::upsert(transaction.into(), &mut connection).unwrap();
+        Transaction::upsert(transaction.clone().into(), &mut connection).unwrap();
 
         // Verify that we can load the right transaction by the `txid`
         let loaded: ln_dlc_node::transaction::Transaction = Transaction::get(
@@ -1717,6 +1721,7 @@ pub mod test {
             1,
             OffsetDateTime::now_utc(),
             OffsetDateTime::now_utc(),
+            "0200...doesntmattermuch".to_string(),
         );
         Transaction::upsert(second_tx.into(), &mut connection).unwrap();
         // Verify that we can load all transactions without fees

--- a/mobile/native/src/schema.rs
+++ b/mobile/native/src/schema.rs
@@ -83,6 +83,7 @@ diesel::table! {
         fee -> BigInt,
         created_at -> BigInt,
         updated_at -> BigInt,
+        raw -> Text,
     }
 }
 


### PR DESCRIPTION
for transactions we are broadcasting we should store the raw transaction so that we can re-broadcast it in the future if needed.

Manually extracting it is a [a lot of work](https://www.notion.so/get10101/Extracted-raw-transactions-b913770b883b4f10a7f1071a09c3ca1f) and only doable for the past 30 days. 


Resolves https://github.com/get10101/10101/issues/1139 by storing the raw tx in the database 

