### PR TITLE
fix(justfile): make `wipe` work on linux

### DIFF
--- a/justfile
+++ b/justfile
@@ -198,7 +198,7 @@ wipe-app:
     fi
 
     # If no path was found, use a dummy path to avoid errors
-    if [[ ! $MACOS_PATH || ! ${MACOS_PATH//[[:space:]]/} ]]; then
+    if [[ -z ${MACOS_PATH+x} || ! $MACOS_PATH || ! ${MACOS_PATH//[[:space:]]/} ]]; then
         echo "no macos path found, setting dummy value" 
         MACOS_PATH="/path/to/dummy/directory"
     fi


### PR DESCRIPTION
Without this, I get
```
+ echo 'Wiping native 10101 app'
Wiping native 10101 app
+ '[' -d /home/restioson/Library/Containers/ ']'
/tmp/justV3YWUx/wipe-app: line 201: MACOS_PATH: unbound variable
```