### PR TITLE
Revert "chore: Use 10101 purple instead of green"

### DIFF
--- a/mobile/lib/features/trade/order_list_item.dart
+++ b/mobile/lib/features/trade/order_list_item.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:get_10101/common/color.dart';
 import 'package:get_10101/features/trade/domain/direction.dart';
 import 'package:get_10101/features/trade/trade_theme.dart';
 import 'package:intl/intl.dart';
@@ -25,7 +24,7 @@ class OrderListItem extends StatelessWidget {
           Icons.pending,
           size: iconSize,
         ),
-      OrderState.filled => const Icon(Icons.check_circle, color: tenTenOnePurple, size: iconSize),
+      OrderState.filled => const Icon(Icons.check_circle, color: Colors.green, size: iconSize),
       OrderState.failed => const Icon(Icons.error, color: Colors.red, size: iconSize),
     };
 

--- a/mobile/lib/features/wallet/wallet_history_item.dart
+++ b/mobile/lib/features/wallet/wallet_history_item.dart
@@ -37,7 +37,7 @@ abstract class WalletHistoryItem extends StatelessWidget {
           size: statusIconSize,
         ),
       WalletHistoryStatus.confirmed =>
-        const Icon(Icons.check_circle, color: tenTenOnePurple, size: statusIconSize),
+        const Icon(Icons.check_circle, color: Colors.green, size: statusIconSize),
       WalletHistoryStatus.expired =>
         const Icon(Icons.timer_off, color: Colors.red, size: statusIconSize),
       WalletHistoryStatus.failed =>
@@ -56,7 +56,7 @@ abstract class WalletHistoryItem extends StatelessWidget {
     };
 
     Color color = switch (data.flow) {
-      PaymentFlow.inbound => tenTenOnePurple,
+      PaymentFlow.inbound => Colors.green.shade600,
       PaymentFlow.outbound => Colors.red.shade600,
     };
 


### PR DESCRIPTION
This reverts commit 7c7d331cb327bb1bb1207ca2c6bf780c1bbc609a.

Lets maybe digest this a bit, but after looking at the app this evening, I kind of feel like the color green looks better than everything in purple. Happy to close that PR if you are convinced of how it currently looks :)

![Screenshot 2023-10-20 at 21 40 14](https://github.com/get10101/10101/assets/382048/2e168906-d2d3-4a6b-9a08-5db9889cb913)
