### PR TITLE
feat: swap side of dollar sign in fiat text (val$ -> $val)

### DIFF
--- a/mobile/lib/common/fiat_text.dart
+++ b/mobile/lib/common/fiat_text.dart
@@ -10,6 +10,6 @@ class FiatText extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final formatter = NumberFormat("#,###,##0.00", "en");
-    return Text("${formatter.format(amount)} \$", style: textStyle);
+    return Text("\$${formatter.format(amount)}", style: textStyle);
   }
 }


### PR DESCRIPTION
![image](https://github.com/get10101/10101/assets/6688948/295f645c-48b9-4019-a637-76a1c63f3ec5)

The dollar sign should go in front of the amount (e.g `$10`, not `10$`, see [here](https://english.stackexchange.com/a/11327))