### PR TITLE
fix: Catch Firebase exception if cannot fetch fcm_token

### DIFF
--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -549,8 +549,13 @@ Future<void> runBackend(bridge.Config config) async {
     appDir = seedDir;
   }
 
-  FirebaseMessaging messaging = FirebaseMessaging.instance;
-  final fcmToken = await messaging.getToken();
+  String fcmToken;
+  try {
+    fcmToken = await FirebaseMessaging.instance.getToken().then((value) => value ?? '');
+  } catch (e) {
+    FLog.error(text: "Error fetching FCM token: $e");
+    fcmToken = '';
+  }
 
   FLog.info(text: "App data will be stored in: $appDir");
   FLog.info(text: "Seed data will be stored in: $seedDir");

--- a/mobile/native/src/orderbook.rs
+++ b/mobile/native/src/orderbook.rs
@@ -79,11 +79,18 @@ pub fn subscribe(
             })
         };
 
+        let fcm_token = if fcm_token.is_empty() {
+            None
+        } else {
+            Some(fcm_token)
+        };
+
         loop {
             let url = url.clone();
             let authenticate = authenticate;
+            let fcm_token = fcm_token.clone();
             let (_, mut stream) =
-                match orderbook_client::subscribe_with_authentication(url, authenticate, Some(fcm_token.to_string())).await {
+                match orderbook_client::subscribe_with_authentication(url, authenticate, fcm_token).await {
                     Ok(split_stream) => split_stream,
                     Err(e) => {
                         tracing::error!("Could not start up orderbook client: {e:#}");


### PR DESCRIPTION
After moving this code around, we're no longer catching the exception; this means that if for whatever reason we cannot receive fcm_token we are not starting the backend at all.

This should never be the case, as push notifications are an opt-in feature.