### PR TITLE
fix: fallback fee too high

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       - -rpcpassword=123
       - -rpcallowip=0.0.0.0/0
       - -rpcbind=0.0.0.0
-      - -fallbackfee=0.1
+      - -fallbackfee=0.00001
       - -zmqpubrawblock=tcp://0.0.0.0:28332
       - -zmqpubrawtx=tcp://0.0.0.0:28333
     ports:


### PR DESCRIPTION
Sometimes we have a ridiculous high fee estimate. This is due to the fallback fee being in **BTC/kvB**. Setting it to 0.00001 should be 1000sat/kvb or 1sat/vbyte

😅