### PR TITLE
fix: Do not navigate during widget build

### DIFF
--- a/mobile/lib/features/wallet/onboarding/fund_wallet_modal.dart
+++ b/mobile/lib/features/wallet/onboarding/fund_wallet_modal.dart
@@ -65,7 +65,10 @@ class _FundWalletModalState extends State<FundWalletModal> {
     const style = TextStyle(fontSize: 20);
 
     if (context.watch<PaymentClaimedChangeNotifier>().isClaimed()) {
-      GoRouter.of(context).go(WalletScreen.route);
+      // We must not navigate during widget build, hence we are registering the navigation post frame.
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        GoRouter.of(context).go(WalletScreen.route);
+      });
     }
 
     return SafeArea(


### PR DESCRIPTION
Fixes an exception thrown at navigating after receiving a payment during funding the app.

```
══╡ EXCEPTION CAUGHT BY FOUNDATION LIBRARY ╞════════════════════════════════════════════════════════
The following assertion was thrown while dispatching notifications for GoRouterDelegate:
setState() or markNeedsBuild() called during build.
This Router<Object> widget cannot be marked as needing to build because the framework is already in
the process of building widgets. A widget can be marked as needing to be built during the build
phase only if one of its ancestors is currently building. This exception is allowed because the
framework builds parent widgets before children, which means a dirty descendant will always be
built. Otherwise, the framework might not visit this widget during this build phase.
The widget on which setState() or markNeedsBuild() was called was:
  Router<Object>
The widget which was currently being built when the offending call was made was:
  FundWalletModal

When the exception was thrown, this was the stack:
#0      Element.markNeedsBuild.<anonymous closure> (package:flutter/src/widgets/framework.dart:4862:9)
#1      Element.markNeedsBuild (package:flutter/src/widgets/framework.dart:4874:6)
#2      State.setState (package:flutter/src/widgets/framework.dart:1158:15)
#3      _RouterState._handleRouterDelegateNotification (package:flutter/src/widgets/router.dart:791:5)
#4      ChangeNotifier.notifyListeners (package:flutter/src/foundation/change_notifier.dart:403:24)
#5      GoRouterDelegate.setNewRoutePath (package:go_router/src/delegate.dart:145:7)
#6      _RouterState._processParsedRouteInformation.<anonymous closure> (package:flutter/src/widgets/router.dart:753:34)
#7      SynchronousFuture.then (package:flutter/src/foundation/synchronous_future.dart:41:39)
#8      _RouterState._processRouteInformation (package:flutter/src/widgets/router.dart:745:8)
#9      _RouterState._handleRouteInformationProviderNotification (package:flutter/src/widgets/router.dart:762:5)
#10     ChangeNotifier.notifyListeners (package:flutter/src/foundation/change_notifier.dart:403:24)
#11     GoRouteInformationProvider.notifyListeners (package:go_router/src/information_provider.dart:141:11)
#12     GoRouteInformationProvider._setValue (package:go_router/src/information_provider.dart:149:7)
#13     GoRouteInformationProvider.go (package:go_router/src/information_provider.dart:171:5)
#14     GoRouter.go (package:go_router/src/router.dart:318:30)
#15     _FundWalletModalState.build (package:get_10101/features/wallet/onboarding/fund_wallet_modal.dart:68:28)
#16     StatefulElement.build (package:flutter/src/widgets/framework.dart:5409:27)
#17     ComponentElement.performRebuild (package:flutter/src/widgets/framework.dart:5297:15)
#18     StatefulElement.performRebuild (package:flutter/src/widgets/framework.dart:5462:11)
#19     Element.rebuild (package:flutter/src/widgets/framework.dart:5016:7)
#20     BuildOwner.buildScope (package:flutter/src/widgets/framework.dart:2779:19)
#21     WidgetsBinding.drawFrame (package:flutter/src/widgets/binding.dart:916:21)
#22     RendererBinding._handlePersistentFrameCallback (package:flutter/src/rendering/binding.dart:360:5)
#23     SchedulerBinding._invokeFrameCallback (package:flutter/src/scheduler/binding.dart:1297:15)
#24     SchedulerBinding.handleDrawFrame (package:flutter/src/scheduler/binding.dart:1227:9)
#25     SchedulerBinding._handleDrawFrame (package:flutter/src/scheduler/binding.dart:1085:5)
#26     _invoke (dart:ui/hooks.dart:170:13)
#27     PlatformDispatcher._drawFrame (dart:ui/platform_dispatcher.dart:401:5)
#28     _drawFrame (dart:ui/hooks.dart:140:31)

The GoRouterDelegate sending notification was:
  Instance of 'GoRouterDelegate'
════════════════════════════════════════════════════════════════════════════════════════════════════
```