### PR TITLE
fix: Handle null fees if no maker order

### DIFF
--- a/mobile/lib/features/stable/bitcoinize_confirmation_sheet.dart
+++ b/mobile/lib/features/stable/bitcoinize_confirmation_sheet.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:get_10101/common/domain/model.dart';
 import 'package:get_10101/common/value_data_row.dart';
 import 'package:get_10101/features/stable/stable_dialog.dart';
 import 'package:get_10101/features/stable/stable_value_change_notifier.dart';
@@ -84,7 +85,7 @@ class BitcoinizeBottomSheet extends StatelessWidget {
           const SizedBox(height: 16.0),
           ValueDataRow(
               type: ValueType.amount,
-              value: stableValues.fee,
+              value: stableValues.fee ?? Amount.zero(),
               label: 'Fees',
               valueTextStyle: const TextStyle(fontSize: 18),
               labelTextStyle: const TextStyle(fontSize: 18)),


### PR DESCRIPTION
In order to calculate the order matching fee a price is required. If we haven't got a price from the maker yet the fee would be null.

The stable screen should probably handle missing orders more gracefully. e.g. by disabling the stabilize or bitcoinize button.