### PR TITLE
fix: funding tx not found

### DIFF
--- a/coordinator/src/collaborative_revert.rs
+++ b/coordinator/src/collaborative_revert.rs
@@ -211,6 +211,11 @@ pub fn confirm_collaborative_revert(
     channel_id: [u8; 32],
     inner_node: Arc<Node<NodeStorage>>,
 ) -> anyhow::Result<Transaction> {
+    tracing::debug!(
+        channel_id = revert_params.channel_id,
+        txid = revert_params.transaction.txid().to_string(),
+        "Confirming collaborative revert"
+    );
     // TODO: check if provided amounts are as expected
     if !revert_params
         .transaction
@@ -291,6 +296,10 @@ pub fn confirm_collaborative_revert(
 
     // if we have a sig here, it means we were able to sign the transaction and can broadcast it
     if own_sig.is_some() {
+        tracing::info!(
+            txid = revert_transaction.txid().to_string(),
+            "Broadcasting collaborative revert transaction"
+        );
         inner_node
             .wallet()
             .broadcast_transaction(&revert_transaction)

--- a/mobile/native/src/ln_dlc/mod.rs
+++ b/mobile/native/src/ln_dlc/mod.rs
@@ -711,9 +711,11 @@ pub fn collaborative_revert_channel(
     let details = channel_manager
         .get_channel_details(&subchannel.channel_id)
         .context("Could not get channel details")?;
+
     let out_point = details
         .original_funding_outpoint
-        .context("Original funding tx didn't have an outpoint")?;
+        .or(details.funding_txo)
+        .context("Could not find original funding outpoint")?;
 
     let address = node.get_unused_address();
 


### PR DESCRIPTION
Apparently it can be that `original_funding_outpoint` is not set. In this case, we can fall back to `funding_txo`.

Also added two more log messages to see what is happening on the coordinator.