### PR TITLE
Fix panic at startup when asking for node id from the backend

### DIFF
--- a/crates/tests-e2e/tests/force_close_position.rs
+++ b/crates/tests-e2e/tests/force_close_position.rs
@@ -12,7 +12,7 @@ async fn can_force_close_position() {
     let coordinator = &test.coordinator;
     let bitcoin = &test.bitcoind;
 
-    let app_pubkey = api::get_node_id().0;
+    let app_pubkey = api::get_node_id().unwrap().0;
 
     let dlc_channels = coordinator.get_dlc_channels().await.unwrap();
 

--- a/crates/tests-e2e/tests/rollover_position.rs
+++ b/crates/tests-e2e/tests/rollover_position.rs
@@ -13,7 +13,7 @@ async fn can_rollover_position() {
     let test = setup::TestSetup::new_with_open_position().await;
     let coordinator = &test.coordinator;
     let dlc_channels = coordinator.get_dlc_channels().await.unwrap();
-    let app_pubkey = api::get_node_id().0;
+    let app_pubkey = api::get_node_id().unwrap().0;
 
     tracing::info!("{:?}", dlc_channels);
 

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -442,8 +442,12 @@ Future<void> logAppSettings(bridge.Config config) async {
   FLog.info(text: "Oracle endpoint: ${config.oracleEndpoint}");
   FLog.info(text: "Oracle PK: ${config.oraclePubkey}");
 
-  String nodeId = rust.api.getNodeId();
-  FLog.info(text: "Node ID: $nodeId");
+  try {
+    String nodeId = rust.api.getNodeId();
+    FLog.info(text: "Node ID: $nodeId");
+  } catch (e) {
+    FLog.error(text: "Failed to get node ID: $e");
+  }
 }
 
 /// Forward the events from change notifiers to the Event service
@@ -500,7 +504,7 @@ Future<void> runBackend(bridge.Config config) async {
   final seedDir = (await getApplicationSupportDirectory()).path;
 
   // We use the app documents dir on iOS to easily access logs and DB from
-  // the device. On other plaftorms we use the seed dir.
+  // the device. On other platforms we use the seed dir.
   String appDir = Platform.isIOS
       ? (await getApplicationDocumentsDirectory()).path
       : (await getApplicationSupportDirectory()).path;

--- a/mobile/native/src/api.rs
+++ b/mobile/native/src/api.rs
@@ -360,8 +360,8 @@ pub fn decode_invoice(invoice: String) -> Result<LightningInvoice> {
     })
 }
 
-pub fn get_node_id() -> SyncReturn<String> {
-    SyncReturn(ln_dlc::get_node_info().pubkey.to_string())
+pub fn get_node_id() -> Result<SyncReturn<String>> {
+    Ok(SyncReturn(ln_dlc::get_node_info()?.pubkey.to_string()))
 }
 
 pub fn get_channel_open_fee_estimate_sat() -> Result<u64> {

--- a/mobile/native/src/ln_dlc/mod.rs
+++ b/mobile/native/src/ln_dlc/mod.rs
@@ -100,8 +100,12 @@ pub fn get_node_key() -> SecretKey {
     NODE.get().inner.node_key()
 }
 
-pub fn get_node_info() -> NodeInfo {
-    NODE.get().inner.info
+pub fn get_node_info() -> Result<NodeInfo> {
+    Ok(NODE
+        .try_get()
+        .context("NODE is not initialised yet, can't retrieve node info")?
+        .inner
+        .info)
 }
 
 pub async fn update_node_settings(settings: LnDlcNodeSettings) {

--- a/mobile/native/src/trade/order/mod.rs
+++ b/mobile/native/src/trade/order/mod.rs
@@ -148,7 +148,7 @@ impl Order {
 impl From<Order> for orderbook_commons::NewOrder {
     fn from(order: Order) -> Self {
         let quantity = Decimal::try_from(order.quantity).expect("to parse into decimal");
-        let trader_id = ln_dlc::get_node_info().pubkey;
+        let trader_id = ln_dlc::get_node_info().expect("to have info").pubkey;
         orderbook_commons::NewOrder {
             id: order.id,
             // todo: this is left out intentionally as market orders do not set a price. this field
@@ -175,7 +175,7 @@ impl From<OrderType> for orderbook_commons::OrderType {
 /// Enroll the user in the beta program
 pub async fn register_beta(email: String) -> Result<()> {
     let register = RegisterParams {
-        pubkey: ln_dlc::get_node_info().pubkey,
+        pubkey: ln_dlc::get_node_info()?.pubkey,
         email: Some(email),
         nostr: None,
     };

--- a/mobile/native/src/trade/position/handler.rs
+++ b/mobile/native/src/trade/position/handler.rs
@@ -35,7 +35,7 @@ pub async fn trade(filled: FilledWith) -> Result<()> {
     tracing::debug!(?order, ?filled, "Filling order with id: {}", order.id);
 
     let trade_params = TradeParams {
-        pubkey: ln_dlc::get_node_info().pubkey,
+        pubkey: ln_dlc::get_node_info()?.pubkey,
         contract_symbol: order.contract_symbol,
         leverage: order.leverage,
         quantity: order.quantity,


### PR DESCRIPTION
Sometimes the app  would panic at startup (for local deployments for me), and I
    figured it was trivial to make it more resilient in this case.

We now log an error if for whatever reason we couldn't display the node id at
    startup (e.g. node wasn't ready) - this should not be a showstopper by any means, and it gets
    logged at later stage anyway.