### PR TITLE
fix: Create route hint on the app side

### DIFF
--- a/crates/ln-dlc-node/src/ln/channel_details.rs
+++ b/crates/ln-dlc-node/src/ln/channel_details.rs
@@ -47,7 +47,6 @@ pub struct ChannelConfig {
 
 impl From<lightning::ln::channelmanager::ChannelDetails> for ChannelDetails {
     fn from(cd: lightning::ln::channelmanager::ChannelDetails) -> Self {
-        let scid = cd.get_outbound_payment_scid();
         ChannelDetails {
             channel_id: cd.channel_id,
             counterparty: cd.counterparty.node_id,
@@ -76,7 +75,7 @@ impl From<lightning::ln::channelmanager::ChannelDetails> for ChannelDetails {
                 max_dust_htlc_exposure_msat: c.max_dust_htlc_exposure_msat,
                 force_close_avoidance_max_fee_satoshis: c.force_close_avoidance_max_fee_satoshis,
             }),
-            scid,
+            scid: cd.short_channel_id,
         }
     }
 }

--- a/crates/ln-dlc-node/src/ln/channel_details.rs
+++ b/crates/ln-dlc-node/src/ln/channel_details.rs
@@ -33,6 +33,7 @@ pub struct ChannelDetails {
     pub inbound_htlc_minimum_msat: Option<u64>,
     pub inbound_htlc_maximum_msat: Option<u64>,
     pub config: Option<ChannelConfig>,
+    pub scid: Option<u64>,
 }
 
 #[derive(Serialize, Debug)]
@@ -46,6 +47,7 @@ pub struct ChannelConfig {
 
 impl From<lightning::ln::channelmanager::ChannelDetails> for ChannelDetails {
     fn from(cd: lightning::ln::channelmanager::ChannelDetails) -> Self {
+        let scid = cd.get_outbound_payment_scid();
         ChannelDetails {
             channel_id: cd.channel_id,
             counterparty: cd.counterparty.node_id,
@@ -74,6 +76,7 @@ impl From<lightning::ln::channelmanager::ChannelDetails> for ChannelDetails {
                 max_dust_htlc_exposure_msat: c.max_dust_htlc_exposure_msat,
                 force_close_avoidance_max_fee_satoshis: c.force_close_avoidance_max_fee_satoshis,
             }),
+            scid,
         }
     }
 }

--- a/crates/ln-dlc-node/src/node/invoice.rs
+++ b/crates/ln-dlc-node/src/node/invoice.rs
@@ -132,10 +132,6 @@ where
     ///
     /// We also specify the [`RoutingFees`] to ensure that the payment is made in accordance with
     /// the fees that we want to charge.
-    ///
-    /// # Errors
-    ///
-    /// An error if the user already has a channel. Use `prepare_payment_with_route_hint` instead.
     pub fn prepare_onboarding_payment(
         &self,
         liquidity_request: LiquidityRequest,
@@ -192,7 +188,7 @@ where
             .find(|channel| channel.counterparty.node_id == target_node)
             .with_context(|| format!("Couldn't find channel for {target_node}"))?;
 
-        let short_channel_id = channel.short_channel_id.with_context(|| {
+        let short_channel_id = channel.get_outbound_payment_scid().with_context(|| {
             format!(
                 "Couldn't find short channel id for channel: {}, trader_id={target_node}",
                 channel.channel_id.to_hex()

--- a/crates/ln-dlc-node/src/tests/just_in_time_channel/create.rs
+++ b/crates/ln-dlc-node/src/tests/just_in_time_channel/create.rs
@@ -341,7 +341,7 @@ pub(crate) async fn send_payment(
     let coordinator_balance_before = coordinator.get_ldk_balance();
     let payee_balance_before = payee.get_ldk_balance();
 
-    let route_hint_hop = coordinator.prepare_payment_with_route_hint(payee.info.pubkey)?;
+    let route_hint_hop = payee.prepare_payment_with_route_hint(coordinator.info.pubkey)?;
 
     let invoice = payee.create_invoice_with_route_hint(
         Some(invoice_amount_sat),

--- a/crates/ln-dlc-node/src/tests/mod.rs
+++ b/crates/ln-dlc-node/src/tests/mod.rs
@@ -462,7 +462,7 @@ async fn wait_for_n_usable_channels(
             .channel_manager
             .list_usable_channels()
             .iter()
-            .all(|c| c.get_outbound_payment_scid().is_some());
+            .all(|c| c.get_inbound_payment_scid().is_some());
 
         Ok((usable_channels_length == channel_count && scids_set).then_some(()))
     })

--- a/crates/ln-dlc-node/src/tests/mod.rs
+++ b/crates/ln-dlc-node/src/tests/mod.rs
@@ -462,7 +462,7 @@ async fn wait_for_n_usable_channels(
             .channel_manager
             .list_usable_channels()
             .iter()
-            .all(|c| c.short_channel_id.is_some());
+            .all(|c| c.get_outbound_payment_scid().is_some());
 
         Ok((usable_channels_length == channel_count && scids_set).then_some(()))
     })

--- a/mobile/native/src/ln_dlc/mod.rs
+++ b/mobile/native/src/ln_dlc/mod.rs
@@ -938,7 +938,7 @@ pub fn create_onboarding_invoice(amount_sats: u64, liquidity_option_id: i32) -> 
             %user_channel_id,
         );
 
-        let final_route_hint_hop : RouteHintHop= match client
+        let final_route_hint_hop : RouteHintHop = match client
             .post(format!(
                 "http://{}/api/prepare_onboarding_payment",
                 config::get_http_endpoint(),

--- a/mobile/native/src/ln_dlc/mod.rs
+++ b/mobile/native/src/ln_dlc/mod.rs
@@ -970,36 +970,18 @@ pub fn create_onboarding_invoice(amount_sats: u64, liquidity_option_id: i32) -> 
 }
 
 pub fn create_invoice(amount_sats: Option<u64>) -> Result<Invoice> {
-    let runtime = get_or_create_tokio_runtime()?;
+    let node = NODE.get();
 
-    runtime.block_on(async {
-        let node = NODE.get();
-        let client = reqwest_client();
+    let final_route_hint_hop = node
+        .inner
+        .prepare_payment_with_route_hint(config::get_coordinator_info().pubkey)?;
 
-        let response = client
-            .post(format!(
-                "http://{}/api/prepare_regular_payment/{}",
-                config::get_http_endpoint(),
-                node.inner.info.pubkey
-            ))
-            .send()
-            .await?;
-
-        if !response.status().is_success() {
-            let text = response.text().await?;
-            bail!("Failed to fetch route hint from coordinator for regular payment: {text}")
-        }
-
-        let final_route_hint_hop: RouteHintHop = response.json().await?;
-        let final_route_hint_hop = final_route_hint_hop.into();
-
-        node.inner.create_invoice_with_route_hint(
-            amount_sats,
-            None,
-            "".to_string(),
-            final_route_hint_hop,
-        )
-    })
+    node.inner.create_invoice_with_route_hint(
+        amount_sats,
+        None,
+        "".to_string(),
+        final_route_hint_hop,
+    )
 }
 
 pub fn send_payment(payment: SendPayment) -> Result<()> {


### PR DESCRIPTION
Gets the current SCID which should be used to identify this channel for outbound payments. This should be used in Routes to describe the first hop or in other contexts where we're sending or forwarding a payment outbound over this channel.
This is either the ChannelDetails::short_channel_id, if set, or the ChannelDetails::outbound_scid_alias. See those for more information.

Obviously, the `inbound_scid_alias` was wrong since it is outbound from the coordinator point of view.