### PR TITLE
feat: Add a configurable position expiry

### DIFF
--- a/coordinator/migrations/2023-08-22-224322_add_position_expiry_to_order/down.sql
+++ b/coordinator/migrations/2023-08-22-224322_add_position_expiry_to_order/down.sql
@@ -1,0 +1,1 @@
+-- This file should undo anything in `up.sql`

--- a/coordinator/migrations/2023-08-22-224322_add_position_expiry_to_order/up.sql
+++ b/coordinator/migrations/2023-08-22-224322_add_position_expiry_to_order/up.sql
@@ -1,0 +1,11 @@
+-- add proposed position expiry column to orders table
+ALTER TABLE
+    orders
+ADD
+    COLUMN position_expiry TIMESTAMP WITH TIME ZONE NOT NULL;
+UPDATE
+    orders
+SET
+    position_expiry = NOW() 
+WHERE
+    expiry IS NULL;

--- a/coordinator/src/orderbook/db/orders.rs
+++ b/coordinator/src/orderbook/db/orders.rs
@@ -64,6 +64,7 @@ struct Order {
     pub timestamp: OffsetDateTime,
     pub order_type: OrderType,
     pub expiry: OffsetDateTime,
+    pub position_expiry: OffsetDateTime,
 }
 
 impl From<Order> for OrderbookOrder {
@@ -79,6 +80,7 @@ impl From<Order> for OrderbookOrder {
             order_type: value.order_type.into(),
             timestamp: value.timestamp,
             expiry: value.expiry,
+            position_expiry: value.position_expiry,
         }
     }
 }
@@ -94,6 +96,7 @@ struct NewOrder {
     pub quantity: f32,
     pub order_type: OrderType,
     pub expiry: OffsetDateTime,
+    pub position_expiry: OffsetDateTime,
 }
 
 impl From<OrderbookNewOrder> for NewOrder {
@@ -114,7 +117,8 @@ impl From<OrderbookNewOrder> for NewOrder {
                 .to_f32()
                 .expect("To be able to convert decimal to f32"),
             order_type: value.order_type.into(),
-            expiry: value.expiry,
+            expiry: value.order_expiry,
+            position_expiry: value.position_expiry,
         }
     }
 }

--- a/coordinator/src/orderbook/tests/registration_test.rs
+++ b/coordinator/src/orderbook/tests/registration_test.rs
@@ -6,6 +6,7 @@ use crate::orderbook::tests::start_postgres;
 use bitcoin::secp256k1::PublicKey;
 use coordinator_commons::RegisterParams;
 use std::str::FromStr;
+use diesel::Connection;
 use testcontainers::clients::Cli;
 
 #[tokio::test]

--- a/coordinator/src/orderbook/tests/sample_test.rs
+++ b/coordinator/src/orderbook/tests/sample_test.rs
@@ -83,6 +83,6 @@ fn dummy_order(expiry: OffsetDateTime) -> NewOrder {
         direction: Direction::Long,
         quantity: dec!(100.0),
         order_type: OrderType::Market,
-        expiry,
+        order_expiry: expiry,
     }
 }

--- a/coordinator/src/rollover.rs
+++ b/coordinator/src/rollover.rs
@@ -13,7 +13,6 @@ use dlc_manager::contract::Contract;
 use dlc_manager::contract::ContractDescriptor;
 use dlc_manager::ChannelId;
 use std::str::FromStr;
-use time::Duration;
 use time::OffsetDateTime;
 use trade::ContractSymbol;
 
@@ -21,6 +20,9 @@ use trade::ContractSymbol;
 struct Rollover {
     counterparty_pubkey: PublicKey,
     contract_descriptor: ContractDescriptor,
+    // Position expiry
+    #[allow(dead_code)]
+    // TODO: is this expiry of *previous* position, before rollover??
     expiry_timestamp: OffsetDateTime,
     margin_coordinator: u64,
     margin_trader: u64,
@@ -78,11 +80,9 @@ impl Rollover {
     }
 
     /// Calculates the maturity time based on the current expiry timestamp.
-    ///
-    /// todo(holzeis): this should come from a configuration https://github.com/get10101/10101/issues/1029
     pub fn maturity_time(&self) -> OffsetDateTime {
-        let tomorrow = self.expiry_timestamp.date() + Duration::days(2);
-        tomorrow.midnight().assume_utc()
+        // TODO: this should come from a configuration https://github.com/get10101/10101/issues/1029
+        orderbook_commons::default_position_expiry()
     }
 }
 

--- a/coordinator/src/schema.rs
+++ b/coordinator/src/schema.rs
@@ -65,6 +65,7 @@ diesel::table! {
         timestamp -> Timestamptz,
         order_type -> OrderTypeType,
         expiry -> Timestamptz,
+        position_expiry -> Timestamptz,
     }
 }
 

--- a/crates/tests-e2e/tests/rollover_position.rs
+++ b/crates/tests-e2e/tests/rollover_position.rs
@@ -23,8 +23,8 @@ async fn can_rollover_position() {
         .unwrap();
 
     let position = test.app.rx.position().expect("position to exist");
-    let tomorrow = position.expiry.date() + Duration::days(2);
-    let new_expiry = tomorrow.midnight().assume_utc();
+    
+    let new_expiry = orderbook_commons::default_position_expiry();
 
     coordinator
         .rollover(&dlc_channel.dlc_channel_id.unwrap())

--- a/maker/src/bin/maker.rs
+++ b/maker/src/bin/maker.rs
@@ -80,6 +80,9 @@ async fn main() -> Result<()> {
     let _running_node = node.start(event_handler)?;
 
     let node_pubkey = node.info.pubkey;
+
+    let position_expiry = opts.position_expiry.unwrap_or(orderbook_commons::default_position_expiry());
+
     tokio::spawn(async move {
         match trading::run(
             &opts.orderbook,

--- a/maker/src/cli.rs
+++ b/maker/src/cli.rs
@@ -5,8 +5,9 @@ use reqwest::Url;
 use std::env::current_dir;
 use std::net::SocketAddr;
 use std::path::PathBuf;
+use time::OffsetDateTime;
 
-#[derive(Parser)]
+#[derive(Debug, Parser)]
 pub struct Opts {
     /// The address to listen on for the Lightning and `rust-dlc` p2p API.
     #[clap(long, default_value = "0.0.0.0:19045")]
@@ -49,6 +50,10 @@ pub struct Opts {
     /// Orders created by maker will be valid for this number of seconds.
     #[clap(long, default_value = "60")]
     pub order_expiry_after_seconds: u64,
+
+    /// Sets a custom position expiry
+    #[clap(long)]
+    position_expiry: Option<String>,
 
     /// The oracle endpoint.
     #[clap(long, default_value = "http://localhost:8081")]

--- a/maker/src/trading/mod.rs
+++ b/maker/src/trading/mod.rs
@@ -23,6 +23,7 @@ pub async fn run(
     network: Network,
     concurrent_orders: usize,
     order_expiry_after: Duration,
+    position_expiry: OffsetDateTime,
 ) -> Result<()> {
     let network = match network {
         Network::Bitcoin => bitmex_stream::Network::Mainnet,
@@ -44,6 +45,7 @@ pub async fn run(
             maker_id,
             dec!(1000),
             OffsetDateTime::now_utc() + order_expiry_after,
+            position_expiry,
         )
     };
 
@@ -70,6 +72,7 @@ pub async fn run(
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn add_order(
     orderbook_client: &OrderbookClient,
     orderbook_url: &Url,
@@ -77,7 +80,8 @@ async fn add_order(
     direction: Direction,
     maker_id: PublicKey,
     quantity: Decimal,
-    expiry: OffsetDateTime,
+    order_expiry: OffsetDateTime,
+    position_expiry: OffsetDateTime,
 ) -> Option<OrderResponse> {
     orderbook_client
         .post_new_order(
@@ -89,7 +93,8 @@ async fn add_order(
                 trader_id: maker_id,
                 direction,
                 order_type: OrderType::Limit,
-                expiry,
+                order_expiry,
+                position_expiry,
             },
         )
         .await

--- a/mobile/native/migrations/2023-08-22-233707_add_position_expiry_to_order/down.sql
+++ b/mobile/native/migrations/2023-08-22-233707_add_position_expiry_to_order/down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE
+    orders DROP COLUMN position_expiry_timestamp;

--- a/mobile/native/migrations/2023-08-22-233707_add_position_expiry_to_order/up.sql
+++ b/mobile/native/migrations/2023-08-22-233707_add_position_expiry_to_order/up.sql
@@ -1,0 +1,3 @@
+ALTER TABLE
+    orders
+    ADD COLUMN position_expiry_timestamp BIGINT NOT NULL DEFAULT 0;

--- a/mobile/native/src/db/models.rs
+++ b/mobile/native/src/db/models.rs
@@ -125,6 +125,7 @@ pub(crate) struct Order {
     pub execution_price: Option<f32>,
     pub failure_reason: Option<FailureReason>,
     pub order_expiry_timestamp: i64,
+    pub position_expiry_timestamp: i64,
 }
 
 impl Order {
@@ -256,6 +257,7 @@ impl From<crate::trade::order::Order> for Order {
             execution_price,
             failure_reason,
             order_expiry_timestamp: value.order_expiry_timestamp.unix_timestamp(),
+            position_expiry_timestamp: value.position_expiry_timestamp.unix_timestamp(),
         }
     }
 }
@@ -278,6 +280,11 @@ impl TryFrom<Order> for crate::trade::order::Order {
                 value.order_expiry_timestamp,
             )
             .expect("unix timestamp to fit in itself"),
+
+            position_expiry_timestamp: OffsetDateTime::from_unix_timestamp(
+                value.position_expiry_timestamp,
+            )
+                .expect("unix timestamp to fit in itself"),
         };
 
         Ok(order)

--- a/mobile/native/src/schema.rs
+++ b/mobile/native/src/schema.rs
@@ -35,6 +35,7 @@ diesel::table! {
         execution_price -> Nullable<Float>,
         failure_reason -> Nullable<Text>,
         order_expiry_timestamp -> BigInt,
+        position_expiry_timestamp -> BigInt,
     }
 }
 

--- a/mobile/native/src/trade/order/api.rs
+++ b/mobile/native/src/trade/order/api.rs
@@ -126,6 +126,8 @@ impl From<NewOrder> for order::Order {
             creation_timestamp: OffsetDateTime::now_utc(),
             // We do not support setting order expiry from the frontend for now
             order_expiry_timestamp: OffsetDateTime::now_utc() + time::Duration::minutes(1),
+            // We do not support setting position expiry from the frontend for now
+            position_expiry_timestamp: orderbook_commons::default_position_expiry(),
         }
     }
 }

--- a/mobile/native/src/trade/order/mod.rs
+++ b/mobile/native/src/trade/order/mod.rs
@@ -114,6 +114,7 @@ pub struct Order {
     pub state: OrderState,
     pub creation_timestamp: OffsetDateTime,
     pub order_expiry_timestamp: OffsetDateTime,
+    pub position_expiry_timestamp: OffsetDateTime,
 }
 
 impl Order {
@@ -158,7 +159,8 @@ impl From<Order> for orderbook_commons::NewOrder {
             trader_id,
             direction: order.direction,
             order_type: order.order_type.into(),
-            expiry: order.order_expiry_timestamp,
+            order_expiry: order.order_expiry_timestamp,
+            position_expiry: order.position_expiry_timestamp,
         }
     }
 }

--- a/mobile/native/src/trade/position/handler.rs
+++ b/mobile/native/src/trade/position/handler.rs
@@ -213,8 +213,9 @@ pub async fn close_position() -> Result<()> {
             execution_price: closing_price.to_f32().expect("to fit into f32"),
         },
         creation_timestamp: OffsetDateTime::now_utc(),
-        // position has already expired, so the order expiry doesn't matter
+        // position has already expired, so the order and position expiry doesn't matter
         order_expiry_timestamp: OffsetDateTime::now_utc() + Duration::minutes(1),
+        position_expiry_timestamp: OffsetDateTime::now_utc() + Duration::minutes(1),
     };
 
     event::publish(&EventInternal::OrderUpdateNotification(order));


### PR DESCRIPTION
Note: both sides need to agree on the position expiry, otherwise the order will not get matched.

an alternative approach would be to just listen to what the coordinator wants to do and follow on with that; can be easily adjusted to make it this way.

I've abandoned work when it was deprioritised and can't justify the effort of rebasing now.

Hopefully this can be a good starting point to whoever decides to do this task.