### PR TITLE
fix: upsert transaction before broadcast

### DIFF
--- a/crates/ln-dlc-node/src/ldk_node_wallet.rs
+++ b/crates/ln-dlc-node/src/ldk_node_wallet.rs
@@ -274,13 +274,13 @@ where
 
         tracing::info!(%txid, raw_tx = %serialize_hex(&tx), "Broadcasting transaction");
 
+        if let Err(e) = self.node_storage.upsert_transaction(tx.into()) {
+            tracing::error!("Failed to store transaction {txid}. Error: {e:#}");
+        }
+
         self.blockchain
             .broadcast(tx)
             .with_context(|| format!("Failed to broadcast transaction {txid}"))?;
-
-        self.node_storage
-            .upsert_transaction(tx.into())
-            .with_context(|| format!("Failed to store transaction {txid}"))?;
 
         Ok(txid)
     }


### PR DESCRIPTION
If broadcasting the transaction fails we would not keep a record of the transaction. By attempting to upsert the transaction beforehand we make sure to update our database before.