### PR TITLE
Add in-app waiting list

### DIFF
--- a/coordinator/migrations/2023-09-22-222049_create_waitlist/down.sql
+++ b/coordinator/migrations/2023-09-22-222049_create_waitlist/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE waitlist;

--- a/coordinator/migrations/2023-09-22-222049_create_waitlist/up.sql
+++ b/coordinator/migrations/2023-09-22-222049_create_waitlist/up.sql
@@ -1,0 +1,13 @@
+-- Create the waitlist table
+CREATE TABLE waitlist (
+    email TEXT PRIMARY KEY,
+    created_timestamp TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    allowed BOOLEAN NOT NULL DEFAULT FALSE,
+    allowed_timestamp TIMESTAMP WITH TIME ZONE
+);
+
+-- Copy distinct emails from users table to the wait-list and set allowed to true
+-- as they're already our users
+INSERT INTO waitlist (email, allowed)
+SELECT DISTINCT email, TRUE FROM users
+WHERE email <> '' AND email IS NOT NULL;

--- a/coordinator/src/db/mod.rs
+++ b/coordinator/src/db/mod.rs
@@ -7,3 +7,4 @@ pub mod spendable_outputs;
 pub mod trades;
 pub mod transactions;
 pub mod user;
+pub mod waitlist;

--- a/coordinator/src/db/waitlist.rs
+++ b/coordinator/src/db/waitlist.rs
@@ -1,0 +1,64 @@
+use crate::schema::waitlist;
+use diesel::prelude::*;
+use serde::Serialize;
+use time::OffsetDateTime;
+
+#[derive(Queryable, Insertable, Identifiable, Debug, PartialEq, Clone, Serialize)]
+#[diesel(table_name = waitlist)]
+#[diesel(primary_key(email))]
+pub struct WaitlistEntry {
+    pub email: String,
+    /// Timestamp when the user was added to the waitlist
+    pub created_timestamp: OffsetDateTime,
+    /// Is the user allowed to access the app
+    pub allowed: bool,
+    /// Timestamp when the user was allowed access
+    pub allowed_timestamp: Option<OffsetDateTime>,
+}
+
+impl WaitlistEntry {
+    pub fn new(email: String, allowed: bool) -> Self {
+        let allowed_timestamp = if allowed {
+            Some(OffsetDateTime::now_utc())
+        } else {
+            None
+        };
+
+        Self {
+            email,
+            created_timestamp: OffsetDateTime::now_utc(),
+            allowed,
+            allowed_timestamp,
+        }
+    }
+
+    pub fn allow(&mut self) {
+        self.allowed = true;
+        self.allowed_timestamp = Some(OffsetDateTime::now_utc());
+    }
+}
+
+/// Insert or modify a waitlist entry
+pub fn upsert(conn: &mut PgConnection, entry: WaitlistEntry) -> QueryResult<WaitlistEntry> {
+    diesel::insert_into(waitlist::table)
+        .values(entry.clone())
+        .on_conflict(waitlist::email)
+        .do_update()
+        .set((
+            waitlist::allowed.eq(entry.allowed),
+            waitlist::allowed_timestamp.eq(entry.allowed_timestamp),
+        ))
+        .get_result(conn)
+}
+
+pub fn with_email(conn: &mut PgConnection, email: &str) -> QueryResult<Option<WaitlistEntry>> {
+    Ok(waitlist::table
+        .filter(waitlist::email.eq(email))
+        .load::<WaitlistEntry>(conn)?
+        .into_iter()
+        .next())
+}
+
+pub fn all(conn: &mut PgConnection) -> QueryResult<Vec<WaitlistEntry>> {
+    waitlist::table.load::<WaitlistEntry>(conn)
+}

--- a/coordinator/src/schema.rs
+++ b/coordinator/src/schema.rs
@@ -213,6 +213,15 @@ diesel::table! {
     }
 }
 
+diesel::table! {
+    waitlist (email) {
+        email -> Text,
+        created_timestamp -> Timestamptz,
+        allowed -> Bool,
+        allowed_timestamp -> Nullable<Timestamptz>,
+    }
+}
+
 diesel::joinable!(trades -> positions (position_id));
 
 diesel::allow_tables_to_appear_in_same_query!(
@@ -226,4 +235,5 @@ diesel::allow_tables_to_appear_in_same_query!(
     trades,
     transactions,
     users,
+    waitlist,
 );

--- a/coordinator/src/settings.rs
+++ b/coordinator/src/settings.rs
@@ -15,6 +15,9 @@ const SETTINGS_FILE_NAME: &str = "coordinator-settings.toml";
 /// Top-level settings.
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct Settings {
+    /// If set to true, new users are allow to trade on the platform without
+    /// previously being on the waitlist.
+    pub auto_allow_new_users: bool,
     pub jit_channels_enabled: bool,
     pub new_positions_enabled: bool,
     /// Defines the sats/vbyte to be used for all transactions within the sub-channel
@@ -40,6 +43,7 @@ pub struct Settings {
 impl Default for Settings {
     fn default() -> Self {
         Self {
+            auto_allow_new_users: false,
             jit_channels_enabled: true,
             new_positions_enabled: true,
             contract_tx_fee_rate: 9,

--- a/crates/coordinator-commons/src/lib.rs
+++ b/crates/coordinator-commons/src/lib.rs
@@ -64,7 +64,7 @@ pub struct RegisterParams {
 
 impl RegisterParams {
     pub fn is_valid(&self) -> bool {
-        self.email.is_some() || self.nostr.is_some()
+        self.email.is_some()
     }
 }
 

--- a/justfile
+++ b/justfile
@@ -169,16 +169,37 @@ wipe-app:
     #!/usr/bin/env bash
     set -euxo pipefail
     echo "Wiping native 10101 app"
+
+    # Locate macOS 10101 application directory if it exists
+    if [ -d "/Users/mariusz/Library/Containers/" ]; then
+        FOUND_DIR=""
+        for dir in $HOME/Library/Containers/*/Data/Library/Application\ Support/finance.get10101.app; do
+            if [ -d "$dir" ]; then
+                FOUND_DIR="$dir"
+                break  # Exit loop after the first match. Remove if you want all matches.
+            fi
+        done
+        # default to dummy dir if nothing got found to ensure nothing unnecessary gets deleted
+        MACOS_PATH="${FOUND_DIR:-/path/to/dummy/directory}"
+    fi
+
+    # If no path was found, use a dummy path to avoid errors
+    if [[ ! $MACOS_PATH || ! ${MACOS_PATH//[[:space:]]/} ]]; then
+        echo "no macos path found, setting dummy value" 
+        MACOS_PATH="/path/to/dummy/directory"
+    fi
+
     # Array of possible app data directories (OS dependent)
     directories=(
       "$HOME/Library/Containers/finance.get10101.app/Data/Library/Application Support/finance.get10101.app"
       "$HOME/Library/Containers/finance.get10101.app/"
+      "$MACOS_PATH"
       "$HOME/.local/share/finance.get10101.app/"
     )
     # Remove all possible app data directories
     for dir in "${directories[@]}"
     do
-        if [ -d "$dir" ]; then
+        if [[ -d "$dir" ]]; then
             echo "App data directory ${dir} exists, removing it now..."
             rm -r "$dir"
         else

--- a/mobile/lib/common/settings_screen.dart
+++ b/mobile/lib/common/settings_screen.dart
@@ -5,6 +5,8 @@ import 'package:f_logs/f_logs.dart';
 import 'package:flutter/material.dart';
 import 'package:get_10101/common/scrollable_safe_area.dart';
 import 'package:get_10101/bridge_generated/bridge_definitions.dart' as bridge;
+import 'package:get_10101/common/snack_bar.dart';
+import 'package:get_10101/util/preferences.dart';
 import 'package:intl/intl.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:provider/provider.dart';
@@ -72,6 +74,13 @@ class _SettingsScreenState extends State<SettingsScreen> {
                     rust.api.forceCloseChannel();
                   },
                   child: const Text("Force-close channel")),
+              ElevatedButton(
+                  onPressed: () async {
+                    final messenger = ScaffoldMessenger.of(context);
+                    await Preferences.instance.clear();
+                    showSnackBar(messenger, "Shared preferences cleared");
+                  },
+                  child: const Text("Clear shared preferences")),
             ],
           ),
         ),

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -216,6 +216,9 @@ class _TenTenOneAppState extends State<TenTenOneApp> {
         if (!hasEmailAddress) {
           FLog.info(text: "adding the email...");
           return WelcomeScreen.route;
+        } else {
+          await Preferences.instance.getEmailAddress().then(
+              (value) => FLog.info(text: "Email already added, skipping welcome screen: $value."));
         }
 
         return null;

--- a/mobile/lib/util/preferences.dart
+++ b/mobile/lib/util/preferences.dart
@@ -1,3 +1,4 @@
+import 'package:f_logs/model/flog/flog.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 class Preferences {
@@ -31,5 +32,11 @@ class Preferences {
   Future<bool> hasEmailAddress() async {
     var email = await getEmailAddress();
     return email.isNotEmpty;
+  }
+
+  Future<void> clear() async {
+    final preferences = await SharedPreferences.getInstance();
+    preferences.clear();
+    FLog.info(text: "Cleared shared preferences");
   }
 }


### PR DESCRIPTION
Check access to the waitlist during in-app registration and prevent from using
the app if they're not allowed.

- If the user is not on the waitlist, add them and display a message that they
  do not have access yet, pointing to our Telegram as well.
- if the user is on the waitlist, check whether they're allowed to access.

Only after successful admission store the email and allow

Add a coordinator setting to allow auto-adding new users (to allow throttling
users during open beta, allowing us to stay within our liquidity constraints).

Add an API to the coordinator to query the waitlist and to add a user to the
waitlist (with options to enable/disable access).

The waitlist is stored as a `waitlist` table in coordinator database, initially
populated from the `users` table to ensure all our current users have immediate access.

Note: I didn't try to go too fancy initially. In the futurue, we could e.g.
     unsubscribe from the orderbook stream if we just want to disable the
     trading functionality.