### PR TITLE
Refactor showSnackbar to fix lint on latest flutter

### DIFF
--- a/mobile/lib/common/snack_bar.dart
+++ b/mobile/lib/common/snack_bar.dart
@@ -3,7 +3,7 @@ import 'package:flutter/material.dart';
 /// Show a snackbar with the given message
 ///
 /// Extracted as a separate function to ensure consistent style of error messages
-void showSnackBar(BuildContext context, String message) {
+void showSnackBar(ScaffoldMessengerState messenger, String message) {
   final snackBar = SnackBar(content: Text(message));
-  ScaffoldMessenger.of(context).showSnackBar(snackBar);
+  messenger.showSnackBar(snackBar);
 }

--- a/mobile/lib/features/wallet/share_invoice_screen.dart
+++ b/mobile/lib/features/wallet/share_invoice_screen.dart
@@ -136,7 +136,7 @@ class _ShareInvoiceScreenState extends State<ShareInvoiceScreen> {
                           router.pop();
                           router.pop();
                         } catch (error) {
-                          showSnackBar(context, error.toString());
+                          showSnackBar(ScaffoldMessenger.of(context), error.toString());
                         } finally {
                           setState(() {
                             _isPayInvoiceButtonDisabled = false;
@@ -158,8 +158,7 @@ class _ShareInvoiceScreenState extends State<ShareInvoiceScreen> {
                   child: OutlinedButton(
                     onPressed: () {
                       Clipboard.setData(ClipboardData(text: widget.invoice.rawInvoice)).then((_) {
-                        ScaffoldMessenger.of(context).showSnackBar(
-                            const SnackBar(content: Text('Invoice copied to clipboard')));
+                        showSnackBar(ScaffoldMessenger.of(context), "Invoice copied to clipboard");
                       });
                     },
                     style: ElevatedButton.styleFrom(

--- a/mobile/lib/features/wallet/share_invoice_screen.dart
+++ b/mobile/lib/features/wallet/share_invoice_screen.dart
@@ -130,13 +130,14 @@ class _ShareInvoiceScreenState extends State<ShareInvoiceScreen> {
                         });
 
                         final router = GoRouter.of(context);
+                        final messenger = ScaffoldMessenger.of(context);
                         try {
                           await payInvoiceWithFaucet(widget.invoice.rawInvoice);
                           // Pop both create invoice screen and share invoice screen
                           router.pop();
                           router.pop();
                         } catch (error) {
-                          showSnackBar(ScaffoldMessenger.of(context), error.toString());
+                          showSnackBar(messenger, error.toString());
                         } finally {
                           setState(() {
                             _isPayInvoiceButtonDisabled = false;

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -17,6 +17,7 @@ import 'package:get_10101/common/channel_status_notifier.dart';
 import 'package:get_10101/common/color.dart';
 import 'package:get_10101/common/domain/service_status.dart';
 import 'package:get_10101/common/service_status_notifier.dart';
+import 'package:get_10101/common/snack_bar.dart';
 import 'package:get_10101/features/stable/stable_screen.dart';
 import 'package:get_10101/features/trade/application/candlestick_service.dart';
 import 'package:get_10101/features/trade/application/order_service.dart';
@@ -265,7 +266,7 @@ class _TenTenOneAppState extends State<TenTenOneApp> {
         }
       } catch (e) {
         FLog.error(text: "Error getting coordinator version: ${e.toString()}");
-        messenger.showSnackBar(const SnackBar(content: Text("Coordinator offline")));
+        showSnackBar(messenger, "Coordinator offline");
       }
     });
   }


### PR DESCRIPTION
When I updated my flutter, I started getting a lint failure for using BuildContext across an async gap. This PR fixes that as well as refactoring showSnackbar so it can be used more widely