### PR TITLE
fix: wait for wallet sync in refresh indicator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Automatically rollover if user opens app during rollover weekend
 - Sync position with dlc channel state
 - Extend coordinator's `/api/version` with commit hash and number
+- When pulling down wallet sync it waits until the sync is finished
 
 ## [1.2.6] - 2023-09-06
 

--- a/mobile/lib/features/wallet/wallet_screen.dart
+++ b/mobile/lib/features/wallet/wallet_screen.dart
@@ -119,6 +119,7 @@ class _WalletScreenState extends State<WalletScreen> {
       body: RefreshIndicator(
         onRefresh: () async {
           await walletChangeNotifier.refreshWalletInfo();
+          await walletChangeNotifier.waitForSyncToComplete();
         },
         child: Container(
           margin: const EdgeInsets.only(top: 7.0),


### PR DESCRIPTION
We made the wallet sync async and hence, the frontend did not wait for it to complete. To overcome this we busy check if the wallet change notifier was called and updated.

resolves #1346

syncing against regtest machine which takes ~4 seconds.
https://github.com/get10101/10101/assets/224613/d5fb6bd9-9be7-4a6a-8dd8-750d87682d28

