### PR TITLE
feat: Automatically rollover in rollover weekend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Show loading screen when app starts with an expired position
 - Fix: Prevent crashing the app when there's no Internet connection
 - feat: Allow exporting the seed phrase even if the Node is offline
+- Changed expiry to next Sunday 3 pm UTC
 
 ## [1.2.6] - 2023-09-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix: Prevent crashing the app when there's no Internet connection
 - feat: Allow exporting the seed phrase even if the Node is offline
 - Changed expiry to next Sunday 3 pm UTC
+- Automatically rollover if user opens app during rollover weekend
 
 ## [1.2.6] - 2023-09-06
 

--- a/coordinator/src/db/positions.rs
+++ b/coordinator/src/db/positions.rs
@@ -134,6 +134,7 @@ impl Position {
     ) -> Result<()> {
         let affected_rows = diesel::update(positions::table)
             .filter(positions::trader_pubkey.eq(trader_pubkey))
+            .filter(positions::position_state.eq(PositionState::Rollover))
             .set((
                 positions::position_state.eq(PositionState::Open),
                 positions::temporary_contract_id.eq(temporary_contract_id.to_hex()),
@@ -169,6 +170,7 @@ impl Position {
     ) -> Result<()> {
         let affected_rows = diesel::update(positions::table)
             .filter(positions::trader_pubkey.eq(trader_pubkey))
+            .filter(positions::position_state.eq(PositionState::Open))
             .set((
                 positions::expiry_timestamp.eq(expiry_timestamp),
                 positions::position_state.eq(PositionState::Rollover),

--- a/coordinator/src/lib.rs
+++ b/coordinator/src/lib.rs
@@ -8,14 +8,13 @@ use diesel_migrations::EmbeddedMigrations;
 use diesel_migrations::MigrationHarness;
 use serde_json::json;
 
-mod rollover;
-
 pub mod admin;
 pub mod cli;
 pub mod db;
 pub mod logger;
 pub mod metrics;
 pub mod node;
+pub mod notification;
 pub mod notification_service;
 pub mod orderbook;
 pub mod position;

--- a/coordinator/src/node.rs
+++ b/coordinator/src/node.rs
@@ -62,6 +62,7 @@ pub mod closed_positions;
 pub mod connection;
 pub mod expired_positions;
 pub mod order_matching_fee;
+pub mod rollover;
 pub mod routing_fees;
 pub mod storage;
 pub mod unrealized_pnl;

--- a/coordinator/src/node/rollover.rs
+++ b/coordinator/src/node/rollover.rs
@@ -78,7 +78,9 @@ async fn check_if_eligible_for_rollover(
     if let Some(position) =
         positions::Position::get_open_position_by_trader(conn, trader_id.to_string())?
     {
-        if coordinator_commons::is_in_rollover_weekend(position.expiry_timestamp) {
+        if coordinator_commons::is_in_rollover_weekend(OffsetDateTime::now_utc())
+            && !position.is_expired()
+        {
             let next_expiry = coordinator_commons::calculate_next_expiry(OffsetDateTime::now_utc());
             if position.expiry_timestamp == next_expiry {
                 tracing::trace!(%trader_id, position_id=position.id, "Position has already been rolled over");

--- a/coordinator/src/notification/mod.rs
+++ b/coordinator/src/notification/mod.rs
@@ -1,0 +1,84 @@
+use anyhow::Result;
+use bitcoin::secp256k1::PublicKey;
+use futures::future::RemoteHandle;
+use futures::FutureExt;
+use orderbook_commons::Message;
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::sync::RwLock;
+use tokio::sync::broadcast;
+use tokio::sync::mpsc;
+
+/// This value is arbitrarily set to 100 and defines the message accepted in the notification
+/// channel buffer.
+const NOTIFICATION_BUFFER_SIZE: usize = 100;
+
+// TODO(holzeis): This enum should be extended to allow for sending push notifications.
+pub enum Notification {
+    Message {
+        trader_id: PublicKey,
+        message: Message,
+    },
+}
+
+#[derive(Clone)]
+pub struct NewUserMessage {
+    pub new_user: PublicKey,
+    pub sender: mpsc::Sender<Message>,
+}
+
+pub fn start(
+    tx_user_feed: broadcast::Sender<NewUserMessage>,
+) -> (RemoteHandle<Result<()>>, mpsc::Sender<Notification>) {
+    let (sender, mut receiver) = mpsc::channel::<Notification>(NOTIFICATION_BUFFER_SIZE);
+
+    let authenticated_users = Arc::new(RwLock::new(HashMap::new()));
+
+    tokio::task::spawn({
+        let traders = authenticated_users.clone();
+        async move {
+            let mut user_feed = tx_user_feed.subscribe();
+            while let Ok(new_user_msg) = user_feed.recv().await {
+                traders
+                    .write()
+                    .expect("RwLock to not be poisoned")
+                    .insert(new_user_msg.new_user, new_user_msg.sender);
+            }
+        }
+    });
+
+    let (fut, remote_handle) = {
+        async move {
+            while let Some(notification) = receiver.recv().await {
+                match notification {
+                    Notification::Message { trader_id, message } => {
+                        tracing::info!(%trader_id, "Sending message: {message:?}");
+
+                        let trader = {
+                            let traders = authenticated_users
+                                .read()
+                                .expect("RwLock to not be poisoned");
+                            traders.get(&trader_id).cloned()
+                        };
+
+                        match trader {
+                            Some(sender) => {
+                                if let Err(e) = sender.send(message).await {
+                                    tracing::warn!("Connection lost to trader {e:#}");
+                                }
+                            }
+                            None => tracing::warn!(%trader_id, "Trader is not connected"),
+                        }
+                    }
+                }
+            }
+
+            Ok(())
+        }
+        .remote_handle()
+    };
+
+    tokio::spawn(fut);
+
+    (remote_handle, sender)
+}

--- a/coordinator/src/orderbook/mod.rs
+++ b/coordinator/src/orderbook/mod.rs
@@ -1,3 +1,4 @@
+pub mod async_match;
 pub mod db;
 pub mod routes;
 pub mod trading;

--- a/coordinator/src/orderbook/trading.rs
+++ b/coordinator/src/orderbook/trading.rs
@@ -25,7 +25,6 @@ use std::cmp::Ordering;
 use std::collections::HashMap;
 use std::str::FromStr;
 use thiserror::Error;
-use time::Duration;
 use time::OffsetDateTime;
 use tokio::sync::broadcast;
 use tokio::sync::mpsc;
@@ -345,8 +344,7 @@ fn match_order(
         return Ok(None);
     }
 
-    let tomorrow = OffsetDateTime::now_utc().date() + Duration::days(7);
-    let expiry_timestamp = tomorrow.midnight().assume_utc();
+    let expiry_timestamp = orderbook_commons::get_expiry_timestamp(OffsetDateTime::now_utc());
 
     // For now we hardcode the oracle pubkey here
     let oracle_pk = XOnlyPublicKey::from_str(

--- a/coordinator/src/position/models.rs
+++ b/coordinator/src/position/models.rs
@@ -74,6 +74,11 @@ pub struct Position {
 }
 
 impl Position {
+    // Returns true if the position is expired
+    pub fn is_expired(&self) -> bool {
+        OffsetDateTime::now_utc() >= self.expiry_timestamp
+    }
+
     /// Calculates the profit and loss for the coordinator in satoshis
     pub fn calculate_coordinator_pnl(&self, quote: Quote) -> Result<i64> {
         let closing_price = match self.closing_price {

--- a/coordinator/src/rollover.rs
+++ b/coordinator/src/rollover.rs
@@ -205,8 +205,8 @@ pub mod tests {
         let event_id = rollover.event_id();
 
         // expect expiry in seven days at midnight.
-        // Thu Aug 24 2023 00:00:00 GMT+0000
-        assert_eq!(event_id, format!("btcusd1692835200"))
+        // Sun Aug 20 2023 15:00:00 GMT+0000
+        assert_eq!(event_id, format!("btcusd1692543600"))
     }
 
     #[test]

--- a/coordinator/src/rollover.rs
+++ b/coordinator/src/rollover.rs
@@ -13,7 +13,6 @@ use dlc_manager::contract::Contract;
 use dlc_manager::contract::ContractDescriptor;
 use dlc_manager::ChannelId;
 use std::str::FromStr;
-use time::Duration;
 use time::OffsetDateTime;
 use trade::ContractSymbol;
 
@@ -81,11 +80,8 @@ impl Rollover {
     }
 
     /// Calculates the maturity time based on the current expiry timestamp.
-    ///
-    /// todo(holzeis): this should come from a configuration https://github.com/get10101/10101/issues/1029
     pub fn maturity_time(&self) -> OffsetDateTime {
-        let tomorrow = self.expiry_timestamp.date() + Duration::days(7);
-        tomorrow.midnight().assume_utc()
+        orderbook_commons::get_expiry_timestamp(self.expiry_timestamp)
     }
 }
 

--- a/crates/orderbook-commons/src/lib.rs
+++ b/crates/orderbook-commons/src/lib.rs
@@ -130,6 +130,7 @@ pub enum OrderbookMsg {
         order: Order,
         filled_with: FilledWith,
     },
+    Rollover,
 }
 
 /// A match for an order

--- a/crates/tests-e2e/src/test_subscriber.rs
+++ b/crates/tests-e2e/src/test_subscriber.rs
@@ -199,7 +199,7 @@ impl Senders {
             native::event::EventInternal::PaymentClaimed(_amount_msats) => {
                 unreachable!("PaymentClaimed event should not be sent to the subscriber");
             }
-            native::event::EventInternal::AsyncTrade(_order_id) => {
+            native::event::EventInternal::BackgroundNotification(_task) => {
                 // ignored
             }
         }

--- a/crates/tests-e2e/tests/rollover_position.rs
+++ b/crates/tests-e2e/tests/rollover_position.rs
@@ -4,7 +4,6 @@ use position::PositionState;
 use tests_e2e::app::AppHandle;
 use tests_e2e::setup;
 use tests_e2e::wait_until;
-use time::Duration;
 use time::OffsetDateTime;
 
 #[tokio::test]
@@ -23,8 +22,7 @@ async fn can_rollover_position() {
         .unwrap();
 
     let position = test.app.rx.position().expect("position to exist");
-    let tomorrow = position.expiry.date() + Duration::days(7);
-    let new_expiry = tomorrow.midnight().assume_utc();
+    let new_expiry = orderbook_commons::get_expiry_timestamp(position.expiry);
 
     coordinator
         .rollover(&dlc_channel.dlc_channel_id.unwrap())

--- a/crates/tests-e2e/tests/rollover_position.rs
+++ b/crates/tests-e2e/tests/rollover_position.rs
@@ -22,7 +22,7 @@ async fn can_rollover_position() {
         .unwrap();
 
     let position = test.app.rx.position().expect("position to exist");
-    let new_expiry = orderbook_commons::get_expiry_timestamp(position.expiry);
+    let new_expiry = coordinator_commons::calculate_next_expiry(position.expiry);
 
     coordinator
         .rollover(&dlc_channel.dlc_channel_id.unwrap())

--- a/mobile/lib/common/domain/background_task.dart
+++ b/mobile/lib/common/domain/background_task.dart
@@ -1,0 +1,51 @@
+import 'package:get_10101/bridge_generated/bridge_definitions.dart' as bridge;
+import 'package:get_10101/features/trade/domain/order.dart';
+
+class AsyncTrade {
+  final OrderReason orderReason;
+
+  AsyncTrade({required this.orderReason});
+
+  static AsyncTrade fromApi(bridge.BackgroundTask_AsyncTrade asyncTrade) {
+    return AsyncTrade(orderReason: OrderReason.fromApi(asyncTrade.field0));
+  }
+
+  static bridge.BackgroundTask apiDummy() {
+    return bridge.BackgroundTask_AsyncTrade(OrderReason.apiDummy());
+  }
+}
+
+enum TaskStatus {
+  pending,
+  failed,
+  success;
+
+  static TaskStatus fromApi(bridge.TaskStatus taskStatus) {
+    switch (taskStatus) {
+      case bridge.TaskStatus.Pending:
+        return TaskStatus.pending;
+      case bridge.TaskStatus.Failed:
+        return TaskStatus.failed;
+      case bridge.TaskStatus.Success:
+        return TaskStatus.success;
+    }
+  }
+
+  static bridge.TaskStatus apiDummy() {
+    return bridge.TaskStatus.Pending;
+  }
+}
+
+class Rollover {
+  final TaskStatus taskStatus;
+
+  Rollover({required this.taskStatus});
+
+  static Rollover fromApi(bridge.BackgroundTask_Rollover rollover) {
+    return Rollover(taskStatus: TaskStatus.fromApi(rollover.field0));
+  }
+
+  static bridge.BackgroundTask apiDummy() {
+    return bridge.BackgroundTask_Rollover(TaskStatus.apiDummy());
+  }
+}

--- a/mobile/lib/features/stable/stable_confirmation_sheet.dart
+++ b/mobile/lib/features/stable/stable_confirmation_sheet.dart
@@ -130,8 +130,6 @@ class _StableBottomSheet extends State<StableBottomSheet> {
       });
     }
 
-    final now = DateTime.now();
-
     return Form(
         key: _formKey,
         child: Column(
@@ -233,7 +231,7 @@ class _StableBottomSheet extends State<StableBottomSheet> {
                           const SizedBox(height: 16.0),
                           ValueDataRow(
                               type: ValueType.date,
-                              value: DateTime.utc(now.year, now.month, now.day + 2).toLocal(),
+                              value: tradeValues.expiry.toLocal(),
                               label: "Expiry",
                               valueTextStyle: const TextStyle(fontSize: 18),
                               labelTextStyle: const TextStyle(fontSize: 18)),

--- a/mobile/lib/features/trade/application/trade_values_service.dart
+++ b/mobile/lib/features/trade/application/trade_values_service.dart
@@ -1,7 +1,7 @@
-import 'package:get_10101/ffi.dart' as rust;
-import 'package:get_10101/features/trade/domain/leverage.dart';
 import 'package:get_10101/common/domain/model.dart';
 import 'package:get_10101/features/trade/domain/direction.dart';
+import 'package:get_10101/features/trade/domain/leverage.dart';
+import 'package:get_10101/ffi.dart' as rust;
 
 class TradeValuesService {
   Amount? calculateMargin(
@@ -38,5 +38,9 @@ class TradeValuesService {
       return rust.api.calculateLiquidationPrice(
           price: price, leverage: leverage.leverage, direction: direction.toApi());
     }
+  }
+
+  DateTime getExpiryTimestamp() {
+    return DateTime.fromMillisecondsSinceEpoch(rust.api.getExpiryTimestamp() * 1000);
   }
 }

--- a/mobile/lib/features/trade/async_order_change_notifier.dart
+++ b/mobile/lib/features/trade/async_order_change_notifier.dart
@@ -2,6 +2,7 @@ import 'package:f_logs/model/flog/flog.dart';
 import 'package:flutter/material.dart';
 import 'package:get_10101/bridge_generated/bridge_definitions.dart' as bridge;
 import 'package:get_10101/common/application/event_service.dart';
+import 'package:get_10101/common/domain/background_task.dart';
 import 'package:get_10101/common/global_keys.dart';
 import 'package:get_10101/features/trade/application/order_service.dart';
 import 'package:get_10101/features/trade/domain/order.dart';
@@ -26,9 +27,10 @@ class AsyncOrderChangeNotifier extends ChangeNotifier implements Subscriber {
 
   @override
   void notify(bridge.Event event) {
-    if (event is bridge.Event_AsyncTrade) {
-      OrderReason reason = OrderReason.fromApi(event.field0);
-      FLog.debug(text: "Received a async trade event. Reason: $reason");
+    if (event is bridge.Event_BackgroundNotification &&
+        event.field0 is bridge.BackgroundTask_AsyncTrade) {
+      AsyncTrade asyncTrade = AsyncTrade.fromApi(event.field0 as bridge.BackgroundTask_AsyncTrade);
+      FLog.debug(text: "Received a async trade event. Reason: ${asyncTrade.orderReason}");
       showDialog(
         context: shellNavigatorKey.currentContext!,
         builder: (context) {
@@ -47,7 +49,7 @@ class AsyncOrderChangeNotifier extends ChangeNotifier implements Subscriber {
           }
 
           late Widget content;
-          switch (reason) {
+          switch (asyncTrade.orderReason) {
             case OrderReason.expired:
               content = const Text("Your position has been closed due to expiry.");
             case OrderReason.manual:

--- a/mobile/lib/features/trade/domain/trade_values.dart
+++ b/mobile/lib/features/trade/domain/trade_values.dart
@@ -16,6 +16,7 @@ class TradeValues {
   Amount? fee; // This fee is an estimate of the order-matching fee.
 
   double fundingRate;
+  DateTime expiry;
 
   // no final so it can be mocked in tests
   TradeValuesService tradeValuesService;
@@ -29,6 +30,7 @@ class TradeValues {
       required this.liquidationPrice,
       required this.fee,
       required this.fundingRate,
+      required this.expiry,
       required this.tradeValuesService});
 
   factory TradeValues.fromQuantity(
@@ -47,6 +49,8 @@ class TradeValues {
 
     Amount? fee = orderMatchingFee(quantity, price);
 
+    DateTime expiry = tradeValuesService.getExpiryTimestamp();
+
     return TradeValues(
         direction: direction,
         margin: margin,
@@ -56,6 +60,7 @@ class TradeValues {
         fundingRate: fundingRate,
         liquidationPrice: liquidationPrice,
         fee: fee,
+        expiry: expiry,
         tradeValuesService: tradeValuesService);
   }
 
@@ -75,6 +80,8 @@ class TradeValues {
 
     Amount? fee = orderMatchingFee(quantity, price);
 
+    DateTime expiry = tradeValuesService.getExpiryTimestamp();
+
     return TradeValues(
         direction: direction,
         margin: margin,
@@ -84,6 +91,7 @@ class TradeValues {
         fundingRate: fundingRate,
         liquidationPrice: liquidationPrice,
         fee: fee,
+        expiry: expiry,
         tradeValuesService: tradeValuesService);
   }
 

--- a/mobile/lib/features/trade/rollover_change_notifier.dart
+++ b/mobile/lib/features/trade/rollover_change_notifier.dart
@@ -1,0 +1,54 @@
+import 'package:f_logs/model/flog/flog.dart';
+import 'package:flutter/material.dart';
+import 'package:get_10101/bridge_generated/bridge_definitions.dart' as bridge;
+import 'package:get_10101/common/application/event_service.dart';
+import 'package:get_10101/common/domain/background_task.dart';
+import 'package:get_10101/common/global_keys.dart';
+import 'package:get_10101/features/trade/order_submission_status_dialog.dart';
+import 'package:provider/provider.dart';
+
+class RolloverChangeNotifier extends ChangeNotifier implements Subscriber {
+  late TaskStatus taskStatus;
+
+  @override
+  void notify(bridge.Event event) {
+    if (event is bridge.Event_BackgroundNotification &&
+        event.field0 is bridge.BackgroundTask_Rollover) {
+      Rollover rollover = Rollover.fromApi(event.field0 as bridge.BackgroundTask_Rollover);
+      FLog.debug(text: "Received a rollover event. Status: ${rollover.taskStatus}");
+
+      taskStatus = rollover.taskStatus;
+
+      if (taskStatus == TaskStatus.pending) {
+        // initialize dialog for the pending task
+        showDialog(
+          context: shellNavigatorKey.currentContext!,
+          builder: (context) {
+            TaskStatus status = context.watch<RolloverChangeNotifier>().taskStatus;
+
+            // todo(holzeis): Reusing the order submission status dialog is not nice, but it's actually suitable for any task execution that has pending,
+            // failed and success states. We may should consider renaming this dialog for its more generic purpose.
+            OrderSubmissionStatusDialogType type = OrderSubmissionStatusDialogType.pendingSubmit;
+            switch (status) {
+              case TaskStatus.pending:
+                type = OrderSubmissionStatusDialogType.successfulSubmit;
+              case TaskStatus.failed:
+                type = OrderSubmissionStatusDialogType.failedFill;
+              case TaskStatus.success:
+                type = OrderSubmissionStatusDialogType.filled;
+            }
+
+            late Widget content = const Text("Rolling over your position");
+
+            return OrderSubmissionStatusDialog(title: "Catching up!", type: type, content: content);
+          },
+        );
+      } else {
+        // notify dialog about changed task status
+        notifyListeners();
+      }
+    } else {
+      FLog.warning(text: "Received unexpected event: ${event.toString()}");
+    }
+  }
+}

--- a/mobile/lib/features/trade/submit_order_change_notifier.dart
+++ b/mobile/lib/features/trade/submit_order_change_notifier.dart
@@ -98,6 +98,7 @@ class SubmitOrderChangeNotifier extends ChangeNotifier implements Subscriber {
             liquidationPrice: position.liquidationPrice,
             fee: fee,
             fundingRate: 0,
+            expiry: position.expiry,
             tradeValuesService: TradeValuesService()),
         PositionAction.close);
   }

--- a/mobile/lib/features/trade/trade_bottom_sheet_confirmation.dart
+++ b/mobile/lib/features/trade/trade_bottom_sheet_confirmation.dart
@@ -101,7 +101,6 @@ class TradeBottomSheetConfirmation extends StatelessWidget {
       pnl = position!.unrealizedPnl != null ? position.unrealizedPnl! : Amount(0);
     }
 
-    DateTime now = DateTime.now().toUtc();
     TextStyle dataRowStyle = const TextStyle(fontSize: 14);
 
     return Container(
@@ -122,7 +121,7 @@ class TradeBottomSheetConfirmation extends StatelessWidget {
                         if (!close)
                           ValueDataRow(
                               type: ValueType.date,
-                              value: DateTime.utc(now.year, now.month, now.day + 7).toLocal(),
+                              value: tradeValues.expiry.toLocal(),
                               label: 'Expiry'),
                         close
                             ? ValueDataRow(

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -12,6 +12,7 @@ import 'package:get_10101/common/application/channel_info_service.dart';
 import 'package:get_10101/common/application/event_service.dart';
 import 'package:get_10101/common/channel_status_notifier.dart';
 import 'package:get_10101/common/color.dart';
+import 'package:get_10101/common/domain/background_task.dart';
 import 'package:get_10101/common/domain/service_status.dart';
 import 'package:get_10101/common/global_keys.dart';
 import 'package:get_10101/common/service_status_notifier.dart';
@@ -27,6 +28,7 @@ import 'package:get_10101/features/trade/domain/position.dart';
 import 'package:get_10101/features/trade/domain/price.dart';
 import 'package:get_10101/features/trade/order_change_notifier.dart';
 import 'package:get_10101/features/trade/position_change_notifier.dart';
+import 'package:get_10101/features/trade/rollover_change_notifier.dart';
 import 'package:get_10101/features/trade/submit_order_change_notifier.dart';
 import 'package:get_10101/features/trade/trade_screen.dart';
 import 'package:get_10101/features/trade/trade_theme.dart';
@@ -87,6 +89,7 @@ void main() async {
     ChangeNotifierProvider(create: (context) => ServiceStatusNotifier()),
     ChangeNotifierProvider(create: (context) => ChannelStatusNotifier()),
     ChangeNotifierProvider(create: (context) => AsyncOrderChangeNotifier(OrderService())),
+    ChangeNotifierProvider(create: (context) => RolloverChangeNotifier()),
     Provider(create: (context) => Environment.parse()),
     Provider(create: (context) => channelInfoService)
   ], child: const TenTenOneApp()));
@@ -477,6 +480,7 @@ void subscribeToNotifiers(BuildContext context) {
   final channelStatusNotifier = context.read<ChannelStatusNotifier>();
   final stableValuesChangeNotifier = context.read<StableValuesChangeNotifier>();
   final asyncOrderChangeNotifier = context.read<AsyncOrderChangeNotifier>();
+  final rolloverChangeNotifier = context.read<RolloverChangeNotifier>();
 
   eventService.subscribe(
       orderChangeNotifier, bridge.Event.orderUpdateNotification(Order.apiDummy()));
@@ -509,7 +513,11 @@ void subscribeToNotifiers(BuildContext context) {
 
   eventService.subscribe(
       asyncOrderChangeNotifier, bridge.Event.orderUpdateNotification(Order.apiDummy()));
-  eventService.subscribe(asyncOrderChangeNotifier, bridge.Event.asyncTrade(OrderReason.apiDummy()));
+  eventService.subscribe(
+      asyncOrderChangeNotifier, bridge.Event.backgroundNotification(AsyncTrade.apiDummy()));
+
+  eventService.subscribe(
+      rolloverChangeNotifier, bridge.Event.backgroundNotification(Rollover.apiDummy()));
 
   channelStatusNotifier.subscribe(eventService);
 

--- a/mobile/native/src/api.rs
+++ b/mobile/native/src/api.rs
@@ -397,5 +397,7 @@ pub fn get_channel_open_fee_estimate_sat() -> Result<u64> {
 }
 
 pub fn get_expiry_timestamp() -> SyncReturn<i64> {
-    SyncReturn(orderbook_commons::get_expiry_timestamp(OffsetDateTime::now_utc()).unix_timestamp())
+    SyncReturn(
+        coordinator_commons::calculate_next_expiry(OffsetDateTime::now_utc()).unix_timestamp(),
+    )
 }

--- a/mobile/native/src/api.rs
+++ b/mobile/native/src/api.rs
@@ -34,6 +34,7 @@ use std::ops::Add;
 use std::str::FromStr;
 use std::time::Duration;
 use std::time::SystemTime;
+use time::OffsetDateTime;
 pub use trade::ContractSymbol;
 pub use trade::Direction;
 
@@ -393,4 +394,8 @@ pub fn get_channel_open_fee_estimate_sat() -> Result<u64> {
     let estimate = FUNDING_TX_WEIGHT_ESTIMATE as f32 * fee_rate.as_sat_per_vb();
 
     Ok(estimate.ceil() as u64)
+}
+
+pub fn get_expiry_timestamp() -> SyncReturn<i64> {
+    SyncReturn(orderbook_commons::get_expiry_timestamp(OffsetDateTime::now_utc()).unix_timestamp())
 }

--- a/mobile/native/src/event/mod.rs
+++ b/mobile/native/src/event/mod.rs
@@ -30,7 +30,6 @@ pub fn publish(event: &EventInternal) {
 pub enum EventInternal {
     Init(String),
     Log(String),
-    AsyncTrade(OrderReason),
     OrderUpdateNotification(Order),
     WalletInfoUpdateNotification(WalletInfo),
     OrderFilledWith(Box<TradeParams>),
@@ -41,6 +40,20 @@ pub enum EventInternal {
     PaymentClaimed(u64),
     ServiceHealthUpdate(ServiceUpdate),
     ChannelStatusUpdate(ChannelStatus),
+    BackgroundNotification(BackgroundTask),
+}
+
+#[derive(Clone, Debug)]
+pub enum BackgroundTask {
+    AsyncTrade(OrderReason),
+    Rollover(TaskStatus),
+}
+
+#[derive(Clone, Debug)]
+pub enum TaskStatus {
+    Pending,
+    Failed,
+    Success,
 }
 
 impl fmt::Display for EventInternal {
@@ -58,7 +71,7 @@ impl fmt::Display for EventInternal {
             EventInternal::PaymentClaimed(_) => "PaymentClaimed",
             EventInternal::ServiceHealthUpdate(_) => "ServiceHealthUpdate",
             EventInternal::ChannelStatusUpdate(_) => "ChannelStatusUpdate",
-            EventInternal::AsyncTrade(_) => "AsyncTrade",
+            EventInternal::BackgroundNotification(_) => "BackgroundNotification",
         }
         .fmt(f)
     }
@@ -81,7 +94,7 @@ impl From<EventInternal> for EventType {
             EventInternal::PaymentClaimed(_) => EventType::PaymentClaimed,
             EventInternal::ServiceHealthUpdate(_) => EventType::ServiceHealthUpdate,
             EventInternal::ChannelStatusUpdate(_) => EventType::ChannelStatusUpdate,
-            EventInternal::AsyncTrade(_) => EventType::AsyncTrade,
+            EventInternal::BackgroundNotification(_) => EventType::BackgroundNotification,
         }
     }
 }
@@ -100,5 +113,5 @@ pub enum EventType {
     PaymentClaimed,
     ServiceHealthUpdate,
     ChannelStatusUpdate,
-    AsyncTrade,
+    BackgroundNotification,
 }

--- a/mobile/native/src/ln_dlc/node.rs
+++ b/mobile/native/src/ln_dlc/node.rs
@@ -1,4 +1,8 @@
 use crate::db;
+use crate::event;
+use crate::event::BackgroundTask;
+use crate::event::EventInternal;
+use crate::event::TaskStatus;
 use crate::trade::order;
 use crate::trade::position;
 use crate::trade::position::PositionState;
@@ -225,6 +229,10 @@ impl Node {
                     // After handling the `RenewRevoke` message, we need to do some post-processing
                     // based on the fact that the DLC channel has been updated.
                     position::handler::set_position_state(PositionState::Open)?;
+
+                    event::publish(&EventInternal::BackgroundNotification(
+                        BackgroundTask::Rollover(TaskStatus::Success),
+                    ));
                 }
                 // ignoring all other channel events.
                 _ => (),

--- a/mobile/native/src/trade/position/handler.rs
+++ b/mobile/native/src/trade/position/handler.rs
@@ -102,6 +102,11 @@ pub async fn async_trade(order: orderbook_commons::Order, filled_with: FilledWit
     Ok(())
 }
 
+/// Rollover dlc to new expiry timestamp
+pub async fn rollover() -> Result<()> {
+    ln_dlc::rollover().await
+}
+
 /// Fetch the positions from the database
 pub fn get_positions() -> Result<Vec<Position>> {
     db::get_positions()

--- a/mobile/native/src/trade/position/handler.rs
+++ b/mobile/native/src/trade/position/handler.rs
@@ -17,7 +17,6 @@ use coordinator_commons::TradeParams;
 use orderbook_commons::FilledWith;
 use orderbook_commons::Prices;
 use rust_decimal::prelude::ToPrimitive;
-use time::Duration;
 use time::OffsetDateTime;
 use trade::ContractSymbol;
 
@@ -162,7 +161,11 @@ pub fn rollover_position(expiry_timestamp: OffsetDateTime) -> Result<()> {
 }
 
 /// Create a position after the creation of a DLC channel.
-pub fn update_position_after_dlc_creation(filled_order: Order, collateral: u64) -> Result<()> {
+pub fn update_position_after_dlc_creation(
+    filled_order: Order,
+    collateral: u64,
+    expiry: OffsetDateTime,
+) -> Result<()> {
     ensure!(
         db::get_positions()?.is_empty(),
         "Cannot create a position if one is already open"
@@ -171,9 +174,6 @@ pub fn update_position_after_dlc_creation(filled_order: Order, collateral: u64) 
     tracing::debug!(order = ?filled_order, %collateral, "Creating position after DLC channel creation");
 
     let average_entry_price = filled_order.execution_price().unwrap_or(0.0);
-
-    let tomorrow = OffsetDateTime::now_utc().date() + Duration::days(7);
-    let expiry = tomorrow.midnight().assume_utc();
 
     let have_a_position = Position {
         leverage: filled_order.leverage,

--- a/mobile/test/trade_test.dart
+++ b/mobile/test/trade_test.dart
@@ -2,7 +2,17 @@ import 'package:candlesticks/candlesticks.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:get_10101/common/amount_denomination_change_notifier.dart';
+@GenerateNiceMocks([MockSpec<ChannelInfoService>()])
+import 'package:get_10101/common/application/channel_info_service.dart';
 import 'package:get_10101/common/domain/model.dart';
+@GenerateNiceMocks([MockSpec<CandlestickService>()])
+import 'package:get_10101/features/trade/application/candlestick_service.dart';
+@GenerateNiceMocks([MockSpec<OrderService>()])
+import 'package:get_10101/features/trade/application/order_service.dart';
+@GenerateNiceMocks([MockSpec<PositionService>()])
+import 'package:get_10101/features/trade/application/position_service.dart';
+@GenerateNiceMocks([MockSpec<TradeValuesService>()])
+import 'package:get_10101/features/trade/application/trade_values_service.dart';
 import 'package:get_10101/features/trade/candlestick_change_notifier.dart';
 import 'package:get_10101/features/trade/domain/price.dart';
 import 'package:get_10101/features/trade/order_change_notifier.dart';
@@ -11,6 +21,8 @@ import 'package:get_10101/features/trade/submit_order_change_notifier.dart';
 import 'package:get_10101/features/trade/trade_screen.dart';
 import 'package:get_10101/features/trade/trade_theme.dart';
 import 'package:get_10101/features/trade/trade_value_change_notifier.dart';
+@GenerateNiceMocks([MockSpec<WalletService>()])
+import 'package:get_10101/features/wallet/application/wallet_service.dart';
 import 'package:get_10101/features/wallet/domain/wallet_balances.dart';
 import 'package:get_10101/features/wallet/domain/wallet_info.dart';
 import 'package:get_10101/features/wallet/wallet_change_notifier.dart';
@@ -19,24 +31,6 @@ import 'package:go_router/go_router.dart';
 import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
 import 'package:provider/provider.dart';
-
-@GenerateNiceMocks([MockSpec<TradeValuesService>()])
-import 'package:get_10101/features/trade/application/trade_values_service.dart';
-
-@GenerateNiceMocks([MockSpec<ChannelInfoService>()])
-import 'package:get_10101/common/application/channel_info_service.dart';
-
-@GenerateNiceMocks([MockSpec<OrderService>()])
-import 'package:get_10101/features/trade/application/order_service.dart';
-
-@GenerateNiceMocks([MockSpec<PositionService>()])
-import 'package:get_10101/features/trade/application/position_service.dart';
-
-@GenerateNiceMocks([MockSpec<WalletService>()])
-import 'package:get_10101/features/wallet/application/wallet_service.dart';
-
-@GenerateNiceMocks([MockSpec<CandlestickService>()])
-import 'package:get_10101/features/trade/application/candlestick_service.dart';
 
 import 'trade_test.mocks.dart';
 
@@ -98,6 +92,7 @@ void main() {
     when(tradeValueService.calculateQuantity(
             price: anyNamed('price'), leverage: anyNamed('leverage'), margin: anyNamed('margin')))
         .thenReturn(0.1);
+    when(tradeValueService.getExpiryTimestamp()).thenReturn(DateTime.now());
 
     // assuming this is an initial funding, no channel exists yet
     when(channelConstraintsService.getChannelInfo()).thenAnswer((_) async {


### PR DESCRIPTION
This change will automatically push the users dlc expiry to the next Sunday 15pm UTC if the user comes online within the rollover weekend (Friday, 15pm UTC - Sunday, 15pm UTC).

The video was taken with an adapted `get_expiry_timestamp` and `is_in_rollover_weekend` logic to provoke the rollover.

https://github.com/get10101/10101/assets/382048/1fd5e6ff-cea7-4f2c-8153-a7c51cc1d4ac

resolves #1123

