### PR TITLE
feat: Make trade / stable screen default if user has a position

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Make trade / stable screen default if user has a position
+
 ## [1.4.0] - 2023-10-06
 
 - Allow up to 5BTC wumbo channels

--- a/mobile/lib/common/loading_screen.dart
+++ b/mobile/lib/common/loading_screen.dart
@@ -1,0 +1,47 @@
+import 'package:flutter/material.dart';
+import 'package:get_10101/features/stable/stable_screen.dart';
+import 'package:get_10101/features/trade/trade_screen.dart';
+import 'package:get_10101/features/wallet/wallet_screen.dart';
+import 'package:get_10101/features/welcome/welcome_screen.dart';
+import 'package:get_10101/util/preferences.dart';
+import 'package:go_router/go_router.dart';
+
+class LoadingScreen extends StatefulWidget {
+  static const route = "/loading";
+
+  const LoadingScreen({super.key});
+
+  @override
+  State<LoadingScreen> createState() => _LoadingScreenState();
+}
+
+class _LoadingScreenState extends State<LoadingScreen> {
+  @override
+  void initState() {
+    super.initState();
+    Future.wait<dynamic>(
+            [Preferences.instance.hasEmailAddress(), Preferences.instance.getOpenPosition()])
+        .then((value) {
+      final hasEmailAddress = value[0];
+      final position = value[1];
+
+      if (!hasEmailAddress) {
+        GoRouter.of(context).go(WelcomeScreen.route);
+      } else {
+        switch (position) {
+          case StableScreen.label:
+            GoRouter.of(context).go(StableScreen.route);
+          case TradeScreen.label:
+            GoRouter.of(context).go(TradeScreen.route);
+          default:
+            GoRouter.of(context).go(WalletScreen.route);
+        }
+      }
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return const Center(child: CircularProgressIndicator());
+  }
+}

--- a/mobile/lib/features/trade/domain/position.dart
+++ b/mobile/lib/features/trade/domain/position.dart
@@ -49,6 +49,8 @@ class Position {
       required this.collateral,
       required this.expiry});
 
+  bool isStable() => direction == Direction.short && leverage == Leverage(1);
+
   Amount getAmountWithUnrealizedPnl() {
     if (unrealizedPnl != null) {
       return Amount(collateral.sats + unrealizedPnl!.sats);

--- a/mobile/lib/features/trade/position_change_notifier.dart
+++ b/mobile/lib/features/trade/position_change_notifier.dart
@@ -7,6 +7,7 @@ import 'package:get_10101/features/trade/application/position_service.dart';
 import 'package:get_10101/features/trade/domain/contract_symbol.dart';
 import 'package:get_10101/features/trade/domain/direction.dart';
 import 'package:get_10101/features/trade/domain/leverage.dart';
+import 'package:get_10101/util/preferences.dart';
 
 import 'domain/position.dart';
 import 'domain/price.dart';
@@ -68,10 +69,18 @@ class PositionChangeNotifier extends ChangeNotifier implements Subscriber {
       }
       positions[position.contractSymbol] = position;
 
+      if (position.isStable()) {
+        Preferences.instance.setOpenStablePosition();
+      } else {
+        Preferences.instance.setOpenTradePosition();
+      }
+
       notifyListeners();
     } else if (event is bridge.Event_PositionClosedNotification) {
       ContractSymbol contractSymbol = ContractSymbol.fromApi(event.field0.contractSymbol);
       positions.remove(contractSymbol);
+
+      Preferences.instance.unsetOpenPosition();
 
       notifyListeners();
     } else if (event is bridge.Event_PriceUpdateNotification) {

--- a/mobile/lib/features/trade/trade_screen.dart
+++ b/mobile/lib/features/trade/trade_screen.dart
@@ -79,7 +79,7 @@ class TradeScreen extends StatelessWidget {
                     "Positions",
                     "Orders",
                   ],
-                  selectedIndex: positionChangeNotifier.positions.isEmpty ? 1 : 0,
+                  selectedIndex: 0,
                   keys: const [tradeScreenTabsPositions, tradeScreenTabsOrders],
                   tabBarViewChildren: [
                     ListView.builder(

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -15,6 +15,7 @@ import 'package:get_10101/common/color.dart';
 import 'package:get_10101/common/domain/background_task.dart';
 import 'package:get_10101/common/domain/service_status.dart';
 import 'package:get_10101/common/global_keys.dart';
+import 'package:get_10101/common/loading_screen.dart';
 import 'package:get_10101/common/recover_dlc_change_notifier.dart';
 import 'package:get_10101/common/service_status_notifier.dart';
 import 'package:get_10101/features/stable/stable_screen.dart';
@@ -56,7 +57,6 @@ import 'package:get_10101/util/constants.dart';
 import 'package:get_10101/util/coordinator_version.dart';
 import 'package:get_10101/util/environment.dart';
 import 'package:get_10101/util/notifications.dart';
-import 'package:get_10101/util/preferences.dart';
 import 'package:go_router/go_router.dart';
 import 'package:http/http.dart' as http;
 import 'package:package_info_plus/package_info_plus.dart';
@@ -122,7 +122,7 @@ class _TenTenOneAppState extends State<TenTenOneApp> {
 
   final GoRouter _router = GoRouter(
       navigatorKey: rootNavigatorKey,
-      initialLocation: WalletScreen.route,
+      initialLocation: LoadingScreen.route,
       routes: <RouteBase>[
         ShellRoute(
           navigatorKey: shellNavigatorKey,
@@ -132,6 +132,12 @@ class _TenTenOneAppState extends State<TenTenOneApp> {
             );
           },
           routes: <RouteBase>[
+            GoRoute(
+              path: LoadingScreen.route,
+              builder: (BuildContext context, GoRouterState state) {
+                return const LoadingScreen();
+              },
+            ),
             GoRoute(
               path: WalletScreen.route,
               builder: (BuildContext context, GoRouterState state) {
@@ -214,17 +220,7 @@ class _TenTenOneAppState extends State<TenTenOneApp> {
               return const WelcomeScreen();
             },
             routes: const []),
-      ],
-      redirect: (BuildContext context, GoRouterState state) async {
-        // TODO: It's not optimal that we read this from shared preferences every time, should probably be set through a provider
-        final hasEmailAddress = await Preferences.instance.hasEmailAddress();
-        if (!hasEmailAddress) {
-          logger.i("adding the email...");
-          return WelcomeScreen.route;
-        }
-
-        return null;
-      });
+      ]);
 
   @override
   void initState() {

--- a/mobile/lib/util/preferences.dart
+++ b/mobile/lib/util/preferences.dart
@@ -1,3 +1,5 @@
+import 'package:get_10101/features/stable/stable_screen.dart';
+import 'package:get_10101/features/trade/trade_screen.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 class Preferences {
@@ -7,6 +9,27 @@ class Preferences {
 
   static const userSeedBackupConfirmed = "userSeedBackupConfirmed";
   static const emailAddress = "emailAddress";
+  static const openPosition = "openPosition";
+
+  getOpenPosition() async {
+    SharedPreferences preferences = await SharedPreferences.getInstance();
+    return preferences.getString(openPosition);
+  }
+
+  setOpenStablePosition() async {
+    SharedPreferences preferences = await SharedPreferences.getInstance();
+    preferences.setString(openPosition, StableScreen.label);
+  }
+
+  setOpenTradePosition() async {
+    SharedPreferences preferences = await SharedPreferences.getInstance();
+    preferences.setString(openPosition, TradeScreen.label);
+  }
+
+  unsetOpenPosition() async {
+    SharedPreferences preferences = await SharedPreferences.getInstance();
+    preferences.remove(openPosition);
+  }
 
   setUserSeedBackupConfirmed() async {
     SharedPreferences preferences = await SharedPreferences.getInstance();


### PR DESCRIPTION
Stores if a position is open in the preferences and reads from it at startup in a loading screen. Once loaded you will be transferred to the correct page.

I had to default the trade screen to the positions, as otherwise you would have always defaulted to the orders, since at load time the position is not there yet.

https://github.com/get10101/10101/assets/382048/58fef395-df8f-4f2d-b413-5d8531bead1d

resolves #1318 

