### PR TITLE
fix: Wait for firebase to initialise before geting the fcm token

### DIFF
--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -69,7 +69,8 @@ void main() async {
 
   setupFlutterLogs();
 
-  initFirebase();
+  await initFirebase();
+  FLog.info(text: "Initialised firebase!");
 
   const ChannelInfoService channelInfoService = ChannelInfoService();
   var tradeValuesService = TradeValuesService();


### PR DESCRIPTION
It can happen that we run into a race condition where we are trying to get a firebase token but firebase is not yet initialised. Awaiting the firebase initialisation should fix the issue.