### PR TITLE
fix: Do not delete orders

### DIFF
--- a/coordinator/src/orderbook/routes.rs
+++ b/coordinator/src/orderbook/routes.rs
@@ -147,21 +147,6 @@ pub async fn put_order(
     Ok(Json(order))
 }
 
-pub async fn delete_order(
-    Path(order_id): Path<Uuid>,
-    State(state): State<Arc<AppState>>,
-) -> Result<Json<usize>, AppError> {
-    let mut conn = get_db_connection(&state)?;
-    let deleted = orderbook::db::orders::delete_with_id(&mut conn, order_id)
-        .map_err(|e| AppError::InternalServerError(format!("Failed to delete order: {e:#}")))?;
-    if deleted > 0 {
-        let sender = state.tx_price_feed.clone();
-        update_pricefeed(Message::DeleteOrder(order_id), sender);
-    }
-
-    Ok(Json(deleted))
-}
-
 pub async fn websocket_handler(
     ws: WebSocketUpgrade,
     State(state): State<Arc<AppState>>,

--- a/coordinator/src/orderbook/tests/sample_test.rs
+++ b/coordinator/src/orderbook/tests/sample_test.rs
@@ -36,12 +36,6 @@ async fn crud_test() {
 
     let order = orders::set_is_taken(&mut conn, order.id, true).unwrap();
     assert_eq!(order.order_state, OrderState::Taken);
-
-    let deleted = orders::delete_with_id(&mut conn, order.id).unwrap();
-    assert_eq!(deleted, 1);
-
-    let orders = orders::all(&mut conn, true).unwrap();
-    assert!(orders.is_empty());
 }
 
 #[tokio::test]

--- a/coordinator/src/routes.rs
+++ b/coordinator/src/routes.rs
@@ -12,7 +12,6 @@ use crate::admin::sign_message;
 use crate::db::user;
 use crate::message::NewUserMessage;
 use crate::node::Node;
-use crate::orderbook::routes::delete_order;
 use crate::orderbook::routes::get_order;
 use crate::orderbook::routes::get_orders;
 use crate::orderbook::routes::post_order;
@@ -117,7 +116,7 @@ pub fn router(
         .route("/api/orderbook/orders", get(get_orders).post(post_order))
         .route(
             "/api/orderbook/orders/:order_id",
-            get(get_order).put(put_order).delete(delete_order),
+            get(get_order).put(put_order),
         )
         .route("/api/orderbook/websocket", get(websocket_handler))
         .route("/api/trade", post(post_trade))

--- a/maker/src/trading/mod.rs
+++ b/maker/src/trading/mod.rs
@@ -60,10 +60,6 @@ pub async fn run(
             let _ = bitmex_pricefeed_tx.send(ServiceStatus::Online);
             tracing::debug!("Received new quote {quote:?}");
 
-            // Clear stale orders. They should have expired by now.
-            for order in orders.iter() {
-                delete_order(&orderbook_client, orderbook_url, order).await;
-            }
             orders.clear();
 
             for _i in 0..concurrent_orders {
@@ -112,15 +108,4 @@ async fn add_order(
             err
         })
         .ok()
-}
-
-async fn delete_order(
-    orderbook_client: &OrderbookClient,
-    orderbook_url: &Url,
-    last_order: &OrderResponse,
-) {
-    let order_id = last_order.id;
-    if let Err(err) = orderbook_client.delete_order(orderbook_url, order_id).await {
-        tracing::error!("Failed deleting old order `{order_id}` because of {err:#}");
-    }
 }

--- a/maker/src/trading/orderbook_http_client.rs
+++ b/maker/src/trading/orderbook_http_client.rs
@@ -3,7 +3,6 @@ use anyhow::Result;
 use orderbook_commons::NewOrder;
 use orderbook_commons::OrderResponse;
 use reqwest::Url;
-use uuid::Uuid;
 
 pub struct OrderbookClient {
     client: reqwest::Client,
@@ -29,19 +28,6 @@ impl OrderbookClient {
             Ok(response)
         } else {
             tracing::error!("Could not create new order");
-            bail!("Could not create new order ")
-        }
-    }
-
-    pub async fn delete_order(&self, url: &Url, order_id: Uuid) -> Result<()> {
-        let url = url.join(format!("/api/orderbook/orders/{order_id}").as_str())?;
-
-        let response = self.client.delete(url).send().await?;
-
-        if response.status().as_u16() == 200 {
-            Ok(())
-        } else {
-            tracing::error!("Could not delete new order");
             bail!("Could not create new order ")
         }
     }


### PR DESCRIPTION
Instead of deleting orders, I propose to keep them in state `Failed`. That might blow up our database, but we could at any time delete `Failed` orders if we want to.

To be consistent with the existing implementation I am also sending a `DeleteOrder` event to update the prices for the apps.

fixes #1347 