### PR TITLE
feat: allow manual trigger of release flow

### DIFF
--- a/.github/workflows/build-release-binaries.yml
+++ b/.github/workflows/build-release-binaries.yml
@@ -3,6 +3,12 @@ name: "Attach binaries to GitHub release"
 on:
   release:
     types: [created]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "The github tag to build the release for e.g. 1.4.1."
+        required: true
+
 
 env:
   FLUTTER_VERSION: "3.13.4"


### PR DESCRIPTION
Would have needed this just now when our release randomly failed. 
Instead, I had to delete the release tag, the release itself and recreate everything. 