### PR TITLE
fix: invalid commitment signed

### DIFF
--- a/mobile/lib/features/trade/application/order_service.dart
+++ b/mobile/lib/features/trade/application/order_service.dart
@@ -14,6 +14,11 @@ class OrderService {
         direction: direction.toApi(),
         orderType: const rust.OrderType.market());
 
+    // The problem here is that we have a concurrency issue when sending a payment and trying to open/close a position.
+    // The sleep here tries to ensure that we do not process the order matching fee payment from an older order while triggering the next order.
+    // This does not fix the underlying issue though: we should block in the protocol that a payment cannot be sent or received at the same time as a subchannel is being added or removed.
+    await Future.delayed(const Duration(seconds: 5));
+
     return await rust.api.submitOrder(order: order);
   }
 


### PR DESCRIPTION
The problem here is that we have a concurrency issue when sending a payment and trying to open/close a position. This does not fix the underlying issue though: we should block in the protocol that a payment cannot be sent or received at the same time as a subchannel is being added or removed.

does not really resolve https://github.com/get10101/10101/issues/1194 but it will make it less likely to happen. 

not 👉 @holzeis 🙈