### PR TITLE
feat(app): Support on-chain wallet recovery

### DIFF
--- a/crates/ln-dlc-node/src/seed.rs
+++ b/crates/ln-dlc-node/src/seed.rs
@@ -43,6 +43,10 @@ impl Bip39Seed {
     /// Initialise a [`Seed`] from a path.
     /// Generates new seed if there was no seed found in the given path
     pub fn initialize(seed_file: &Path) -> Result<Self> {
+        // Ensure parent directory exists
+        if let Some(parent) = seed_file.parent() {
+            create_dir_all(parent)?;
+        }
         let seed = if !seed_file.exists() {
             tracing::info!("No seed found. Generating new seed");
             let seed = Self::new()?;

--- a/crates/ln-dlc-node/src/seed.rs
+++ b/crates/ln-dlc-node/src/seed.rs
@@ -1,4 +1,5 @@
 use anyhow::bail;
+use anyhow::Context;
 use anyhow::Result;
 use bdk::bitcoin;
 use bdk::bitcoin::util::bip32::ExtendedPrivKey;
@@ -7,9 +8,10 @@ use bip39::Mnemonic;
 use bitcoin::Network;
 use hkdf::Hkdf;
 use sha2::Sha256;
+use std::fs::create_dir_all;
 use std::path::Path;
 
-#[derive(Clone)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct Bip39Seed {
     mnemonic: Mnemonic,
 }
@@ -22,6 +24,20 @@ impl Bip39Seed {
         let mnemonic = Mnemonic::generate_in_with(&mut rng, Language::English, word_count)?;
 
         Ok(Self { mnemonic })
+    }
+
+    /// Restore a [`Seed`] from a mnemonic. Writes the seed to the given path.
+    pub fn restore_from_mnemonic(seed_words: &str, target_seed_file: &Path) -> Result<Self> {
+        let mnemonic = Mnemonic::parse(seed_words)?;
+        let seed = Self { mnemonic };
+
+        // Ensure parent directory exists
+        if let Some(parent) = target_seed_file.parent() {
+            create_dir_all(parent)?;
+        }
+        seed.write_to(target_seed_file)
+            .context("cannot write to file")?;
+        Ok(seed)
     }
 
     /// Initialise a [`Seed`] from a path.
@@ -161,5 +177,21 @@ mod tests {
             hex::encode(ln_seed),
             "1cf21ab62bf5a5ee40896158cbbc18b9ad75805e1824a252d8060c6c075b228f"
         );
+    }
+
+    #[test]
+    fn restore_same_seed_from_exported_mnemonic() {
+        let seed = Bip39Seed::new().unwrap();
+        let seed_words = seed.get_seed_phrase().join(" ");
+
+        let restore_path = &temp_dir().join("seed_restored");
+        let seed_restored = Bip39Seed::restore_from_mnemonic(&seed_words, restore_path).unwrap();
+
+        assert!(
+            seed == seed_restored,
+            "Restored seed should be the same as the original seed"
+        );
+
+        std::fs::remove_file(restore_path).unwrap(); // clear the temp file
     }
 }

--- a/mobile/lib/backend.dart
+++ b/mobile/lib/backend.dart
@@ -1,0 +1,75 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:get_10101/features/trade/candlestick_change_notifier.dart';
+import 'package:get_10101/features/trade/order_change_notifier.dart';
+import 'package:get_10101/features/trade/position_change_notifier.dart';
+import 'package:get_10101/ffi.dart' as rust;
+import 'package:get_10101/bridge_generated/bridge_definitions.dart' as bridge;
+import 'package:get_10101/logger/logger.dart';
+import 'package:get_10101/util/environment.dart';
+import 'package:get_10101/util/file.dart';
+import 'package:path_provider/path_provider.dart';
+import 'package:firebase_messaging/firebase_messaging.dart';
+import 'package:provider/provider.dart';
+
+/// Run the backend and retry a number of times if it fails for whatever reason
+Future<void> runBackend(BuildContext context) async {
+  bridge.Config config = Environment.parse();
+
+  context.read<CandlestickChangeNotifier>().initialize();
+  final orderChangeNotifier = context.read<OrderChangeNotifier>();
+  final positionChangeNotifier = context.read<PositionChangeNotifier>();
+
+  final seedDir = (await getApplicationSupportDirectory()).path;
+
+  // We use the app documents dir on iOS to easily access logs and DB from
+  // the device. On other platforms we use the seed dir.
+  String appDir = Platform.isIOS
+      ? (await getApplicationDocumentsDirectory()).path
+      : (await getApplicationSupportDirectory()).path;
+
+  final actualSeedDir = (await getActualSeedPath(config)).path;
+  if (File('$actualSeedDir/db').existsSync()) {
+    logger.i(
+        "App has already data in the seed dir. For compatibility reasons we will not switch to the new app dir.");
+    appDir = seedDir;
+  }
+
+  String fcmToken;
+  try {
+    fcmToken = await FirebaseMessaging.instance.getToken().then((value) => value ?? '');
+  } catch (e) {
+    logger.e("Error fetching FCM token: $e");
+    fcmToken = '';
+  }
+
+  logger.i("App data will be stored in: $appDir");
+  logger.i("Seed data will be stored in: $seedDir");
+
+  await _startBackend(config: config, appDir: appDir, seedDir: seedDir, fcmToken: fcmToken);
+
+  // these notifiers depend on the backend running
+  orderChangeNotifier.initialize();
+  positionChangeNotifier.initialize();
+}
+
+Future<void> _startBackend({config, appDir, seedDir, fcmToken}) async {
+  int retries = 3;
+
+  for (int i = 0; i < retries; i++) {
+    try {
+      await rust.api
+          .runInFlutter(config: config, appDir: appDir, seedDir: seedDir, fcmToken: fcmToken);
+      break; // If successful, exit loop
+    } catch (e) {
+      logger.i("Attempt ${i + 1} failed: $e");
+      if (i < retries - 1) {
+        await Future.delayed(const Duration(seconds: 5));
+      } else {
+        logger.e("Max retries reached, backend could not start.");
+        exit(-1);
+      }
+    }
+  }
+}

--- a/mobile/lib/backend.dart
+++ b/mobile/lib/backend.dart
@@ -55,21 +55,12 @@ Future<void> runBackend(BuildContext context) async {
 }
 
 Future<void> _startBackend({config, appDir, seedDir, fcmToken}) async {
-  int retries = 3;
-
-  for (int i = 0; i < retries; i++) {
-    try {
-      await rust.api
-          .runInFlutter(config: config, appDir: appDir, seedDir: seedDir, fcmToken: fcmToken);
-      break; // If successful, exit loop
-    } catch (e) {
-      logger.i("Attempt ${i + 1} failed: $e");
-      if (i < retries - 1) {
-        await Future.delayed(const Duration(seconds: 5));
-      } else {
-        logger.e("Max retries reached, backend could not start.");
-        exit(-1);
-      }
-    }
+  try {
+    await rust.api
+        .runInFlutter(config: config, appDir: appDir, seedDir: seedDir, fcmToken: fcmToken);
+  } catch (e) {
+    logger.e("Launching the app failed $e");
+    await Future.delayed(const Duration(seconds: 5));
+    exit(-1);
   }
 }

--- a/mobile/lib/common/init_service.dart
+++ b/mobile/lib/common/init_service.dart
@@ -156,7 +156,6 @@ void prepareBackend(BuildContext context, bridge.Config config) {
   subscribeToNotifiers(context);
 
   _logAppSettings(config);
-
 }
 
 void _setupRustLogging() {
@@ -203,11 +202,4 @@ Future<void> _logAppSettings(bridge.Config config) async {
   logger.i("Coordinator: ${config.coordinatorPubkey}@${config.host}:${config.p2PPort}");
   logger.i("Oracle endpoint: ${config.oracleEndpoint}");
   logger.i("Oracle PK: ${config.oraclePubkey}");
-
-  try {
-    String nodeId = rust.api.getNodeId();
-    logger.i("Node ID: $nodeId");
-  } catch (e) {
-    logger.e("Failed to get node ID: $e");
-  }
 }

--- a/mobile/lib/common/init_service.dart
+++ b/mobile/lib/common/init_service.dart
@@ -157,7 +157,6 @@ void prepareBackend(BuildContext context, bridge.Config config) {
 
   _logAppSettings(config);
 
-  rust.api.updateLastLogin().then((lastLogin) => logger.d("Last login was at ${lastLogin.date}"));
 }
 
 void _setupRustLogging() {

--- a/mobile/lib/common/init_service.dart
+++ b/mobile/lib/common/init_service.dart
@@ -1,11 +1,14 @@
+import 'dart:io';
+
 import 'package:flutter/material.dart';
+import 'package:get_10101/features/trade/candlestick_change_notifier.dart';
+import 'package:get_10101/features/trade/order_change_notifier.dart';
+import 'package:get_10101/ffi.dart' as rust;
+import 'package:get_10101/features/trade/position_change_notifier.dart';
 import 'package:get_10101/common/amount_denomination_change_notifier.dart';
 import 'package:get_10101/common/service_status_notifier.dart';
 import 'package:get_10101/common/recover_dlc_change_notifier.dart';
 import 'package:get_10101/features/stable/stable_value_change_notifier.dart';
-import 'package:get_10101/features/trade/candlestick_change_notifier.dart';
-import 'package:get_10101/features/trade/order_change_notifier.dart';
-import 'package:get_10101/features/trade/position_change_notifier.dart';
 import 'package:get_10101/features/wallet/application/faucet_service.dart';
 import 'package:get_10101/features/trade/rollover_change_notifier.dart';
 import 'package:get_10101/features/trade/trade_value_change_notifier.dart';
@@ -29,11 +32,15 @@ import 'package:get_10101/features/trade/domain/price.dart';
 import 'package:get_10101/features/wallet/domain/wallet_info.dart';
 import 'package:get_10101/common/application/event_service.dart';
 import 'package:get_10101/logger/logger.dart';
+import 'package:get_10101/util/environment.dart';
 import 'package:nested/nested.dart';
+import 'package:package_info_plus/package_info_plus.dart';
 import 'package:provider/provider.dart';
 import 'package:get_10101/bridge_generated/bridge_definitions.dart' as bridge;
 
-List<SingleChildWidget> createProviders(bridge.Config config) {
+List<SingleChildWidget> createProviders() {
+  bridge.Config config = Environment.parse();
+
   const ChannelInfoService channelInfoService = ChannelInfoService();
   var tradeValuesService = TradeValuesService();
 
@@ -137,4 +144,71 @@ void subscribeToNotifiers(BuildContext context) {
 
   eventService.subscribe(
       AnonSubscriber((event) => logger.i(event.field0)), const bridge.Event.log(""));
+}
+
+/// Initialisation step of the app.
+/// Prepares the backend and the notifiers.
+///
+/// Throws an exception if we cannot update the last login time.
+void prepareBackend(BuildContext context, bridge.Config config) {
+  _setupRustLogging();
+
+  subscribeToNotifiers(context);
+
+  _logAppSettings(config);
+
+  rust.api.updateLastLogin().then((lastLogin) => logger.d("Last login was at ${lastLogin.date}"));
+}
+
+void _setupRustLogging() {
+  rust.api.initLogging().listen((event) {
+    if (Platform.isAndroid || Platform.isIOS) {
+      var message = event.target != ""
+          ? 'r: ${event.target}: ${event.msg} ${event.data}'
+          : 'r: ${event.msg} ${event.data}';
+      switch (event.level) {
+        case "INFO":
+          logger.i(message);
+        case "DEBUG":
+          logger.d(message);
+        case "ERROR":
+          logger.e(message);
+        case "WARN":
+          logger.w(message);
+        case "TRACE":
+          logger.t(message);
+        default:
+          logger.d(message);
+      }
+    }
+  });
+}
+
+Future<void> _logAppSettings(bridge.Config config) async {
+  String commit = const String.fromEnvironment('COMMIT');
+  if (commit.isNotEmpty) {
+    logger.i("Built on commit: $commit");
+  }
+
+  String branch = const String.fromEnvironment('BRANCH');
+  if (branch.isNotEmpty) {
+    logger.i("Built on branch: $branch");
+  }
+
+  PackageInfo packageInfo = await PackageInfo.fromPlatform();
+  logger.i("Build number: ${packageInfo.buildNumber}");
+  logger.i("Build version: ${packageInfo.version}");
+
+  logger.i("Network: ${config.network}");
+  logger.i("Esplora endpoint: ${config.esploraEndpoint}");
+  logger.i("Coordinator: ${config.coordinatorPubkey}@${config.host}:${config.p2PPort}");
+  logger.i("Oracle endpoint: ${config.oracleEndpoint}");
+  logger.i("Oracle PK: ${config.oraclePubkey}");
+
+  try {
+    String nodeId = rust.api.getNodeId();
+    logger.i("Node ID: $nodeId");
+  } catch (e) {
+    logger.e("Failed to get node ID: $e");
+  }
 }

--- a/mobile/lib/common/loading_screen.dart
+++ b/mobile/lib/common/loading_screen.dart
@@ -1,9 +1,13 @@
 import 'package:flutter/material.dart';
+import 'package:get_10101/backend.dart';
 import 'package:get_10101/features/stable/stable_screen.dart';
 import 'package:get_10101/features/trade/trade_screen.dart';
 import 'package:get_10101/features/wallet/wallet_screen.dart';
+import 'package:get_10101/features/welcome/new_wallet_screen.dart';
 import 'package:get_10101/features/welcome/welcome_screen.dart';
+import 'package:get_10101/logger/logger.dart';
 import 'package:get_10101/util/preferences.dart';
+import 'package:get_10101/util/file.dart';
 import 'package:go_router/go_router.dart';
 
 class LoadingScreen extends StatefulWidget {
@@ -19,11 +23,27 @@ class _LoadingScreenState extends State<LoadingScreen> {
   @override
   void initState() {
     super.initState();
-    Future.wait<dynamic>(
-            [Preferences.instance.hasEmailAddress(), Preferences.instance.getOpenPosition()])
-        .then((value) {
+    Future.wait<dynamic>([
+      Preferences.instance.hasEmailAddress(),
+      Preferences.instance.getOpenPosition(),
+      isSeedFilePresent(),
+    ]).then((value) {
       final hasEmailAddress = value[0];
       final position = value[1];
+      final isSeedFilePresent = value[2];
+
+      logger.d("Scanning for seed file: $isSeedFilePresent");
+
+      if (isSeedFilePresent) {
+        runBackend(context).then((value) {
+          logger.i("Backend started");
+        });
+      } else {
+        // No seed file: let the user choose whether they want to create a new
+        // wallet or import their old one
+        GoRouter.of(context).go(NewWalletScreen.route);
+        return;
+      }
 
       if (!hasEmailAddress) {
         GoRouter.of(context).go(WelcomeScreen.route);

--- a/mobile/lib/common/routes.dart
+++ b/mobile/lib/common/routes.dart
@@ -8,13 +8,15 @@ import 'package:get_10101/features/wallet/domain/wallet_type.dart';
 import 'package:get_10101/features/wallet/onboarding/onboarding_screen.dart';
 import 'package:get_10101/features/wallet/receive_screen.dart';
 import 'package:get_10101/features/wallet/scanner_screen.dart';
+import 'package:get_10101/features/welcome/seed_import_screen.dart';
 import 'package:get_10101/features/wallet/seed_screen.dart';
 import 'package:get_10101/features/wallet/send/send_screen.dart';
 import 'package:get_10101/features/wallet/wallet_screen.dart';
 import 'package:get_10101/features/welcome/welcome_screen.dart';
 import 'package:go_router/go_router.dart';
+import 'package:get_10101/features/welcome/new_wallet_screen.dart';
 
-GoRouter createRouter() {
+GoRouter createRoutes() {
   return GoRouter(
       navigatorKey: rootNavigatorKey,
       initialLocation: LoadingScreen.route,
@@ -98,6 +100,20 @@ GoRouter createRouter() {
             ),
           ],
         ),
+        GoRoute(
+            path: NewWalletScreen.route,
+            builder: (BuildContext context, GoRouterState state) {
+              return const NewWalletScreen();
+            },
+            routes: <RouteBase>[
+              GoRoute(
+                  path: SeedPhraseImporter.subRouteName,
+                  parentNavigatorKey: rootNavigatorKey,
+                  builder: (BuildContext context, GoRouterState state) {
+                    return const SeedPhraseImporter();
+                  },
+                  routes: const []),
+            ]),
         GoRoute(
             path: WelcomeScreen.route,
             parentNavigatorKey: rootNavigatorKey,

--- a/mobile/lib/features/wallet/seed_screen.dart
+++ b/mobile/lib/features/wallet/seed_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:get_10101/features/wallet/seed_words.dart';
 import 'package:get_10101/features/wallet/wallet_screen.dart';
 import 'package:go_router/go_router.dart';
 import 'package:get_10101/util/preferences.dart';
@@ -11,10 +12,10 @@ class SeedScreen extends StatefulWidget {
   const SeedScreen({super.key});
 
   @override
-  State<SeedScreen> createState() => _SendScreenState();
+  State<SeedScreen> createState() => _SeedScreenState();
 }
 
-class _SendScreenState extends State<SeedScreen> {
+class _SeedScreenState extends State<SeedScreen> {
   bool checked = false;
   bool visibility = false;
 
@@ -28,21 +29,6 @@ class _SendScreenState extends State<SeedScreen> {
 
   @override
   Widget build(BuildContext context) {
-    final firstColumn = phrase!
-        .getRange(0, 6)
-        .toList()
-        .asMap()
-        .entries
-        .map((entry) => SeedWord(entry.value, entry.key + 1, visibility))
-        .toList();
-    final secondColumn = phrase!
-        .getRange(6, 12)
-        .toList()
-        .asMap()
-        .entries
-        .map((entry) => SeedWord(entry.value, entry.key + 7, visibility))
-        .toList();
-
     return Scaffold(
       appBar: AppBar(
         title: const Text('Backup Seed'),
@@ -70,15 +56,7 @@ class _SendScreenState extends State<SeedScreen> {
                 padding: const EdgeInsets.all(20.0),
                 child: Column(
                   children: [
-                    Row(
-                      mainAxisAlignment: MainAxisAlignment.center,
-                      crossAxisAlignment: CrossAxisAlignment.center,
-                      children: [
-                        Column(crossAxisAlignment: CrossAxisAlignment.start, children: firstColumn),
-                        const SizedBox(width: 10),
-                        Column(crossAxisAlignment: CrossAxisAlignment.start, children: secondColumn)
-                      ],
-                    ),
+                    buildSeedWordsWidget(phrase!, visibility),
                     const SizedBox(height: 10),
                     Center(
                       child: Row(
@@ -140,39 +118,5 @@ class _SendScreenState extends State<SeedScreen> {
         ),
       )),
     );
-  }
-}
-
-class SeedWord extends StatelessWidget {
-  final String? word;
-  final int? index;
-  final bool visibility;
-
-  const SeedWord(this.word, this.index, this.visibility, {super.key});
-
-  @override
-  Widget build(BuildContext context) {
-    return Container(
-        padding: const EdgeInsets.fromLTRB(0, 10, 0, 0),
-        child: Row(
-            crossAxisAlignment: visibility ? CrossAxisAlignment.baseline : CrossAxisAlignment.end,
-            textBaseline: TextBaseline.alphabetic,
-            children: [
-              SizedBox(
-                width: 25.0,
-                child: Text(
-                  '#$index',
-                  style: TextStyle(fontSize: 12, color: Colors.grey[600]),
-                ),
-              ),
-              const SizedBox(width: 5),
-              visibility
-                  ? Text(
-                      word!,
-                      style: const TextStyle(fontSize: 20, fontWeight: FontWeight.bold),
-                    )
-                  : Container(
-                      color: Colors.grey[300], child: const SizedBox(width: 100, height: 24))
-            ]));
   }
 }

--- a/mobile/lib/features/wallet/seed_words.dart
+++ b/mobile/lib/features/wallet/seed_words.dart
@@ -1,0 +1,62 @@
+import 'package:flutter/material.dart';
+
+Row buildSeedWordsWidget(List<String> phrase, bool visible) {
+  final firstColumn = phrase
+      .getRange(0, 6)
+      .toList()
+      .asMap()
+      .entries
+      .map((entry) => SeedWord(entry.value, entry.key + 1, visible))
+      .toList();
+  final secondColumn = phrase
+      .getRange(6, 12)
+      .toList()
+      .asMap()
+      .entries
+      .map((entry) => SeedWord(entry.value, entry.key + 7, visible))
+      .toList();
+
+  return Row(
+    mainAxisAlignment: MainAxisAlignment.center,
+    crossAxisAlignment: CrossAxisAlignment.center,
+    children: [
+      Column(crossAxisAlignment: CrossAxisAlignment.start, children: firstColumn),
+      const SizedBox(width: 10),
+      Column(crossAxisAlignment: CrossAxisAlignment.start, children: secondColumn)
+    ],
+  );
+}
+
+class SeedWord extends StatelessWidget {
+  final String? word;
+  final int? index;
+  final bool visibility;
+
+  const SeedWord(this.word, this.index, this.visibility, {super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+        padding: const EdgeInsets.fromLTRB(0, 10, 0, 0),
+        child: Row(
+            crossAxisAlignment: visibility ? CrossAxisAlignment.baseline : CrossAxisAlignment.end,
+            textBaseline: TextBaseline.alphabetic,
+            children: [
+              SizedBox(
+                width: 25.0,
+                child: Text(
+                  '#$index',
+                  style: TextStyle(fontSize: 12, color: Colors.grey[600]),
+                ),
+              ),
+              const SizedBox(width: 5),
+              visibility
+                  ? Text(
+                      word!,
+                      style: const TextStyle(fontSize: 20, fontWeight: FontWeight.bold),
+                    )
+                  : Container(
+                      color: Colors.grey[300], child: const SizedBox(width: 100, height: 24))
+            ]));
+  }
+}

--- a/mobile/lib/features/welcome/new_wallet_screen.dart
+++ b/mobile/lib/features/welcome/new_wallet_screen.dart
@@ -1,0 +1,137 @@
+import 'package:font_awesome_flutter/font_awesome_flutter.dart';
+import 'package:get_10101/common/color.dart';
+import 'package:get_10101/common/loading_screen.dart';
+import 'package:get_10101/features/welcome/seed_import_screen.dart';
+import 'package:get_10101/logger/logger.dart';
+import 'package:flutter/material.dart';
+import 'package:get_10101/common/scrollable_safe_area.dart';
+import 'package:go_router/go_router.dart';
+
+class NewWalletScreen extends StatefulWidget {
+  static const route = "/new-wallet";
+  static const label = "Welcome";
+
+  const NewWalletScreen({Key? key}) : super(key: key);
+
+  @override
+  State<NewWalletScreen> createState() => _NewWalletScreenState();
+}
+
+class _NewWalletScreenState extends State<NewWalletScreen> {
+  final GlobalKey<FormState> _formKey = GlobalKey<FormState>();
+
+  bool buttonsDisabled = false;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+        body: ScrollableSafeArea(
+            child: Form(
+      key: _formKey,
+      child: Container(
+        color: Colors.white,
+        padding: const EdgeInsets.all(20.0),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          crossAxisAlignment: CrossAxisAlignment.center,
+          children: <Widget>[
+            const Spacer(),
+            Center(
+              child: Image.asset('assets/10101_logo_icon.png', width: 150, height: 150),
+            ),
+            const Spacer(),
+            Column(children: [
+              ElevatedButton(
+                  // TODO: block the button until the backend is started
+                  onPressed: buttonsDisabled
+                      ? null
+                      : () async {
+                          setState(() {
+                            buttonsDisabled = true;
+                          });
+
+                          runBackend(context).then((value) {
+                            logger.i("Backend started");
+                            GoRouter.of(context).go(LoadingScreen.route);
+                            setState(() {
+                              buttonsDisabled = true;
+                            });
+                          });
+                        },
+                  style: ButtonStyle(
+                    padding: MaterialStateProperty.all<EdgeInsets>(const EdgeInsets.all(15)),
+                    backgroundColor: MaterialStateProperty.all<Color>(tenTenOnePurple),
+                    shape: MaterialStateProperty.all<RoundedRectangleBorder>(
+                      RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(18.0),
+                        side: const BorderSide(color: tenTenOnePurple),
+                      ),
+                    ),
+                  ),
+                  child: const Wrap(
+                    children: <Widget>[
+                      Icon(
+                        FontAwesomeIcons.vault,
+                        color: Colors.white,
+                        size: 24.0,
+                      ),
+                      SizedBox(
+                        width: 10,
+                      ),
+                      Text(
+                        "Create wallet",
+                        style: TextStyle(fontSize: 20, color: Colors.white),
+                      ),
+                    ],
+                  )),
+              const SizedBox(height: 20),
+              ElevatedButton(
+                onPressed: buttonsDisabled
+                    ? null
+                    : () {
+                        setState(() {
+                          buttonsDisabled = true;
+                          GoRouter.of(context).go(SeedPhraseImporter.route);
+                          buttonsDisabled = false;
+                        });
+                      },
+                style: ButtonStyle(
+                  padding: MaterialStateProperty.all<EdgeInsets>(const EdgeInsets.all(15)),
+                  backgroundColor: MaterialStateProperty.all<Color>(Colors.white),
+                  shape: MaterialStateProperty.all<RoundedRectangleBorder>(
+                    RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(18.0),
+                      side: const BorderSide(color: tenTenOnePurple),
+                    ),
+                  ),
+                ),
+                child: const Wrap(
+                  children: <Widget>[
+                    Icon(
+                      FontAwesomeIcons.download,
+                      color: tenTenOnePurple,
+                      size: 24.0,
+                    ),
+                    SizedBox(
+                      width: 10,
+                    ),
+                    Text(
+                      "Restore wallet",
+                      style: TextStyle(
+                          fontSize: 20, color: Colors.black), // Set the text color to black
+                    ),
+                  ],
+                ),
+              )
+            ]),
+          ],
+        ),
+      ),
+    )));
+  }
+
+  @override
+  void initState() {
+    super.initState();
+  }
+}

--- a/mobile/lib/features/welcome/new_wallet_screen.dart
+++ b/mobile/lib/features/welcome/new_wallet_screen.dart
@@ -45,31 +45,73 @@ class _NewWalletScreenState extends State<NewWalletScreen> {
             ),
             const Spacer(),
             Column(children: [
-              ElevatedButton(
-                  // TODO: block the button until the backend is started
+              SizedBox(
+                width: 250,
+                child: ElevatedButton(
+                    // TODO: block the button until the backend is started
+                    onPressed: buttonsDisabled
+                        ? null
+                        : () async {
+                            setState(() {
+                              buttonsDisabled = true;
+                            });
+                            final seedPath = await getSeedFilePath();
+                            await api.initNewMnemonic(targetSeedFilePath: seedPath).then((value) {
+                              GoRouter.of(context).go(LoadingScreen.route);
+                            }).catchError((error) {
+                              logger.e("Could not create seed", error: error);
+                              showSnackBar(ScaffoldMessenger.of(rootNavigatorKey.currentContext!),
+                                  "Failed to create seed: $error");
+                            });
+
+                            // In case there was an error and we did not go forward, we want to be able to click the button again.
+                            setState(() {
+                              buttonsDisabled = false;
+                            });
+                          },
+                    style: ButtonStyle(
+                      padding: MaterialStateProperty.all<EdgeInsets>(const EdgeInsets.all(15)),
+                      backgroundColor: MaterialStateProperty.all<Color>(tenTenOnePurple),
+                      shape: MaterialStateProperty.all<RoundedRectangleBorder>(
+                        RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(18.0),
+                          side: const BorderSide(color: tenTenOnePurple),
+                        ),
+                      ),
+                    ),
+                    child: const Wrap(
+                      children: <Widget>[
+                        Icon(
+                          FontAwesomeIcons.vault,
+                          color: Colors.white,
+                          size: 24.0,
+                        ),
+                        SizedBox(
+                          width: 10,
+                        ),
+                        Text(
+                          "Create wallet",
+                          style: TextStyle(fontSize: 20, color: Colors.white),
+                        ),
+                      ],
+                    )),
+              ),
+              const SizedBox(height: 20),
+              SizedBox(
+                width: 250,
+                child: ElevatedButton(
                   onPressed: buttonsDisabled
                       ? null
-                      : () async {
+                      : () {
                           setState(() {
                             buttonsDisabled = true;
-                          });
-                          final seedPath = await getSeedFilePath();
-                          await api.initNewMnemonic(targetSeedFilePath: seedPath).then((value) {
-                            GoRouter.of(context).go(LoadingScreen.route);
-                          }).catchError((error) {
-                            logger.e("Could not create seed", error: error);
-                            showSnackBar(ScaffoldMessenger.of(rootNavigatorKey.currentContext!),
-                                "Failed to create seed: $error");
-                          });
-
-                          // In case there was an error and we did not go forward, we want to be able to click the button again.
-                          setState(() {
+                            GoRouter.of(context).go(SeedPhraseImporter.route);
                             buttonsDisabled = false;
                           });
                         },
                   style: ButtonStyle(
                     padding: MaterialStateProperty.all<EdgeInsets>(const EdgeInsets.all(15)),
-                    backgroundColor: MaterialStateProperty.all<Color>(tenTenOnePurple),
+                    backgroundColor: MaterialStateProperty.all<Color>(Colors.white),
                     shape: MaterialStateProperty.all<RoundedRectangleBorder>(
                       RoundedRectangleBorder(
                         borderRadius: BorderRadius.circular(18.0),
@@ -80,56 +122,20 @@ class _NewWalletScreenState extends State<NewWalletScreen> {
                   child: const Wrap(
                     children: <Widget>[
                       Icon(
-                        FontAwesomeIcons.vault,
-                        color: Colors.white,
+                        FontAwesomeIcons.download,
+                        color: tenTenOnePurple,
                         size: 24.0,
                       ),
                       SizedBox(
                         width: 10,
                       ),
                       Text(
-                        "Create wallet",
-                        style: TextStyle(fontSize: 20, color: Colors.white),
+                        "Restore wallet",
+                        style: TextStyle(
+                            fontSize: 20, color: Colors.black), // Set the text color to black
                       ),
                     ],
-                  )),
-              const SizedBox(height: 20),
-              ElevatedButton(
-                onPressed: buttonsDisabled
-                    ? null
-                    : () {
-                        setState(() {
-                          buttonsDisabled = true;
-                          GoRouter.of(context).go(SeedPhraseImporter.route);
-                          buttonsDisabled = false;
-                        });
-                      },
-                style: ButtonStyle(
-                  padding: MaterialStateProperty.all<EdgeInsets>(const EdgeInsets.all(15)),
-                  backgroundColor: MaterialStateProperty.all<Color>(Colors.white),
-                  shape: MaterialStateProperty.all<RoundedRectangleBorder>(
-                    RoundedRectangleBorder(
-                      borderRadius: BorderRadius.circular(18.0),
-                      side: const BorderSide(color: tenTenOnePurple),
-                    ),
                   ),
-                ),
-                child: const Wrap(
-                  children: <Widget>[
-                    Icon(
-                      FontAwesomeIcons.download,
-                      color: tenTenOnePurple,
-                      size: 24.0,
-                    ),
-                    SizedBox(
-                      width: 10,
-                    ),
-                    Text(
-                      "Restore wallet",
-                      style: TextStyle(
-                          fontSize: 20, color: Colors.black), // Set the text color to black
-                    ),
-                  ],
                 ),
               )
             ]),

--- a/mobile/lib/features/welcome/seed_import_screen.dart
+++ b/mobile/lib/features/welcome/seed_import_screen.dart
@@ -1,0 +1,211 @@
+import 'package:flutter/material.dart';
+import 'package:get_10101/common/color.dart';
+import 'package:get_10101/common/global_keys.dart';
+import 'package:get_10101/common/loading_screen.dart';
+import 'package:get_10101/common/snack_bar.dart';
+import 'package:get_10101/features/welcome/new_wallet_screen.dart';
+import 'package:get_10101/ffi.dart';
+import 'package:get_10101/logger/logger.dart';
+import 'package:get_10101/util/file.dart';
+import 'package:go_router/go_router.dart';
+
+class SeedPhraseImporter extends StatefulWidget {
+  static const route = "${NewWalletScreen.route}/$subRouteName";
+  static const subRouteName = "seed-importer";
+
+  const SeedPhraseImporter({Key? key}) : super(key: key);
+
+  @override
+  SeedPhraseImporterState createState() => SeedPhraseImporterState();
+}
+
+class SeedPhraseImporterState extends State<SeedPhraseImporter> {
+  late TextEditingController _controller;
+  late List<String> twelveWords;
+  late FocusNode focusNode;
+
+  @override
+  void initState() {
+    twelveWords = [];
+    _controller = TextEditingController();
+    focusNode = FocusNode();
+    super.initState();
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    twelveWords.clear();
+    focusNode.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    var isImportDisabled = twelveWords.length < 12;
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Manual restore')),
+      // this is needed to prevent an overflow when the keyboard is up
+      resizeToAvoidBottomInset: false,
+      body: Column(
+        mainAxisAlignment: MainAxisAlignment.start,
+        children: <Widget>[
+          const Padding(
+            padding: EdgeInsets.all(16.0),
+            child: Text(
+              "Please enter your seed phrase.",
+              style: TextStyle(fontSize: 20),
+            ),
+          ),
+          SizedBox(
+            child: Padding(
+              padding: const EdgeInsets.all(16.0),
+              child: TextField(
+                autofocus: true,
+                focusNode: focusNode,
+                controller: _controller,
+                enabled: twelveWords.length < 12,
+                decoration: const InputDecoration(
+                  border: OutlineInputBorder(),
+                  labelText: 'Enter keywords from your seed',
+                ),
+                onSubmitted: (String value) async {
+                  if (value.isNotEmpty) {
+                    setState(() {
+                      var split = value.split(" ");
+                      twelveWords.addAll(split);
+                      _controller.clear();
+                      focusNode.requestFocus();
+                    });
+                  }
+                },
+              ),
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.fromLTRB(16.0, 16.0, 16.0, 0),
+            child: WordTable(words: twelveWords),
+          ),
+          Padding(
+              padding: const EdgeInsets.fromLTRB(16.0, 16.0, 16.0, 32),
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                children: [
+                  ElevatedButton(
+                    style: ButtonStyle(
+                      padding: MaterialStateProperty.all<EdgeInsets>(
+                          const EdgeInsets.fromLTRB(20, 14, 20, 14)),
+                    ),
+                    onPressed: () {
+                      setState(() {
+                        twelveWords.clear();
+                        _controller.clear();
+                      });
+                    },
+                    child: const Text(
+                      "Clear",
+                      style: TextStyle(fontSize: 20),
+                    ),
+                  ),
+                  ElevatedButton(
+                    style: ButtonStyle(
+                      padding: MaterialStateProperty.all<EdgeInsets>(
+                          const EdgeInsets.fromLTRB(20, 14, 20, 14)),
+                      backgroundColor:
+                          MaterialStateProperty.resolveWith<Color>((Set<MaterialState> states) {
+                        if (states.contains(MaterialState.disabled)) {
+                          return Colors.grey; // Change to the desired disabled color
+                        }
+                        return tenTenOnePurple; // Change to the desired enabled color
+                      }),
+                      foregroundColor:
+                          MaterialStateProperty.resolveWith<Color>((Set<MaterialState> states) {
+                        if (states.contains(MaterialState.disabled)) {
+                          return Colors.black; // Change to the desired disabled text color
+                        }
+                        return Colors.white; // Change to the desired enabled text color
+                      }),
+                    ),
+                    onPressed: isImportDisabled
+                        ? null
+                        : () async {
+                            logger.i("Restoring a previous wallet from a given seed phrase");
+                            final seedPhrase = twelveWords.join(" ");
+                            try {
+                              final seedPath = await getSeedFilePath();
+                              logger.i("Restoring seed into $seedPath");
+                              await api
+                                  .restoreFromSeedPhrase(
+                                      seedPhrase: seedPhrase, targetSeedFilePath: seedPath)
+                                  .then((value) => GoRouter.of(context).go(LoadingScreen.route))
+                                  .catchError((error) {
+                                showSnackBar(ScaffoldMessenger.of(rootNavigatorKey.currentContext!),
+                                    "Failed to restore seed: $error");
+                              });
+                            } catch (e) {
+                              logger.e("Error restoring from seed phrase: $e");
+                              showSnackBar(ScaffoldMessenger.of(rootNavigatorKey.currentContext!),
+                                  "Failed to restore seed: $e");
+                            }
+                          },
+                    child: const Text(
+                      "Import",
+                      style: TextStyle(fontSize: 20),
+                    ),
+                  ),
+                ],
+              )),
+        ],
+      ),
+    );
+  }
+}
+
+class WordTable extends StatelessWidget {
+  final List<String> words;
+
+  const WordTable({super.key, required this.words});
+
+  @override
+  Widget build(BuildContext context) {
+    return Table(
+      children: List.generate(6, (row) {
+        return TableRow(
+          children: List.generate(2, (col) {
+            return TableCell(
+              child: Padding(
+                padding: const EdgeInsets.all(8.0),
+                child: RichText(
+                  text: TextSpan(
+                    children: [
+                      TextSpan(
+                        text: '#${calculateIndex(col, row) + 1} ',
+                        style: TextStyle(color: tenTenOnePurple.shade300, fontSize: 20),
+                      ),
+                      TextSpan(
+                        text: getWord(calculateIndex(col, row), words),
+                        style: const TextStyle(color: Colors.black, fontSize: 20),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            );
+          }),
+        );
+      }),
+    );
+  }
+}
+
+int calculateIndex(int col, int row) => col == 0 ? row : row + 6;
+
+String getWord(int index, List<String> words) {
+  if (index >= 0 && index < words.length) {
+    var word = words[index];
+    return word;
+  } else {
+    return '';
+  }
+}

--- a/mobile/lib/features/welcome/seed_import_screen.dart
+++ b/mobile/lib/features/welcome/seed_import_screen.dart
@@ -92,66 +92,73 @@ class SeedPhraseImporterState extends State<SeedPhraseImporter> {
               child: Row(
                 mainAxisAlignment: MainAxisAlignment.spaceEvenly,
                 children: [
-                  ElevatedButton(
-                    style: ButtonStyle(
-                      padding: MaterialStateProperty.all<EdgeInsets>(
-                          const EdgeInsets.fromLTRB(20, 14, 20, 14)),
-                    ),
-                    onPressed: () {
-                      setState(() {
-                        twelveWords.clear();
-                        _controller.clear();
-                      });
-                    },
-                    child: const Text(
-                      "Clear",
-                      style: TextStyle(fontSize: 20),
+                  SizedBox(
+                    width: 120,
+                    child: ElevatedButton(
+                      style: ButtonStyle(
+                        padding: MaterialStateProperty.all<EdgeInsets>(
+                            const EdgeInsets.fromLTRB(20, 10, 20, 10)),
+                      ),
+                      onPressed: () {
+                        setState(() {
+                          twelveWords.clear();
+                          _controller.clear();
+                        });
+                      },
+                      child: const Text(
+                        "Clear",
+                        style: TextStyle(fontSize: 20),
+                      ),
                     ),
                   ),
-                  ElevatedButton(
-                    style: ButtonStyle(
-                      padding: MaterialStateProperty.all<EdgeInsets>(
-                          const EdgeInsets.fromLTRB(20, 14, 20, 14)),
-                      backgroundColor:
-                          MaterialStateProperty.resolveWith<Color>((Set<MaterialState> states) {
-                        if (states.contains(MaterialState.disabled)) {
-                          return Colors.grey; // Change to the desired disabled color
-                        }
-                        return tenTenOnePurple; // Change to the desired enabled color
-                      }),
-                      foregroundColor:
-                          MaterialStateProperty.resolveWith<Color>((Set<MaterialState> states) {
-                        if (states.contains(MaterialState.disabled)) {
-                          return Colors.black; // Change to the desired disabled text color
-                        }
-                        return Colors.white; // Change to the desired enabled text color
-                      }),
-                    ),
-                    onPressed: isImportDisabled
-                        ? null
-                        : () async {
-                            logger.i("Restoring a previous wallet from a given seed phrase");
-                            final seedPhrase = twelveWords.join(" ");
-                            try {
-                              final seedPath = await getSeedFilePath();
-                              logger.i("Restoring seed into $seedPath");
-                              await api
-                                  .restoreFromSeedPhrase(
-                                      seedPhrase: seedPhrase, targetSeedFilePath: seedPath)
-                                  .then((value) => GoRouter.of(context).go(LoadingScreen.route))
-                                  .catchError((error) {
+                  SizedBox(
+                    width: 120,
+                    child: ElevatedButton(
+                      style: ButtonStyle(
+                        padding: MaterialStateProperty.all<EdgeInsets>(
+                            const EdgeInsets.fromLTRB(20, 10, 20, 10)),
+                        backgroundColor:
+                            MaterialStateProperty.resolveWith<Color>((Set<MaterialState> states) {
+                          if (states.contains(MaterialState.disabled)) {
+                            return Colors.grey; // Change to the desired disabled color
+                          }
+                          return tenTenOnePurple; // Change to the desired enabled color
+                        }),
+                        foregroundColor:
+                            MaterialStateProperty.resolveWith<Color>((Set<MaterialState> states) {
+                          if (states.contains(MaterialState.disabled)) {
+                            return Colors.black; // Change to the desired disabled text color
+                          }
+                          return Colors.white; // Change to the desired enabled text color
+                        }),
+                      ),
+                      onPressed: isImportDisabled
+                          ? null
+                          : () async {
+                              logger.i("Restoring a previous wallet from a given seed phrase");
+                              final seedPhrase = twelveWords.join(" ");
+                              try {
+                                final seedPath = await getSeedFilePath();
+                                logger.i("Restoring seed into $seedPath");
+                                await api
+                                    .restoreFromSeedPhrase(
+                                        seedPhrase: seedPhrase, targetSeedFilePath: seedPath)
+                                    .then((value) => GoRouter.of(context).go(LoadingScreen.route))
+                                    .catchError((error) {
+                                  showSnackBar(
+                                      ScaffoldMessenger.of(rootNavigatorKey.currentContext!),
+                                      "Failed to restore seed: $error");
+                                });
+                              } catch (e) {
+                                logger.e("Error restoring from seed phrase: $e");
                                 showSnackBar(ScaffoldMessenger.of(rootNavigatorKey.currentContext!),
-                                    "Failed to restore seed: $error");
-                              });
-                            } catch (e) {
-                              logger.e("Error restoring from seed phrase: $e");
-                              showSnackBar(ScaffoldMessenger.of(rootNavigatorKey.currentContext!),
-                                  "Failed to restore seed: $e");
-                            }
-                          },
-                    child: const Text(
-                      "Import",
-                      style: TextStyle(fontSize: 20),
+                                    "Failed to restore seed: $e");
+                              }
+                            },
+                      child: const Text(
+                        "Import",
+                        style: TextStyle(fontSize: 20),
+                      ),
                     ),
                   ),
                 ],

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -1,30 +1,16 @@
-import 'dart:convert';
-import 'dart:io';
-
-import 'package:firebase_messaging/firebase_messaging.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_native_splash/flutter_native_splash.dart';
 import 'package:flutter_rust_bridge/flutter_rust_bridge.dart';
 import 'package:get_10101/bridge_generated/bridge_definitions.dart' as bridge;
 import 'package:get_10101/common/color.dart';
-import 'package:get_10101/common/global_keys.dart';
+import 'package:get_10101/util/compare_coordinator_version.dart';
 import 'package:get_10101/common/init_service.dart';
 import 'package:get_10101/common/routes.dart';
-import 'package:get_10101/features/trade/candlestick_change_notifier.dart';
-import 'package:get_10101/features/trade/order_change_notifier.dart';
-import 'package:get_10101/features/trade/position_change_notifier.dart';
 import 'package:get_10101/features/trade/trade_theme.dart';
 import 'package:get_10101/features/wallet/wallet_theme.dart';
-import 'package:get_10101/ffi.dart' as rust;
-import 'package:get_10101/util/coordinator_version.dart';
-import 'package:get_10101/util/environment.dart';
 import 'package:get_10101/util/notifications.dart';
 import 'package:go_router/go_router.dart';
-import 'package:http/http.dart' as http;
-import 'package:package_info_plus/package_info_plus.dart';
-import 'package:path_provider/path_provider.dart';
 import 'package:provider/provider.dart';
-import 'package:version/version.dart';
 import 'package:get_10101/logger/logger.dart';
 
 void main() async {
@@ -33,10 +19,7 @@ void main() async {
 
   await initFirebase();
 
-  var config = Environment.parse();
-
-  var providers = createProviders(config);
-  runApp(MultiProvider(providers: providers, child: const TenTenOneApp()));
+  runApp(MultiProvider(providers: createProviders(), child: const TenTenOneApp()));
 }
 
 class TenTenOneApp extends StatefulWidget {
@@ -50,7 +33,7 @@ class _TenTenOneAppState extends State<TenTenOneApp> with WidgetsBindingObserver
   final GlobalKey<ScaffoldMessengerState> scaffoldMessengerKey =
       GlobalKey<ScaffoldMessengerState>();
 
-  final GoRouter _router = createRouter();
+  late GoRouter _router;
 
   @override
   void initState() {
@@ -59,6 +42,7 @@ class _TenTenOneAppState extends State<TenTenOneApp> with WidgetsBindingObserver
     WidgetsBinding.instance.addObserver(this);
 
     final config = context.read<bridge.Config>();
+    _router = createRoutes();
 
     init(config);
 
@@ -102,191 +86,14 @@ class _TenTenOneAppState extends State<TenTenOneApp> with WidgetsBindingObserver
   }
 
   Future<void> init(bridge.Config config) async {
-    final orderChangeNotifier = context.read<OrderChangeNotifier>();
-    final positionChangeNotifier = context.read<PositionChangeNotifier>();
-    final candlestickChangeNotifier = context.read<CandlestickChangeNotifier>();
-
     try {
-      setupRustLogging();
-
-      subscribeToNotifiers(context);
-
-      await runBackend(config);
-      logger.i("Backend started");
-
-      orderChangeNotifier.initialize();
-      positionChangeNotifier.initialize();
-      candlestickChangeNotifier.initialize();
-
-      logAppSettings(config);
-
-      rust.api
-          .updateLastLogin()
-          .then((lastLogin) => logger.d("Last login was at ${lastLogin.date}"));
+      prepareBackend(context, config);
     } on FfiException catch (error) {
       logger.e("Failed to initialise: Error: ${error.message}", error: error);
     } catch (error) {
       logger.e("Failed to initialise: $error", error: error);
     } finally {
       FlutterNativeSplash.remove();
-    }
-  }
-
-  void setupRustLogging() {
-    rust.api.initLogging().listen((event) {
-      if (Platform.isAndroid || Platform.isIOS) {
-        var message = event.target != ""
-            ? 'r: ${event.target}: ${event.msg} ${event.data}'
-            : 'r: ${event.msg} ${event.data}';
-        switch (event.level) {
-          case "INFO":
-            logger.i(message);
-          case "DEBUG":
-            logger.d(message);
-          case "ERROR":
-            logger.e(message);
-          case "WARN":
-            logger.w(message);
-          case "TRACE":
-            logger.t(message);
-          default:
-            logger.d(message);
-        }
-      }
-    });
-  }
-}
-
-/// Compare the version of the coordinator with the version of the app
-///
-/// - If the coordinator is newer, suggest to update the app.
-/// - If the app is newer, log it.
-/// - If the coordinator cannot be reached, show a warning that the app may not function properly.
-Future<void> compareCoordinatorVersion(bridge.Config config) async {
-  PackageInfo packageInfo = await PackageInfo.fromPlatform();
-  try {
-    final response = await http.get(
-      Uri.parse('http://${config.host}:${config.httpPort}/api/version'),
-    );
-
-    final clientVersion = Version.parse(packageInfo.version);
-    final coordinatorVersion = CoordinatorVersion.fromJson(jsonDecode(response.body));
-    logger.i("Coordinator version: ${coordinatorVersion.version.toString()}");
-
-    if (coordinatorVersion.version > clientVersion) {
-      logger.w("Client out of date. Current version: ${clientVersion.toString()}");
-      showDialog(
-          context: shellNavigatorKey.currentContext!,
-          builder: (context) => AlertDialog(
-                  title: const Text("Update available"),
-                  content: Text("A new version of 10101 is available: "
-                      "${coordinatorVersion.version.toString()}.\n\n"
-                      "Please note that if you do not update 10101, the app"
-                      " may not function properly."),
-                  actions: [
-                    TextButton(
-                      onPressed: () => Navigator.pop(context, 'OK'),
-                      child: const Text('OK'),
-                    ),
-                  ]));
-    } else if (coordinatorVersion.version < clientVersion) {
-      logger.w("10101 is newer than LSP: ${coordinatorVersion.version.toString()}");
-    } else {
-      logger.i("Client is up to date: ${clientVersion.toString()}");
-    }
-  } catch (e) {
-    logger.e("Error getting coordinator version: ${e.toString()}");
-    showDialog(
-        context: shellNavigatorKey.currentContext!,
-        builder: (context) => AlertDialog(
-                title: const Text("Cannot reach LSP"),
-                content: const Text("Please check your Internet connection.\n"
-                    "Please note that without Internet access, the app "
-                    "functionality is severely limited."),
-                actions: [
-                  TextButton(
-                    onPressed: () => Navigator.pop(context, 'OK'),
-                    child: const Text('OK'),
-                  ),
-                ]));
-  }
-}
-
-Future<void> logAppSettings(bridge.Config config) async {
-  String commit = const String.fromEnvironment('COMMIT');
-  if (commit.isNotEmpty) {
-    logger.i("Built on commit: $commit");
-  }
-
-  String branch = const String.fromEnvironment('BRANCH');
-  if (branch.isNotEmpty) {
-    logger.i("Built on branch: $branch");
-  }
-
-  PackageInfo packageInfo = await PackageInfo.fromPlatform();
-  logger.i("Build number: ${packageInfo.buildNumber}");
-  logger.i("Build version: ${packageInfo.version}");
-
-  logger.i("Network: ${config.network}");
-  logger.i("Esplora endpoint: ${config.esploraEndpoint}");
-  logger.i("Coordinator: ${config.coordinatorPubkey}@${config.host}:${config.p2PPort}");
-  logger.i("Oracle endpoint: ${config.oracleEndpoint}");
-  logger.i("Oracle PK: ${config.oraclePubkey}");
-
-  try {
-    String nodeId = rust.api.getNodeId();
-    logger.i("Node ID: $nodeId");
-  } catch (e) {
-    logger.e("Failed to get node ID: $e");
-  }
-}
-
-Future<void> runBackend(bridge.Config config) async {
-  final seedDir = (await getApplicationSupportDirectory()).path;
-
-  // We use the app documents dir on iOS to easily access logs and DB from
-  // the device. On other platforms we use the seed dir.
-  String appDir = Platform.isIOS
-      ? (await getApplicationDocumentsDirectory()).path
-      : (await getApplicationSupportDirectory()).path;
-
-  final network = config.network == "mainnet" ? "bitcoin" : config.network;
-  if (File('$seedDir/$network/db').existsSync()) {
-    logger.i(
-        "App has already data in the seed dir. For compatibility reasons we will not switch to the new app dir.");
-    appDir = seedDir;
-  }
-
-  String fcmToken;
-  try {
-    fcmToken = await FirebaseMessaging.instance.getToken().then((value) => value ?? '');
-  } catch (e) {
-    logger.e("Error fetching FCM token: $e");
-    fcmToken = '';
-  }
-
-  logger.i("App data will be stored in: $appDir");
-  logger.i("Seed data will be stored in: $seedDir");
-  await startBackend(config: config, appDir: appDir, seedDir: seedDir, fcmToken: fcmToken);
-}
-
-/// Start the backend and retry a number of times if it fails for whatever reason
-Future<void> startBackend({config, appDir, seedDir, fcmToken}) async {
-  int retries = 3;
-
-  for (int i = 0; i < retries; i++) {
-    try {
-      await rust.api
-          .runInFlutter(config: config, appDir: appDir, seedDir: seedDir, fcmToken: fcmToken);
-      break; // If successful, exit loop
-    } catch (e) {
-      logger.i("Attempt ${i + 1} failed: $e");
-      if (i < retries - 1) {
-        await Future.delayed(const Duration(seconds: 5));
-      } else {
-        logger.e("Max retries reached, backend could not start.");
-        exit(-1);
-      }
     }
   }
 }

--- a/mobile/lib/util/compare_coordinator_version.dart
+++ b/mobile/lib/util/compare_coordinator_version.dart
@@ -1,0 +1,64 @@
+import 'dart:convert';
+import 'package:get_10101/bridge_generated/bridge_definitions.dart' as bridge;
+import 'package:flutter/material.dart';
+import 'package:get_10101/common/global_keys.dart';
+import 'package:get_10101/logger/logger.dart';
+import 'package:get_10101/util/coordinator_version.dart';
+import 'package:http/http.dart' as http;
+import 'package:package_info_plus/package_info_plus.dart';
+import 'package:version/version.dart';
+
+/// Compare the version of the coordinator with the version of the app
+///
+/// - If the coordinator is newer, suggest to update the app.
+/// - If the app is newer, log it.
+/// - If the coordinator cannot be reached, show a warning that the app may not function properly.
+Future<void> compareCoordinatorVersion(bridge.Config config) async {
+  PackageInfo packageInfo = await PackageInfo.fromPlatform();
+  try {
+    final response = await http.get(
+      Uri.parse('http://${config.host}:${config.httpPort}/api/version'),
+    );
+
+    final clientVersion = Version.parse(packageInfo.version);
+    final coordinatorVersion = CoordinatorVersion.fromJson(jsonDecode(response.body));
+    logger.i("Coordinator version: ${coordinatorVersion.version.toString()}");
+
+    if (coordinatorVersion.version > clientVersion) {
+      logger.w("Client out of date. Current version: ${clientVersion.toString()}");
+      showDialog(
+          context: shellNavigatorKey.currentContext!,
+          builder: (context) => AlertDialog(
+                  title: const Text("Update available"),
+                  content: Text("A new version of 10101 is available: "
+                      "${coordinatorVersion.version.toString()}.\n\n"
+                      "Please note that if you do not update 10101, the app"
+                      " may not function properly."),
+                  actions: [
+                    TextButton(
+                      onPressed: () => Navigator.pop(context, 'OK'),
+                      child: const Text('OK'),
+                    ),
+                  ]));
+    } else if (coordinatorVersion.version < clientVersion) {
+      logger.w("10101 is newer than LSP: ${coordinatorVersion.version.toString()}");
+    } else {
+      logger.i("Client is up to date: ${clientVersion.toString()}");
+    }
+  } catch (e) {
+    logger.e("Error getting coordinator version: ${e.toString()}");
+    showDialog(
+        context: shellNavigatorKey.currentContext!,
+        builder: (context) => AlertDialog(
+                title: const Text("Cannot reach LSP"),
+                content: const Text("Please check your Internet connection.\n"
+                    "Please note that without Internet access, the app "
+                    "functionality is severely limited."),
+                actions: [
+                  TextButton(
+                    onPressed: () => Navigator.pop(context, 'OK'),
+                    child: const Text('OK'),
+                  ),
+                ]));
+  }
+}

--- a/mobile/lib/util/file.dart
+++ b/mobile/lib/util/file.dart
@@ -1,0 +1,31 @@
+import 'dart:io';
+
+import 'package:get_10101/bridge_generated/bridge_definitions.dart' as bridge;
+import 'package:get_10101/logger/logger.dart';
+import 'package:get_10101/util/environment.dart';
+import 'package:path_provider/path_provider.dart';
+
+Future<String> getSeedFilePath() async {
+  final config = Environment.parse();
+  final seedDir = (await getActualSeedPath(config)).path;
+
+  final seedFilePath = '$seedDir/seed';
+  return seedFilePath;
+}
+
+Future<bool> isSeedFilePresent() async {
+  final seedFilePath = await getSeedFilePath();
+  logger.d("Scanning for seed file in : $seedFilePath");
+  return File(seedFilePath).existsSync();
+}
+
+/// Take into account that the backend creates seed dir inside "network"
+/// sub-directory
+Future<Directory> getActualSeedPath(bridge.Config config) async {
+  final seedDir = (await getApplicationSupportDirectory()).path;
+
+  // We need to adjust the naming of the seed dir for mainnet
+  final network = config.network == "mainnet" ? "bitcoin" : config.network;
+  final seedPath = '$seedDir/$network';
+  return Directory(seedPath);
+}

--- a/mobile/native/migrations/2023-10-23-141646_remove_last_login/down.sql
+++ b/mobile/native/migrations/2023-10-23-141646_remove_last_login/down.sql
@@ -1,0 +1,4 @@
+CREATE TABLE if not exists last_login (
+                            id INTEGER PRIMARY KEY AUTOINCREMENT,
+                            date TEXT NOT NULL
+)

--- a/mobile/native/migrations/2023-10-23-141646_remove_last_login/up.sql
+++ b/mobile/native/migrations/2023-10-23-141646_remove_last_login/up.sql
@@ -1,0 +1,1 @@
+drop table if exists last_login;

--- a/mobile/native/src/api.rs
+++ b/mobile/native/src/api.rs
@@ -31,6 +31,7 @@ use rust_decimal::prelude::FromPrimitive;
 use rust_decimal::Decimal;
 use state::Storage;
 use std::backtrace::Backtrace;
+use std::path::PathBuf;
 use time::OffsetDateTime;
 pub use trade::ContractSymbol;
 pub use trade::Direction;
@@ -418,6 +419,12 @@ pub fn update_last_login() -> Result<LastLogin> {
 
 pub fn get_seed_phrase() -> SyncReturn<Vec<String>> {
     SyncReturn(ln_dlc::get_seed_phrase())
+}
+
+pub fn restore_from_seed_phrase(seed_phrase: String, target_seed_file_path: String) -> Result<()> {
+    let file_path = PathBuf::from(target_seed_file_path);
+    tracing::info!("Restoring seed from phrase to {:?}", file_path);
+    ln_dlc::restore_from_mnemonic(&seed_phrase, file_path.as_path())
 }
 
 /// Enroll a user in the beta program

--- a/mobile/native/src/api.rs
+++ b/mobile/native/src/api.rs
@@ -422,6 +422,12 @@ pub fn restore_from_seed_phrase(seed_phrase: String, target_seed_file_path: Stri
     ln_dlc::restore_from_mnemonic(&seed_phrase, file_path.as_path())
 }
 
+pub fn init_new_mnemonic(target_seed_file_path: String) -> Result<()> {
+    let file_path = PathBuf::from(target_seed_file_path);
+    tracing::info!("Creating a new seed in {:?}", file_path);
+    ln_dlc::init_new_mnemonic(file_path.as_path())
+}
+
 /// Enroll a user in the beta program
 #[tokio::main(flavor = "current_thread")]
 pub async fn register_beta(email: String) -> Result<()> {

--- a/mobile/native/src/api.rs
+++ b/mobile/native/src/api.rs
@@ -412,11 +412,6 @@ pub struct LastLogin {
     pub date: String,
 }
 
-pub fn update_last_login() -> Result<LastLogin> {
-    let last_login = db::update_last_login()?;
-    Ok(last_login)
-}
-
 pub fn get_seed_phrase() -> SyncReturn<Vec<String>> {
     SyncReturn(ln_dlc::get_seed_phrase())
 }

--- a/mobile/native/src/db/mod.rs
+++ b/mobile/native/src/db/mod.rs
@@ -1,4 +1,3 @@
-use crate::api;
 use crate::db::models::base64_engine;
 use crate::db::models::Channel;
 use crate::db::models::Order;
@@ -103,13 +102,6 @@ pub fn connection() -> Result<PooledConnection<ConnectionManager<SqliteConnectio
 
     pool.get()
         .map_err(|e| anyhow!("cannot acquire database connection: {e:#}"))
-}
-
-pub fn update_last_login() -> Result<api::LastLogin> {
-    let mut db = connection()?;
-    let now = OffsetDateTime::now_utc();
-    let last_login = models::LastLogin::update_last_login(now, &mut db)?.into();
-    Ok(last_login)
 }
 
 pub fn insert_order(order: trade::order::Order) -> Result<trade::order::Order> {

--- a/mobile/native/src/ln_dlc/mod.rs
+++ b/mobile/native/src/ln_dlc/mod.rs
@@ -370,6 +370,11 @@ pub fn run(data_dir: String, seed_dir: String, runtime: &Runtime) -> Result<()> 
     })
 }
 
+pub fn init_new_mnemonic(target_seed_file: &Path) -> Result<()> {
+    Bip39Seed::initialize(target_seed_file)?;
+    Ok(())
+}
+
 pub fn restore_from_mnemonic(seed_words: &str, target_seed_file: &Path) -> Result<()> {
     Bip39Seed::restore_from_mnemonic(seed_words, target_seed_file)?;
     Ok(())

--- a/mobile/native/src/ln_dlc/mod.rs
+++ b/mobile/native/src/ln_dlc/mod.rs
@@ -370,6 +370,11 @@ pub fn run(data_dir: String, seed_dir: String, runtime: &Runtime) -> Result<()> 
     })
 }
 
+pub fn restore_from_mnemonic(seed_words: &str, target_seed_file: &Path) -> Result<()> {
+    Bip39Seed::restore_from_mnemonic(seed_words, target_seed_file)?;
+    Ok(())
+}
+
 fn keep_wallet_balance_and_history_up_to_date(node: &Node) -> Result<()> {
     let wallet_balances = node
         .get_wallet_balances()

--- a/mobile/native/src/schema.rs
+++ b/mobile/native/src/schema.rs
@@ -16,13 +16,6 @@ diesel::table! {
 }
 
 diesel::table! {
-    last_login (id) {
-        id -> Nullable<Integer>,
-        date -> Text,
-    }
-}
-
-diesel::table! {
     orders (id) {
         id -> Text,
         leverage -> Float,
@@ -95,7 +88,6 @@ diesel::table! {
 
 diesel::allow_tables_to_appear_in_same_query!(
     channels,
-    last_login,
     orders,
     payments,
     positions,

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -456,6 +456,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  font_awesome_flutter:
+    dependency: "direct main"
+    description:
+      name: font_awesome_flutter
+      sha256: "52671aea66da73b58d42ec6d0912b727a42248dd9a7c76d6c20f275783c48c08"
+      url: "https://pub.dev"
+    source: hosted
+    version: "10.6.0"
   freezed:
     dependency: "direct dev"
     description:

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -21,6 +21,7 @@ dependencies:
   slide_to_confirm: ^1.1.0
   path_provider: ^2.0.15
   freezed_annotation: ^2.2.0
+  font_awesome_flutter: 10.6.0
   expandable: ^5.0.1
   qr_flutter: ^4.0.0
   share_plus: ^7.0.2

--- a/mobile/test/util_test.dart
+++ b/mobile/test/util_test.dart
@@ -1,4 +1,5 @@
 import 'package:get_10101/features/wallet/application/util.dart';
+import 'package:get_10101/features/welcome/seed_import_screen.dart';
 import 'package:test/test.dart';
 
 void main() {
@@ -26,5 +27,19 @@ void main() {
       expect(leading, "");
       expect(balance, "2.11 010 000");
     });
+  });
+
+  test('calculateIndex returns the correct index for col=0', () {
+    const col = 0;
+
+    expect(calculateIndex(col, 0), 0);
+    expect(calculateIndex(col, 2), 2);
+  });
+
+  test('calculateIndex returns the correct index for col=1', () {
+    const col = 1;
+
+    expect(calculateIndex(col, 0), 6);
+    expect(calculateIndex(col, 2), 8);
   });
 }


### PR DESCRIPTION
- Allow choice between new and imported wallet on first startup
- add screens where user can input the seed (with confirmation step)
- add backend support for seed recovery
- add unit test to doublecheck whether recovered seed is the same as exported


<img width="315" alt="image" src="https://github.com/get10101/10101/assets/8319440/3ab25a2a-fcbf-4ef2-b7d5-2611489e8a80">

<img width="315" alt="image" src="https://github.com/get10101/10101/assets/8319440/320f0c85-760f-4ab5-9049-2d6ed25fadfb">

<img width="315" alt="image" src="https://github.com/get10101/10101/assets/8319440/3d6d5305-e5ad-453e-bb80-3e4edd2a439a">


