### PR TITLE
chore: Only broadcast node if at least one channel

### DIFF
--- a/crates/ln-dlc-node/src/node/mod.rs
+++ b/crates/ln-dlc-node/src/node/mod.rs
@@ -466,6 +466,7 @@ where
             &self.alias,
             self.announcement_addresses.clone(),
             self.peer_manager.clone(),
+            self.channel_manager.clone(),
         )?);
 
         handles.push(manage_sub_channels(
@@ -727,12 +728,17 @@ fn spawn_broadcast_node_annoucements(
     alias: &str,
     announcement_addresses: Vec<NetAddress>,
     peer_manager: Arc<PeerManager>,
+    channel_manager: Arc<ChannelManager>,
 ) -> Result<RemoteHandle<()>> {
     let alias = alias_as_bytes(alias)?;
     let (fut, remote_handle) = async move {
         let mut interval = tokio::time::interval(BROADCAST_NODE_ANNOUNCEMENT_INTERVAL);
         loop {
-            broadcast_node_announcement(&peer_manager, alias, announcement_addresses.clone());
+            if !channel_manager.list_channels().is_empty() {
+                // Other nodes will ignore our node announcement if we don't have at least one channel,
+                // hence, we should only broadcast our node announcement if we have at least one channel.
+                broadcast_node_announcement(&peer_manager, alias, announcement_addresses.clone());
+            }
 
             interval.tick().await;
         }

--- a/crates/ln-dlc-node/src/node/mod.rs
+++ b/crates/ln-dlc-node/src/node/mod.rs
@@ -734,9 +734,10 @@ fn spawn_broadcast_node_annoucements(
     let (fut, remote_handle) = async move {
         let mut interval = tokio::time::interval(BROADCAST_NODE_ANNOUNCEMENT_INTERVAL);
         loop {
-            if !channel_manager.list_channels().is_empty() {
-                // Other nodes will ignore our node announcement if we don't have at least one channel,
-                // hence, we should only broadcast our node announcement if we have at least one channel.
+            if channel_manager.list_channels().iter().any(|c| c.is_public) {
+                // Other nodes will ignore our node announcement if we don't have at least one
+                // public channel, hence, we should only broadcast our node
+                // announcement if we have at least one channel.
                 broadcast_node_announcement(&peer_manager, alias, announcement_addresses.clone());
             }
 

--- a/crates/ln-dlc-node/src/node/peer_manager.rs
+++ b/crates/ln-dlc-node/src/node/peer_manager.rs
@@ -9,8 +9,16 @@ pub fn broadcast_node_announcement(
     alias: [u8; 32],
     inc_connection_addresses: Vec<NetAddress>,
 ) {
-    tracing::debug!(?inc_connection_addresses, "Broadcasting node announcement");
-
+    let known_peers = peer_manager
+        .get_peer_node_ids()
+        .iter()
+        .map(|(pk, _)| pk.to_string())
+        .collect::<Vec<_>>();
+    tracing::debug!(
+        ?inc_connection_addresses,
+        ?known_peers,
+        "Broadcasting node announcement"
+    );
     peer_manager.broadcast_node_announcement(NODE_COLOR, alias, inc_connection_addresses)
 }
 


### PR DESCRIPTION
This change includes two changes

1. We now only broadcast node announcements if we have at least one public channel.
2. We only open the channel with the maker after we have opened the lnd channel. This produces more reliably results when running `just fund`.

It also looks like there is an issue with node announcements in rust-lightning in general. In the tests we've seen multiple occasions where the coordinator refused to broadcast node announcements to lnd. Including gossiping known nodes and channels.

e.g. even though the coordinator and the maker shared a `usable` and `public` channel, the coordinator refused the makers node announcement.

`lightning::ln::peer_handler: Error handling message from 038ad93a14076c86eec6c8d390315e742601d9634baf2755d88c987139ab62e16d; ignoring: No existing channels for node_announcement `