### PR TITLE
feat: also return commit hash and number in version api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Changed expiry to next Sunday 3 pm UTC
 - Automatically rollover if user opens app during rollover weekend
 - Sync position with dlc channel state
+- Extend coordinator's `/api/version` with commit hash and number
 
 ## [1.2.6] - 2023-09-06
 

--- a/coordinator/build.rs
+++ b/coordinator/build.rs
@@ -1,14 +1,15 @@
-// This file is used to generate the environment variables for the Rust analyzer
-// to make autometrics docstrings resolve the chosen Prometheus URL.
-
+use std::process::Command;
 fn main() {
-    // Uncomment the `premetheus_url` line with the desired URL
-    // Note: Reload Rust analyzer after changing the Prometheus URL to regenerate the links
-
-    // regtest URL
-    let prometheus_url = "http://testnet.itchysats.network:9090";
-
-    // local debugging
-    // let prometheus_url = "http://localhost:9090";
-    println!("cargo:rustc-env=PROMETHEUS_URL={prometheus_url}");
+    let output = Command::new("git")
+        .args(["rev-parse", "HEAD"])
+        .output()
+        .expect("To be able to get commit hash");
+    let git_hash = String::from_utf8(output.stdout).expect("To be a valid string");
+    let output = Command::new("git")
+        .args(["rev-parse", "--abbrev-ref", "HEAD"])
+        .output()
+        .expect("To be able to get branch name");
+    let branch_name = String::from_utf8(output.stdout).expect("To be a valid string");
+    println!("cargo:rustc-env=COMMIT_HASH={}", git_hash);
+    println!("cargo:rustc-env=BRANCH_NAME={}", branch_name);
 }

--- a/coordinator/src/routes.rs
+++ b/coordinator/src/routes.rs
@@ -509,6 +509,17 @@ pub async fn get_health() -> Result<Json<String>, AppError> {
     Ok(Json("Server is healthy".to_string()))
 }
 
-pub async fn version() -> Result<Json<String>, AppError> {
-    Ok(Json(env!("CARGO_PKG_VERSION").to_string()))
+#[derive(Serialize)]
+pub struct Version {
+    version: String,
+    commit_hash: String,
+    branch: String,
+}
+
+pub async fn version() -> Result<Json<Version>, AppError> {
+    Ok(Json(Version {
+        version: env!("CARGO_PKG_VERSION").to_string(),
+        commit_hash: env!("COMMIT_HASH").to_string(),
+        branch: env!("BRANCH_NAME").to_string(),
+    }))
 }

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -48,6 +48,7 @@ import 'package:get_10101/features/wallet/wallet_screen.dart';
 import 'package:get_10101/features/wallet/wallet_theme.dart';
 import 'package:get_10101/features/welcome/welcome_screen.dart';
 import 'package:get_10101/ffi.dart' as rust;
+import 'package:get_10101/util/coordinator_version.dart';
 import 'package:get_10101/util/constants.dart';
 import 'package:get_10101/util/environment.dart';
 import 'package:get_10101/util/notifications.dart';
@@ -320,7 +321,7 @@ LogLevel mapLogLevel(String level) {
 
 /// Compare the version of the coordinator with the version of the app
 ///
-/// - If the coordinator is newer, suggest to update the app.k
+/// - If the coordinator is newer, suggest to update the app.
 /// - If the app is newer, log it.
 /// - If the coordinator cannot be reached, show a warning that the app may not function properly.
 Future<void> compareCoordinatorVersion(bridge.Config config) async {
@@ -331,17 +332,17 @@ Future<void> compareCoordinatorVersion(bridge.Config config) async {
     );
 
     final clientVersion = Version.parse(packageInfo.version);
-    final coordinatorVersion = Version.parse(jsonDecode(response.body));
-    FLog.info(text: "Coordinator version: ${coordinatorVersion.toString()}");
+    final coordinatorVersion = CoordinatorVersion.fromJson(jsonDecode(response.body));
+    FLog.info(text: "Coordinator version: ${coordinatorVersion.version.toString()}");
 
-    if (coordinatorVersion > clientVersion) {
+    if (coordinatorVersion.version > clientVersion) {
       FLog.warning(text: "Client out of date. Current version: ${clientVersion.toString()}");
       showDialog(
           context: shellNavigatorKey.currentContext!,
           builder: (context) => AlertDialog(
                   title: const Text("Update available"),
                   content: Text("A new version of 10101 is available: "
-                      "${coordinatorVersion.toString()}.\n\n"
+                      "${coordinatorVersion.version.toString()}.\n\n"
                       "Please note that if you do not update 10101, the app"
                       " may not function properly."),
                   actions: [
@@ -350,8 +351,8 @@ Future<void> compareCoordinatorVersion(bridge.Config config) async {
                       child: const Text('OK'),
                     ),
                   ]));
-    } else if (coordinatorVersion < clientVersion) {
-      FLog.warning(text: "10101 is newer than LSP: ${coordinatorVersion.toString()}");
+    } else if (coordinatorVersion.version < clientVersion) {
+      FLog.warning(text: "10101 is newer than LSP: ${coordinatorVersion.version.toString()}");
     } else {
       FLog.info(text: "Client is up to date: ${clientVersion.toString()}");
     }

--- a/mobile/lib/util/coordinator_version.dart
+++ b/mobile/lib/util/coordinator_version.dart
@@ -1,0 +1,9 @@
+import 'package:version/version.dart';
+
+class CoordinatorVersion {
+  final Version version;
+
+  CoordinatorVersion(this.version);
+
+  CoordinatorVersion.fromJson(Map<String, dynamic> json) : version = Version.parse(json['version']);
+}


### PR DESCRIPTION
Useful to figure out what exact version the coordinator is running. 

Note: breaking change for old clients but I guess we can live with that. It will show a warning that the coordinator is not reachable until they upgrade