### PR TITLE
Avoid panics at startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Find match on an expired position
 - Show loading screen when app starts with an expired position
+- Fix: Prevent crashing the app when there's no Internet connection
+- feat: Allow exporting the seed phrase even if the Node is offline
 
 ## [1.2.6] - 2023-09-06
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3453,6 +3453,7 @@ dependencies = [
  "maker",
  "native",
  "orderbook-commons",
+ "parking_lot 0.12.1",
  "quote",
  "reqwest",
  "serde",

--- a/crates/ln-dlc-node/src/ln_dlc_wallet.rs
+++ b/crates/ln-dlc-node/src/ln_dlc_wallet.rs
@@ -1,7 +1,6 @@
 use crate::fee_rate_estimator::FeeRateEstimator;
 use crate::ldk_node_wallet;
 use crate::node::Storage;
-use crate::seed::Bip39Seed;
 use crate::TracingLogger;
 use anyhow::Result;
 use bdk::blockchain::EsploraBlockchain;
@@ -39,7 +38,6 @@ pub struct LnDlcWallet {
     ln_wallet: Arc<ldk_node_wallet::Wallet<sled::Tree, EsploraBlockchain, FeeRateEstimator>>,
     storage: Arc<SledStorageProvider>,
     secp: Secp256k1<All>,
-    seed: Bip39Seed,
     network: Network,
     /// Cache for the last unused address according to the latest on-chain sync.
     ///
@@ -56,7 +54,6 @@ impl LnDlcWallet {
         on_chain_wallet: bdk::Wallet<bdk::sled::Tree>,
         fee_rate_estimator: Arc<FeeRateEstimator>,
         storage: Arc<SledStorageProvider>,
-        seed: Bip39Seed,
         bdk_client_stop_gap: usize,
         bdk_client_concurrency: u8,
         node_storage: Arc<dyn Storage + Send + Sync + 'static>,
@@ -82,14 +79,9 @@ impl LnDlcWallet {
             ln_wallet: wallet,
             storage,
             secp: Secp256k1::new(),
-            seed,
             network,
             address_cache: RwLock::new(last_unused_address),
         }
-    }
-
-    pub fn get_seed_phrase(&self) -> Vec<String> {
-        self.seed.get_seed_phrase()
     }
 
     // TODO: Better to keep this private and expose the necessary APIs instead.

--- a/crates/ln-dlc-node/src/node/mod.rs
+++ b/crates/ln-dlc-node/src/node/mod.rs
@@ -282,7 +282,6 @@ where
                 on_chain_wallet.inner,
                 fee_rate_estimator.clone(),
                 dlc_storage.clone(),
-                seed.clone(),
                 settings.bdk_client_stop_gap,
                 settings.bdk_client_concurrency,
                 node_storage.clone(),

--- a/crates/ln-dlc-node/src/node/mod.rs
+++ b/crates/ln-dlc-node/src/node/mod.rs
@@ -261,7 +261,9 @@ where
         let persister = Arc::new(FilesystemPersister::new(ldk_data_dir.clone()));
 
         let dlc_storage = Arc::new(SledStorageProvider::new(
-            data_dir.to_str().expect("data_dir"),
+            data_dir
+                .to_str()
+                .context("data_dir for sled storage should be specified")?,
         )?);
 
         let on_chain_dir = data_dir.join("on_chain");

--- a/crates/ln-dlc-node/src/node/wallet.rs
+++ b/crates/ln-dlc-node/src/node/wallet.rs
@@ -48,10 +48,6 @@ impl<P> Node<P>
 where
     P: Storage,
 {
-    pub fn get_seed_phrase(&self) -> Vec<String> {
-        self.wallet.get_seed_phrase()
-    }
-
     pub fn wallet(
         &self,
     ) -> Arc<ldk_node_wallet::Wallet<sled::Tree, EsploraBlockchain, FeeRateEstimator>> {

--- a/crates/tests-e2e/Cargo.toml
+++ b/crates/tests-e2e/Cargo.toml
@@ -15,6 +15,7 @@ ln-dlc-node = { path = "../ln-dlc-node" }
 maker = { path = "../../maker" }
 native = { path = "../../mobile/native" }
 orderbook-commons = { path = "../orderbook-commons" }
+parking_lot = { version = "0.12.1" }
 quote = "1.0.28"
 reqwest = { version = "0.11", default-features = false, features = ["json"] }
 serde = { version = "1.0.152", features = ["serde_derive"] }

--- a/crates/tests-e2e/src/test_subscriber.rs
+++ b/crates/tests-e2e/src/test_subscriber.rs
@@ -10,6 +10,7 @@ use native::ln_dlc::ChannelStatus;
 use native::trade::order::Order;
 use native::trade::position::Position;
 use orderbook_commons::Prices;
+use parking_lot::Mutex;
 use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::watch;
@@ -74,10 +75,7 @@ impl TestSubscriber {
                 while let Ok(()) = service_rx.changed().await {
                     if let Some(ServiceUpdate { service, status }) = *service_rx.borrow() {
                         tracing::debug!(?service, ?status, "Updating status in the services map");
-                        services
-                            .lock()
-                            .expect("mutex not poisoned")
-                            .insert(service, status);
+                        services.lock().insert(service, status);
                     }
                 }
                 panic!("service_rx channel closed");
@@ -130,7 +128,6 @@ impl TestSubscriber {
     pub fn status(&self, service: Service) -> ServiceStatus {
         self.services
             .lock()
-            .expect("mutex not poisoned")
             .get(&service)
             .copied()
             .unwrap_or_default()
@@ -216,12 +213,10 @@ pub struct ThreadSafeSenders(Arc<Mutex<Senders>>);
 
 impl Subscriber for ThreadSafeSenders {
     fn notify(&self, event: &native::event::EventInternal) {
-        let guard = self.0.lock().expect("mutex not poisoned");
-        guard.notify(event);
+        self.0.lock().notify(event)
     }
 
     fn events(&self) -> Vec<EventType> {
-        let guard = self.0.lock().expect("mutex not poisoned");
-        guard.events()
+        self.0.lock().events()
     }
 }

--- a/crates/tests-e2e/src/test_subscriber.rs
+++ b/crates/tests-e2e/src/test_subscriber.rs
@@ -12,7 +12,6 @@ use native::trade::position::Position;
 use orderbook_commons::Prices;
 use std::collections::HashMap;
 use std::sync::Arc;
-use std::sync::Mutex;
 use tokio::sync::watch;
 
 pub struct Senders {

--- a/maker/src/trading/orderbook_client.rs
+++ b/maker/src/trading/orderbook_client.rs
@@ -15,7 +15,7 @@ impl OrderbookClient {
             client: reqwest::Client::builder()
                 .timeout(std::time::Duration::from_secs(30))
                 .build()
-                .expect("Could not build reqwest client"),
+                .expect("to build client from static config"),
         }
     }
 

--- a/mobile/ios/Podfile.lock
+++ b/mobile/ios/Podfile.lock
@@ -75,6 +75,8 @@ PODS:
     - FlutterMacOS
   - social_share (0.0.1):
     - Flutter
+  - url_launcher_ios (0.0.1):
+    - Flutter
 
 DEPENDENCIES:
   - firebase_core (from `.symlinks/plugins/firebase_core/ios`)
@@ -87,6 +89,7 @@ DEPENDENCIES:
   - share_plus (from `.symlinks/plugins/share_plus/ios`)
   - shared_preferences_foundation (from `.symlinks/plugins/shared_preferences_foundation/darwin`)
   - social_share (from `.symlinks/plugins/social_share/ios`)
+  - url_launcher_ios (from `.symlinks/plugins/url_launcher_ios/ios`)
 
 SPEC REPOS:
   trunk:
@@ -121,6 +124,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/shared_preferences_foundation/darwin"
   social_share:
     :path: ".symlinks/plugins/social_share/ios"
+  url_launcher_ios:
+    :path: ".symlinks/plugins/url_launcher_ios/ios"
 
 SPEC CHECKSUMS:
   Firebase: 07150e75d142fb9399f6777fa56a187b17f833a0
@@ -142,6 +147,7 @@ SPEC CHECKSUMS:
   share_plus: 599aa54e4ea31d4b4c0e9c911bcc26c55e791028
   shared_preferences_foundation: 5b919d13b803cadd15ed2dc053125c68730e5126
   social_share: 702a5e3842addd22db515aa9e1e00a4b80a0296d
+  url_launcher_ios: 08a3dfac5fb39e8759aeb0abbd5d9480f30fc8b4
 
 PODFILE CHECKSUM: cc1f88378b4bfcf93a6ce00d2c587857c6008d3b
 

--- a/mobile/lib/common/service_status_notifier.dart
+++ b/mobile/lib/common/service_status_notifier.dart
@@ -32,6 +32,10 @@ class ServiceStatusNotifier extends ChangeNotifier implements Subscriber {
 }
 
 bridge.ServiceStatus foldValues(Map<bridge.Service, bridge.ServiceStatus> map) {
+  if (map.isEmpty) {
+    // App is offline at startup
+    return bridge.ServiceStatus.Offline;
+  }
   return map.values.fold(bridge.ServiceStatus.Online, (previousValue, element) {
     if (previousValue == bridge.ServiceStatus.Offline || element == bridge.ServiceStatus.Offline) {
       return bridge.ServiceStatus.Offline;

--- a/mobile/lib/common/service_status_notifier_test.dart
+++ b/mobile/lib/common/service_status_notifier_test.dart
@@ -28,4 +28,10 @@ void main() {
     };
     expect(foldValues(testMap4), ServiceStatus.Offline, reason: 'At least one service is offline');
   });
+
+  test('Nothing is online at startup', () {
+    Map<Service, ServiceStatus> situationAtStartup = <Service, ServiceStatus>{};
+    expect(foldValues(situationAtStartup), ServiceStatus.Offline,
+        reason: "Everything is unknown - app is offline at startup");
+  });
 }

--- a/mobile/lib/common/settings_screen.dart
+++ b/mobile/lib/common/settings_screen.dart
@@ -26,8 +26,13 @@ class _SettingsScreenState extends State<SettingsScreen> {
 
   @override
   void initState() {
-    var nodeId = rust.api.getNodeId();
-    _nodeId = nodeId;
+    try {
+      var nodeId = rust.api.getNodeId();
+      _nodeId = nodeId;
+    } catch (e) {
+      FLog.error(text: "Error getting node id: $e");
+      _nodeId = "UNKNOWN";
+    }
     loadValues();
     super.initState();
   }

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -306,6 +306,8 @@ class _TenTenOneAppState extends State<TenTenOneApp> {
 
       final lastLogin = await rust.api.updateLastLogin();
       FLog.debug(text: "Last login was at ${lastLogin.date}");
+
+      await walletChangeNotifier.refreshWalletInfo();
     } on FfiException catch (error) {
       FLog.error(text: "Failed to initialise: Error: ${error.message}", exception: error);
     } catch (error) {
@@ -313,7 +315,6 @@ class _TenTenOneAppState extends State<TenTenOneApp> {
     } finally {
       FlutterNativeSplash.remove();
     }
-    await walletChangeNotifier.refreshWalletInfo();
   }
 
   setupRustLogging() {

--- a/mobile/native/src/channel_fee.rs
+++ b/mobile/native/src/channel_fee.rs
@@ -12,10 +12,10 @@ use bitcoin::Txid;
 use ln_dlc_node::node::rust_dlc_manager::subchannel::LNChannelManager;
 use ln_dlc_node::node::rust_dlc_manager::ChannelId;
 use ln_dlc_node::node::ChannelManager;
+use parking_lot::Mutex;
 use serde::Deserialize;
 use serde::Serialize;
 use std::sync::Arc;
-use std::sync::Mutex;
 use std::time::Duration;
 use tokio::runtime::Handle;
 
@@ -150,24 +150,15 @@ impl ChannelFeePaymentSubscriber {
     }
 
     fn set_open_channel_info(&self, channel_id: &ChannelId, transaction: EsploraTransaction) {
-        *self
-            .open_channel_info
-            .lock()
-            .expect("Mutex to not be poisoned") = Some((*channel_id, transaction));
+        *self.open_channel_info.lock() = Some((*channel_id, transaction));
     }
 
     fn unset_open_channel_info(&self) {
-        *self
-            .open_channel_info
-            .lock()
-            .expect("Mutex to not be poisoned") = None;
+        *self.open_channel_info.lock() = None;
     }
 
     fn get_open_channel_info(&self) -> Option<(ChannelId, EsploraTransaction)> {
-        self.open_channel_info
-            .lock()
-            .expect("Mutex to not be poisoned")
-            .clone()
+        self.open_channel_info.lock().clone()
     }
 
     async fn wait_for_outbound_capacity(

--- a/mobile/native/src/ln_dlc/mod.rs
+++ b/mobile/native/src/ln_dlc/mod.rs
@@ -85,7 +85,7 @@ pub const FUNDING_TX_WEIGHT_ESTIMATE: u64 = 220;
 static NODE: Storage<Arc<Node>> = Storage::new();
 
 pub async fn refresh_wallet_info() -> Result<()> {
-    let node = NODE.get();
+    let node = NODE.try_get().context("failed to get ln dlc node")?;
     let wallet = node.inner.wallet();
 
     spawn_blocking(move || wallet.sync()).await??;

--- a/mobile/native/src/ln_dlc/mod.rs
+++ b/mobile/native/src/ln_dlc/mod.rs
@@ -83,6 +83,7 @@ const CHECK_OPEN_ORDERS_INTERVAL: Duration = Duration::from_secs(60);
 pub const FUNDING_TX_WEIGHT_ESTIMATE: u64 = 220;
 
 static NODE: Storage<Arc<Node>> = Storage::new();
+static SEED: Storage<Bip39Seed> = Storage::new();
 
 pub async fn refresh_wallet_info() -> Result<()> {
     let node = NODE.try_get().context("failed to get ln dlc node")?;
@@ -95,7 +96,9 @@ pub async fn refresh_wallet_info() -> Result<()> {
 }
 
 pub fn get_seed_phrase() -> Vec<String> {
-    NODE.get().get_seed_phrase()
+    SEED.try_get()
+        .expect("SEED to be initialised")
+        .get_seed_phrase()
 }
 
 pub fn get_node_key() -> SecretKey {
@@ -191,6 +194,7 @@ pub fn run(data_dir: String, seed_dir: String, runtime: &Runtime) -> Result<()> 
 
         let seed_path = seed_dir.join("seed");
         let seed = Bip39Seed::initialize(&seed_path)?;
+        SEED.set(seed.clone());
 
         let (event_sender, event_receiver) = watch::channel::<Option<Event>>(None);
 

--- a/mobile/native/src/ln_dlc/node.rs
+++ b/mobile/native/src/ln_dlc/node.rs
@@ -81,10 +81,6 @@ pub struct WalletHistories {
 }
 
 impl Node {
-    pub fn get_seed_phrase(&self) -> Vec<String> {
-        self.inner.get_seed_phrase()
-    }
-
     pub fn get_blockchain_height(&self) -> Result<u64> {
         self.inner.get_blockchain_height()
     }

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -181,10 +181,10 @@ packages:
     dependency: transitive
     description:
       name: collection
-      sha256: f092b211a4319e98e5ff58223576de6c2803db36221657b46c82574721240687
+      sha256: "4a07be6cb69c84d677a6c3096fcf960cc3285a8330b4603e0d463d15d9bd934c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.2"
+    version: "1.17.1"
   colorize:
     dependency: transitive
     description:
@@ -604,18 +604,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "1803e76e6653768d64ed8ff2e1e67bea3ad4b923eb5c56a295c3e634bad5960e"
+      sha256: "6501fbd55da300384b768785b83e5ce66991266cec21af89ab9ae7f5ce1c4cbb"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.16"
+    version: "0.12.15"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "9528f2f296073ff54cb9fee677df673ace1218163c3bc7628093e7eed5203d41"
+      sha256: d92141dc6fe1dad30722f9aa826c7fbc896d021d792f80678280601aff8cf724
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.0"
+    version: "0.2.0"
   meta:
     dependency: "direct main"
     description:
@@ -1017,10 +1017,10 @@ packages:
     dependency: transitive
     description:
       name: source_span
-      sha256: "53e943d4206a5e30df338fd4c6e7a077e02254531b138a15aec3bd143c1a8b3c"
+      sha256: dd904f795d4b4f3b870833847c461801f6750a9fa8e61ea5ac53f9422b31f250
       url: "https://pub.dev"
     source: hosted
-    version: "1.10.0"
+    version: "1.9.1"
   stack_trace:
     dependency: transitive
     description:
@@ -1073,26 +1073,26 @@ packages:
     dependency: "direct main"
     description:
       name: test
-      sha256: "13b41f318e2a5751c3169137103b60c584297353d4b1761b66029bae6411fe46"
+      sha256: "3dac9aecf2c3991d09b9cdde4f98ded7b30804a88a0d7e4e7e1678e78d6b97f4"
       url: "https://pub.dev"
     source: hosted
-    version: "1.24.3"
+    version: "1.24.1"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "75760ffd7786fffdfb9597c35c5b27eaeec82be8edfb6d71d32651128ed7aab8"
+      sha256: eb6ac1540b26de412b3403a163d919ba86f6a973fe6cc50ae3541b80092fdcfb
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.0"
+    version: "0.5.1"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "99806e9e6d95c7b059b7a0fc08f07fc53fabe54a829497f0d9676299f1e8637e"
+      sha256: "5138dbffb77b2289ecb12b81c11ba46036590b72a64a7a90d6ffb880f1a29e93"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.3"
+    version: "0.5.1"
   timeago:
     dependency: "direct main"
     description:
@@ -1269,14 +1269,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.0"
-  web:
-    dependency: transitive
-    description:
-      name: web
-      sha256: dc8ccd225a2005c1be616fe02951e2e342092edf968cf0844220383757ef8f10
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.1.4-beta"
   web_socket_channel:
     dependency: transitive
     description:
@@ -1342,5 +1334,5 @@ packages:
     source: hosted
     version: "2.1.1"
 sdks:
-  dart: ">=3.1.0-185.0.dev <4.0.0"
+  dart: ">=3.0.0 <4.0.0"
   flutter: ">=3.10.0"


### PR DESCRIPTION
- ensure the app doesn't crash even if the backend cannot be started (e.g. no Internet, coordinator/esplora is down)
- clearly communicate limited functionality by a alert dialog
- show red 'Offline' status in the corner of the screen (thermostat)

Even if the backend cannot be started, the user can:
- export seed (!)
- share logs
- see most of the UI (although most of the functionality is disabled)

I also cleaned some unnecessary `expect` calls whilst investigating this issue.
![flutter_05](https://github.com/get10101/10101/assets/8319440/933eebd3-7719-4000-aa0e-b61d9938b74b)

![flutter_06](https://github.com/get10101/10101/assets/8319440/6cb76e18-58a3-4582-8a9e-7ec67f1e785a)
