### PR TITLE
chore: replace logger framework

### DIFF
--- a/mobile/lib/common/application/event_service.dart
+++ b/mobile/lib/common/application/event_service.dart
@@ -1,6 +1,6 @@
 import 'dart:collection';
 
-import 'package:f_logs/model/flog/flog.dart';
+import 'package:get_10101/logger.dart';
 import 'package:get_10101/ffi.dart';
 
 abstract class Subscriber {
@@ -13,7 +13,7 @@ class EventService {
   EventService.create() {
     api.subscribe().listen((Event event) {
       if (subscribers[event.runtimeType] == null) {
-        FLog.debug(text: "found no subscribers, skipping event");
+        logger.d("found no subscribers, skipping event");
         return;
       }
 

--- a/mobile/lib/common/channel_status_notifier.dart
+++ b/mobile/lib/common/channel_status_notifier.dart
@@ -1,8 +1,8 @@
-import 'package:f_logs/f_logs.dart';
 import 'package:flutter/material.dart';
 import 'package:get_10101/bridge_generated/bridge_definitions.dart' as bridge;
 import 'package:get_10101/common/application/event_service.dart';
 import 'package:get_10101/ffi.dart';
+import 'package:get_10101/logger.dart';
 
 /// Sends channel status notifications to subscribers.
 ///
@@ -37,7 +37,7 @@ class ChannelStatusNotifier extends ChangeNotifier implements Subscriber {
   /// notify all listeners.
   void notify(bridge.Event event) {
     if (event is bridge.Event_ChannelStatusUpdate) {
-      FLog.debug(text: "Received channel status update: ${event.toString()}");
+      logger.d("Received channel status update: ${event.toString()}");
       latest = event.field0;
 
       notifyListeners();

--- a/mobile/lib/common/recover_dlc_change_notifier.dart
+++ b/mobile/lib/common/recover_dlc_change_notifier.dart
@@ -1,10 +1,10 @@
-import 'package:f_logs/model/flog/flog.dart';
 import 'package:flutter/material.dart';
 import 'package:get_10101/bridge_generated/bridge_definitions.dart' as bridge;
 import 'package:get_10101/common/application/event_service.dart';
 import 'package:get_10101/common/domain/background_task.dart';
 import 'package:get_10101/common/global_keys.dart';
 import 'package:get_10101/common/task_status_dialog.dart';
+import 'package:get_10101/logger.dart';
 import 'package:provider/provider.dart';
 
 class RecoverDlcChangeNotifier extends ChangeNotifier implements Subscriber {
@@ -18,7 +18,7 @@ class RecoverDlcChangeNotifier extends ChangeNotifier implements Subscriber {
         return;
       }
       RecoverDlc recoverDlc = RecoverDlc.fromApi(event.field0 as bridge.BackgroundTask_RecoverDlc);
-      FLog.debug(text: "Received a recover dlc event. Status: ${recoverDlc.taskStatus}");
+      logger.d("Received a recover dlc event. Status: ${recoverDlc.taskStatus}");
 
       taskStatus = recoverDlc.taskStatus;
 

--- a/mobile/lib/common/service_status_notifier.dart
+++ b/mobile/lib/common/service_status_notifier.dart
@@ -1,7 +1,7 @@
-import 'package:f_logs/f_logs.dart';
 import 'package:flutter/material.dart';
 import 'package:get_10101/bridge_generated/bridge_definitions.dart' as bridge;
 import 'package:get_10101/common/application/event_service.dart';
+import 'package:get_10101/logger.dart';
 
 class ServiceStatusNotifier extends ChangeNotifier implements Subscriber {
   Map<bridge.Service, bridge.ServiceStatus> services = <bridge.Service, bridge.ServiceStatus>{};
@@ -20,13 +20,13 @@ class ServiceStatusNotifier extends ChangeNotifier implements Subscriber {
   @override
   void notify(bridge.Event event) {
     if (event is bridge.Event_ServiceHealthUpdate) {
-      FLog.debug(text: "Received event: ${event.toString()}");
+      logger.d("Received event: ${event.toString()}");
       var update = event.field0;
       services[update.service] = update.status;
 
       notifyListeners();
     } else {
-      FLog.warning(text: "Received unexpected event: ${event.toString()}");
+      logger.w("Received unexpected event: ${event.toString()}");
     }
   }
 }

--- a/mobile/lib/common/settings_screen.dart
+++ b/mobile/lib/common/settings_screen.dart
@@ -1,19 +1,20 @@
 import 'dart:convert';
 import 'dart:io';
 
-import 'package:f_logs/f_logs.dart';
 import 'package:flutter/material.dart';
 import 'package:get_10101/common/channel_status_notifier.dart';
 import 'package:get_10101/common/scrollable_safe_area.dart';
 import 'package:get_10101/bridge_generated/bridge_definitions.dart' as bridge;
 import 'package:get_10101/common/snack_bar.dart';
 import 'package:get_10101/features/trade/position_change_notifier.dart';
+import 'package:get_10101/hybrid_logger.dart';
 import 'package:intl/intl.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:provider/provider.dart';
 import 'package:share_plus/share_plus.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 import 'package:get_10101/ffi.dart' as rust;
+import 'package:get_10101/logger.dart';
 
 class SettingsScreen extends StatefulWidget {
   const SettingsScreen({super.key});
@@ -36,7 +37,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
       var nodeId = rust.api.getNodeId();
       _nodeId = nodeId;
     } catch (e) {
-      FLog.error(text: "Error getting node id: $e");
+      logger.e("Error getting node id: $e");
       _nodeId = "UNKNOWN";
     }
 
@@ -47,7 +48,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
   Future<void> loadValues() async {
     var value = await PackageInfo.fromPlatform();
 
-    FLog.info(text: "All values $value");
+    logger.i("All values $value");
     setState(() {
       _buildNumber = value.buildNumber;
       _version = value.version;
@@ -202,7 +203,11 @@ class _SettingsScreenState extends State<SettingsScreen> {
         ),
         ElevatedButton(
             onPressed: () async {
-              var file = await FLog.exportLogs();
+              // TODO:
+              logger.toString();
+
+              // TODO: fix me
+              var file = await HybridOutput.logFilePath();
               var logsAsString = await file.readAsString();
               final List<int> bytes = utf8.encode(logsAsString);
               final Directory tempDir = await getTemporaryDirectory();

--- a/mobile/lib/features/trade/async_order_change_notifier.dart
+++ b/mobile/lib/features/trade/async_order_change_notifier.dart
@@ -1,4 +1,4 @@
-import 'package:f_logs/model/flog/flog.dart';
+import 'package:get_10101/logger.dart';
 import 'package:flutter/material.dart';
 import 'package:get_10101/bridge_generated/bridge_definitions.dart' as bridge;
 import 'package:get_10101/common/application/event_service.dart';
@@ -33,7 +33,7 @@ class AsyncOrderChangeNotifier extends ChangeNotifier implements Subscriber {
         return;
       }
       AsyncTrade asyncTrade = AsyncTrade.fromApi(event.field0 as bridge.BackgroundTask_AsyncTrade);
-      FLog.debug(text: "Received a async trade event. Reason: ${asyncTrade.orderReason}");
+      logger.d("Received a async trade event. Reason: ${asyncTrade.orderReason}");
       showDialog(
         context: shellNavigatorKey.currentContext!,
         builder: (context) {
@@ -56,7 +56,7 @@ class AsyncOrderChangeNotifier extends ChangeNotifier implements Subscriber {
             case OrderReason.expired:
               content = const Text("Your position has been closed due to expiry.");
             case OrderReason.manual:
-              FLog.error(text: "A manual order should not appear as an async trade!");
+              logger.e("A manual order should not appear as an async trade!");
               content = Container();
           }
 
@@ -70,7 +70,7 @@ class AsyncOrderChangeNotifier extends ChangeNotifier implements Subscriber {
         notifyListeners();
       }
     } else {
-      FLog.warning(text: "Received unexpected event: ${event.toString()}");
+      logger.w("Received unexpected event: ${event.toString()}");
     }
   }
 }

--- a/mobile/lib/features/trade/order_change_notifier.dart
+++ b/mobile/lib/features/trade/order_change_notifier.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:f_logs/model/flog/flog.dart';
+import 'package:get_10101/logger.dart';
 import 'package:get_10101/bridge_generated/bridge_definitions.dart' as bridge;
 import 'package:get_10101/common/application/event_service.dart';
 import 'package:get_10101/features/trade/application/order_service.dart';
@@ -33,7 +33,7 @@ class OrderChangeNotifier extends ChangeNotifier implements Subscriber {
 
       notifyListeners();
     } else {
-      FLog.warning(text: "Received unexpected event: ${event.toString()}");
+      logger.w("Received unexpected event: ${event.toString()}");
     }
   }
 

--- a/mobile/lib/features/trade/position_change_notifier.dart
+++ b/mobile/lib/features/trade/position_change_notifier.dart
@@ -1,4 +1,4 @@
-import 'package:f_logs/model/flog/flog.dart';
+import 'package:get_10101/logger.dart';
 import 'package:flutter/material.dart';
 import 'package:get_10101/bridge_generated/bridge_definitions.dart' as bridge;
 import 'package:get_10101/common/application/event_service.dart';
@@ -87,7 +87,7 @@ class PositionChangeNotifier extends ChangeNotifier implements Subscriber {
 
       notifyListeners();
     } else {
-      FLog.warning(text: "Received unexpected event: ${event.toString()}");
+      logger.w("Received unexpected event: ${event.toString()}");
     }
   }
 }

--- a/mobile/lib/features/trade/rollover_change_notifier.dart
+++ b/mobile/lib/features/trade/rollover_change_notifier.dart
@@ -1,4 +1,4 @@
-import 'package:f_logs/model/flog/flog.dart';
+import 'package:get_10101/logger.dart';
 import 'package:flutter/material.dart';
 import 'package:get_10101/bridge_generated/bridge_definitions.dart' as bridge;
 import 'package:get_10101/common/application/event_service.dart';
@@ -19,7 +19,7 @@ class RolloverChangeNotifier extends ChangeNotifier implements Subscriber {
       }
 
       Rollover rollover = Rollover.fromApi(event.field0 as bridge.BackgroundTask_Rollover);
-      FLog.debug(text: "Received a rollover event. Status: ${rollover.taskStatus}");
+      logger.d("Received a rollover event. Status: ${rollover.taskStatus}");
 
       taskStatus = rollover.taskStatus;
 
@@ -44,7 +44,7 @@ class RolloverChangeNotifier extends ChangeNotifier implements Subscriber {
         notifyListeners();
       }
     } else {
-      FLog.warning(text: "Received unexpected event: ${event.toString()}");
+      logger.w("Received unexpected event: ${event.toString()}");
     }
   }
 }

--- a/mobile/lib/features/trade/submit_order_change_notifier.dart
+++ b/mobile/lib/features/trade/submit_order_change_notifier.dart
@@ -1,4 +1,4 @@
-import 'package:f_logs/model/flog/flog.dart';
+import 'package:get_10101/logger.dart';
 import 'package:flutter/material.dart';
 import 'package:get_10101/bridge_generated/bridge_definitions.dart' as bridge;
 import 'package:get_10101/common/application/event_service.dart';
@@ -54,7 +54,7 @@ class SubmitOrderChangeNotifier extends ChangeNotifier implements Subscriber {
           tradeValues.quantity!, ContractSymbol.btcusd, tradeValues.direction);
       _pendingOrder!.state = PendingOrderState.submittedSuccessfully;
     } catch (exception) {
-      FLog.error(text: "Failed to submit order: $exception");
+      logger.e("Failed to submit order: $exception");
       _pendingOrder!.state = PendingOrderState.submissionFailed;
     }
 
@@ -82,7 +82,7 @@ class SubmitOrderChangeNotifier extends ChangeNotifier implements Subscriber {
         notifyListeners();
       }
     } else {
-      FLog.warning(text: "Received unexpected event: ${event.toString()}");
+      logger.w("Received unexpected event: ${event.toString()}");
     }
   }
 

--- a/mobile/lib/features/trade/trade_bottom_sheet_tab.dart
+++ b/mobile/lib/features/trade/trade_bottom_sheet_tab.dart
@@ -1,7 +1,6 @@
 import 'dart:async';
 import 'dart:math';
 
-import 'package:f_logs/f_logs.dart';
 import 'package:flutter/material.dart';
 import 'package:get_10101/common/amount_text.dart';
 import 'package:get_10101/common/amount_text_input_form_field.dart';
@@ -23,6 +22,7 @@ import 'package:get_10101/features/trade/trade_theme.dart';
 import 'package:get_10101/features/trade/trade_value_change_notifier.dart';
 import 'package:get_10101/features/wallet/domain/wallet_info.dart';
 import 'package:get_10101/features/wallet/wallet_change_notifier.dart';
+import 'package:get_10101/logger.dart';
 import 'package:go_router/go_router.dart';
 import 'package:provider/provider.dart';
 
@@ -332,7 +332,7 @@ class _TradeBottomSheetTabState extends State<TradeBottomSheetTab> {
                         Amount margin = Amount.parseAmount(value);
                         context.read<TradeValuesChangeNotifier>().updateMargin(direction, margin);
                       } catch (error) {
-                        FLog.error(text: "Error: $error");
+                        logger.e("Error: $error");
                         context
                             .read<TradeValuesChangeNotifier>()
                             .updateMargin(direction, Amount.zero());

--- a/mobile/lib/features/wallet/application/faucet_service.dart
+++ b/mobile/lib/features/wallet/application/faucet_service.dart
@@ -1,6 +1,6 @@
 import 'dart:convert';
 
-import 'package:f_logs/f_logs.dart';
+import 'package:get_10101/logger.dart';
 import 'package:http/http.dart' as http;
 
 class FaucetService {
@@ -24,7 +24,7 @@ class FaucetService {
     if (response.statusCode != 200 || !response.body.contains('"payment_error":""')) {
       throw Exception("Payment failed: Received ${response.statusCode} ${response.body}");
     } else {
-      FLog.info(text: "Paying invoice succeeded: ${response.body}");
+      logger.i("Paying invoice succeeded: ${response.body}");
     }
   }
 
@@ -40,12 +40,12 @@ class FaucetService {
       Uri.parse('$faucet/$invoice'),
     );
 
-    FLog.info(text: "Response ${response.body}${response.statusCode}");
+    logger.i("Response ${response.body}${response.statusCode}");
 
     if (response.statusCode != 200) {
       throw Exception("Payment failed: Received ${response.statusCode}. ${response.body}");
     } else {
-      FLog.info(text: "Paying invoice succeeded: ${response.body}");
+      logger.i("Paying invoice succeeded: ${response.body}");
     }
   }
 }

--- a/mobile/lib/features/wallet/application/wallet_service.dart
+++ b/mobile/lib/features/wallet/application/wallet_service.dart
@@ -1,8 +1,8 @@
-import 'package:f_logs/f_logs.dart';
-import 'package:flutter_rust_bridge/flutter_rust_bridge.dart';
 import 'package:get_10101/common/domain/model.dart';
+import 'package:flutter_rust_bridge/flutter_rust_bridge.dart';
 import 'package:get_10101/features/wallet/domain/lightning_invoice.dart';
 import 'package:get_10101/ffi.dart' as rust;
+import 'package:get_10101/logger.dart';
 
 class WalletService {
   const WalletService();
@@ -11,7 +11,7 @@ class WalletService {
     try {
       await rust.api.refreshWalletInfo();
     } catch (error) {
-      FLog.error(text: "Failed to refresh wallet info: $error");
+      logger.e("Failed to refresh wallet info: $error");
     }
   }
 
@@ -20,13 +20,13 @@ class WalletService {
     try {
       String invoice = await rust.api
           .createOnboardingInvoice(amountSats: amount.sats, liquidityOptionId: liquidityOptionId);
-      FLog.info(text: "Successfully created invoice.");
+      logger.i("Successfully created invoice.");
       return invoice;
     } catch (error) {
       if (error is FfiException && error.message.contains("cannot provide required liquidity")) {
         rethrow;
       } else {
-        FLog.error(text: "Error: $error", exception: error);
+        logger.e("Error: $error", error: error);
         return null;
       }
     }
@@ -35,22 +35,22 @@ class WalletService {
   Future<String?> createInvoice(Amount? amount) async {
     try {
       String invoice = await rust.api.createInvoice(amountSats: amount?.sats);
-      FLog.info(text: "Successfully created invoice.");
+      logger.i("Successfully created invoice.");
       return invoice;
     } catch (error) {
-      FLog.error(text: "Error: $error", exception: error);
+      logger.e("Error: $error", error: error);
     }
     return null;
   }
 
   Future<LightningInvoice?> decodeInvoice(String invoice) async {
     try {
-      FLog.debug(text: "Decoding invoice $invoice");
+      logger.d("Decoding invoice $invoice");
       rust.LightningInvoice lightningInvoice = await rust.api.decodeInvoice(invoice: invoice);
-      FLog.debug(text: "Successfully decoded invoice.");
+      logger.d("Successfully decoded invoice.");
       return LightningInvoice.fromApi(lightningInvoice);
     } catch (error) {
-      FLog.debug(text: "Failed to decode invoice: $error", exception: error);
+      logger.d("Failed to decode invoice: $error", error: error);
       return null;
     }
   }

--- a/mobile/lib/features/wallet/onboarding/liquidity_card.dart
+++ b/mobile/lib/features/wallet/onboarding/liquidity_card.dart
@@ -1,4 +1,3 @@
-import 'package:f_logs/f_logs.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_rust_bridge/flutter_rust_bridge.dart';
@@ -10,6 +9,7 @@ import 'package:get_10101/common/snack_bar.dart';
 import 'package:get_10101/common/value_data_row.dart';
 import 'package:get_10101/features/wallet/onboarding/fund_wallet_modal.dart';
 import 'package:get_10101/features/wallet/wallet_change_notifier.dart';
+import 'package:get_10101/logger.dart';
 import 'package:go_router/go_router.dart';
 import 'package:provider/provider.dart';
 import 'package:url_launcher/url_launcher.dart';
@@ -65,7 +65,7 @@ class _LiquidityCardState extends State<LiquidityCard> {
                       .then(
                           (invoice) => showFundWalletModal(context, widget.amount!, fee, invoice!))
                       .catchError((error) {
-                    FLog.error(text: "Failed to create invoice! Error: $error");
+                    logger.e("Failed to create invoice!", error: error);
                     if (error is FfiException &&
                         error.message.contains("cannot provide required liquidity")) {
                       showNoLiquidityDialog();

--- a/mobile/lib/features/wallet/send_payment_change_notifier.dart
+++ b/mobile/lib/features/wallet/send_payment_change_notifier.dart
@@ -1,4 +1,4 @@
-import 'package:f_logs/model/flog/flog.dart';
+import 'package:get_10101/logger.dart';
 import 'package:flutter/material.dart';
 import 'package:get_10101/features/wallet/application/wallet_service.dart';
 import 'package:get_10101/features/wallet/domain/lightning_invoice.dart';
@@ -37,7 +37,7 @@ class SendPaymentChangeNotifier extends ChangeNotifier {
       await walletService.payInvoice(raw);
       _pendingPayment!.state = PendingPaymentState.succeeded;
     } catch (exception) {
-      FLog.error(text: "Failed to submit order: $exception");
+      logger.e("Failed to submit order: $exception");
       _pendingPayment!.state = PendingPaymentState.failed;
     }
 

--- a/mobile/lib/features/wallet/send_payment_screen.dart
+++ b/mobile/lib/features/wallet/send_payment_screen.dart
@@ -1,6 +1,5 @@
 import 'dart:math';
 
-import 'package:f_logs/f_logs.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:get_10101/common/application/channel_info_service.dart';
@@ -13,6 +12,7 @@ import 'package:get_10101/features/wallet/domain/lightning_invoice.dart';
 import 'package:get_10101/features/wallet/send_payment_change_notifier.dart';
 import 'package:get_10101/features/wallet/wallet_change_notifier.dart';
 import 'package:get_10101/features/wallet/wallet_screen.dart';
+import 'package:get_10101/logger.dart';
 import 'package:go_router/go_router.dart';
 import 'package:provider/provider.dart';
 
@@ -106,7 +106,7 @@ class _SendPaymentScreenState extends State<SendPaymentScreen> {
                     ),
                     controller: _textEditingController,
                     onChanged: (value) async {
-                      FLog.debug(text: value);
+                      logger.d(value);
 
                       setState(() {
                         isDecoding = true;

--- a/mobile/lib/features/wallet/share_invoice_screen.dart
+++ b/mobile/lib/features/wallet/share_invoice_screen.dart
@@ -1,4 +1,3 @@
-import 'package:f_logs/f_logs.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:get_10101/bridge_generated/bridge_definitions.dart' as bridge;
@@ -8,6 +7,7 @@ import 'package:get_10101/features/wallet/application/faucet_service.dart';
 import 'package:get_10101/features/wallet/domain/share_invoice.dart';
 import 'package:get_10101/features/wallet/payment_claimed_change_notifier.dart';
 import 'package:get_10101/features/wallet/wallet_screen.dart';
+import 'package:get_10101/logger.dart';
 import 'package:go_router/go_router.dart';
 import 'package:provider/provider.dart';
 import 'package:qr_flutter/qr_flutter.dart';
@@ -40,7 +40,7 @@ class _ShareInvoiceScreenState extends State<ShareInvoiceScreen> {
     if (context.watch<PaymentClaimedChangeNotifier>().isClaimed()) {
       // routing is not allowed during building a widget, hence we need to register the route navigation after the widget has been build.
       WidgetsBinding.instance.addPostFrameCallback((_) {
-        FLog.debug(text: "Payment received!");
+        logger.d("Payment received!");
         GoRouter.of(context).pop();
       });
     }

--- a/mobile/lib/features/wallet/wallet_change_notifier.dart
+++ b/mobile/lib/features/wallet/wallet_change_notifier.dart
@@ -1,11 +1,12 @@
 import 'dart:async';
-import 'package:f_logs/f_logs.dart';
+
 import 'package:flutter/material.dart' hide Flow;
 import 'package:get_10101/bridge_generated/bridge_definitions.dart' as bridge;
 import 'package:get_10101/common/application/event_service.dart';
 import 'package:get_10101/common/domain/model.dart';
 import 'package:get_10101/features/wallet/application/wallet_service.dart';
 import 'package:get_10101/features/wallet/domain/wallet_balances.dart';
+import 'package:get_10101/logger.dart';
 import 'domain/wallet_info.dart';
 
 class WalletChangeNotifier extends ChangeNotifier implements Subscriber {
@@ -26,7 +27,7 @@ class WalletChangeNotifier extends ChangeNotifier implements Subscriber {
     this.walletInfo = walletInfo;
     syncing = false;
 
-    FLog.trace(text: 'Successfully synced payment history');
+    logger.t('Successfully synced payment history');
     super.notifyListeners();
   }
 
@@ -44,7 +45,7 @@ class WalletChangeNotifier extends ChangeNotifier implements Subscriber {
     if (event is bridge.Event_WalletInfoUpdateNotification) {
       update(WalletInfo.fromApi(event.field0));
     } else {
-      FLog.warning(text: "Received unexpected event: ${event.toString()}");
+      logger.w("Received unexpected event: ${event.toString()}");
     }
     syncing = false;
   }

--- a/mobile/lib/features/welcome/welcome_screen.dart
+++ b/mobile/lib/features/welcome/welcome_screen.dart
@@ -1,4 +1,4 @@
-import 'package:f_logs/model/flog/flog.dart';
+import 'package:get_10101/logger.dart';
 import 'package:flutter/material.dart';
 import 'package:get_10101/common/scrollable_safe_area.dart';
 import 'package:get_10101/common/snack_bar.dart';
@@ -80,7 +80,7 @@ class _WelcomeScreenState extends State<WelcomeScreen> {
                       try {
                         api.registerBeta(email: _email);
                         Preferences.instance.setEmailAddress(_email);
-                        FLog.info(text: "Successfully stored the email address $_email .");
+                        logger.i("Successfully stored the email address $_email .");
                         context.go(WalletScreen.route);
                       } catch (e) {
                         showSnackBar(ScaffoldMessenger.of(context), "$e");
@@ -104,7 +104,7 @@ class _WelcomeScreenState extends State<WelcomeScreen> {
 
     Preferences.instance.getEmailAddress().then((value) => setState(() {
           _email = value;
-          FLog.info(text: "retrieved stored email from the preferences: $_email.");
+          logger.i("retrieved stored email from the preferences: $_email.");
         }));
   }
 }

--- a/mobile/lib/hybrid_logger.dart
+++ b/mobile/lib/hybrid_logger.dart
@@ -1,0 +1,49 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:logger/logger.dart';
+import 'package:path_provider/path_provider.dart';
+
+/// Writes the log output to a file.
+class HybridOutput extends LogOutput {
+  final bool overrideExisting;
+  final Encoding encoding;
+  IOSink? _sink;
+
+  HybridOutput({
+    this.overrideExisting = false,
+    this.encoding = utf8,
+  });
+
+  @override
+  Future<void> init() async {
+    File logFile = await logFilePath();
+
+    _sink = logFile.openWrite(
+      mode: overrideExisting ? FileMode.writeOnly : FileMode.writeOnlyAppend,
+      encoding: encoding,
+    );
+    output(OutputEvent(LogEvent(Level.info, "Test"),
+        ["HybridOutputLogger initialized. Will print into console and '${logFile.path}'"]));
+  }
+
+  static Future<File> logFilePath() async {
+    final dataDir = await getApplicationSupportDirectory();
+    final logFile = File('${dataDir.path}/app_log.log');
+    return logFile;
+  }
+
+  @override
+  void output(OutputEvent event) {
+    _sink?.writeAll(event.lines, '\n');
+    _sink?.writeln();
+    // ignore: avoid_print
+    event.lines.forEach(print);
+  }
+
+  @override
+  Future<void> destroy() async {
+    await _sink?.flush();
+    await _sink?.close();
+  }
+}

--- a/mobile/lib/logger.dart
+++ b/mobile/lib/logger.dart
@@ -1,0 +1,17 @@
+import 'package:get_10101/hybrid_logger.dart';
+import 'package:logger/logger.dart';
+
+Logger get logger => AppLogger.instance;
+
+class AppLogger {
+  static final Logger _logger = Logger(
+      output: HybridOutput(),
+      printer: SimplePrinter(
+          // Colorful log messages
+          colors: false,
+          // Should each log print contain a timestamp
+          printTime: true));
+
+  // Getter to access the logger instance
+  static final instance = _logger;
+}

--- a/mobile/lib/logger.dart
+++ b/mobile/lib/logger.dart
@@ -1,4 +1,5 @@
 import 'package:get_10101/hybrid_logger.dart';
+import 'package:get_10101/simple_utc_printer.dart';
 import 'package:logger/logger.dart';
 
 Logger get logger => AppLogger.instance;
@@ -6,7 +7,7 @@ Logger get logger => AppLogger.instance;
 class AppLogger {
   static final Logger _logger = Logger(
       output: HybridOutput(),
-      printer: SimplePrinter(
+      printer: SimpleUTCPrinter(
           // Colorful log messages
           colors: false,
           // Should each log print contain a timestamp

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -297,8 +297,8 @@ class _TenTenOneAppState extends State<TenTenOneApp> {
     rust.api.initLogging().listen((event) {
       if (Platform.isAndroid || Platform.isIOS) {
         var message = event.target != ""
-            ? '${event.target}: ${event.msg} ${event.data}'
-            : '${event.msg} ${event.data}';
+            ? 'r: ${event.target}: ${event.msg} ${event.data}'
+            : 'r: ${event.msg} ${event.data}';
         switch (event.level) {
           case "INFO":
             logger.i(message);

--- a/mobile/lib/simple_utc_printer.dart
+++ b/mobile/lib/simple_utc_printer.dart
@@ -1,0 +1,57 @@
+import 'dart:convert';
+
+import 'package:logger/logger.dart';
+
+/// Outputs simple log messages:
+/// ```
+/// [E] Log message  ERROR: Error info
+/// ```
+class SimpleUTCPrinter extends LogPrinter {
+  static final levelPrefixes = {
+    Level.trace: '[T]',
+    Level.debug: '[D]',
+    Level.info: '[I]',
+    Level.warning: '[W]',
+    Level.error: '[E]',
+    Level.fatal: '[FATAL]',
+  };
+
+  static final levelColors = {
+    Level.trace: AnsiColor.fg(AnsiColor.grey(0.5)),
+    Level.debug: const AnsiColor.none(),
+    Level.info: const AnsiColor.fg(12),
+    Level.warning: const AnsiColor.fg(208),
+    Level.error: const AnsiColor.fg(196),
+    Level.fatal: const AnsiColor.fg(199),
+  };
+
+  final bool printTime;
+  final bool colors;
+
+  SimpleUTCPrinter({this.printTime = false, this.colors = true});
+
+  @override
+  List<String> log(LogEvent event) {
+    var messageStr = _stringifyMessage(event.message);
+    var errorStr = event.error != null ? '  ERROR: ${event.error}' : '';
+    var timeStr = printTime ? 'TIME: ${event.time.toUtc().toIso8601String()}' : '';
+    return ['${_labelFor(event.level)} $timeStr $messageStr$errorStr'];
+  }
+
+  String _labelFor(Level level) {
+    var prefix = levelPrefixes[level]!;
+    var color = levelColors[level]!;
+
+    return colors ? color(prefix) : prefix;
+  }
+
+  String _stringifyMessage(dynamic message) {
+    final finalMessage = message is Function ? message() : message;
+    if (finalMessage is Map || finalMessage is Iterable) {
+      var encoder = const JsonEncoder.withIndent(null);
+      return encoder.convert(finalMessage);
+    } else {
+      return finalMessage.toString();
+    }
+  }
+}

--- a/mobile/lib/util/notifications.dart
+++ b/mobile/lib/util/notifications.dart
@@ -1,4 +1,4 @@
-import 'package:f_logs/model/flog/flog.dart';
+import 'package:get_10101/logger.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:firebase_messaging/firebase_messaging.dart';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
@@ -18,14 +18,14 @@ Future<void> requestNotificationPermission() async {
     sound: true,
   );
 
-  FLog.info(text: "User granted permission: ${settings.authorizationStatus}");
+  logger.i("User granted permission: ${settings.authorizationStatus}");
 }
 
 Future<void> initFirebase() async {
   final env = Environment.parse();
 
   try {
-    FLog.info(text: "Initialising Firebase");
+    logger.i("Initialising Firebase");
     await Firebase.initializeApp(
       options: DefaultFirebaseOptions(env.network).currentPlatform,
     );
@@ -33,7 +33,7 @@ Future<void> initFirebase() async {
     final flutterLocalNotificationsPlugin = initLocalNotifications();
     await configureFirebase(flutterLocalNotificationsPlugin);
   } catch (e) {
-    FLog.error(text: "Error setting up Firebase: ${e.toString()}");
+    logger.e("Error setting up Firebase: ${e.toString()}");
   }
 }
 
@@ -41,10 +41,10 @@ Future<void> configureFirebase(FlutterLocalNotificationsPlugin localNotification
   // Configure message handler
   FirebaseMessaging.onMessage.listen((RemoteMessage message) {
     // TODO: Handle messages from Firebase
-    FLog.debug(text: "Firebase message received: ${message.data}");
+    logger.d("Firebase message received: ${message.data}");
 
     if (message.notification != null) {
-      FLog.debug(text: "Message also contained a notification: ${message.notification}");
+      logger.d("Message also contained a notification: ${message.notification}");
       showNotification(message.notification!.toMap(), localNotifications);
     }
   });
@@ -69,13 +69,13 @@ FlutterLocalNotificationsPlugin initLocalNotifications() {
 
 /// Handle background messages (when the app is not running)
 Future<void> _firebaseMessagingBackgroundHandler(RemoteMessage message) async {
-  FLog.debug(text: "Handling a background message: ${message.messageId}");
+  logger.d("Handling a background message: ${message.messageId}");
 
   await Firebase.initializeApp();
   final localNotifications = initLocalNotifications();
 
   if (message.notification != null) {
-    FLog.debug(text: "Message also contained a notification: ${message.notification}");
+    logger.d("Message also contained a notification: ${message.notification}");
     showNotification(message.notification!.toMap(), localNotifications);
   }
 }
@@ -103,7 +103,7 @@ void showNotification(
     macOS: darwinPlatformChannelSpecifics,
   );
 
-  FLog.debug(text: "Showing notification: ${message['title']} with body ${message['body']}");
+  logger.d("Showing notification: ${message['title']} with body ${message['body']}");
 
   await localNotifications.show(
     0,

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -281,14 +281,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.0.1"
-  f_logs:
-    dependency: "direct main"
-    description:
-      name: f_logs
-      sha256: "8ccf733949dcc934d7c7425e94a973cee71af1d7675b94dd1fbd6cbe707a3ce7"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.0.1"
   fake_async:
     dependency: transitive
     description:
@@ -592,6 +584,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.1"
+  logger:
+    dependency: "direct main"
+    description:
+      name: logger
+      sha256: "6bbb9d6f7056729537a4309bda2e74e18e5d9f14302489cc1e93f33b3fe32cac"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.2+1"
   logging:
     dependency: transitive
     description:
@@ -856,14 +856,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.2.2"
-  sembast:
-    dependency: transitive
-    description:
-      name: sembast
-      sha256: da8dd3774b6001bde09378da28e94c40bd4daecde32adb44837517c12e991321
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.4.9"
   share_plus:
     dependency: "direct main"
     description:
@@ -1053,14 +1045,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.2.0"
-  synchronized:
-    dependency: transitive
-    description:
-      name: synchronized
-      sha256: "5fcbd27688af6082f5abd611af56ee575342c30e87541d0245f7ff99faa02c60"
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.1.0"
   term_glyph:
     dependency: transitive
     description:
@@ -1317,14 +1301,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.3.0"
-  xxtea:
-    dependency: transitive
-    description:
-      name: xxtea
-      sha256: edd57229638e16e88f4bb299737fe76a235d0f11da6df8573b3c7f28dec283ce
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.1.0"
   yaml:
     dependency: transitive
     description:

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -9,7 +9,6 @@ dependencies:
     sdk: flutter
   cupertino_icons: ^1.0.5
   ffi: ^2.0.2
-  f_logs: ^2.0.1
   flutter_rust_bridge: ^1.78.0
   flutter_speed_dial: ^7.0.0
   meta: ^1.8.0
@@ -25,6 +24,7 @@ dependencies:
   expandable: ^5.0.1
   qr_flutter: ^4.0.0
   share_plus: ^7.0.2
+  logger: ^2.0.2+1
   candlesticks: ^2.1.0
   http: ^0.13.6
   timeago: ^3.3.0


### PR DESCRIPTION
With this new logger we can easily log into a file and into the console.

Second commit is optional, let me know if you want to keep it or drop it. 

Initial few log files look like this: 

```
flutter: [I] TIME: 2023-10-06T15:41:17.320986 r: Initialized logger
flutter: [I] TIME: 2023-10-06T15:41:17.656526 Coordinator version: 1.3.0
flutter: [I] TIME: 2023-10-06T15:41:17.657005 Client is up to date: 1.3.0
flutter: [I] TIME: 2023-10-06T15:41:19.653350 App data will be stored in: /Users/bonomat/Library/Developer/CoreSimulator/Devices/BBD86D27-7B1E-4237-BBDB-34FF9F250C78/data/Containers/Data/Application/E8A20B9D-0E4D-4568-A60C-5FD5FA6337D4/Documents
flutter: [I] TIME: 2023-10-06T15:41:19.653961 Seed data will be stored in: /Users/bonomat/Library/Developer/CoreSimulator/Devices/BBD86D27-7B1E-4237-BBDB-34FF9F250C78/data/Containers/Data/Application/E8A20B9D-0E4D-4568-A60C-5FD5FA6337D4/Library/Application Support
flutter: [D] TIME: 2023-10-06T15:41:19.661211 r: Parsing config from flutter config: Config { coordinator_pubkey: "02dd6abec97f9a748bf76ad502b004ce05d1b2d1f43a9e76bd7d85e767ffb022c9", esplora_endpoint: "http://127.0.0.1:3000", host: "127.0.0.1", p2p_port: 9045, http_port: 8000, network: "regtest", oracle_endpoint: "http://127.0.0.1:8081", oracle_pubkey: "16f88cf7d21e6c0f46bcbc983a4e3b19726c6c98858cc31c83551a88fde171c0", health_check_interval_secs: 2 }
flutter: [D] TIME: 2023-10-06T15:41:19.685110 r: Database migration run - db initialized
```


Log file for the app in the simulator will be located in  (depending on your device id)

`~/Library/Developer/CoreSimulator/Devices/BBD86D27-7B1E-4237-BBDB-34FF9F250C78/data/Containers/Data/Application/A654B954-9614-40F7-9984-1C253FF929E4/Library/Application Support/app_log.log`


@klochowicz : this solves the problem of losing logs for the app as the logs are stored in a file right away.

fixes: https://github.com/get10101/10101/issues/1202