### PR TITLE
fix: Send push notification for expired position if user is not online

### DIFF
--- a/coordinator/src/bin/coordinator.rs
+++ b/coordinator/src/bin/coordinator.rs
@@ -208,16 +208,18 @@ async fn main() -> Result<()> {
 
     let (tx_price_feed, _rx) = broadcast::channel(100);
 
-    let (_handle, auth_users_notifier) =
-        spawn_delivering_messages_to_authenticated_users(tx_user_feed.clone());
-
     let notification_service = NotificationService::new(opts.fcm_api_key.clone());
+
+    let (_handle, auth_users_notifier) = spawn_delivering_messages_to_authenticated_users(
+        pool.clone(),
+        notification_service.get_sender(),
+        tx_user_feed.clone(),
+    );
 
     let (_handle, trading_sender) = trading::start(
         pool.clone(),
         tx_price_feed.clone(),
         auth_users_notifier.clone(),
-        notification_service.get_sender(),
         network,
     );
     let _handle = async_match::monitor(

--- a/coordinator/src/node/rollover.rs
+++ b/coordinator/src/node/rollover.rs
@@ -101,6 +101,10 @@ async fn check_if_eligible_for_rollover(
             let message = OrderbookMessage::TraderMessage {
                 trader_id,
                 message: Message::Rollover,
+                // Ignore push notifying the user for that message as this is anyways only triggered
+                // when the user just connected to the websocket and we have a separate task that is
+                // push notifying the user if the rollover window is about to start.
+                notification: None,
             };
             if let Err(e) = notifier.send(message).await {
                 tracing::debug!("Failed to notify trader. Error: {e:#}");

--- a/coordinator/src/orderbook/async_match.rs
+++ b/coordinator/src/orderbook/async_match.rs
@@ -69,7 +69,14 @@ async fn process_pending_match(
             OrderReason::Expired => Message::AsyncMatch { order, filled_with },
         };
 
-        let msg = OrderbookMessage::TraderMessage { trader_id, message };
+        // Sending no optional push notification as this is only executed if the user just
+        // registered on the websocket. So we can assume that the user is still online.
+        let notification = None;
+        let msg = OrderbookMessage::TraderMessage {
+            trader_id,
+            message,
+            notification,
+        };
         if let Err(e) = notifier.send(msg).await {
             tracing::error!("Failed to send notification. Error: {e:#}");
         }

--- a/coordinator/src/orderbook/trading.rs
+++ b/coordinator/src/orderbook/trading.rs
@@ -1,7 +1,4 @@
-use crate::db::user;
 use crate::message::OrderbookMessage;
-use crate::notifications::FcmToken;
-use crate::notifications::Notification;
 use crate::notifications::NotificationKind;
 use crate::orderbook::db::matches;
 use crate::orderbook::db::orders;
@@ -90,7 +87,6 @@ pub fn start(
     pool: Pool<ConnectionManager<PgConnection>>,
     tx_price_feed: broadcast::Sender<Message>,
     notifier: mpsc::Sender<OrderbookMessage>,
-    notification_sender: mpsc::Sender<Notification>,
     network: Network,
 ) -> (RemoteHandle<Result<()>>, mpsc::Sender<NewOrderMessage>) {
     let (sender, mut receiver) = mpsc::channel::<NewOrderMessage>(NEW_ORDERS_BUFFER_SIZE);
@@ -101,14 +97,12 @@ pub fn start(
                 let mut conn = pool.get()?;
                 let tx_price_feed = tx_price_feed.clone();
                 let notifier = notifier.clone();
-                let notification_sender = notification_sender.clone();
                 async move {
                     let new_order = new_order_msg.new_order;
                     let result = process_new_order(
                         &mut conn,
                         notifier,
                         tx_price_feed,
-                        notification_sender,
                         new_order,
                         new_order_msg.order_reason,
                         network,
@@ -141,7 +135,6 @@ async fn process_new_order(
     conn: &mut PgConnection,
     notifier: mpsc::Sender<OrderbookMessage>,
     tx_price_feed: broadcast::Sender<Message>,
-    notification_sender: mpsc::Sender<Notification>,
     new_order: NewOrder,
     order_reason: OrderReason,
     network: Network,
@@ -224,29 +217,22 @@ async fn process_new_order(
                 },
             };
 
-            let msg = OrderbookMessage::TraderMessage { trader_id, message };
+            let notification = match &order.order_reason {
+                OrderReason::Expired => Some(NotificationKind::PositionExpired),
+                OrderReason::Manual => None,
+            };
+            let msg = OrderbookMessage::TraderMessage {
+                trader_id,
+                message,
+                notification,
+            };
             let order_state = match notifier.send(msg).await {
                 Ok(()) => {
                     tracing::debug!(%trader_id, order_id, "Successfully notified trader");
                     OrderState::Matched
                 }
                 Err(e) => {
-                    tracing::warn!(%trader_id, order_id, "{e:#}");
-
-                    if let Some(user) = user::by_id(conn, trader_id.to_string())? {
-                        tracing::debug!(%trader_id, order_id, "Sending push notification to user");
-
-                        if let Ok(fcm_token) = FcmToken::new(user.fcm_token) {
-                            notification_sender
-                                .send(Notification {
-                                    user_fcm_token: fcm_token,
-                                    notification_kind: NotificationKind::PositionExpired,
-                                })
-                                .await?;
-                        }
-                    } else {
-                        tracing::warn!(%trader_id, order_id, "User has no FCM token");
-                    }
+                    tracing::warn!(%trader_id, order_id, "Failed to send trader message. Error: {e:#}");
 
                     if order.order_type == OrderType::Limit {
                         // FIXME: The maker is currently not connected to the web socket so we


### PR DESCRIPTION
Before we were only sending a push notification if the message was not successfully send via the channel. Which is basically never the case.