### PR TITLE
chore: mine 100 blocks to make output spendable

### DIFF
--- a/crates/tests-e2e/tests/maker.rs
+++ b/crates/tests-e2e/tests/maker.rs
@@ -30,8 +30,11 @@ async fn maker_can_open_channel_to_coordinator_and_send_payment() -> Result<()> 
         .send_to_address(address, Amount::ONE_BTC)
         .await
         .unwrap();
-    bitcoind.mine(1).await.unwrap();
+    bitcoind.mine(101).await.unwrap();
     maker.sync_on_chain().await.unwrap();
+
+    let maker_on_chain_balance = maker.get_balance().await.unwrap().onchain;
+    assert!(maker_on_chain_balance > 0);
 
     let balance_maker_before_channel = maker.get_balance().await?.offchain;
 


### PR DESCRIPTION
Unfortunately I was not able to reproduce the flakyness in CI. An assumption I have is that we either did not pick up the funds yet or the output was not yet spendable. By mining 100 blocks and ensuring the balance we will learn more

