### PR TITLE
Improve Close channel buttons

### DIFF
--- a/justfile
+++ b/justfile
@@ -110,6 +110,20 @@ run-regtest args="":
         --dart-define="COORDINATOR_P2P_ENDPOINT={{public_regtest_coordinator}}" \
         --dart-define="COORDINATOR_PORT_HTTP={{public_coordinator_http_port}}" \
         --dart-define="ORACLE_ENDPOINT={{public_regtest_oracle_endpoint}}" \
+        --dart-define="ORACLE_PUBKEY={{public_regtest_oracle_pk}}" 
+
+
+# Specify correct Android flavor to run against our public regtest server
+run-regtest-android args="":
+    #!/usr/bin/env bash
+    cd mobile && \
+      flutter run {{args}} \
+        --dart-define="COMMIT=$(git rev-parse HEAD)" \
+        --dart-define="BRANCH=$(git rev-parse --abbrev-ref HEAD)" \
+        --dart-define="ESPLORA_ENDPOINT={{public_regtest_esplora}}" \
+        --dart-define="COORDINATOR_P2P_ENDPOINT={{public_regtest_coordinator}}" \
+        --dart-define="COORDINATOR_PORT_HTTP={{public_coordinator_http_port}}" \
+        --dart-define="ORACLE_ENDPOINT={{public_regtest_oracle_endpoint}}" \
         --dart-define="ORACLE_PUBKEY={{public_regtest_oracle_pk}}" \
         --flavor test
 

--- a/mobile/lib/common/settings_screen.dart
+++ b/mobile/lib/common/settings_screen.dart
@@ -5,6 +5,7 @@ import 'package:f_logs/f_logs.dart';
 import 'package:flutter/material.dart';
 import 'package:get_10101/common/scrollable_safe_area.dart';
 import 'package:get_10101/bridge_generated/bridge_definitions.dart' as bridge;
+import 'package:get_10101/common/snack_bar.dart';
 import 'package:intl/intl.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:provider/provider.dart';
@@ -59,8 +60,13 @@ class _SettingsScreenState extends State<SettingsScreen> {
       body: ScrollableSafeArea(
           child: Column(children: [
         ElevatedButton(
-            onPressed: () {
-              rust.api.closeChannel();
+            onPressed: () async {
+              final messenger = ScaffoldMessenger.of(context);
+              try {
+                await rust.api.closeChannel();
+              } catch (e) {
+                showSnackBar(messenger, e.toString());
+              }
             },
             child: const Text("Close channel")),
         Visibility(
@@ -68,8 +74,13 @@ class _SettingsScreenState extends State<SettingsScreen> {
           child: Column(
             children: [
               ElevatedButton(
-                  onPressed: () {
-                    rust.api.forceCloseChannel();
+                  onPressed: () async {
+                    final messenger = ScaffoldMessenger.of(context);
+                    try {
+                      await rust.api.forceCloseChannel();
+                    } catch (e) {
+                      showSnackBar(messenger, e.toString());
+                    }
                   },
                   child: const Text("Force-close channel")),
             ],

--- a/mobile/lib/common/settings_screen.dart
+++ b/mobile/lib/common/settings_screen.dart
@@ -58,15 +58,15 @@ class _SettingsScreenState extends State<SettingsScreen> {
       appBar: AppBar(title: const Text("Settings")),
       body: ScrollableSafeArea(
           child: Column(children: [
+        ElevatedButton(
+            onPressed: () {
+              rust.api.closeChannel();
+            },
+            child: const Text("Close channel")),
         Visibility(
           visible: config.network == "regtest",
           child: Column(
             children: [
-              ElevatedButton(
-                  onPressed: () {
-                    rust.api.closeChannel();
-                  },
-                  child: const Text("Close channel")),
               ElevatedButton(
                   onPressed: () {
                     rust.api.forceCloseChannel();

--- a/mobile/lib/common/settings_screen.dart
+++ b/mobile/lib/common/settings_screen.dart
@@ -25,6 +25,9 @@ class _SettingsScreenState extends State<SettingsScreen> {
   String _version = '';
   String _nodeId = "";
 
+  // Variable preventing the user from spamming the close channel buttons
+  bool _isCloseChannelButtonDisabled = false;
+
   @override
   void initState() {
     try {
@@ -34,6 +37,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
       FLog.error(text: "Error getting node id: $e");
       _nodeId = "UNKNOWN";
     }
+
     loadValues();
     super.initState();
   }
@@ -60,28 +64,46 @@ class _SettingsScreenState extends State<SettingsScreen> {
       body: ScrollableSafeArea(
           child: Column(children: [
         ElevatedButton(
-            onPressed: () async {
-              final messenger = ScaffoldMessenger.of(context);
-              try {
-                await rust.api.closeChannel();
-              } catch (e) {
-                showSnackBar(messenger, e.toString());
-              }
-            },
+            onPressed: _isCloseChannelButtonDisabled
+                ? null
+                : () async {
+                    setState(() {
+                      _isCloseChannelButtonDisabled = true;
+                    });
+                    final messenger = ScaffoldMessenger.of(context);
+                    try {
+                      await rust.api.closeChannel();
+                    } catch (e) {
+                      showSnackBar(messenger, e.toString());
+                    } finally {
+                      setState(() {
+                        _isCloseChannelButtonDisabled = false;
+                      });
+                    }
+                  },
             child: const Text("Close channel")),
         Visibility(
           visible: config.network == "regtest",
           child: Column(
             children: [
               ElevatedButton(
-                  onPressed: () async {
-                    final messenger = ScaffoldMessenger.of(context);
-                    try {
-                      await rust.api.forceCloseChannel();
-                    } catch (e) {
-                      showSnackBar(messenger, e.toString());
-                    }
-                  },
+                  onPressed: _isCloseChannelButtonDisabled
+                      ? null
+                      : () async {
+                          setState(() {
+                            _isCloseChannelButtonDisabled = true;
+                          });
+                          final messenger = ScaffoldMessenger.of(context);
+                          try {
+                            await rust.api.forceCloseChannel();
+                          } catch (e) {
+                            showSnackBar(messenger, e.toString());
+                          } finally {
+                            setState(() {
+                              _isCloseChannelButtonDisabled = false;
+                            });
+                          }
+                        },
                   child: const Text("Force-close channel")),
             ],
           ),

--- a/mobile/lib/common/settings_screen.dart
+++ b/mobile/lib/common/settings_screen.dart
@@ -3,9 +3,11 @@ import 'dart:io';
 
 import 'package:f_logs/f_logs.dart';
 import 'package:flutter/material.dart';
+import 'package:get_10101/common/channel_status_notifier.dart';
 import 'package:get_10101/common/scrollable_safe_area.dart';
 import 'package:get_10101/bridge_generated/bridge_definitions.dart' as bridge;
 import 'package:get_10101/common/snack_bar.dart';
+import 'package:get_10101/features/trade/position_change_notifier.dart';
 import 'package:intl/intl.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:provider/provider.dart';
@@ -72,6 +74,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
                     });
                     final messenger = ScaffoldMessenger.of(context);
                     try {
+                      ensureCanCloseChannel(context);
                       await rust.api.closeChannel();
                     } catch (e) {
                       showSnackBar(messenger, e.toString());
@@ -95,6 +98,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
                           });
                           final messenger = ScaffoldMessenger.of(context);
                           try {
+                            ensureCanCloseChannel(context);
                             await rust.api.forceCloseChannel();
                           } catch (e) {
                             showSnackBar(messenger, e.toString());
@@ -211,5 +215,15 @@ class _SettingsScreenState extends State<SettingsScreen> {
             child: const Text("Share logs")),
       ])),
     );
+  }
+}
+
+/// Throws if the channel is not in a state where it can be closed.
+void ensureCanCloseChannel(BuildContext context) {
+  if (context.read<PositionChangeNotifier>().positions.isNotEmpty) {
+    throw Exception("In order to close your Lighting Channel you need to close all your positions");
+  }
+  if (context.read<ChannelStatusNotifier>().isClosing()) {
+    throw Exception("Your channel is already closing");
   }
 }


### PR DESCRIPTION
- always show close channel button
- catch exceptions and show errors if any
- prevent accidental abuse of the API by repeated clicks