### PR TITLE
fix: Use go to wallet screen instead of pop

### DIFF
--- a/mobile/lib/features/wallet/onboarding/fund_wallet_modal.dart
+++ b/mobile/lib/features/wallet/onboarding/fund_wallet_modal.dart
@@ -1,4 +1,3 @@
-import 'package:f_logs/model/flog/flog.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:get_10101/bridge_generated/bridge_definitions.dart' as bridge;
@@ -7,6 +6,7 @@ import 'package:get_10101/common/snack_bar.dart';
 import 'package:get_10101/common/value_data_row.dart';
 import 'package:get_10101/features/wallet/application/faucet_service.dart';
 import 'package:get_10101/features/wallet/payment_claimed_change_notifier.dart';
+import 'package:get_10101/features/wallet/wallet_screen.dart';
 import 'package:go_router/go_router.dart';
 import 'package:provider/provider.dart';
 import 'package:qr_flutter/qr_flutter.dart';
@@ -65,12 +65,7 @@ class _FundWalletModalState extends State<FundWalletModal> {
     const style = TextStyle(fontSize: 20);
 
     if (context.watch<PaymentClaimedChangeNotifier>().isClaimed()) {
-      // routing is not allowed during building a widget, hence we need to register the route navigation after the widget has been build.
-      WidgetsBinding.instance.addPostFrameCallback((_) {
-        FLog.debug(text: "Payment received!");
-        GoRouter.of(context).pop();
-        GoRouter.of(context).pop();
-      });
+      GoRouter.of(context).go(WalletScreen.route);
     }
 
     return SafeArea(

--- a/mobile/lib/features/wallet/payment_claimed_change_notifier.dart
+++ b/mobile/lib/features/wallet/payment_claimed_change_notifier.dart
@@ -6,13 +6,9 @@ import 'package:get_10101/common/application/event_service.dart';
 class PaymentClaimedChangeNotifier extends ChangeNotifier implements Subscriber {
   bool _claimed = false;
 
-  void waitForPayment() {
-    _claimed = false;
-  }
+  void waitForPayment() => _claimed = false;
 
-  bool isClaimed() {
-    return _claimed;
-  }
+  bool isClaimed() => _claimed;
 
   @override
   void notify(Event event) {


### PR DESCRIPTION
It's weird but if you pop only once you don't get back to the wallet screen and if you pop twice you get back to the wallet screen but also get the exception.

fixes: #1435 