### PR TITLE
Reduce usage of `dynamic` keyword

### DIFF
--- a/mobile/lib/common/domain/model.dart
+++ b/mobile/lib/common/domain/model.dart
@@ -19,7 +19,7 @@ class Amount {
 
   double asDouble() => _sats.toDouble();
 
-  Amount.parse(dynamic value) : _sats = Decimal.parse(value);
+  Amount.parse(String value) : _sats = Decimal.parse(value);
 
   Amount.zero() : _sats = Decimal.zero;
 

--- a/mobile/lib/common/loading_screen.dart
+++ b/mobile/lib/common/loading_screen.dart
@@ -22,8 +22,8 @@ class _LoadingScreenState extends State<LoadingScreen> {
     Future.wait<dynamic>(
             [Preferences.instance.hasEmailAddress(), Preferences.instance.getOpenPosition()])
         .then((value) {
-      final hasEmailAddress = value[0];
-      final position = value[1];
+      final bool hasEmailAddress = value[0];
+      final String? position = value[1];
 
       if (!hasEmailAddress) {
         GoRouter.of(context).go(WelcomeScreen.route);

--- a/mobile/lib/common/status_screen.dart
+++ b/mobile/lib/common/status_screen.dart
@@ -35,22 +35,19 @@ class _StatusScreenState extends State<StatusScreen> {
             children: [
               const SizedBox(height: 20),
               ValueDataRow(
-                type: ValueType.text,
-                value: overallStatus,
+                value: Text(overallStatus),
                 label: "Services",
                 valueTextStyle: const TextStyle(fontWeight: FontWeight.bold),
               ),
               const Divider(),
               ValueDataRow(
-                type: ValueType.text,
-                value: orderbookStatus,
+                value: Text(orderbookStatus),
                 label: "Orderbook",
                 valueTextStyle: const TextStyle(fontWeight: FontWeight.bold),
               ),
               const SizedBox(height: 10),
               ValueDataRow(
-                type: ValueType.text,
-                value: coordinatorStatus,
+                value: Text(coordinatorStatus),
                 label: "LSP",
                 valueTextStyle: const TextStyle(fontWeight: FontWeight.bold),
               ),
@@ -62,8 +59,7 @@ class _StatusScreenState extends State<StatusScreen> {
             children: [
               const SizedBox(height: 20),
               ValueDataRow(
-                type: ValueType.text,
-                value: channelStatus,
+                value: Text(channelStatus),
                 label: "Channel status",
                 valueTextStyle: const TextStyle(fontWeight: FontWeight.bold),
               ),

--- a/mobile/lib/common/value_data_row.dart
+++ b/mobile/lib/common/value_data_row.dart
@@ -1,21 +1,42 @@
 import 'package:flutter/material.dart';
-import 'package:get_10101/common/amount_text.dart';
-import 'package:get_10101/common/fiat_text.dart';
 import 'package:intl/intl.dart';
 
-enum ValueType { date, amount, fiat, percentage, contracts, loading, text }
+/// A DateValue displays a `DateTime` with the format `dd.MM.yy-kk:mm`.
+class DateValue extends StatelessWidget {
+  final DateTime date;
+  final TextStyle textStyle;
+  const DateValue(this.date, {super.key, this.textStyle = const TextStyle()});
 
-class ValueDataRow extends StatelessWidget {
-  final ValueType type;
+  @override
+  Widget build(BuildContext context) {
+    return Text(DateFormat('dd.MM.yy-kk:mm').format(date));
+  }
+}
+
+/// A LoadingValue displays a widget (given by the `builder` function) when the
+/// `value` is not `null`, else displaying a `CircularProgressIndicator`
+class LoadingValue<T> extends StatelessWidget {
+  final Widget Function(T) builder;
+  final T? value;
+  const LoadingValue({super.key, required this.value, required this.builder});
+
+  @override
+  Widget build(BuildContext context) {
+    return this.value != null
+        ? builder(this.value as T)
+        : const SizedBox(width: 20, height: 20, child: CircularProgressIndicator());
+  }
+}
+
+class ValueDataRow<T extends Widget> extends StatelessWidget {
   final String label;
   final String sublabel;
-  final dynamic value;
+  final T value;
   final TextStyle valueTextStyle;
   final TextStyle labelTextStyle;
 
   const ValueDataRow(
       {super.key,
-      required this.type,
       required this.value,
       required this.label,
       this.sublabel = "",
@@ -24,38 +45,6 @@ class ValueDataRow extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    Widget widget;
-
-    switch (type) {
-      case ValueType.amount:
-        widget = AmountText(
-          amount: value,
-          textStyle: valueTextStyle,
-        );
-        break;
-      case ValueType.fiat:
-        widget = FiatText(amount: value, textStyle: valueTextStyle);
-        break;
-      case ValueType.percentage:
-        widget = Text("$value %", style: valueTextStyle);
-        break;
-      case ValueType.contracts:
-        widget = Text("$value contracts", style: valueTextStyle);
-        break;
-      case ValueType.loading:
-        widget = const SizedBox(width: 20, height: 20, child: CircularProgressIndicator());
-        break;
-      case ValueType.date:
-        widget = Text(DateFormat('dd.MM.yy-kk:mm').format(value), style: valueTextStyle);
-        break;
-      case ValueType.text:
-        widget = SizedBox(
-            width: 100,
-            child: Text(value,
-                textAlign: TextAlign.end, style: valueTextStyle, overflow: TextOverflow.ellipsis));
-        break;
-    }
-
     return Row(
       mainAxisAlignment: MainAxisAlignment.spaceBetween,
       children: [
@@ -67,7 +56,7 @@ class ValueDataRow extends StatelessWidget {
           const SizedBox(width: 2),
           Text(sublabel, style: const TextStyle(fontSize: 12, color: Colors.grey)),
         ]),
-        widget
+        value
       ],
     );
   }

--- a/mobile/lib/features/stable/bitcoinize_confirmation_sheet.dart
+++ b/mobile/lib/features/stable/bitcoinize_confirmation_sheet.dart
@@ -1,4 +1,6 @@
 import 'package:flutter/material.dart';
+import 'package:get_10101/common/amount_text.dart';
+import 'package:get_10101/common/fiat_text.dart';
 import 'package:get_10101/common/value_data_row.dart';
 import 'package:get_10101/features/stable/stable_dialog.dart';
 import 'package:get_10101/features/stable/stable_value_change_notifier.dart';
@@ -69,22 +71,20 @@ class BitcoinizeBottomSheet extends StatelessWidget {
           ),
           const SizedBox(height: 16.0),
           ValueDataRow(
-              type: ValueType.fiat,
-              value: position.quantity.asDouble(),
+              value: FiatText(amount: position.quantity.asDouble()),
               label: 'You have',
               valueTextStyle: const TextStyle(fontSize: 18),
               labelTextStyle: const TextStyle(fontSize: 18)),
           const SizedBox(height: 16.0),
           ValueDataRow(
-              type: ValueType.amount,
-              value: position.getAmountWithUnrealizedPnl(),
+              value: AmountText(amount: position.getAmountWithUnrealizedPnl()),
               label: 'You will receive',
               valueTextStyle: const TextStyle(fontSize: 18),
               labelTextStyle: const TextStyle(fontSize: 18)),
           const SizedBox(height: 16.0),
           ValueDataRow(
-              type: ValueType.amount,
-              value: stableValues.fee,
+              // TODO: what should we do if null?
+              value: AmountText(amount: stableValues.fee!),
               label: 'Fees',
               valueTextStyle: const TextStyle(fontSize: 18),
               labelTextStyle: const TextStyle(fontSize: 18)),

--- a/mobile/lib/features/stable/stable_confirmation_sheet.dart
+++ b/mobile/lib/features/stable/stable_confirmation_sheet.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:math';
 
 import 'package:flutter/material.dart';
+import 'package:get_10101/common/amount_text.dart';
 import 'package:get_10101/common/amount_text_input_form_field.dart';
 import 'package:get_10101/common/application/channel_info_service.dart';
 import 'package:get_10101/common/domain/channel.dart';
@@ -186,22 +187,22 @@ class _StableBottomSheet extends State<StableBottomSheet> {
                           ),
                           const SizedBox(height: 20.0),
                           ValueDataRow(
-                              type: ValueType.amount,
-                              value: tradeValues.margin,
+                              value: AmountText(
+                                  amount: tradeValues.margin!,
+                                  textStyle:
+                                      const TextStyle(fontSize: 18)), // TODO: what to do if null?
                               label: "Costs in Sats",
-                              valueTextStyle: const TextStyle(fontSize: 18),
                               labelTextStyle: const TextStyle(fontSize: 18)),
                           const SizedBox(height: 16.0),
                           ValueDataRow(
-                              type: ValueType.date,
-                              value: tradeValues.expiry.toLocal(),
+                              value: DateValue(tradeValues.expiry.toLocal(),
+                                  textStyle: const TextStyle(fontSize: 18)),
                               label: "Expiry",
-                              valueTextStyle: const TextStyle(fontSize: 18),
                               labelTextStyle: const TextStyle(fontSize: 18)),
                           const SizedBox(height: 16.0),
                           ValueDataRow(
-                              type: ValueType.amount,
-                              value: tradeValues.fee,
+                              value:
+                                  AmountText(amount: tradeValues.fee!), // TODO: what to do if null?
                               label: "Fees",
                               valueTextStyle: const TextStyle(fontSize: 18),
                               labelTextStyle: const TextStyle(fontSize: 18)),

--- a/mobile/lib/features/stable/stable_dialog.dart
+++ b/mobile/lib/features/stable/stable_dialog.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:get_10101/common/amount_text.dart';
 import 'package:get_10101/common/domain/background_task.dart';
 import 'package:get_10101/common/task_status_dialog.dart';
 import 'package:get_10101/common/value_data_row.dart';
@@ -78,24 +79,22 @@ Widget createSubmitWidget(PendingOrder pendingOrder, TextStyle style) {
           runSpacing: 10,
           children: [
             ValueDataRow(
-                type: pendingOrder.positionAction == PositionAction.close
-                    ? ValueType.text
-                    : ValueType.amount,
                 value: pendingOrder.positionAction == PositionAction.close
-                    ? "${pendingOrder.tradeValues?.quantity!.toInt} \$"
-                    : pendingOrder.tradeValues?.margin,
+                    ? Text("${pendingOrder.tradeValues?.quantity!.toInt} \$")
+                    : AmountText(
+                        amount:
+                            (pendingOrder.tradeValues?.margin)!), // TODO: what to do if null here?
                 label: pendingOrder.positionAction == PositionAction.open
                     ? "Stabilize"
                     : "Bitcoinize"),
             ValueDataRow(
-                type: pendingOrder.positionAction == PositionAction.open
-                    ? ValueType.text
-                    : ValueType.amount,
                 value: pendingOrder.positionAction == PositionAction.open
-                    ? "${pendingOrder.tradeValues?.quantity!.toInt} \$"
-                    : pendingOrder.tradeValues?.margin,
+                    ? Text("${pendingOrder.tradeValues?.quantity!.toInt} \$")
+                    : AmountText(
+                        amount:
+                            (pendingOrder.tradeValues?.margin)!), // TODO: what to do if null here?
                 label: "Into"),
-            ValueDataRow(type: ValueType.amount, value: pendingOrder.tradeValues?.fee, label: "Fee")
+            ValueDataRow(value: AmountText(amount: (pendingOrder.tradeValues?.fee)!), label: "Fee")
           ],
         ),
       ),

--- a/mobile/lib/features/stable/stable_screen.dart
+++ b/mobile/lib/features/stable/stable_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:get_10101/common/amount_text.dart';
 import 'package:get_10101/common/fiat_text.dart';
 import 'package:get_10101/common/value_data_row.dart';
 import 'package:get_10101/features/stable/bitcoinize_confirmation_sheet.dart';
@@ -62,16 +63,14 @@ class _StableScreenState extends State<StableScreen> {
       widgets = [
         Column(children: [
           ValueDataRow(
-            type: ValueType.date,
-            value: position.expiry,
+            value: DateValue(position.expiry),
             valueTextStyle: const TextStyle(fontSize: 18),
             label: "Expiry",
             labelTextStyle: const TextStyle(fontSize: 18),
           ),
           const SizedBox(height: 10),
           ValueDataRow(
-            type: ValueType.amount,
-            value: position.getAmountWithUnrealizedPnl(),
+            value: AmountText(amount: position.getAmountWithUnrealizedPnl()),
             valueTextStyle: const TextStyle(fontSize: 18),
             label: "Sats",
             labelTextStyle: const TextStyle(fontSize: 18),

--- a/mobile/lib/features/trade/application/trade_values_service.dart
+++ b/mobile/lib/features/trade/application/trade_values_service.dart
@@ -5,10 +5,7 @@ import 'package:get_10101/ffi.dart' as rust;
 
 class TradeValuesService {
   Amount? calculateMargin(
-      {required double? price,
-      required Amount? quantity,
-      required Leverage leverage,
-      dynamic hint}) {
+      {required double? price, required Amount? quantity, required Leverage leverage}) {
     if (price == null || quantity == null) {
       return null;
     } else {
@@ -18,7 +15,7 @@ class TradeValuesService {
   }
 
   Amount? calculateQuantity(
-      {required double? price, required Amount? margin, required Leverage leverage, dynamic hint}) {
+      {required double? price, required Amount? margin, required Leverage leverage}) {
     if (price == null || margin == null) {
       return null;
     } else {
@@ -29,10 +26,7 @@ class TradeValuesService {
   }
 
   double? calculateLiquidationPrice(
-      {required double? price,
-      required Leverage leverage,
-      required Direction direction,
-      dynamic hint}) {
+      {required double? price, required Leverage leverage, required Direction direction}) {
     if (price == null) {
       return null;
     } else {

--- a/mobile/lib/features/trade/position_list_item.dart
+++ b/mobile/lib/features/trade/position_list_item.dart
@@ -1,6 +1,8 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
+import 'package:get_10101/common/amount_text.dart';
+import 'package:get_10101/common/fiat_text.dart';
 import 'package:get_10101/common/value_data_row.dart';
 import 'package:get_10101/features/trade/domain/direction.dart';
 import 'package:get_10101/features/trade/domain/position.dart';
@@ -102,57 +104,50 @@ class _PositionListItemState extends State<PositionListItem> {
               child: Wrap(
                 runSpacing: 5,
                 children: [
-                  notNullPosition.unrealizedPnl == null
-                      ? const ValueDataRow(
-                          type: ValueType.loading, value: "", label: "Unrealized P/L")
-                      : ValueDataRow(
-                          type: ValueType.amount,
-                          value: notNullPosition.unrealizedPnl,
-                          label: "Unrealized P/L",
-                          valueTextStyle: dataRowStyle.apply(
-                              color: notNullPosition.unrealizedPnl!.sats.isNegative
-                                  ? tradeTheme.loss
-                                  : tradeTheme.profit),
-                          labelTextStyle: dataRowStyle,
-                        ),
                   ValueDataRow(
-                    type: ValueType.amount,
-                    value: notNullPosition.collateral,
+                      value: LoadingValue(
+                          value: notNullPosition.unrealizedPnl,
+                          builder: (pnl) {
+                            return AmountText(
+                                amount: pnl,
+                                textStyle: dataRowStyle.apply(
+                                    color: notNullPosition.unrealizedPnl!.sats.isNegative
+                                        ? tradeTheme.loss
+                                        : tradeTheme.profit));
+                          }),
+                      label: "Unrealized P/L"),
+                  ValueDataRow(
+                    value: AmountText(amount: notNullPosition.collateral),
                     label: "Margin",
                     valueTextStyle: dataRowStyle,
                     labelTextStyle: dataRowStyle,
                   ),
                   ValueDataRow(
-                    type: ValueType.text,
-                    value: notNullPosition.leverage.formatted(),
+                    value: Text(notNullPosition.leverage.formatted()),
                     label: "Leverage",
                     valueTextStyle: dataRowStyle,
                     labelTextStyle: dataRowStyle,
                   ),
                   ValueDataRow(
-                    type: ValueType.date,
-                    value: notNullPosition.expiry,
+                    value: DateValue(notNullPosition.expiry),
                     label: "Expiry",
                     valueTextStyle: dataRowStyle,
                     labelTextStyle: dataRowStyle,
                   ),
                   ValueDataRow(
-                    type: ValueType.contracts,
-                    value: formatter.format(notNullPosition.quantity.toInt),
+                    value: Text("${formatter.format(notNullPosition.quantity.toInt)} contracts",
+                        style: dataRowStyle),
                     label: "Quantity",
-                    valueTextStyle: dataRowStyle,
                     labelTextStyle: dataRowStyle,
                   ),
                   ValueDataRow(
-                    type: ValueType.fiat,
-                    value: notNullPosition.liquidationPrice,
+                    value: FiatText(amount: notNullPosition.liquidationPrice),
                     label: "Liquidation price",
                     valueTextStyle: dataRowStyle,
                     labelTextStyle: dataRowStyle,
                   ),
                   ValueDataRow(
-                    type: ValueType.fiat,
-                    value: notNullPosition.averageEntryPrice,
+                    value: FiatText(amount: notNullPosition.averageEntryPrice),
                     label: "Average entry price",
                     valueTextStyle: dataRowStyle,
                     labelTextStyle: dataRowStyle,

--- a/mobile/lib/features/trade/trade_bottom_sheet_confirmation.dart
+++ b/mobile/lib/features/trade/trade_bottom_sheet_confirmation.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:get_10101/common/amount_text.dart';
 import 'package:get_10101/common/domain/model.dart';
+import 'package:get_10101/common/fiat_text.dart';
 import 'package:get_10101/common/value_data_row.dart';
 import 'package:get_10101/features/trade/contract_symbol_icon.dart';
 import 'package:get_10101/features/trade/domain/contract_symbol.dart';
@@ -120,39 +121,34 @@ class TradeBottomSheetConfirmation extends StatelessWidget {
                       children: [
                         if (!close)
                           ValueDataRow(
-                              type: ValueType.date,
-                              value: tradeValues.expiry.toLocal(),
-                              label: 'Expiry'),
+                              value: DateValue(tradeValues.expiry.toLocal()), label: 'Expiry'),
                         close
                             ? ValueDataRow(
-                                type: ValueType.fiat,
-                                value: tradeValues.price ?? 0.0,
+                                value: FiatText(amount: tradeValues.price ?? 0.0),
                                 label: 'Market Price')
                             : ValueDataRow(
-                                type: ValueType.amount, value: tradeValues.margin, label: 'Margin'),
+                                value: AmountText(amount: tradeValues.margin!),
+                                label: 'Margin'), // TODO: what to do if null
                         close
                             ? ValueDataRow(
-                                type: ValueType.amount,
-                                value: pnl,
+                                value: AmountText(amount: pnl),
                                 label: 'Unrealized P/L',
                                 valueTextStyle: dataRowStyle.apply(
                                     color:
                                         pnl.sats.isNegative ? tradeTheme.loss : tradeTheme.profit))
                             : ValueDataRow(
-                                type: ValueType.fiat,
-                                value: tradeValues.liquidationPrice ?? 0.0,
+                                value: FiatText(amount: tradeValues.liquidationPrice ?? 0.0),
                                 label: 'Liquidation Price',
                               ),
                         ValueDataRow(
-                          type: ValueType.amount,
-                          value: tradeValues.fee ?? Amount.zero(),
+                          value: AmountText(amount: tradeValues.fee ?? Amount.zero()),
                           label: "Fee estimate",
                         ),
                       ],
                     ),
                     !close ? const Divider() : const SizedBox(height: 0),
                     !close
-                        ? ValueDataRow(type: ValueType.amount, value: total, label: "Total")
+                        ? ValueDataRow(value: AmountText(amount: total), label: "Total")
                         : const SizedBox(height: 0),
                   ],
                 ),

--- a/mobile/lib/features/trade/trade_bottom_sheet_tab.dart
+++ b/mobile/lib/features/trade/trade_bottom_sheet_tab.dart
@@ -9,6 +9,7 @@ import 'package:get_10101/common/application/channel_info_service.dart';
 import 'package:get_10101/common/domain/channel.dart';
 import 'package:get_10101/common/domain/liquidity_option.dart';
 import 'package:get_10101/common/domain/model.dart';
+import 'package:get_10101/common/fiat_text.dart';
 import 'package:get_10101/common/modal_bottom_sheet_info.dart';
 import 'package:get_10101/common/value_data_row.dart';
 import 'package:get_10101/features/trade/domain/direction.dart';
@@ -376,14 +377,13 @@ class _TradeBottomSheetTabState extends State<TradeBottomSheetTab> {
                     provider.fromDirection(direction).liquidationPrice ?? 0.0,
                 builder: (context, liquidationPrice, child) {
                   return ValueDataRow(
-                      type: ValueType.fiat, value: liquidationPrice, label: "Liquidation:");
+                      value: FiatText(amount: liquidationPrice), label: "Liquidation:");
                 }),
             const SizedBox(width: 55),
             Selector<TradeValuesChangeNotifier, Amount>(
                 selector: (_, provider) => provider.orderMatchingFee(direction) ?? Amount.zero(),
-                builder: (context, fee, child) {
-                  return ValueDataRow(type: ValueType.amount, value: fee, label: "Fee:");
-                }),
+                builder: (context, fee, child) =>
+                    ValueDataRow(value: AmountText(amount: fee), label: "Fee:")),
           ],
         )
       ],

--- a/mobile/lib/features/trade/trade_dialog.dart
+++ b/mobile/lib/features/trade/trade_dialog.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import 'package:flutter/material.dart';
+import 'package:get_10101/common/amount_text.dart';
 import 'package:get_10101/common/domain/background_task.dart';
 import 'package:get_10101/common/domain/model.dart';
 import 'package:get_10101/common/task_status_dialog.dart';
@@ -72,11 +73,13 @@ Widget createSubmitWidget(
           runSpacing: 10,
           children: [
             pendingOrder.positionAction == PositionAction.close
-                ? ValueDataRow(type: ValueType.amount, value: pendingOrder.pnl, label: pnlText)
+                ? ValueDataRow(
+                    value: AmountText(amount: pendingOrder.pnl!),
+                    label: pnlText) // TODO:  what to do when null
                 : ValueDataRow(
-                    type: ValueType.amount, value: pendingOrderValues?.margin, label: "Margin"),
+                    value: AmountText(amount: (pendingOrderValues?.margin)!), label: "Margin"),
             ValueDataRow(
-                type: ValueType.amount, value: pendingOrderValues?.fee ?? Amount(0), label: "Fee")
+                value: AmountText(amount: pendingOrderValues?.fee ?? Amount(0)), label: "Fee")
           ],
         ),
       ),

--- a/mobile/lib/features/wallet/onboarding/fund_wallet_modal.dart
+++ b/mobile/lib/features/wallet/onboarding/fund_wallet_modal.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:get_10101/bridge_generated/bridge_definitions.dart' as bridge;
+import 'package:get_10101/common/amount_text.dart';
 import 'package:get_10101/common/domain/model.dart';
 import 'package:get_10101/common/snack_bar.dart';
 import 'package:get_10101/common/value_data_row.dart';
@@ -179,16 +180,14 @@ class _FundWalletModalState extends State<FundWalletModal> {
             child: Column(
               children: [
                 ValueDataRow(
-                  type: ValueType.amount,
-                  value: widget.amount,
+                  value: AmountText(amount: widget.amount),
                   label: "Amount",
                   labelTextStyle: style,
                   valueTextStyle: style,
                 ),
                 const Divider(),
                 ValueDataRow(
-                  type: ValueType.amount,
-                  value: widget.fee,
+                  value: AmountText(amount: widget.fee),
                   label: "Fee",
                   labelTextStyle: style,
                   valueTextStyle: style,

--- a/mobile/lib/features/wallet/onboarding/liquidity_card.dart
+++ b/mobile/lib/features/wallet/onboarding/liquidity_card.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_rust_bridge/flutter_rust_bridge.dart';
+import 'package:get_10101/common/amount_text.dart';
 import 'package:get_10101/common/color.dart';
 import 'package:get_10101/common/domain/liquidity_option.dart';
 import 'package:get_10101/common/domain/model.dart';
@@ -101,8 +102,7 @@ class _LiquidityCardState extends State<LiquidityCard> {
                 Container(
                   padding: const EdgeInsets.fromLTRB(16, 0, 16, 0),
                   child: ValueDataRow(
-                    type: ValueType.amount,
-                    value: widget.tradeUpTo,
+                    value: AmountText(amount: widget.tradeUpTo),
                     label: "Trade up to",
                     valueTextStyle: fontStyle,
                     labelTextStyle: fontStyle,
@@ -112,8 +112,7 @@ class _LiquidityCardState extends State<LiquidityCard> {
                 Container(
                   padding: const EdgeInsets.fromLTRB(16, 0, 16, 0),
                   child: ValueDataRow(
-                      type: ValueType.amount,
-                      value: fee,
+                      value: AmountText(amount: fee),
                       label: "Fee",
                       valueTextStyle: fontStyle,
                       labelTextStyle: fontStyle),
@@ -122,8 +121,7 @@ class _LiquidityCardState extends State<LiquidityCard> {
                 Container(
                   padding: const EdgeInsets.fromLTRB(16, 0, 16, 0),
                   child: ValueDataRow(
-                      type: ValueType.amount,
-                      value: minDeposit,
+                      value: AmountText(amount: minDeposit),
                       label: "Min deposit",
                       valueTextStyle: fontStyle,
                       labelTextStyle: fontStyle),
@@ -132,8 +130,7 @@ class _LiquidityCardState extends State<LiquidityCard> {
                 Container(
                   padding: const EdgeInsets.fromLTRB(16, 0, 16, 10),
                   child: ValueDataRow(
-                    type: ValueType.amount,
-                    value: widget.maxDeposit,
+                    value: AmountText(amount: widget.maxDeposit),
                     label: "Max deposit",
                     valueTextStyle: fontStyle,
                     labelTextStyle: fontStyle,

--- a/mobile/lib/features/wallet/send_payment_screen.dart
+++ b/mobile/lib/features/wallet/send_payment_screen.dart
@@ -2,6 +2,7 @@ import 'dart:math';
 
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:get_10101/common/amount_text.dart';
 import 'package:get_10101/common/application/channel_info_service.dart';
 import 'package:get_10101/common/domain/channel.dart';
 import 'package:get_10101/common/domain/model.dart';
@@ -164,24 +165,21 @@ class _SendPaymentScreenState extends State<SendPaymentScreen> {
                             height: 10,
                           ),
                           ValueDataRow(
-                            type: ValueType.amount,
-                            value: _lightningInvoice!.amountSats,
+                            value: AmountText(amount: _lightningInvoice!.amountSats),
                             label: "Amount",
                           ),
                           const SizedBox(
                             height: 5,
                           ),
                           ValueDataRow(
-                            type: ValueType.text,
-                            value: _lightningInvoice!.payee,
+                            value: Text(_lightningInvoice!.payee),
                             label: "Recipient",
                           ),
                           const SizedBox(
                             height: 5,
                           ),
                           ValueDataRow(
-                            type: ValueType.date,
-                            value: _lightningInvoice!.expiry,
+                            value: DateValue(_lightningInvoice!.expiry),
                             label: "Expiry",
                           ),
                           if (_lightningInvoice!.amountSats == Amount.zero())

--- a/mobile/lib/features/wallet/share_invoice_screen.dart
+++ b/mobile/lib/features/wallet/share_invoice_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:get_10101/bridge_generated/bridge_definitions.dart' as bridge;
+import 'package:get_10101/common/amount_text.dart';
 import 'package:get_10101/common/snack_bar.dart';
 import 'package:get_10101/common/value_data_row.dart';
 import 'package:get_10101/features/wallet/application/faucet_service.dart';
@@ -82,8 +83,7 @@ class _ShareInvoiceScreenState extends State<ShareInvoiceScreen> {
                         // Size of the qr image minus padding
                         width: qrWidth - 2 * qrPadding,
                         child: ValueDataRow(
-                          type: ValueType.amount,
-                          value: widget.invoice.invoiceAmount,
+                          value: AmountText(amount: widget.invoice.invoiceAmount),
                           label: 'Amount',
                         ))),
                 const SizedBox(height: 10)

--- a/mobile/lib/features/wallet/wallet_screen.dart
+++ b/mobile/lib/features/wallet/wallet_screen.dart
@@ -70,14 +70,15 @@ class _WalletScreenState extends State<WalletScreen> {
                           runSpacing: 10,
                           children: [
                             ValueDataRow(
-                                type: ValueType.amount,
-                                value: sendPaymentChangeNotifier
-                                    .pendingPayment?.decodedInvoice.amountSats,
+                                value: AmountText(
+                                    amount: (sendPaymentChangeNotifier
+                                        .pendingPayment
+                                        ?.decodedInvoice
+                                        .amountSats)!), // TODO: what to do when null
                                 label: "Amount"),
                             ValueDataRow(
-                                type: ValueType.text,
-                                value:
-                                    sendPaymentChangeNotifier.pendingPayment?.decodedInvoice.payee,
+                                value: Text((sendPaymentChangeNotifier.pendingPayment
+                                    ?.decodedInvoice.payee)!), // TODO: what to do when null
                                 label: "Recipient")
                           ],
                         ),

--- a/mobile/lib/util/preferences.dart
+++ b/mobile/lib/util/preferences.dart
@@ -11,7 +11,7 @@ class Preferences {
   static const emailAddress = "emailAddress";
   static const openPosition = "openPosition";
 
-  getOpenPosition() async {
+  Future<String?> getOpenPosition() async {
     SharedPreferences preferences = await SharedPreferences.getInstance();
     return preferences.getString(openPosition);
   }


### PR DESCRIPTION
This removes some uses of the `dynamic` keyword, thus making the code more type safe.

I've added quite a few TODOs here which must first be resolved. These are all at sites where I've explicitly added null checks (`!`) where they were previously implicit. Hence, I'm not sure if they were intentionally implicit before, or we just forgot to handle the null case. Maybe someone who is familiar with those parts can give some guidance on how we should handle nulls there?

I also need to still handle the clipping case when text is too long (force ellipsise it).
