### PR TITLE
chore: Shorten expiry and rollover cycles for regtest

### DIFF
--- a/coordinator/src/bin/coordinator.rs
+++ b/coordinator/src/bin/coordinator.rs
@@ -201,11 +201,20 @@ async fn main() -> Result<()> {
 
     let (_handle, notifier) = notification::start(tx_user_feed.clone());
 
-    let (_handle, trading_sender) =
-        trading::start(pool.clone(), tx_price_feed.clone(), notifier.clone());
+    let (_handle, trading_sender) = trading::start(
+        pool.clone(),
+        tx_price_feed.clone(),
+        notifier.clone(),
+        network,
+    );
 
-    let _handle = async_match::monitor(pool.clone(), tx_user_feed.clone(), notifier.clone());
-    let _handle = rollover::monitor(pool.clone(), tx_user_feed.clone(), notifier);
+    let _handle = async_match::monitor(
+        pool.clone(),
+        tx_user_feed.clone(),
+        notifier.clone(),
+        network,
+    );
+    let _handle = rollover::monitor(pool.clone(), tx_user_feed.clone(), notifier, network);
 
     tokio::spawn({
         let node = node.clone();

--- a/coordinator/src/routes.rs
+++ b/coordinator/src/routes.rs
@@ -274,7 +274,7 @@ pub async fn rollover(
 
     state
         .node
-        .propose_rollover(dlc_channel_id)
+        .propose_rollover(dlc_channel_id, state.node.inner.network)
         .await
         .map_err(|e| {
             AppError::InternalServerError(format!(

--- a/crates/coordinator-commons/src/lib.rs
+++ b/crates/coordinator-commons/src/lib.rs
@@ -1,4 +1,5 @@
 use bdk::bitcoin::secp256k1::PublicKey;
+use bdk::bitcoin::Network;
 use orderbook_commons::FilledWith;
 use rust_decimal::Decimal;
 use serde::Deserialize;
@@ -83,88 +84,119 @@ pub struct TokenUpdateParams {
     pub fcm_token: String,
 }
 
-/// Calculates the expiry timestamp at the next Sunday at 3 pm UTC from a given offset date time.
-/// If the argument falls in between Friday, 3 pm UTC and Sunday, 3pm UTC, the expiry will be
-/// calculated to next weeks Sunday at 3 pm
-pub fn calculate_next_expiry(time: OffsetDateTime) -> OffsetDateTime {
-    let days = if is_in_rollover_weekend(time) || time.weekday() == Weekday::Sunday {
-        // if the provided time is in the rollover weekend or on a sunday, we expire the sunday the
-        // week after.
-        7 - time.weekday().number_from_monday() + 7
-    } else {
-        7 - time.weekday().number_from_monday()
-    };
-    let time = time.date().with_hms(15, 0, 0).expect("to fit into time");
+/// Calculates the next expiry timestamp based on the given timestamp and the network.
+pub fn calculate_next_expiry(timestamp: OffsetDateTime, network: Network) -> OffsetDateTime {
+    match network {
+        // Calculates the expiry timestamp at the next Sunday at 3 pm UTC from a given offset date
+        // time. If the argument falls in between Friday, 3 pm UTC and Sunday, 3pm UTC, the
+        // expiry will be calculated to next weeks Sunday at 3 pm
+        Network::Bitcoin => {
+            let days = if is_eligible_for_rollover(timestamp, network)
+                || timestamp.weekday() == Weekday::Sunday
+            {
+                // if the provided timestamp is in the rollover weekend or on a sunday, we expire
+                // the sunday the week after.
+                7 - timestamp.weekday().number_from_monday() + 7
+            } else {
+                7 - timestamp.weekday().number_from_monday()
+            };
+            let time = timestamp
+                .date()
+                .with_hms(15, 0, 0)
+                .expect("to fit into time");
 
-    (time + Duration::days(days as i64)).assume_utc()
+            (time + Duration::days(days as i64)).assume_utc()
+        }
+        // Calculates the expiry timestamp on the same day at midnight unless its already in
+        // rollover then the next day midnight.
+        _ => {
+            if is_eligible_for_rollover(timestamp, network) {
+                let after_tomorrow = timestamp.date() + Duration::days(2);
+                after_tomorrow.midnight().assume_utc()
+            } else {
+                let tomorrow = timestamp.date() + Duration::days(1);
+                tomorrow.midnight().assume_utc()
+            }
+        }
+    }
 }
 
 /// Checks whether the provided expiry date is eligible for a rollover
-///
-/// Returns true if the given date falls in between friday 15 pm UTC and sunday 15 pm UTC
-pub fn is_in_rollover_weekend(timestamp: OffsetDateTime) -> bool {
-    match timestamp.weekday() {
-        Weekday::Friday => timestamp.time() >= time!(15:00),
-        Weekday::Saturday => true,
-        Weekday::Sunday => timestamp.time() < time!(15:00),
-        _ => false,
+pub fn is_eligible_for_rollover(timestamp: OffsetDateTime, network: Network) -> bool {
+    match network {
+        // Returns true if the given date falls in between Friday 15 pm UTC and Sunday 15 pm UTC
+        Network::Bitcoin => match timestamp.weekday() {
+            Weekday::Friday => timestamp.time() >= time!(15:00),
+            Weekday::Saturday => true,
+            Weekday::Sunday => timestamp.time() < time!(15:00),
+            _ => false,
+        },
+        // Returns true if the timestamp is less than 8 hours from now
+        _ => {
+            let midnight = (OffsetDateTime::now_utc().date() + Duration::days(1))
+                .midnight()
+                .assume_utc();
+            (midnight - timestamp) < Duration::hours(8)
+        }
     }
 }
 
 #[cfg(test)]
 mod test {
     use crate::calculate_next_expiry;
-    use crate::is_in_rollover_weekend;
+    use crate::is_eligible_for_rollover;
+    use bdk::bitcoin::Network;
+    use time::Duration;
     use time::OffsetDateTime;
 
     #[test]
-    fn test_is_not_in_rollover_weekend() {
+    fn test_is_not_eligible_for_rollover() {
         // Wed Aug 09 2023 09:30:23 GMT+0000
         let expiry = OffsetDateTime::from_unix_timestamp(1691573423).unwrap();
-        assert!(!is_in_rollover_weekend(expiry));
+        assert!(!is_eligible_for_rollover(expiry, Network::Bitcoin));
     }
 
     #[test]
-    fn test_is_just_in_rollover_weekend_friday() {
+    fn test_is_just_eligible_for_rollover_friday() {
         // Fri Aug 11 2023 15:00:00 GMT+0000
         let expiry = OffsetDateTime::from_unix_timestamp(1691766000).unwrap();
-        assert!(is_in_rollover_weekend(expiry));
+        assert!(is_eligible_for_rollover(expiry, Network::Bitcoin));
 
         // Fri Aug 11 2023 15:00:01 GMT+0000
         let expiry = OffsetDateTime::from_unix_timestamp(1691766001).unwrap();
-        assert!(is_in_rollover_weekend(expiry));
+        assert!(is_eligible_for_rollover(expiry, Network::Bitcoin));
     }
 
     #[test]
-    fn test_is_in_rollover_weekend_saturday() {
+    fn test_is_eligible_for_rollover_saturday() {
         // Sat Aug 12 2023 16:00:00 GMT+0000
         let expiry = OffsetDateTime::from_unix_timestamp(1691856000).unwrap();
-        assert!(is_in_rollover_weekend(expiry));
+        assert!(is_eligible_for_rollover(expiry, Network::Bitcoin));
     }
 
     #[test]
-    fn test_is_just_in_rollover_weekend_sunday() {
+    fn test_is_just_eligible_for_rollover_sunday() {
         // Sun Aug 13 2023 14:59:59 GMT+0000
         let expiry = OffsetDateTime::from_unix_timestamp(1691938799).unwrap();
-        assert!(is_in_rollover_weekend(expiry));
+        assert!(is_eligible_for_rollover(expiry, Network::Bitcoin));
     }
 
     #[test]
-    fn test_is_just_not_in_rollover_weekend_sunday() {
+    fn test_is_just_not_eligible_for_rollover_sunday() {
         // Sun Aug 13 2023 15:00:00 GMT+0000
         let expiry = OffsetDateTime::from_unix_timestamp(1691938800).unwrap();
-        assert!(!is_in_rollover_weekend(expiry));
+        assert!(!is_eligible_for_rollover(expiry, Network::Bitcoin));
 
         // Sun Aug 13 2023 15:00:01 GMT+0000
         let expiry = OffsetDateTime::from_unix_timestamp(1691938801).unwrap();
-        assert!(!is_in_rollover_weekend(expiry));
+        assert!(!is_eligible_for_rollover(expiry, Network::Bitcoin));
     }
 
     #[test]
     fn test_expiry_timestamp_before_friday_15pm() {
         // Wed Aug 09 2023 09:30:23 GMT+0000
         let from = OffsetDateTime::from_unix_timestamp(1691573423).unwrap();
-        let expiry = calculate_next_expiry(from);
+        let expiry = calculate_next_expiry(from, Network::Bitcoin);
 
         // Sun Aug 13 2023 15:00:00 GMT+0000
         assert_eq!(1691938800, expiry.unix_timestamp());
@@ -174,7 +206,7 @@ mod test {
     fn test_expiry_timestamp_just_before_friday_15pm() {
         // Fri Aug 11 2023 14:59:59 GMT+0000
         let from = OffsetDateTime::from_unix_timestamp(1691765999).unwrap();
-        let expiry = calculate_next_expiry(from);
+        let expiry = calculate_next_expiry(from, Network::Bitcoin);
 
         // Sun Aug 13 2023 15:00:00 GMT+0000
         assert_eq!(1691938800, expiry.unix_timestamp());
@@ -184,7 +216,7 @@ mod test {
     fn test_expiry_timestamp_just_after_friday_15pm() {
         // Fri Aug 11 2023 15:00:01 GMT+0000
         let from = OffsetDateTime::from_unix_timestamp(1691766001).unwrap();
-        let expiry = calculate_next_expiry(from);
+        let expiry = calculate_next_expiry(from, Network::Bitcoin);
 
         // Sun Aug 20 2023 15:00:00 GMT+0000
         assert_eq!(1692543600, expiry.unix_timestamp());
@@ -194,7 +226,7 @@ mod test {
     fn test_expiry_timestamp_at_friday_15pm() {
         // Fri Aug 11 2023 15:00:00 GMT+0000
         let from = OffsetDateTime::from_unix_timestamp(1691766000).unwrap();
-        let expiry = calculate_next_expiry(from);
+        let expiry = calculate_next_expiry(from, Network::Bitcoin);
 
         // Sun Aug 20 2023 15:00:00 GMT+0000
         assert_eq!(1692543600, expiry.unix_timestamp());
@@ -204,7 +236,7 @@ mod test {
     fn test_expiry_timestamp_after_sunday_15pm() {
         // Sun Aug 06 2023 16:00:00 GMT+0000
         let from = OffsetDateTime::from_unix_timestamp(1691337600).unwrap();
-        let expiry = calculate_next_expiry(from);
+        let expiry = calculate_next_expiry(from, Network::Bitcoin);
 
         // Sun Aug 13 2023 15:00:00 GMT+0000
         assert_eq!(1691938800, expiry.unix_timestamp());
@@ -212,11 +244,55 @@ mod test {
 
     #[test]
     fn test_expiry_timestamp_on_saturday() {
-        // // Sat Aug 12 2023 16:00:00 GMT+0000
+        // Sat Aug 12 2023 16:00:00 GMT+0000
         let from = OffsetDateTime::from_unix_timestamp(1691856000).unwrap();
-        let expiry = calculate_next_expiry(from);
+        let expiry = calculate_next_expiry(from, Network::Bitcoin);
 
         // Sun Aug 20 2023 15:00:00 GMT+0000
         assert_eq!(1692543600, expiry.unix_timestamp());
+    }
+
+    #[test]
+    fn test_expiry_timestamp_regtest_midnight() {
+        // 12:00 on the current day
+        let timestamp = OffsetDateTime::now_utc().date().midnight() + Duration::hours(12);
+        let expiry = calculate_next_expiry(timestamp.assume_utc(), Network::Regtest);
+
+        let midnight = (OffsetDateTime::now_utc().date() + Duration::days(1))
+            .midnight()
+            .assume_utc();
+
+        assert_eq!(midnight, expiry);
+    }
+
+    #[test]
+    fn test_expiry_timestamp_regtest_next_midnight() {
+        // 20:00 on the current day
+        let timestamp = OffsetDateTime::now_utc().date().midnight() + Duration::hours(20);
+        let expiry = calculate_next_expiry(timestamp.assume_utc(), Network::Regtest);
+
+        let next_midnight = (timestamp.date() + Duration::days(2))
+            .midnight()
+            .assume_utc();
+
+        assert_eq!(next_midnight, expiry);
+    }
+
+    #[test]
+    fn test_is_not_eligable_for_rollover_regtest() {
+        let timestamp = OffsetDateTime::now_utc().date().midnight() + Duration::hours(16);
+        assert!(!is_eligible_for_rollover(
+            timestamp.assume_utc(),
+            Network::Regtest
+        ))
+    }
+
+    #[test]
+    fn test_is_eligable_for_rollover_regtest() {
+        let timestamp = OffsetDateTime::now_utc().date().midnight() + Duration::hours(17);
+        assert!(is_eligible_for_rollover(
+            timestamp.assume_utc(),
+            Network::Regtest
+        ))
     }
 }

--- a/crates/tests-e2e/tests/rollover_position.rs
+++ b/crates/tests-e2e/tests/rollover_position.rs
@@ -1,3 +1,4 @@
+use bitcoin::Network;
 use native::api;
 use native::trade::position;
 use position::PositionState;
@@ -22,7 +23,7 @@ async fn can_rollover_position() {
         .unwrap();
 
     let position = test.app.rx.position().expect("position to exist");
-    let new_expiry = coordinator_commons::calculate_next_expiry(position.expiry);
+    let new_expiry = coordinator_commons::calculate_next_expiry(position.expiry, Network::Bitcoin);
 
     coordinator
         .rollover(&dlc_channel.dlc_channel_id.unwrap())

--- a/mobile/lib/features/trade/application/trade_values_service.dart
+++ b/mobile/lib/features/trade/application/trade_values_service.dart
@@ -41,6 +41,8 @@ class TradeValuesService {
   }
 
   DateTime getExpiryTimestamp() {
-    return DateTime.fromMillisecondsSinceEpoch(rust.api.getExpiryTimestamp() * 1000);
+    String network = const String.fromEnvironment('NETWORK', defaultValue: "regtest");
+    return DateTime.fromMillisecondsSinceEpoch(
+        rust.api.getExpiryTimestamp(network: network) * 1000);
   }
 }

--- a/mobile/lib/features/trade/domain/trade_values.dart
+++ b/mobile/lib/features/trade/domain/trade_values.dart
@@ -109,7 +109,6 @@ class TradeValues {
 
   updatePriceAndQuantity(double? price) {
     this.price = price;
-    // _recalculateMargin();
     _recalculateQuantity();
     _recalculateLiquidationPrice();
     _recalculateFee();
@@ -117,7 +116,6 @@ class TradeValues {
 
   updatePriceAndMargin(double? price) {
     this.price = price;
-    // _recalculateMargin();
     _recalculateMargin();
     _recalculateLiquidationPrice();
     _recalculateFee();

--- a/mobile/native/src/api.rs
+++ b/mobile/native/src/api.rs
@@ -396,8 +396,10 @@ pub fn get_channel_open_fee_estimate_sat() -> Result<u64> {
     Ok(estimate.ceil() as u64)
 }
 
-pub fn get_expiry_timestamp() -> SyncReturn<i64> {
+pub fn get_expiry_timestamp(network: String) -> SyncReturn<i64> {
+    let network = config::api::parse_network(&network);
     SyncReturn(
-        coordinator_commons::calculate_next_expiry(OffsetDateTime::now_utc()).unix_timestamp(),
+        coordinator_commons::calculate_next_expiry(OffsetDateTime::now_utc(), network)
+            .unix_timestamp(),
     )
 }

--- a/mobile/native/src/config/api.rs
+++ b/mobile/native/src/config/api.rs
@@ -41,7 +41,7 @@ impl From<Config> for ConfigInternal {
     }
 }
 
-fn parse_network(network: &str) -> Network {
+pub fn parse_network(network: &str) -> Network {
     match network {
         "signet" => Network::Signet,
         "testnet" => Network::Testnet,


### PR DESCRIPTION
Adds a shorter expiry and rollover cycle for regtest.

Expiry at midnight the same day unless the position is opened during the rollover window. In that case the expiry is calculated to the next day midnight.

Rollover window: 8 hours before expiry.

resolves #1324 