### PR TITLE
fix: use string for url instead of URL

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -617,7 +617,7 @@ dependencies = [
 
 [[package]]
 name = "coordinator"
-version = "1.2.4"
+version = "1.2.5"
 dependencies = [
  "anyhow",
  "atty",
@@ -2104,7 +2104,6 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "trade",
- "url",
  "uuid",
 ]
 

--- a/mobile/native/Cargo.toml
+++ b/mobile/native/Cargo.toml
@@ -38,5 +38,4 @@ tokio = { version = "1.25.0", features = ["macros", "rt", "rt-multi-thread", "sy
 tracing = "0.1.37"
 tracing-subscriber = { version = "0.3", default-features = false, features = ["fmt", "env-filter", "time", "json"] }
 trade = { path = "../../crates/trade" }
-url = "2.3.1"
 uuid = { version = "1.3.0", features = ["v4", "fast-rng", "macro-diagnostics"] }

--- a/mobile/native/src/channel_fee.rs
+++ b/mobile/native/src/channel_fee.rs
@@ -195,7 +195,7 @@ impl ChannelFeePaymentSubscriber {
 
 async fn fetch_funding_transaction(txid: Txid) -> Result<EsploraTransaction> {
     reqwest_client()
-        .get(format!("{}tx/{txid}", config::get_esplora_endpoint()))
+        .get(format!("{}/tx/{txid}", config::get_esplora_endpoint()))
         .send()
         .await?
         .json()

--- a/mobile/native/src/config/api.rs
+++ b/mobile/native/src/config/api.rs
@@ -3,7 +3,6 @@ use bdk::bitcoin::Network;
 use bdk::bitcoin::XOnlyPublicKey;
 use flutter_rust_bridge::frb;
 use std::str::FromStr;
-use url::Url;
 
 #[frb]
 #[derive(Debug, Clone)]
@@ -24,8 +23,7 @@ impl From<Config> for ConfigInternal {
         tracing::debug!(?config, "Parsing config from flutter");
         Self {
             coordinator_pubkey: config.coordinator_pubkey.parse().expect("PK to be valid"),
-            esplora_endpoint: Url::parse(config.esplora_endpoint.as_str())
-                .expect("esplora endpoint to be valid"),
+            esplora_endpoint: config.esplora_endpoint,
             http_endpoint: format!("{}:{}", config.host, config.http_port)
                 .parse()
                 .expect("host and http_port to be valid"),

--- a/mobile/native/src/config/mod.rs
+++ b/mobile/native/src/config/mod.rs
@@ -9,14 +9,13 @@ use ln_dlc_node::node::OracleInfo;
 use state::Storage;
 use std::net::SocketAddr;
 use std::time::Duration;
-use url::Url;
 
 static CONFIG: Storage<ConfigInternal> = Storage::new();
 
 #[derive(Clone)]
 pub struct ConfigInternal {
     coordinator_pubkey: PublicKey,
-    esplora_endpoint: Url,
+    esplora_endpoint: String,
     http_endpoint: SocketAddr,
     p2p_endpoint: SocketAddr,
     network: bitcoin::Network,
@@ -47,7 +46,7 @@ pub fn get_coordinator_info() -> NodeInfo {
     }
 }
 
-pub fn get_esplora_endpoint() -> Url {
+pub fn get_esplora_endpoint() -> String {
     CONFIG.get().esplora_endpoint.clone()
 }
 

--- a/mobile/native/src/ln_dlc/mod.rs
+++ b/mobile/native/src/ln_dlc/mod.rs
@@ -199,7 +199,7 @@ pub fn run(data_dir: String, seed_dir: String, runtime: &Runtime) -> Result<()> 
             address,
             SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), address.port()),
             util::into_net_addresses(address),
-            config::get_esplora_endpoint().to_string(),
+            config::get_esplora_endpoint(),
             seed,
             ephemeral_randomness,
             LnDlcNodeSettings::default(),


### PR DESCRIPTION
The reason for that is that URL is putting a trailing / at the file which becomes an issue in downstream libraries such as esplora-client. This is a temp fix, a proper fix will follow.

Note: make sure to pass in ESPLORA_ENDPOINT always without a trailing `/`, i.e. `ESPLORA_ENDPOINT=http://46.17.98.29:3000`