### PR TITLE
fix: Charge fees on calculated settlement amount

### DIFF
--- a/coordinator/src/position/models.rs
+++ b/coordinator/src/position/models.rs
@@ -156,7 +156,8 @@ fn calculate_accept_settlement_amount(
     short_leverage: f32,
     direction: Direction,
 ) -> Result<u64> {
-    let close_position_fee = order_matching_fee_taker(quantity, closing_price).to_sat() as i64;
+    let open_position_fee = order_matching_fee_taker(quantity, opening_price).to_sat();
+    let close_position_fee = order_matching_fee_taker(quantity, closing_price).to_sat();
 
     let pnl = calculate_pnl(
         opening_price,
@@ -172,10 +173,10 @@ fn calculate_accept_settlement_amount(
         Direction::Short => short_leverage,
     };
 
-    let margin_trader_without_opening_fees = calculate_margin(opening_price, quantity, leverage);
+    let margin_trader = calculate_margin(opening_price, quantity, leverage);
 
-    let accept_settlement_amount = Decimal::from(margin_trader_without_opening_fees)
-        + Decimal::from(pnl)
+    let accept_settlement_amount = Decimal::from(margin_trader) + Decimal::from(pnl)
+        - Decimal::from(open_position_fee)
         - Decimal::from(close_position_fee);
     // the amount can only be positive, adding a safeguard here with the max comparison to
     // ensure the i64 fits into u64

--- a/mobile/native/src/ln_dlc/mod.rs
+++ b/mobile/native/src/ln_dlc/mod.rs
@@ -540,7 +540,7 @@ fn derive_trades_from_filled_orders() -> Result<Vec<WalletHistoryItem>> {
             let execution_price = Decimal::try_from(
                 first
                     .execution_price()
-                    .context("execution price to be set on a filled order")?,
+                    .expect("execution price to be set on a filled order"),
             )?;
             let fee = order_matching_fee_taker(first.quantity, execution_price).to_sat();
             let amount_sats = amount_sats + fee;
@@ -566,7 +566,7 @@ fn derive_trades_from_filled_orders() -> Result<Vec<WalletHistoryItem>> {
                 let execution_price = Decimal::try_from(
                     order
                         .execution_price()
-                        .context("execution price to be set on a filled order")?,
+                        .expect("execution price to be set on a filled order"),
                 )?;
 
                 // Closing the position.

--- a/mobile/native/src/ln_dlc/node.rs
+++ b/mobile/native/src/ln_dlc/node.rs
@@ -34,8 +34,6 @@ use ln_dlc_node::HTLCStatus;
 use ln_dlc_node::MillisatAmount;
 use ln_dlc_node::PaymentFlow;
 use ln_dlc_node::PaymentInfo;
-use orderbook_commons::order_matching_fee_taker;
-use rust_decimal::Decimal;
 use std::sync::Arc;
 use std::time::Duration;
 use time::OffsetDateTime;
@@ -242,17 +240,9 @@ impl Node {
             let filled_order = order::handler::order_filled()
                 .context("Cannot mark order as filled for confirmed DLC")?;
 
-            let execution_price = filled_order
-                .execution_price()
-                .context("expect execution price")?;
-            let open_position_fee = order_matching_fee_taker(
-                filled_order.quantity,
-                Decimal::try_from(execution_price)?,
-            );
-
             position::handler::update_position_after_dlc_creation(
                 filled_order,
-                accept_collateral - open_position_fee.to_sat(),
+                accept_collateral,
                 expiry_timestamp,
             )
             .context("Failed to update position after DLC creation")?;

--- a/mobile/native/src/ln_dlc/sync_position_to_dlc.rs
+++ b/mobile/native/src/ln_dlc/sync_position_to_dlc.rs
@@ -7,14 +7,11 @@ use crate::ln_dlc::node::Node;
 use crate::trade::order;
 use crate::trade::position;
 use crate::trade::position::Position;
-use anyhow::Context;
 use anyhow::Result;
 use ln_dlc_node::node::rust_dlc_manager::subchannel::SubChannel;
 use ln_dlc_node::node::rust_dlc_manager::subchannel::SubChannelState;
 use ln_dlc_node::node::rust_dlc_manager::ChannelId;
 use ln_dlc_node::node::rust_dlc_manager::Storage;
-use orderbook_commons::order_matching_fee_taker;
-use rust_decimal::Decimal;
 use std::time::Duration;
 
 #[derive(PartialEq, Clone, Debug)]
@@ -55,20 +52,13 @@ impl Node {
             Some(SyncPositionToDlcAction::CreatePosition(channel_id)) => {
                 match order::handler::order_filled() {
                     Ok(order) => {
-                        let execution_price =
-                            order.execution_price().context("expect execution price")?;
-                        let open_position_fee = order_matching_fee_taker(
-                            order.quantity,
-                            Decimal::try_from(execution_price)?,
-                        );
-
                         let (accept_collateral, expiry_timestamp) = self
                             .inner
                             .get_collateral_and_expiry_for_confirmed_contract(channel_id)?;
 
                         position::handler::update_position_after_dlc_creation(
                             order,
-                            accept_collateral - open_position_fee.to_sat(),
+                            accept_collateral,
                             expiry_timestamp,
                         )?;
 


### PR DESCRIPTION
After reviewing our initial approach, it turns out there is no easy way of achieving enforced fee payment without any rust-dlc changes. To simplify things I've reverted the corresponding change impacting the payout curve and margins.

A proper solution should be tackled with #250.