### PR TITLE
fix: show balance of synth usd 

### DIFF
--- a/mobile/lib/features/trade/domain/leverage.dart
+++ b/mobile/lib/features/trade/domain/leverage.dart
@@ -4,4 +4,12 @@ class Leverage {
   Leverage(this.leverage);
 
   String formatted() => "x${leverage % 1 == 0 ? leverage.toInt().toString() : leverage.toString()}";
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is Leverage && runtimeType == other.runtimeType && leverage == other.leverage;
+
+  @override
+  int get hashCode => leverage.hashCode;
 }

--- a/mobile/test/leverage_test.dart
+++ b/mobile/test/leverage_test.dart
@@ -1,0 +1,18 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get_10101/features/trade/domain/leverage.dart';
+
+void main() {
+  test('Test leverage equality', () {
+    final leverage1 = Leverage(1);
+    final leverageAlso1 = Leverage(1);
+
+    expect(leverage1, equals(leverageAlso1));
+  });
+
+  test('Test leverage not equality', () {
+    final leverage1 = Leverage(1);
+    final leverage2 = Leverage(2);
+
+    expect(leverage1, isNot(equals(leverage2)));
+  });
+}


### PR DESCRIPTION
in `hasStableUSD()` we are comparing the leverage of the position to be equal the Leverage(0), i.e. `positionUsd.leverage == Leverage(1);`. For this to work we need to implement equal on `Leverage`.

Resolves https://github.com/get10101/10101/issues/1193

![image](https://github.com/get10101/10101/assets/224613/8813120f-dda0-4d08-98fe-bb622a6a86b2)

![image](https://github.com/get10101/10101/assets/224613/1db2b7c3-75af-497c-aa6e-de2d4eab88b2)
