### PR TITLE
chore: Increase websocket reconnect timeout

### DIFF
--- a/mobile/native/src/orderbook.rs
+++ b/mobile/native/src/orderbook.rs
@@ -23,7 +23,9 @@ use tokio::runtime::Runtime;
 use tokio::sync::watch;
 use uuid::Uuid;
 
-const WS_RECONNECT_TIMEOUT: Duration = Duration::from_secs(2);
+/// The reconnect timeout should be high enough for the coordinator to get ready. If its too early
+/// we may not be ready process messages which require dlc actions.
+const WS_RECONNECT_TIMEOUT: Duration = Duration::from_secs(5);
 const EXPIRED_ORDER_PRUNING_INTERVAL: Duration = Duration::from_secs(30);
 
 pub fn subscribe(


### PR DESCRIPTION
If we are reconnecting too eagerly we run into an issue during rollover windows.

If the user has the app open while "moving" into the rollover window and the coordinator restarts. The coordinator will identify that the users position needs to be rolled over upon a reconnect on the websocket, but the coordinator might not yet be ready to do that yet.

I guess this issue is not happening on the app side, as the app is connecting to the coordinator before it is subscribing to the websocket.

By increasing the websocket reconnect timeout to 5 seconds the `keep_connected` tasks should have enough time (every second) to reconnect to the coordinator.