### PR TITLE
fix: Invalid commitment tx signature from peer after processing pending Accept or CloseAccept message

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -953,7 +953,7 @@ dependencies = [
 [[package]]
 name = "dlc"
 version = "0.4.0"
-source = "git+https://github.com/p2pderivatives/rust-dlc?rev=22b7052#22b70527f5d499153710c3aaac1a7a7315be32f3"
+source = "git+https://github.com/p2pderivatives/rust-dlc?rev=fe7cfa3d2de7d3414b21c1bbd58932d2d83191c5#fe7cfa3d2de7d3414b21c1bbd58932d2d83191c5"
 dependencies = [
  "bitcoin",
  "miniscript 8.0.0",
@@ -965,7 +965,7 @@ dependencies = [
 [[package]]
 name = "dlc-manager"
 version = "0.4.0"
-source = "git+https://github.com/p2pderivatives/rust-dlc?rev=22b7052#22b70527f5d499153710c3aaac1a7a7315be32f3"
+source = "git+https://github.com/p2pderivatives/rust-dlc?rev=fe7cfa3d2de7d3414b21c1bbd58932d2d83191c5#fe7cfa3d2de7d3414b21c1bbd58932d2d83191c5"
 dependencies = [
  "async-trait",
  "bitcoin",
@@ -981,7 +981,7 @@ dependencies = [
 [[package]]
 name = "dlc-messages"
 version = "0.4.0"
-source = "git+https://github.com/p2pderivatives/rust-dlc?rev=22b7052#22b70527f5d499153710c3aaac1a7a7315be32f3"
+source = "git+https://github.com/p2pderivatives/rust-dlc?rev=fe7cfa3d2de7d3414b21c1bbd58932d2d83191c5#fe7cfa3d2de7d3414b21c1bbd58932d2d83191c5"
 dependencies = [
  "bitcoin",
  "dlc",
@@ -994,7 +994,7 @@ dependencies = [
 [[package]]
 name = "dlc-sled-storage-provider"
 version = "0.1.0"
-source = "git+https://github.com/p2pderivatives/rust-dlc?rev=22b7052#22b70527f5d499153710c3aaac1a7a7315be32f3"
+source = "git+https://github.com/p2pderivatives/rust-dlc?rev=fe7cfa3d2de7d3414b21c1bbd58932d2d83191c5#fe7cfa3d2de7d3414b21c1bbd58932d2d83191c5"
 dependencies = [
  "bitcoin",
  "dlc-manager",
@@ -1008,7 +1008,7 @@ dependencies = [
 [[package]]
 name = "dlc-trie"
 version = "0.4.0"
-source = "git+https://github.com/p2pderivatives/rust-dlc?rev=22b7052#22b70527f5d499153710c3aaac1a7a7315be32f3"
+source = "git+https://github.com/p2pderivatives/rust-dlc?rev=fe7cfa3d2de7d3414b21c1bbd58932d2d83191c5#fe7cfa3d2de7d3414b21c1bbd58932d2d83191c5"
 dependencies = [
  "bitcoin",
  "dlc",
@@ -2375,7 +2375,7 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 [[package]]
 name = "p2pd-oracle-client"
 version = "0.1.0"
-source = "git+https://github.com/p2pderivatives/rust-dlc?rev=22b7052#22b70527f5d499153710c3aaac1a7a7315be32f3"
+source = "git+https://github.com/p2pderivatives/rust-dlc?rev=fe7cfa3d2de7d3414b21c1bbd58932d2d83191c5#fe7cfa3d2de7d3414b21c1bbd58932d2d83191c5"
 dependencies = [
  "chrono",
  "dlc-manager",
@@ -3219,7 +3219,7 @@ dependencies = [
 [[package]]
 name = "simple-wallet"
 version = "0.1.0"
-source = "git+https://github.com/p2pderivatives/rust-dlc?rev=22b7052#22b70527f5d499153710c3aaac1a7a7315be32f3"
+source = "git+https://github.com/p2pderivatives/rust-dlc?rev=fe7cfa3d2de7d3414b21c1bbd58932d2d83191c5#fe7cfa3d2de7d3414b21c1bbd58932d2d83191c5"
 dependencies = [
  "bitcoin",
  "dlc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,13 +4,13 @@ resolver = "2"
 
 [patch.crates-io]
 # We should usually track the `feature/ln-dlc-channels[-10101]` branch
-dlc-manager = { git = "https://github.com/p2pderivatives/rust-dlc", rev = "22b7052" }
-dlc-messages = { git = "https://github.com/p2pderivatives/rust-dlc", rev = "22b7052" }
-dlc = { git = "https://github.com/p2pderivatives/rust-dlc", rev = "22b7052" }
-dlc-sled-storage-provider = { git = "https://github.com/p2pderivatives/rust-dlc", rev = "22b7052" }
-p2pd-oracle-client = { git = "https://github.com/p2pderivatives/rust-dlc", rev = "22b7052" }
-dlc-trie = { git = "https://github.com/p2pderivatives/rust-dlc", rev = "22b7052" }
-simple-wallet = { git = "https://github.com/p2pderivatives/rust-dlc", rev = "22b7052" }
+dlc-manager = { git = "https://github.com/p2pderivatives/rust-dlc", rev = "fe7cfa3d2de7d3414b21c1bbd58932d2d83191c5" }
+dlc-messages = { git = "https://github.com/p2pderivatives/rust-dlc", rev = "fe7cfa3d2de7d3414b21c1bbd58932d2d83191c5" }
+dlc = { git = "https://github.com/p2pderivatives/rust-dlc", rev = "fe7cfa3d2de7d3414b21c1bbd58932d2d83191c5" }
+dlc-sled-storage-provider = { git = "https://github.com/p2pderivatives/rust-dlc", rev = "fe7cfa3d2de7d3414b21c1bbd58932d2d83191c5" }
+p2pd-oracle-client = { git = "https://github.com/p2pderivatives/rust-dlc", rev = "fe7cfa3d2de7d3414b21c1bbd58932d2d83191c5" }
+dlc-trie = { git = "https://github.com/p2pderivatives/rust-dlc", rev = "fe7cfa3d2de7d3414b21c1bbd58932d2d83191c5" }
+simple-wallet = { git = "https://github.com/p2pderivatives/rust-dlc", rev = "fe7cfa3d2de7d3414b21c1bbd58932d2d83191c5" }
 
 # We should usually track the `split-tx-experiment[-10101]` branch
 lightning = { git = "https://github.com/p2pderivatives/rust-lightning/", rev = "420d961d" }

--- a/crates/ln-dlc-node/src/tests/dlc/dlc_setup_with_reconnects.rs
+++ b/crates/ln-dlc-node/src/tests/dlc/dlc_setup_with_reconnects.rs
@@ -541,18 +541,14 @@ async fn can_lose_connection_before_processing_subchannel_accept() {
     app.reconnect(coordinator.info).await.unwrap();
 
     // Process the app's `Accept` and send `Confirm`
-    // Invalid state: Misuse error: Invalid commitment signed: Close : Invalid commitment tx
-    // signature from peer
-    let result = wait_until_dlc_channel_state(
+    wait_until_dlc_channel_state(
         Duration::from_secs(30),
         &coordinator,
         app.info.pubkey,
         SubChannelStateName::Confirmed,
     )
-    .await;
-
-    assert!(result.is_err());
-    tracing::error!("{:#}", result.err().unwrap());
+    .await
+    .unwrap();
 
     // Create `Accept` message from pending `ReAccept` Action
     sub_channel_manager_periodic_check(app.sub_channel_manager.clone(), &app.dlc_message_handler)
@@ -580,7 +576,6 @@ async fn can_lose_connection_before_processing_subchannel_accept() {
     .unwrap();
 
     // Process the app's `Finalize` and send `Revoke`
-    // This will panic: Commitment txids are unique outside of fuzzing, where hashes can collide
     wait_until_dlc_channel_state(
         Duration::from_secs(30),
         &coordinator,
@@ -672,8 +667,6 @@ async fn can_lose_connection_before_processing_subchannel_close_accept() {
         .unwrap();
 
     // Process `CloseAccept` and send `CloseConfirm`
-    // Invalid state: Misuse error: Invalid commitment signed: Close : Invalid commitment tx
-    // signature from peer
     wait_until_dlc_channel_state(
         Duration::from_secs(30),
         &coordinator,


### PR DESCRIPTION
Error happens when the pending `Accept` or `CloseAccept` message is processed after connection has lost and the channel is re-established again.

The first commit e9bdf053689b9fc533633796a2fa362701e3e257 reproduces the errors reported in #1074 and #1141.
The second commit 5ec59d271ed640b94ded9a5c8126e0427991eb43 points to the fix in `rust-dlc` https://github.com/p2pderivatives/rust-dlc/pull/142. Note, this is still pointing to the PR as it is waiting a review. We may want to want for the merge there before merging this PR.

fixes #1074 
fixes #1141 

Note, already broken channels will not get recovered with that fix and have to be force-closed.