### PR TITLE
fix: Ensure the fcm token is stored to the users table

### DIFF
--- a/coordinator/migrations/2023-09-22-145256_unique_pubkey/down.sql
+++ b/coordinator/migrations/2023-09-22-145256_unique_pubkey/down.sql
@@ -1,0 +1,3 @@
+-- This file should undo anything in `up.sql`
+ALTER TABLE users
+    DROP CONSTRAINT unique_pubkey;

--- a/coordinator/migrations/2023-09-22-145256_unique_pubkey/up.sql
+++ b/coordinator/migrations/2023-09-22-145256_unique_pubkey/up.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "users"
+    ADD CONSTRAINT unique_pubkey UNIQUE (pubkey);
+

--- a/crates/coordinator-commons/src/lib.rs
+++ b/crates/coordinator-commons/src/lib.rs
@@ -77,12 +77,6 @@ pub struct LspConfig {
     /// The fee rate to be used for the DLC contracts in sats/vbyte
     pub contract_tx_fee_rate: u64,
 }
-/// FCM token update parameters
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct TokenUpdateParams {
-    pub pubkey: String,
-    pub fcm_token: String,
-}
 
 /// Calculates the next expiry timestamp based on the given timestamp and the network.
 pub fn calculate_next_expiry(timestamp: OffsetDateTime, network: Network) -> OffsetDateTime {

--- a/crates/orderbook-client/examples/authenticated.rs
+++ b/crates/orderbook-client/examples/authenticated.rs
@@ -26,7 +26,8 @@ async fn main() -> Result<Never> {
 
     loop {
         let (_, mut stream) =
-            orderbook_client::subscribe_with_authentication(url.clone(), &authenticate).await?;
+            orderbook_client::subscribe_with_authentication(url.clone(), &authenticate, None)
+                .await?;
 
         loop {
             match stream.try_next().await {

--- a/crates/orderbook-commons/src/lib.rs
+++ b/crates/orderbook-commons/src/lib.rs
@@ -111,8 +111,13 @@ pub struct OrderResponse {
 
 #[derive(Serialize, Clone, Deserialize, Debug)]
 pub enum OrderbookRequest {
-    Authenticate(Signature),
-    LimitOrderFilledMatches { trader_id: PublicKey },
+    Authenticate {
+        fcm_token: Option<String>,
+        signature: Signature,
+    },
+    LimitOrderFilledMatches {
+        trader_id: PublicKey,
+    },
 }
 
 impl TryFrom<OrderbookRequest> for tungstenite::Message {

--- a/crates/tests-e2e/src/app.rs
+++ b/crates/tests-e2e/src/app.rs
@@ -29,6 +29,7 @@ pub async fn run_app() -> AppHandle {
                 test_config(),
                 app_dir,
                 seed_dir,
+                "".to_string(),
                 native::api::IncludeBacktraceOnPanic::No,
             )
             .expect("Could not run app")

--- a/maker/src/orderbook_ws.rs
+++ b/maker/src/orderbook_ws.rs
@@ -84,7 +84,8 @@ impl Client {
             loop {
                 let url = url.clone();
                 let authenticate = auth_fn;
-                match orderbook_client::subscribe_with_authentication(url, authenticate).await {
+                match orderbook_client::subscribe_with_authentication(url, authenticate, None).await
+                {
                     Ok((mut sink, mut stream)) => {
                         // We request the filled matches for all our limit orders periodically.
                         let (task, _handle) = async move {

--- a/mobile/native/src/api.rs
+++ b/mobile/native/src/api.rs
@@ -227,10 +227,21 @@ pub fn subscribe(stream: StreamSink<event::api::Event>) {
 }
 
 /// Wrapper for Flutter purposes - can throw an exception.
-pub fn run_in_flutter(config: Config, app_dir: String, seed_dir: String) -> Result<()> {
+pub fn run_in_flutter(
+    config: Config,
+    app_dir: String,
+    seed_dir: String,
+    fcm_token: String,
+) -> Result<()> {
     let result = if !IS_INITIALISED.try_get().unwrap_or(&false) {
-        run(config, app_dir, seed_dir, IncludeBacktraceOnPanic::Yes)
-            .context("Failed to start the backend")
+        run(
+            config,
+            app_dir,
+            seed_dir,
+            fcm_token,
+            IncludeBacktraceOnPanic::Yes,
+        )
+        .context("Failed to start the backend")
     } else {
         Ok(())
     };
@@ -248,6 +259,7 @@ pub fn run(
     config: Config,
     app_dir: String,
     seed_dir: String,
+    fcm_token: String,
     backtrace_on_panic: IncludeBacktraceOnPanic,
 ) -> Result<()> {
     if backtrace_on_panic == IncludeBacktraceOnPanic::Yes {
@@ -271,7 +283,7 @@ pub fn run(
 
     let (_health, tx) = health::Health::new(config, runtime);
 
-    orderbook::subscribe(ln_dlc::get_node_key(), runtime, tx.orderbook)
+    orderbook::subscribe(ln_dlc::get_node_key(), runtime, tx.orderbook, fcm_token)
 }
 
 pub fn get_unused_address() -> SyncReturn<String> {
@@ -336,12 +348,6 @@ pub fn get_seed_phrase() -> SyncReturn<Vec<String>> {
 #[tokio::main(flavor = "current_thread")]
 pub async fn register_beta(email: String) -> Result<()> {
     users::register_beta(email).await
-}
-
-/// Send the Firebase token to the LSP for push notifications
-#[tokio::main(flavor = "current_thread")]
-pub async fn update_fcm_token(fcm_token: String) -> Result<()> {
-    users::update_fcm_token(fcm_token).await
 }
 
 pub struct LightningInvoice {

--- a/mobile/native/src/orderbook.rs
+++ b/mobile/native/src/orderbook.rs
@@ -30,6 +30,7 @@ pub fn subscribe(
     secret_key: SecretKey,
     runtime: &Runtime,
     orderbook_status: watch::Sender<ServiceStatus>,
+    fcm_token: String,
 ) -> Result<()> {
     runtime.spawn(async move {
         let url = format!(
@@ -80,7 +81,7 @@ pub fn subscribe(
             let url = url.clone();
             let authenticate = authenticate;
             let (_, mut stream) =
-                match orderbook_client::subscribe_with_authentication(url, authenticate).await {
+                match orderbook_client::subscribe_with_authentication(url, authenticate, Some(fcm_token.to_string())).await {
                     Ok(split_stream) => split_stream,
                     Err(e) => {
                         tracing::error!("Could not start up orderbook client: {e:#}");

--- a/mobile/native/src/trade/users/mod.rs
+++ b/mobile/native/src/trade/users/mod.rs
@@ -5,26 +5,6 @@ use anyhow::anyhow;
 use anyhow::Context;
 use anyhow::Result;
 use coordinator_commons::RegisterParams;
-use coordinator_commons::TokenUpdateParams;
-
-pub async fn update_fcm_token(fcm_token: String) -> Result<()> {
-    let token_update = TokenUpdateParams {
-        pubkey: ln_dlc::get_node_info()?.pubkey.to_string(),
-        fcm_token,
-    };
-
-    reqwest_client()
-        .post(format!(
-            "http://{}/api/fcm_token",
-            config::get_http_endpoint()
-        ))
-        .json(&token_update)
-        .send()
-        .await
-        .context("Failed to update FCM token with coordinator")?
-        .error_for_status()?;
-    Ok(())
-}
 
 /// Enroll the user in the beta program
 pub async fn register_beta(email: String) -> Result<()> {


### PR DESCRIPTION
This change addresses a couple of things

1. The fcm token update required the node to be up, but did not wait for the backend to start. Thus it was very likely that we were running into a race condition with the node not yet being initialized and the fcm token not being updated to the database.
2. Upon initial registration we call the register endpoint to create the user. In the background the fcm token update api was called. It was very likely that the user was not faster than the fcm token update, thus the user record did not exist at the time the fcm token is being updated. (this would have been fixed at the second start of the app)

I opted to remove the fcm token update api alltogether and rather send the `fcm token` with our initial `OrderbookMsg::Authenticate`. This ensures firstly, that the node has been successfully started before sending the `fcm_token` and secondly protects the api from being misused by an unauthenticated request. (note, we may want to switch other apis to a similar interaction pattern)

I also opted to ignore the scenario where the `fcm_token` could change during runtime. Judging from https://firebase.google.com/docs/cloud-messaging/manage-tokens the freshness threshold is two months, so I guess we should be good given that the `fcm_token` will be updated on every start of the app.

Lastly I adapted the user email insert and fcm token update to upserts to deal with a potential conflict that either update could come first. This way we ensure we will not loose the email nor the `fcm_token` in any race condition.

fixes #1348 