### PR TITLE
fix: Pay to on-chain address

### DIFF
--- a/mobile/lib/features/wallet/domain/destination.dart
+++ b/mobile/lib/features/wallet/domain/destination.dart
@@ -3,12 +3,12 @@ import 'package:get_10101/common/domain/model.dart';
 import 'package:get_10101/features/wallet/domain/wallet_type.dart';
 
 abstract class Destination {
-  final Amount? amount;
+  final Amount amount;
   final String description;
   final String payee;
   final String raw;
 
-  Destination({this.amount, this.description = "", this.payee = "", required this.raw});
+  Destination({required this.amount, this.description = "", this.payee = "", required this.raw});
 
   WalletType getWalletType();
 }
@@ -17,14 +17,15 @@ class OnChainAddress extends Destination {
   final String address;
 
   OnChainAddress(
-      {super.amount,
+      {required super.amount,
       super.description = "",
       super.payee = "",
       required this.address,
       required super.raw});
 
   static fromAddress(rust.Destination_OnChainAddress address) {
-    return OnChainAddress(address: address.field0, payee: address.field0, raw: address.field0);
+    return OnChainAddress(
+        amount: Amount.zero(), address: address.field0, payee: address.field0, raw: address.field0);
   }
 
   static fromApi(rust.Destination_Bip21 uri) {

--- a/mobile/lib/features/wallet/send/confirm_payment_modal.dart
+++ b/mobile/lib/features/wallet/send/confirm_payment_modal.dart
@@ -46,8 +46,7 @@ class ConfirmPayment extends StatelessWidget {
   Widget build(BuildContext context) {
     final walletService = context.read<WalletChangeNotifier>().service;
 
-    final amt =
-        destination.amount != null && destination.amount!.sats > 0 ? destination.amount! : amount!;
+    final amt = destination.amount.sats > 0 ? destination.amount : amount!;
 
     return SafeArea(
       child: Padding(

--- a/mobile/lib/features/wallet/send/confirm_payment_modal.dart
+++ b/mobile/lib/features/wallet/send/confirm_payment_modal.dart
@@ -97,7 +97,7 @@ class ConfirmPayment extends StatelessWidget {
                   }).catchError((error) {
                     logger.e("Failed to send payment: $error");
                     if (destination.getWalletType() == WalletType.onChain) {
-                      showSnackBar(messenger, error);
+                      showSnackBar(messenger, error.toString());
                     }
                     context.read<PaymentChangeNotifier>().failPayment();
                   });

--- a/mobile/lib/features/wallet/send/send_screen.dart
+++ b/mobile/lib/features/wallet/send/send_screen.dart
@@ -81,25 +81,15 @@ class _SendScreenState extends State<SendScreen> {
                             setState(() => _invalidDestination = true);
                             return;
                           }
-                          if (destination.amount != null) {
-                            setState(() {
-                              _destination = destination;
-                              _amount = destination.amount!;
-                              _controller.text = _amount!.formatted();
 
-                              _invalidDestination = false;
-                              _valid = _formKey.currentState?.validate() ?? false;
-                            });
-                          } else {
-                            setState(() {
-                              _destination = destination;
-                              _amount = Amount.zero();
-                              _controller.text = _amount!.formatted();
+                          setState(() {
+                            _destination = destination;
+                            _amount = destination.amount;
+                            _controller.text = _amount!.formatted();
 
-                              _invalidDestination = false;
-                              _valid = _formKey.currentState?.validate() ?? false;
-                            });
-                          }
+                            _invalidDestination = false;
+                            _valid = _formKey.currentState?.validate() ?? false;
+                          });
                         });
                       }),
                   style: OutlinedButton.styleFrom(
@@ -174,9 +164,7 @@ class _SendScreenState extends State<SendScreen> {
                 controller: _controller,
                 label: "",
                 value: _amount ?? Amount.zero(),
-                enabled: _destination != null &&
-                    _destination!.amount != null &&
-                    _destination!.amount!.sats == 0,
+                enabled: _destination != null && _destination!.amount.sats == 0,
                 onChanged: (value) {
                   setState(() {
                     _amount = Amount.parseAmount(value);


### PR DESCRIPTION
The amount was not editable when entering a plain on-chain address, because no amount was set. Requiring an amount to be set in all cases (zero if unknown) allows the ui validation to behave properly.