### PR TITLE
Catch possible exception during registration

### DIFF
--- a/crates/ln-dlc-node/src/node/storage.rs
+++ b/crates/ln-dlc-node/src/node/storage.rs
@@ -124,7 +124,7 @@ impl Storage for InMemoryStore {
     ) -> Result<()> {
         let mut payments = self.payments.lock();
         match payments.get_mut(payment_hash) {
-            Some(mut payment) => {
+            Some(payment) => {
                 payment.status = htlc_status;
 
                 if let amt_msat @ MillisatAmount(Some(_)) = amt_msat {

--- a/mobile/lib/features/welcome/welcome_screen.dart
+++ b/mobile/lib/features/welcome/welcome_screen.dart
@@ -1,6 +1,7 @@
 import 'package:f_logs/model/flog/flog.dart';
 import 'package:flutter/material.dart';
 import 'package:get_10101/common/scrollable_safe_area.dart';
+import 'package:get_10101/common/snack_bar.dart';
 import 'package:get_10101/features/wallet/wallet_screen.dart';
 import 'package:get_10101/util/preferences.dart';
 import 'package:go_router/go_router.dart';
@@ -76,10 +77,14 @@ class _WelcomeScreenState extends State<WelcomeScreen> {
                   onPressed: () {
                     if (_formKey.currentState != null && _formKey.currentState!.validate()) {
                       _formKey.currentState?.save();
-                      api.registerBeta(email: _email);
-                      Preferences.instance.setEmailAddress(_email);
-                      FLog.info(text: "Successfully stored the email address $_email .");
-                      context.go(WalletScreen.route);
+                      try {
+                        api.registerBeta(email: _email);
+                        Preferences.instance.setEmailAddress(_email);
+                        FLog.info(text: "Successfully stored the email address $_email .");
+                        context.go(WalletScreen.route);
+                      } catch (e) {
+                        showSnackBar(ScaffoldMessenger.of(context), "$e");
+                      }
                     }
                   },
                   child: const Text(


### PR DESCRIPTION
Catch a hole in the registration process, where the app would only store the email locally if the coordinator was unreachable during app registration.