### PR TITLE
feat: allow 5 BTC wumbo channels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Allow up to 5BTC wumbo channels
 - Add push notification reminder that the rollover window is open now.
 
 ## [1.3.0] - 2023-09-27

--- a/crates/ln-dlc-node/src/config.rs
+++ b/crates/ln-dlc-node/src/config.rs
@@ -90,6 +90,7 @@ pub fn coordinator_config() -> UserConfig {
             force_announced_channel_preference: true,
             // LND's max to_self_delay is 2016, so we want to be compatible.
             their_to_self_delay: 2016,
+            max_funding_satoshis: 500_000_000,
             ..Default::default()
         },
         channel_config: ChannelConfig {

--- a/crates/tests-e2e/examples/fund.rs
+++ b/crates/tests-e2e/examples/fund.rs
@@ -99,7 +99,7 @@ async fn fund_everything(faucet: &str, coordinator: &str, maker: &str) -> Result
         .fund(
             &lnd_addr.address,
             Amount::ONE_BTC
-                .checked_mul(2)
+                .checked_mul(10)
                 .expect("small integers to multiply"),
         )
         .await?;
@@ -123,15 +123,7 @@ async fn fund_everything(faucet: &str, coordinator: &str, maker: &str) -> Result
     let lnd_balance = get_text(&format!("{faucet}/lnd/v1/balance/blockchain")).await?;
     tracing::info!("faucet lightning balance: {}", lnd_balance);
 
-    open_channel(
-        &node,
-        Amount::ONE_BTC
-            .checked_div(10)
-            .expect("small integers to divide"),
-        faucet,
-        &bitcoind,
-    )
-    .await?;
+    open_channel(&node, Amount::ONE_BTC * 5, faucet, &bitcoind).await?;
 
     // wait until channel has `peer_alias` set correctly
     tracing::info!("Waiting until channel is has correct peer_alias set");

--- a/services/faucet/lnd.conf
+++ b/services/faucet/lnd.conf
@@ -90,3 +90,9 @@ db.backend=bolt
 
 [bolt]
 db.bolt.auto-compact=true
+
+[protocol]
+
+; If set, then lnd will create and accept requests for channels larger than 0.16
+; BTC
+protocol.wumbo-channels=true


### PR DESCRIPTION
Also, our faucet now opens a 5 BTC channel to the coordinator.