### PR TITLE
Fund maker and open channel

### DIFF
--- a/justfile
+++ b/justfile
@@ -96,6 +96,7 @@ run args="":
       --dart-define="COMMIT=$(git rev-parse HEAD)" \
       --dart-define="BRANCH=$(git rev-parse --abbrev-ref HEAD)" \
       --dart-define="REGTEST_FAUCET=http://localhost:8080" \
+      --dart-define="REGTEST_MAKER_FAUCET=http://localhost:18000/api/pay-invoice" \
       --dart-define="HEALTH_CHECK_INTERVAL_SECONDS=2"
 
 # Run against our public regtest server
@@ -123,6 +124,7 @@ run-local-android args="":
         --dart-define="ESPLORA_ENDPOINT=http://${LOCAL_IP}:3000" \
         --dart-define="COORDINATOR_P2P_ENDPOINT=02dd6abec97f9a748bf76ad502b004ce05d1b2d1f43a9e76bd7d85e767ffb022c9@${LOCAL_IP}:9045" \
         --dart-define="REGTEST_FAUCET=http://${LOCAL_IP}:8080" \
+        --dart-define="REGTEST_MAKER_FAUCET=http://${LOCAL_IP}:18000/api/pay-invoice" \
         --dart-define="COORDINATOR_PORT_HTTP=8000" \
         --dart-define="ORACLE_ENDPOINT=http://${LOCAL_IP}:8081" \
         --dart-define="ORACLE_PUBKEY=16f88cf7d21e6c0f46bcbc983a4e3b19726c6c98858cc31c83551a88fde171c0" \

--- a/maker/src/routes.rs
+++ b/maker/src/routes.rs
@@ -61,9 +61,17 @@ pub fn router(
         .route("/api/pay-invoice/:invoice", post(pay_invoice))
         .route("/api/sync-on-chain", post(sync_on_chain))
         .route("/api/position", get(get_position))
+        .route("/api/node", get(get_node_info))
         .route("/metrics", get(get_metrics))
         .route("/health", get(get_health))
         .with_state(app_state)
+}
+
+pub async fn get_node_info(
+    State(app_state): State<Arc<AppState>>,
+) -> Result<Json<NodeInfo>, AppError> {
+    let node_info = app_state.node.info;
+    Ok(Json(node_info))
 }
 
 pub async fn connect_to_peer(


### PR DESCRIPTION
This comes handy if LND doesn't work as expected.

You can then use `curl -X POST http://localhost:18000/api/pay-invoice/putinvoicehere` to pay any invoices and fund the app. 

Or you can use the new `fund with maker button` :) 

![image](https://github.com/get10101/10101/assets/224613/6627b3a3-73a5-463e-8e15-908d241547af)
