### PR TITLE
Add user registration timestamp to `dlc_channels` endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -617,7 +617,7 @@ dependencies = [
 
 [[package]]
 name = "coordinator"
-version = "1.2.5"
+version = "1.2.6"
 dependencies = [
  "anyhow",
  "atty",


### PR DESCRIPTION
Often times we get multiple entries with the same (or similar) `user_email`s as users reopen their channels.

Adding the context of when the user was registered to this HTTP response helps identify the relevant channel quickly when debugging.