### PR TITLE
feat: Add stable flag to orders and positions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Receive bitcoin in wallet
 - Send bitcoin in wallet to address or BIP21 URI
 - Redesign send and receive screens
+- Add stable flag to position and order
 
 ## [1.4.1] - 2023-10-09
 

--- a/coordinator/migrations/2023-10-16-113322_add_stable_flag/down.sql
+++ b/coordinator/migrations/2023-10-16-113322_add_stable_flag/down.sql
@@ -1,0 +1,6 @@
+-- This file should undo anything in `up.sql`
+ALTER TABLE orders
+    DROP COLUMN "stable";
+
+ALTER TABLE positions
+    DROP COLUMN "stable";

--- a/coordinator/migrations/2023-10-16-113322_add_stable_flag/up.sql
+++ b/coordinator/migrations/2023-10-16-113322_add_stable_flag/up.sql
@@ -1,0 +1,6 @@
+-- Your SQL goes here
+ALTER TABLE "orders"
+    ADD COLUMN "stable" BOOLEAN NOT NULL DEFAULT false;
+
+ALTER TABLE "positions"
+    ADD COLUMN "stable" BOOLEAN NOT NULL DEFAULT false;

--- a/coordinator/src/db/positions.rs
+++ b/coordinator/src/db/positions.rs
@@ -38,6 +38,7 @@ pub struct Position {
     pub closing_price: Option<f32>,
     pub coordinator_leverage: f32,
     pub trader_margin: i64,
+    pub stable: bool,
 }
 
 impl Position {
@@ -280,6 +281,7 @@ impl From<Position> for crate::position::models::Position {
             closing_price: value.closing_price,
             coordinator_leverage: value.coordinator_leverage,
             trader_margin: value.trader_margin,
+            stable: value.stable,
         }
     }
 }
@@ -299,6 +301,7 @@ struct NewPosition {
     pub trader_pubkey: String,
     pub temporary_contract_id: String,
     pub trader_margin: i64,
+    pub stable: bool,
 }
 
 impl From<crate::position::models::NewPosition> for NewPosition {
@@ -316,6 +319,7 @@ impl From<crate::position::models::NewPosition> for NewPosition {
             trader_pubkey: value.trader.to_string(),
             temporary_contract_id: value.temporary_contract_id.to_hex(),
             trader_margin: value.trader_margin,
+            stable: value.stable,
         }
     }
 }

--- a/coordinator/src/node.rs
+++ b/coordinator/src/node.rs
@@ -244,6 +244,7 @@ impl Node {
                     trade_params,
                     fee_payment_hash,
                     coordinator_leverage,
+                    order.stable,
                 )
                 .await?;
             }
@@ -283,6 +284,7 @@ impl Node {
         trade_params: &TradeParams,
         fee_payment_hash: PaymentHash,
         coordinator_leverage: f32,
+        stable: bool,
     ) -> Result<()> {
         let peer_id = trade_params.pubkey;
         tracing::info!(%peer_id, ?trade_params, "Opening position");
@@ -360,6 +362,7 @@ impl Node {
             fee_payment_hash,
             temporary_contract_id,
             coordinator_leverage,
+            stable,
         )
     }
 
@@ -371,6 +374,7 @@ impl Node {
         fee_payment_hash: PaymentHash,
         temporary_contract_id: ContractId,
         coordinator_leverage: f32,
+        stable: bool,
     ) -> Result<()> {
         let liquidation_price = liquidation_price(trade_params);
         let margin_coordinator = margin_coordinator(trade_params, coordinator_leverage);
@@ -393,6 +397,7 @@ impl Node {
             expiry_timestamp: trade_params.filled_with.expiry_timestamp,
             temporary_contract_id,
             trader_margin: margin_trader as i64,
+            stable,
         };
         tracing::debug!(?new_position, "Inserting new position into db");
 

--- a/coordinator/src/node/expired_positions.rs
+++ b/coordinator/src/node/expired_positions.rs
@@ -93,6 +93,7 @@ pub async fn close(node: Node, trading_sender: mpsc::Sender<NewOrderMessage>) ->
             // a certain time period we can assume the channel to be abandoned and we should force
             // close.
             expiry: OffsetDateTime::now_utc().add(EXPIRED_POSITION_TIMEOUT),
+            stable: position.stable,
         };
 
         let (sender, mut receiver) = mpsc::channel::<Result<Order>>(1);

--- a/coordinator/src/orderbook/db/orders.rs
+++ b/coordinator/src/orderbook/db/orders.rs
@@ -97,6 +97,7 @@ struct Order {
     pub contract_symbol: ContractSymbol,
     pub leverage: f32,
     pub order_reason: OrderReason,
+    pub stable: bool,
 }
 
 impl From<Order> for OrderbookOrder {
@@ -115,6 +116,7 @@ impl From<Order> for OrderbookOrder {
             expiry: value.expiry,
             order_state: value.order_state.into(),
             order_reason: value.order_reason.into(),
+            stable: value.stable,
         }
     }
 }
@@ -150,6 +152,7 @@ struct NewOrder {
     pub order_reason: OrderReason,
     pub contract_symbol: ContractSymbol,
     pub leverage: f32,
+    pub stable: bool,
 }
 
 impl From<OrderbookNewOrder> for NewOrder {
@@ -173,6 +176,7 @@ impl From<OrderbookNewOrder> for NewOrder {
             order_reason: OrderReason::Manual,
             contract_symbol: value.contract_symbol.into(),
             leverage: value.leverage,
+            stable: value.stable,
         }
     }
 }

--- a/coordinator/src/orderbook/tests/sample_test.rs
+++ b/coordinator/src/orderbook/tests/sample_test.rs
@@ -119,5 +119,6 @@ fn dummy_order(expiry: OffsetDateTime) -> NewOrder {
         expiry,
         contract_symbol: trade::ContractSymbol::BtcUsd,
         leverage: 1.0,
+        stable: false,
     }
 }

--- a/coordinator/src/orderbook/trading.rs
+++ b/coordinator/src/orderbook/trading.rs
@@ -439,6 +439,7 @@ pub mod tests {
             expiry: OffsetDateTime::now_utc() + Duration::minutes(1),
             order_state: OrderState::Open,
             order_reason: OrderReason::Manual,
+            stable: false,
         }
     }
 
@@ -579,6 +580,7 @@ pub mod tests {
             expiry: OffsetDateTime::now_utc() + Duration::minutes(1),
             order_state: OrderState::Open,
             order_reason: OrderReason::Manual,
+            stable: false,
         };
 
         let matched_orders = match_order(&order, all_orders, Network::Bitcoin)
@@ -655,6 +657,7 @@ pub mod tests {
             expiry: OffsetDateTime::now_utc() + Duration::minutes(1),
             order_state: OrderState::Open,
             order_reason: OrderReason::Manual,
+            stable: false,
         };
 
         assert!(match_order(&order, all_orders, Network::Bitcoin).is_err());
@@ -705,6 +708,7 @@ pub mod tests {
             expiry: OffsetDateTime::now_utc() + Duration::minutes(1),
             order_state: OrderState::Open,
             order_reason: OrderReason::Manual,
+            stable: false,
         };
 
         let matched_orders = match_order(&order, all_orders, Network::Bitcoin).unwrap();

--- a/coordinator/src/position/models.rs
+++ b/coordinator/src/position/models.rs
@@ -27,6 +27,7 @@ pub struct NewPosition {
     pub expiry_timestamp: OffsetDateTime,
     pub temporary_contract_id: ContractId,
     pub trader_margin: i64,
+    pub stable: bool,
 }
 
 #[derive(Clone, PartialEq, Debug)]
@@ -78,6 +79,7 @@ pub struct Position {
     pub temporary_contract_id: Option<ContractId>,
     pub closing_price: Option<f32>,
     pub trader_margin: i64,
+    pub stable: bool,
 }
 
 impl Position {
@@ -502,6 +504,7 @@ pub mod tests {
                 closing_price: None,
                 coordinator_leverage: 2.0,
                 trader_margin: 1000,
+                stable: false,
             }
         }
 

--- a/coordinator/src/schema.rs
+++ b/coordinator/src/schema.rs
@@ -142,6 +142,7 @@ diesel::table! {
         contract_symbol -> ContractSymbolType,
         leverage -> Float4,
         order_reason -> OrderReasonType,
+        stable -> Bool,
     }
 }
 
@@ -193,6 +194,7 @@ diesel::table! {
         closing_price -> Nullable<Float4>,
         coordinator_leverage -> Float4,
         trader_margin -> Int8,
+        stable -> Bool,
     }
 }
 

--- a/crates/orderbook-commons/src/lib.rs
+++ b/crates/orderbook-commons/src/lib.rs
@@ -61,6 +61,7 @@ pub struct Order {
     pub expiry: OffsetDateTime,
     pub order_state: OrderState,
     pub order_reason: OrderReason,
+    pub stable: bool,
 }
 
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
@@ -91,6 +92,7 @@ pub struct NewOrder {
     pub leverage: f32,
     pub order_type: OrderType,
     pub expiry: OffsetDateTime,
+    pub stable: bool,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq)]

--- a/crates/orderbook-commons/src/price.rs
+++ b/crates/orderbook-commons/src/price.rs
@@ -104,6 +104,7 @@ mod test {
             expiry: OffsetDateTime::now_utc(),
             order_state,
             order_reason: OrderReason::Manual,
+            stable: false,
         }
     }
 

--- a/crates/tests-e2e/src/setup.rs
+++ b/crates/tests-e2e/src/setup.rs
@@ -109,5 +109,6 @@ pub fn dummy_order() -> NewOrder {
         direction: api::Direction::Long,
         quantity: 1.0,
         order_type: Box::new(OrderType::Market),
+        stable: false,
     }
 }

--- a/crates/tests-e2e/tests/open_position.rs
+++ b/crates/tests-e2e/tests/open_position.rs
@@ -17,6 +17,7 @@ fn dummy_order() -> NewOrder {
         direction: api::Direction::Long,
         quantity: 1.0,
         order_type: Box::new(OrderType::Market),
+        stable: false,
     }
 }
 

--- a/maker/src/trading/mod.rs
+++ b/maker/src/trading/mod.rs
@@ -142,6 +142,7 @@ async fn add_10101_order(
                 leverage: 1.0,
                 order_type: OrderType::Limit,
                 expiry,
+                stable: false,
             },
         )
         .await

--- a/mobile/lib/features/stable/bitcoinize_confirmation_sheet.dart
+++ b/mobile/lib/features/stable/bitcoinize_confirmation_sheet.dart
@@ -99,7 +99,8 @@ class BitcoinizeBottomSheet extends StatelessWidget {
                     final submitOrderChangeNotifier = context.read<SubmitOrderChangeNotifier>();
                     stableValues.margin = position.getAmountWithUnrealizedPnl();
                     submitOrderChangeNotifier.closePosition(
-                        position, stableValues.price, stableValues.fee);
+                        position, stableValues.price, stableValues.fee,
+                        stable: true);
 
                     // Return to the stable screen before submitting the pending order so that the dialog is displayed under the correct context
                     GoRouter.of(context).pop();

--- a/mobile/lib/features/stable/stable_confirmation_sheet.dart
+++ b/mobile/lib/features/stable/stable_confirmation_sheet.dart
@@ -216,7 +216,8 @@ class _StableBottomSheet extends State<StableBottomSheet> {
                                       stableValuesChangeNotifier.stableValues();
 
                                   submitOrderChangeNotifier.submitPendingOrder(
-                                      tradeValues, PositionAction.open);
+                                      tradeValues, PositionAction.open,
+                                      stable: true);
 
                                   // Return to the trade screen before submitting the pending order so that the dialog is displayed under the correct context
                                   GoRouter.of(context).pop();

--- a/mobile/lib/features/trade/application/order_service.dart
+++ b/mobile/lib/features/trade/application/order_service.dart
@@ -7,13 +7,14 @@ import 'package:get_10101/ffi.dart' as rust;
 
 class OrderService {
   Future<String> submitMarketOrder(Leverage leverage, Amount quantity,
-      ContractSymbol contractSymbol, Direction direction) async {
+      ContractSymbol contractSymbol, Direction direction, bool stable) async {
     rust.NewOrder order = rust.NewOrder(
         leverage: leverage.leverage,
         quantity: quantity.asDouble(),
         contractSymbol: contractSymbol.toApi(),
         direction: direction.toApi(),
-        orderType: const rust.OrderType.market());
+        orderType: const rust.OrderType.market(),
+        stable: stable);
 
     // The problem here is that we have a concurrency issue when sending a payment and trying to open/close a position.
     // The sleep here tries to ensure that we do not process the order matching fee payment from an older order while triggering the next order.

--- a/mobile/lib/features/trade/domain/position.dart
+++ b/mobile/lib/features/trade/domain/position.dart
@@ -30,6 +30,7 @@ class Position {
   final Direction direction;
   final double averageEntryPrice;
   final double liquidationPrice;
+  final bool stable;
 
   // The unrealized PnL is calculated from the current price
   Amount? unrealizedPnl;
@@ -47,9 +48,10 @@ class Position {
       required this.positionState,
       this.unrealizedPnl,
       required this.collateral,
-      required this.expiry});
+      required this.expiry,
+      required this.stable});
 
-  bool isStable() => direction == Direction.short && leverage == Leverage(1);
+  bool isStable() => stable;
 
   Amount getAmountWithUnrealizedPnl() {
     if (unrealizedPnl != null) {
@@ -70,6 +72,7 @@ class Position {
       liquidationPrice: position.liquidationPrice,
       collateral: Amount(position.collateral),
       expiry: DateTime.fromMillisecondsSinceEpoch(position.expiry * 1000),
+      stable: position.stable,
     );
   }
 
@@ -84,6 +87,7 @@ class Position {
       liquidationPrice: 0,
       collateral: 0,
       expiry: 0,
+      stable: false,
     );
   }
 }

--- a/mobile/lib/features/trade/position_change_notifier.dart
+++ b/mobile/lib/features/trade/position_change_notifier.dart
@@ -5,8 +5,6 @@ import 'package:get_10101/common/application/event_service.dart';
 import 'package:get_10101/common/domain/model.dart';
 import 'package:get_10101/features/trade/application/position_service.dart';
 import 'package:get_10101/features/trade/domain/contract_symbol.dart';
-import 'package:get_10101/features/trade/domain/direction.dart';
-import 'package:get_10101/features/trade/domain/leverage.dart';
 import 'package:get_10101/util/preferences.dart';
 
 import 'domain/position.dart';
@@ -40,9 +38,7 @@ class PositionChangeNotifier extends ChangeNotifier implements Subscriber {
 
   bool hasStableUSD() {
     final positionUsd = positions[ContractSymbol.btcusd];
-    return positionUsd != null &&
-        positionUsd.direction == Direction.short &&
-        positionUsd.leverage == Leverage(1);
+    return positionUsd != null && positionUsd.stable;
   }
 
   Future<void> initialize() async {

--- a/mobile/lib/features/trade/submit_order_change_notifier.dart
+++ b/mobile/lib/features/trade/submit_order_change_notifier.dart
@@ -43,7 +43,8 @@ class SubmitOrderChangeNotifier extends ChangeNotifier implements Subscriber {
 
   SubmitOrderChangeNotifier(this.orderService);
 
-  submitPendingOrder(TradeValues tradeValues, PositionAction positionAction, {Amount? pnl}) async {
+  submitPendingOrder(TradeValues tradeValues, PositionAction positionAction,
+      {Amount? pnl, bool stable = false}) async {
     _pendingOrder = PendingOrder(tradeValues, positionAction, pnl);
 
     // notify listeners about pending order in state "pending"
@@ -52,7 +53,7 @@ class SubmitOrderChangeNotifier extends ChangeNotifier implements Subscriber {
     try {
       assert(tradeValues.quantity != null, 'Quantity cannot be null when submitting order');
       _pendingOrder!.id = await orderService.submitMarketOrder(tradeValues.leverage,
-          tradeValues.quantity!, ContractSymbol.btcusd, tradeValues.direction);
+          tradeValues.quantity!, ContractSymbol.btcusd, tradeValues.direction, stable);
       _pendingOrder!.state = PendingOrderState.submittedSuccessfully;
     } catch (exception) {
       logger.e("Failed to submit order: $exception");
@@ -87,7 +88,8 @@ class SubmitOrderChangeNotifier extends ChangeNotifier implements Subscriber {
     }
   }
 
-  Future<void> closePosition(Position position, double? closingPrice, Amount? fee) async {
+  Future<void> closePosition(Position position, double? closingPrice, Amount? fee,
+      {bool stable = false}) async {
     await submitPendingOrder(
         TradeValues(
             direction: position.direction.opposite(),
@@ -101,7 +103,8 @@ class SubmitOrderChangeNotifier extends ChangeNotifier implements Subscriber {
             expiry: position.expiry,
             tradeValuesService: TradeValuesService()),
         PositionAction.close,
-        pnl: position.unrealizedPnl);
+        pnl: position.unrealizedPnl,
+        stable: stable);
   }
 
   PendingOrder? get pendingOrder => _pendingOrder;

--- a/mobile/native/migrations/2023-10-16-113115_add_stable_flag/down.sql
+++ b/mobile/native/migrations/2023-10-16-113115_add_stable_flag/down.sql
@@ -1,0 +1,6 @@
+-- This file should undo anything in `up.sql`
+ALTER TABLE
+    orders DROP COLUMN "stable";
+
+ALTER TABLE
+    positions DROP COLUMN "stable";

--- a/mobile/native/migrations/2023-10-16-113115_add_stable_flag/up.sql
+++ b/mobile/native/migrations/2023-10-16-113115_add_stable_flag/up.sql
@@ -1,0 +1,10 @@
+-- Your SQL goes here
+ALTER TABLE
+    orders
+    ADD
+        COLUMN "stable" BOOLEAN NOT NULL DEFAULT false;
+
+ALTER TABLE
+    positions
+    ADD
+        COLUMN "stable" BOOLEAN NOT NULL DEFAULT false;

--- a/mobile/native/src/db/models.rs
+++ b/mobile/native/src/db/models.rs
@@ -126,6 +126,7 @@ pub(crate) struct Order {
     pub failure_reason: Option<FailureReason>,
     pub order_expiry_timestamp: i64,
     pub reason: OrderReason,
+    pub stable: bool,
 }
 
 impl Order {
@@ -271,6 +272,7 @@ impl From<crate::trade::order::Order> for Order {
             failure_reason,
             order_expiry_timestamp: value.order_expiry_timestamp.unix_timestamp(),
             reason: value.reason.into(),
+            stable: value.stable,
         }
     }
 }
@@ -312,6 +314,7 @@ impl TryFrom<Order> for crate::trade::order::Order {
             )
             .expect("unix timestamp to fit in itself"),
             reason: value.reason.into(),
+            stable: value.stable,
         };
 
         Ok(order)
@@ -332,6 +335,7 @@ pub(crate) struct Position {
     pub creation_timestamp: i64,
     pub expiry_timestamp: i64,
     pub updated_timestamp: i64,
+    pub stable: bool,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, FromSqlRow, AsExpression)]
@@ -422,6 +426,7 @@ impl From<Position> for crate::trade::position::Position {
                 .expect("to fit into unix timestamp"),
             created: OffsetDateTime::from_unix_timestamp(value.creation_timestamp)
                 .expect("to fit into unix timestamp"),
+            stable: value.stable,
         }
     }
 }
@@ -440,6 +445,7 @@ impl From<crate::trade::position::Position> for Position {
             creation_timestamp: OffsetDateTime::now_utc().unix_timestamp(),
             updated_timestamp: OffsetDateTime::now_utc().unix_timestamp(),
             expiry_timestamp: value.expiry.unix_timestamp(),
+            stable: value.stable,
         }
     }
 }
@@ -1377,6 +1383,7 @@ pub mod test {
             failure_reason,
             order_expiry_timestamp: expiry_timestamp.unix_timestamp(),
             reason: OrderReason::Manual,
+            stable: false,
         };
 
         Order::insert(
@@ -1391,6 +1398,7 @@ pub mod test {
                 creation_timestamp,
                 order_expiry_timestamp: expiry_timestamp,
                 reason: crate::trade::order::OrderReason::Manual,
+                stable: false,
             }
             .into(),
             &mut connection,
@@ -1410,6 +1418,7 @@ pub mod test {
                 creation_timestamp,
                 order_expiry_timestamp: expiry_timestamp,
                 reason: crate::trade::order::OrderReason::Manual,
+                stable: false,
             }
             .into(),
             &mut connection,
@@ -1478,6 +1487,7 @@ pub mod test {
                 creation_timestamp,
                 order_expiry_timestamp,
                 reason: crate::trade::order::OrderReason::Manual,
+                stable: false,
             }
             .into(),
             &mut connection,
@@ -1500,6 +1510,7 @@ pub mod test {
                 creation_timestamp,
                 order_expiry_timestamp,
                 reason: crate::trade::order::OrderReason::Manual,
+                stable: false,
             }
             .into(),
             &mut connection,

--- a/mobile/native/src/ln_dlc/sync_position_to_dlc.rs
+++ b/mobile/native/src/ln_dlc/sync_position_to_dlc.rs
@@ -364,6 +364,7 @@ mod test {
             expiry: OffsetDateTime::now_utc(),
             updated: OffsetDateTime::now_utc(),
             created: OffsetDateTime::now_utc(),
+            stable: false,
         }
     }
 

--- a/mobile/native/src/schema.rs
+++ b/mobile/native/src/schema.rs
@@ -37,6 +37,7 @@ diesel::table! {
         failure_reason -> Nullable<Text>,
         order_expiry_timestamp -> BigInt,
         reason -> Text,
+        stable -> Bool,
     }
 }
 
@@ -70,6 +71,7 @@ diesel::table! {
         creation_timestamp -> BigInt,
         expiry_timestamp -> BigInt,
         updated_timestamp -> BigInt,
+        stable -> Bool,
     }
 }
 

--- a/mobile/native/src/trade/order/api.rs
+++ b/mobile/native/src/trade/order/api.rs
@@ -45,6 +45,8 @@ pub struct NewOrder {
     // missing
     #[frb(non_final)]
     pub order_type: Box<OrderType>,
+    #[frb(non_final)]
+    pub stable: bool,
 }
 
 #[frb]
@@ -154,6 +156,7 @@ impl From<NewOrder> for order::Order {
             // We do not support setting order expiry from the frontend for now
             order_expiry_timestamp: OffsetDateTime::now_utc() + time::Duration::minutes(1),
             reason: order::OrderReason::Manual,
+            stable: value.stable,
         }
     }
 }

--- a/mobile/native/src/trade/order/mod.rs
+++ b/mobile/native/src/trade/order/mod.rs
@@ -133,6 +133,7 @@ pub struct Order {
     pub creation_timestamp: OffsetDateTime,
     pub order_expiry_timestamp: OffsetDateTime,
     pub reason: OrderReason,
+    pub stable: bool,
 }
 
 impl Order {
@@ -180,6 +181,7 @@ impl From<Order> for orderbook_commons::NewOrder {
             leverage: order.leverage,
             order_type: order.order_type.into(),
             expiry: order.order_expiry_timestamp,
+            stable: order.stable,
         }
     }
 }

--- a/mobile/native/src/trade/position/api.rs
+++ b/mobile/native/src/trade/position/api.rs
@@ -48,6 +48,7 @@ pub struct Position {
     pub position_state: PositionState,
     pub collateral: u64,
     pub expiry: i64,
+    pub stable: bool,
 }
 
 impl From<position::PositionState> for PositionState {
@@ -72,6 +73,7 @@ impl From<position::Position> for Position {
             position_state: value.position_state.into(),
             collateral: value.collateral,
             expiry: value.expiry.unix_timestamp(),
+            stable: value.stable,
         }
     }
 }

--- a/mobile/native/src/trade/position/handler.rs
+++ b/mobile/native/src/trade/position/handler.rs
@@ -79,6 +79,7 @@ pub async fn async_trade(order: orderbook_commons::Order, filled_with: FilledWit
         creation_timestamp: order.timestamp,
         order_expiry_timestamp: order.expiry,
         reason: order.order_reason.into(),
+        stable: order.stable,
     };
 
     db::insert_order(order)?;
@@ -200,6 +201,7 @@ pub fn update_position_after_dlc_creation(
         expiry,
         updated: OffsetDateTime::now_utc(),
         created: OffsetDateTime::now_utc(),
+        stable: filled_order.stable,
     };
 
     let position = db::insert_position(have_a_position)?;

--- a/mobile/native/src/trade/position/mod.rs
+++ b/mobile/native/src/trade/position/mod.rs
@@ -51,4 +51,5 @@ pub struct Position {
     pub expiry: OffsetDateTime,
     pub updated: OffsetDateTime,
     pub created: OffsetDateTime,
+    pub stable: bool,
 }

--- a/mobile/test/trade_test.dart
+++ b/mobile/test/trade_test.dart
@@ -169,7 +169,7 @@ void main() {
         const Offset(275, 0), const Duration(seconds: 2),
         pointer: 7);
 
-    verify(orderService.submitMarketOrder(any, any, any, any)).called(1);
+    verify(orderService.submitMarketOrder(any, any, any, any, any)).called(1);
   });
 }
 


### PR DESCRIPTION
This allows us to know the intent under which a short leverage 1 positions has been created without guessing.

Note, we have far too many models that represent the same thing. 🙈


https://github.com/get10101/10101/assets/382048/67b11d17-4879-4e9c-ab1b-6bbc7283ef6c

resolves #1441 

