### PR TITLE
chore: Improving collaborative revert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Improve collab revert
 - Improved settings screen
 
 ## [1.4.3] - 2023-10-23

--- a/coordinator/src/admin.rs
+++ b/coordinator/src/admin.rs
@@ -201,7 +201,7 @@ pub async fn list_peers(State(state): State<Arc<AppState>>) -> Json<Vec<PublicKe
 }
 
 #[derive(Debug, Deserialize)]
-pub struct CloseChanelParams {
+pub struct CloseChannelParams {
     #[serde(default, deserialize_with = "empty_string_as_none")]
     force: Option<bool>,
 }
@@ -287,7 +287,7 @@ pub async fn send_payment(
 #[instrument(skip_all, err(Debug))]
 pub async fn close_channel(
     Path(channel_id_string): Path<String>,
-    Query(params): Query<CloseChanelParams>,
+    Query(params): Query<CloseChannelParams>,
     State(state): State<Arc<AppState>>,
 ) -> Result<(), AppError> {
     let channel_id = hex::decode(channel_id_string.clone())

--- a/coordinator/src/collaborative_revert.rs
+++ b/coordinator/src/collaborative_revert.rs
@@ -116,14 +116,14 @@ pub async fn notify_user_to_collaboratively_revert(
         "Collaborative revert temporary values"
     );
 
-    let coordinator_addrss = node.get_unused_address();
+    let coordinator_address = node.get_unused_address();
     let coordinator_amount = Amount::from_sat(coordinator_amount as u64 - fee / 2);
     let trader_amount = Amount::from_sat(trader_amount - fee / 2);
 
     // TODO: check if trader still has more than dust
     tracing::info!(
         channel_id = channel_id_string,
-        coordinator_address = %coordinator_addrss,
+        coordinator_address = %coordinator_address,
         coordinator_amount = coordinator_amount.to_sat(),
         trader_amount = trader_amount.to_sat(),
         "Proposing collaborative revert");
@@ -134,7 +134,7 @@ pub async fn notify_user_to_collaboratively_revert(
             channel_id,
             trader_pubkey: position.trader,
             price: revert_params.price.to_f32().expect("to fit into f32"),
-            coordinator_address: coordinator_addrss.clone(),
+            coordinator_address: coordinator_address.clone(),
             coordinator_amount_sats: coordinator_amount,
             trader_amount_sats: trader_amount,
             timestamp: OffsetDateTime::now_utc(),
@@ -149,7 +149,7 @@ pub async fn notify_user_to_collaboratively_revert(
             trader_id: position.trader,
             message: Message::CollaborativeRevert {
                 channel_id,
-                coordinator_address: coordinator_addrss,
+                coordinator_address,
                 coordinator_amount,
                 trader_amount,
                 execution_price: revert_params.price,

--- a/coordinator/src/collaborative_revert.rs
+++ b/coordinator/src/collaborative_revert.rs
@@ -152,6 +152,7 @@ pub async fn notify_user_to_collaboratively_revert(
                 coordinator_address: coordinator_addrss,
                 coordinator_amount,
                 trader_amount,
+                execution_price: revert_params.price,
             },
             notification: Some(NotificationKind::CollaborativeRevert),
         })

--- a/coordinator/src/collaborative_revert.rs
+++ b/coordinator/src/collaborative_revert.rs
@@ -2,6 +2,7 @@ use crate::db;
 use crate::db::positions::Position;
 use crate::message::OrderbookMessage;
 use crate::node::storage::NodeStorage;
+use crate::notifications::NotificationKind;
 use crate::position;
 use anyhow::anyhow;
 use anyhow::bail;
@@ -144,7 +145,7 @@ pub async fn notify_user_to_collaboratively_revert(
     // try to notify user
     let sender = auth_users_notifier;
     sender
-        .send(OrderbookMessage::CollaborativeRevert {
+        .send(OrderbookMessage::TraderMessage {
             trader_id: position.trader,
             message: Message::CollaborativeRevert {
                 channel_id,
@@ -152,6 +153,7 @@ pub async fn notify_user_to_collaboratively_revert(
                 coordinator_amount,
                 trader_amount,
             },
+            notification: Some(NotificationKind::CollaborativeRevert),
         })
         .await
         .map_err(|error| anyhow!("Could send message to notify user {error:#}"))?;

--- a/coordinator/src/collaborative_revert.rs
+++ b/coordinator/src/collaborative_revert.rs
@@ -28,7 +28,6 @@ use rust_decimal::prelude::ToPrimitive;
 use std::sync::Arc;
 use time::OffsetDateTime;
 use tokio::sync::mpsc;
-use trade::bitmex_client::Quote;
 
 /// The weight for the collaborative close transaction. It's expected to have 1 input (from the fund
 /// transaction) and 2 outputs, one for each party.
@@ -68,34 +67,36 @@ pub async fn notify_user_to_collaboratively_revert(
         .calculate_settlement_amount(revert_params.price)
         .context("Could not calculate settlement amount")?;
 
-    let pnl = position
-        .calculate_coordinator_pnl(Quote {
-            bid_size: 0,
-            ask_size: 0,
-            bid_price: revert_params.price,
-            ask_price: revert_params.price,
-            symbol: "".to_string(),
-            timestamp: OffsetDateTime::now_utc(),
-        })
-        .context("Could not calculate coordinator pnl")?;
+    let trade_settled = sub_channel.fund_value_satoshis == channel_details.channel_value_satoshis;
 
     // There is no easy way to get the total tx fee for all subchannel transactions, hence, we
     // estimate it. This transaction fee is shared among both users fairly
     let dlc_channel_fee = calculate_dlc_channel_tx_fees(
+        trade_settled,
         sub_channel.fund_value_satoshis,
-        pnl,
         channel_details.inbound_capacity_msat / 1000,
         channel_details.outbound_capacity_msat / 1000,
-        position.trader_margin,
-        position.coordinator_margin,
+        position.trader_margin as u64,
+        position.coordinator_margin as u64,
+        channel_details.unspendable_punishment_reserve.unwrap_or(0),
     )?;
 
     // Coordinator's amount is the total channel's value (fund_value_satoshis) whatever the taker
     // had (inbound_capacity), the taker's PnL (settlement_amount) and the transaction fee
-    let coordinator_amount = sub_channel.fund_value_satoshis as i64
-        - (channel_details.inbound_capacity_msat / 1000) as i64
-        - settlement_amount as i64
-        - (dlc_channel_fee as f64 / 2.0) as i64;
+    let coordinator_amount = match trade_settled {
+        false => {
+            sub_channel.fund_value_satoshis as i64
+                - (channel_details.inbound_capacity_msat / 1000) as i64
+                - settlement_amount as i64
+                - (dlc_channel_fee as f64 / 2.0) as i64
+                - channel_details.unspendable_punishment_reserve.unwrap_or(0) as i64
+        }
+        true => {
+            sub_channel.fund_value_satoshis as i64
+                - (channel_details.inbound_capacity_msat / 1000) as i64
+                - channel_details.unspendable_punishment_reserve.unwrap_or(0) as i64
+        }
+    };
     let trader_amount = sub_channel.fund_value_satoshis - coordinator_amount as u64;
 
     let fee = weight_to_fee(
@@ -164,30 +165,31 @@ pub async fn notify_user_to_collaboratively_revert(
 }
 
 fn calculate_dlc_channel_tx_fees(
-    initial_funding: u64,
-    pnl: i64,
+    trade_settled: bool,
+    sub_channel_sats: u64,
     inbound_capacity: u64,
     outbound_capacity: u64,
-    trader_margin: i64,
-    coordinator_margin: i64,
+    trader_margin: u64,
+    coordinator_margin: u64,
+    reserve: u64,
 ) -> anyhow::Result<u64> {
-    let dlc_tx_fee = initial_funding
+    let mut dlc_tx_fee = sub_channel_sats
         .checked_sub(inbound_capacity)
         .context("could not subtract inbound capacity")?
         .checked_sub(outbound_capacity)
         .context("could not subtract outbound capacity")?
-        .checked_sub(
-            trader_margin
-                .checked_sub(pnl)
-                .context("could not substract pnl")? as u64,
-        )
-        .context("could not subtract trader margin")?
-        .checked_sub(
-            coordinator_margin
-                .checked_add(pnl)
-                .context("could not add pnl")? as u64,
-        )
-        .context("could not subtract coordinator margin")?;
+        .checked_sub(reserve * 2)
+        .context("could not substract the reserve")?;
+
+    if !trade_settled {
+        // the ln channel has not yet been updated so we need to take the margins into account.
+        dlc_tx_fee = dlc_tx_fee
+            .checked_sub(trader_margin)
+            .context("could not subtract trader margin")?
+            .checked_sub(coordinator_margin)
+            .context("could not subtract coordinator margin")?;
+    }
+
     Ok(dlc_tx_fee)
 }
 
@@ -196,17 +198,27 @@ pub mod tests {
     use crate::collaborative_revert::calculate_dlc_channel_tx_fees;
 
     #[test]
-    pub fn calculate_transaction_fee_for_dlc_channel_transactions() {
+    pub fn calculate_transaction_fee_for_dlc_channel_transactions_with_smaller_ln_channel() {
         let total_fee =
-            calculate_dlc_channel_tx_fees(200_000, -4047, 65_450, 85_673, 18_690, 18_690).unwrap();
-        assert_eq!(total_fee, 11_497);
+            calculate_dlc_channel_tx_fees(false, 200_000, 65_450, 85_673, 18_690, 18_690, 1_000)
+                .unwrap();
+        assert_eq!(total_fee, 9_497);
+    }
+
+    #[test]
+    pub fn calculate_transaction_fee_for_dlc_channel_transactions_with_equal_ln_channel() {
+        let total_fee =
+            calculate_dlc_channel_tx_fees(true, 200_000, 84_140, 104_363, 18_690, 18_690, 1_000)
+                .unwrap();
+        assert_eq!(total_fee, 9_497);
     }
 
     #[test]
     pub fn ensure_overflow_being_caught() {
-        assert!(
-            calculate_dlc_channel_tx_fees(200_000, -100, 65_383, 88_330, 180_362, 180_362).is_err()
-        );
+        assert!(calculate_dlc_channel_tx_fees(
+            false, 200_000, 84_140, 104_363, 18_690, 18_690, 1_000
+        )
+        .is_err());
     }
 }
 

--- a/coordinator/src/db/collaborative_reverts.rs
+++ b/coordinator/src/db/collaborative_reverts.rs
@@ -3,6 +3,7 @@ use crate::position::models::parse_channel_id;
 use crate::schema::collaborative_reverts;
 use anyhow::ensure;
 use anyhow::Result;
+use bitcoin::hashes::hex::ToHex;
 use bitcoin::secp256k1::PublicKey;
 use bitcoin::Address;
 use bitcoin::Amount;
@@ -14,6 +15,7 @@ use diesel::OptionalExtension;
 use diesel::PgConnection;
 use diesel::Queryable;
 use diesel::RunQueryDsl;
+use dlc_manager::ChannelId;
 use std::str::FromStr;
 use time::OffsetDateTime;
 
@@ -68,6 +70,14 @@ pub(crate) fn insert(
         .execute(conn)?;
 
     ensure!(affected_rows > 0, "Could not insert collaborative revert");
+
+    Ok(())
+}
+
+pub(crate) fn delete(conn: &mut PgConnection, channel_id: ChannelId) -> Result<()> {
+    diesel::delete(collaborative_reverts::table)
+        .filter(collaborative_reverts::channel_id.eq(channel_id.to_hex()))
+        .execute(conn)?;
 
     Ok(())
 }

--- a/coordinator/src/orderbook/collaborative_revert.rs
+++ b/coordinator/src/orderbook/collaborative_revert.rs
@@ -10,6 +10,7 @@ use diesel::PgConnection;
 use futures::future::RemoteHandle;
 use futures::FutureExt;
 use orderbook_commons::Message;
+use rust_decimal::Decimal;
 use tokio::sync::broadcast;
 use tokio::sync::mpsc;
 
@@ -62,8 +63,9 @@ async fn process_pending_collaborative_revert(
                     coordinator_address: revert.coordinator_address,
                     coordinator_amount: revert.coordinator_amount_sats,
                     trader_amount: revert.trader_amount_sats,
+                    execution_price: Decimal::try_from(revert.price).expect("to fit into decimal"),
                 },
-                notification: None
+                notification: None,
             };
             if let Err(e) = notifier.send(msg).await {
                 bail!("Failed to send notification. Error: {e:#}");

--- a/coordinator/src/orderbook/collaborative_revert.rs
+++ b/coordinator/src/orderbook/collaborative_revert.rs
@@ -55,7 +55,7 @@ async fn process_pending_collaborative_revert(
 
             // Sending no optional push notification as this is only executed if the user just
             // registered on the websocket. So we can assume that the user is still online.
-            let msg = OrderbookMessage::CollaborativeRevert {
+            let msg = OrderbookMessage::TraderMessage {
                 trader_id,
                 message: Message::CollaborativeRevert {
                     channel_id: revert.channel_id,
@@ -63,6 +63,7 @@ async fn process_pending_collaborative_revert(
                     coordinator_amount: revert.coordinator_amount_sats,
                     trader_amount: revert.trader_amount_sats,
                 },
+                notification: None
             };
             if let Err(e) = notifier.send(msg).await {
                 bail!("Failed to send notification. Error: {e:#}");

--- a/crates/orderbook-commons/src/lib.rs
+++ b/crates/orderbook-commons/src/lib.rs
@@ -160,6 +160,8 @@ pub enum Message {
         coordinator_amount: Amount,
         #[serde(with = "bitcoin::util::amount::serde::as_sat")]
         trader_amount: Amount,
+        #[serde(with = "rust_decimal::serde::float")]
+        execution_price: Decimal,
     },
 }
 

--- a/mobile/lib/common/collab_revert_change_notifier.dart
+++ b/mobile/lib/common/collab_revert_change_notifier.dart
@@ -1,0 +1,43 @@
+import 'package:flutter/material.dart';
+import 'package:get_10101/bridge_generated/bridge_definitions.dart' as bridge;
+import 'package:get_10101/common/application/event_service.dart';
+import 'package:get_10101/common/domain/background_task.dart';
+import 'package:get_10101/common/global_keys.dart';
+import 'package:get_10101/common/task_status_dialog.dart';
+import 'package:get_10101/logger/logger.dart';
+import 'package:provider/provider.dart';
+
+class CollabRevertChangeNotifier extends ChangeNotifier implements Subscriber {
+  late TaskStatus taskStatus;
+
+  @override
+  void notify(bridge.Event event) {
+    if (event is bridge.Event_BackgroundNotification) {
+      if (event.field0 is! bridge.BackgroundTask_CollabRevert) {
+        // ignoring other kinds of background tasks
+        return;
+      }
+      CollabRevert collabRevert =
+          CollabRevert.fromApi(event.field0 as bridge.BackgroundTask_CollabRevert);
+      logger.d("Received a collab revert channel event. Status: ${collabRevert.taskStatus}");
+
+      taskStatus = collabRevert.taskStatus;
+
+      if (taskStatus == TaskStatus.pending) {
+        // initialize dialog for the pending task
+        showDialog(
+          context: shellNavigatorKey.currentContext!,
+          builder: (context) {
+            TaskStatus status = context.watch<CollabRevertChangeNotifier>().taskStatus;
+            late Widget content = const Text("Your channel has been closed collaboratively!");
+            return TaskStatusDialog(
+                title: "Collaborative Channel Close!", status: status, content: content);
+          },
+        );
+      } else {
+        // notify dialog about changed task status
+        notifyListeners();
+      }
+    }
+  }
+}

--- a/mobile/lib/common/domain/background_task.dart
+++ b/mobile/lib/common/domain/background_task.dart
@@ -63,3 +63,17 @@ class RecoverDlc {
     return bridge.BackgroundTask_RecoverDlc(TaskStatus.apiDummy());
   }
 }
+
+class CollabRevert {
+  final TaskStatus taskStatus;
+
+  CollabRevert({required this.taskStatus});
+
+  static CollabRevert fromApi(bridge.BackgroundTask_CollabRevert collabRevert) {
+    return CollabRevert(taskStatus: TaskStatus.fromApi(collabRevert.field0));
+  }
+
+  static bridge.BackgroundTask apiDummy() {
+    return bridge.BackgroundTask_CollabRevert(TaskStatus.apiDummy());
+  }
+}

--- a/mobile/lib/common/init_service.dart
+++ b/mobile/lib/common/init_service.dart
@@ -6,6 +6,7 @@ import 'package:get_10101/features/trade/order_change_notifier.dart';
 import 'package:get_10101/ffi.dart' as rust;
 import 'package:get_10101/features/trade/position_change_notifier.dart';
 import 'package:get_10101/common/amount_denomination_change_notifier.dart';
+import 'package:get_10101/common/collab_revert_change_notifier.dart';
 import 'package:get_10101/common/service_status_notifier.dart';
 import 'package:get_10101/common/recover_dlc_change_notifier.dart';
 import 'package:get_10101/features/stable/stable_value_change_notifier.dart';
@@ -65,6 +66,7 @@ List<SingleChildWidget> createProviders() {
     ChangeNotifierProvider(create: (context) => RecoverDlcChangeNotifier()),
     ChangeNotifierProvider(create: (context) => PaymentClaimedChangeNotifier()),
     ChangeNotifierProvider(create: (context) => PaymentChangeNotifier()),
+    ChangeNotifierProvider(create: (context) => CollabRevertChangeNotifier()),
     Provider(create: (context) => config),
     Provider(create: (context) => channelInfoService)
   ];
@@ -94,6 +96,7 @@ void subscribeToNotifiers(BuildContext context) {
   final recoverDlcChangeNotifier = context.read<RecoverDlcChangeNotifier>();
   final paymentClaimedChangeNotifier = context.read<PaymentClaimedChangeNotifier>();
   final paymentChangeNotifier = context.read<PaymentChangeNotifier>();
+  final collabRevertChangeNotifier = context.read<CollabRevertChangeNotifier>();
 
   eventService.subscribe(
       orderChangeNotifier, bridge.Event.orderUpdateNotification(Order.apiDummy()));
@@ -139,6 +142,9 @@ void subscribeToNotifiers(BuildContext context) {
 
   eventService.subscribe(paymentChangeNotifier, const bridge.Event.paymentSent());
   eventService.subscribe(paymentChangeNotifier, const bridge.Event.paymentFailed());
+
+  eventService.subscribe(
+      collabRevertChangeNotifier, bridge.Event.backgroundNotification(CollabRevert.apiDummy()));
 
   channelStatusNotifier.subscribe(eventService);
 

--- a/mobile/native/src/event/api.rs
+++ b/mobile/native/src/event/api.rs
@@ -43,6 +43,8 @@ pub enum BackgroundTask {
     /// The app was started with a dlc channel in an intermediate state. This task is in pending
     /// until the dlc protocol reaches a final state.
     RecoverDlc(TaskStatus),
+    /// The coordinator wants to collaboratively close a ln channel with a stuck position.
+    CollabRevert(TaskStatus),
 }
 
 impl From<EventInternal> for Event {
@@ -141,6 +143,9 @@ impl From<event::BackgroundTask> for BackgroundTask {
             }
             event::BackgroundTask::Rollover(status) => BackgroundTask::Rollover(status.into()),
             event::BackgroundTask::RecoverDlc(status) => BackgroundTask::RecoverDlc(status.into()),
+            event::BackgroundTask::CollabRevert(status) => {
+                BackgroundTask::CollabRevert(status.into())
+            }
         }
     }
 }

--- a/mobile/native/src/event/mod.rs
+++ b/mobile/native/src/event/mod.rs
@@ -49,6 +49,7 @@ pub enum EventInternal {
 pub enum BackgroundTask {
     AsyncTrade(OrderReason),
     Rollover(TaskStatus),
+    CollabRevert(TaskStatus),
     RecoverDlc(TaskStatus),
 }
 

--- a/mobile/native/src/ln_dlc/mod.rs
+++ b/mobile/native/src/ln_dlc/mod.rs
@@ -706,6 +706,7 @@ pub fn collaborative_revert_channel(
     coordinator_address: Address,
     coordinator_amount: Amount,
     trader_amount: Amount,
+    execution_price: Decimal,
 ) -> Result<()> {
     let node = NODE.try_get().context("failed to get ln dlc node")?;
 

--- a/mobile/native/src/ln_dlc/mod.rs
+++ b/mobile/native/src/ln_dlc/mod.rs
@@ -18,6 +18,9 @@ use crate::ln_dlc::node::NodeStorage;
 use crate::trade::order;
 use crate::trade::order::FailureReason;
 use crate::trade::order::Order;
+use crate::trade::order::OrderReason;
+use crate::trade::order::OrderState;
+use crate::trade::order::OrderType;
 use crate::trade::position;
 use anyhow::anyhow;
 use anyhow::bail;
@@ -57,6 +60,7 @@ use ln_dlc_node::channel::JIT_FEE_INVOICE_DESCRIPTION_PREFIX;
 use ln_dlc_node::config::app_config;
 use ln_dlc_node::node::rust_dlc_manager;
 use ln_dlc_node::node::rust_dlc_manager::subchannel::LNChannelManager;
+use ln_dlc_node::node::rust_dlc_manager::subchannel::SubChannel;
 use ln_dlc_node::node::rust_dlc_manager::subchannel::SubChannelState;
 use ln_dlc_node::node::rust_dlc_manager::ChannelId;
 use ln_dlc_node::node::rust_dlc_manager::Storage as DlcStorage;
@@ -73,6 +77,7 @@ use orderbook_commons::order_matching_fee_taker;
 use orderbook_commons::RouteHintHop;
 use rust_decimal::prelude::FromPrimitive;
 use rust_decimal::prelude::Signed;
+use rust_decimal::prelude::ToPrimitive;
 use rust_decimal::Decimal;
 use rust_decimal::RoundingStrategy;
 use state::Storage;
@@ -789,46 +794,118 @@ pub fn collaborative_revert_channel(
 
         let client = reqwest_client();
         let runtime = get_or_create_tokio_runtime()?;
-        runtime.spawn(async move {
-            match client
-                .post(format!(
-                    "http://{}/api/channels/revertconfirm",
-                    config::get_http_endpoint(),
-                ))
-                .json(&data)
-                .send()
-                .await
-            {
-                Ok(response) => match response.text().await {
-                    Ok(response) => {
-                        tracing::info!(
-                            response,
-                            "Received response from confirming reverting a channel"
-                        );
-
-                        match db::delete_positions() {
-                            Ok(_) => {
-                                event::publish(&EventInternal::PositionCloseNotification(
-                                    ContractSymbol::BtcUsd,
-                                ));
-                            }
-                            Err(error) => {
-                                tracing::error!("Could not delete position : {error:#}");
+        runtime.spawn({
+            let sub_channel = subchannel.clone();
+            async move {
+                match client
+                    .post(format!(
+                        "http://{}/api/channels/revertconfirm",
+                        config::get_http_endpoint(),
+                    ))
+                    .json(&data)
+                    .send()
+                    .await
+                {
+                    Ok(response) => match response.text().await {
+                        Ok(response) => {
+                            tracing::info!(
+                                response,
+                                "Received response from confirming reverting a channel"
+                            );
+                            if let Err(e) =
+                                update_state_after_collab_revert(sub_channel, execution_price)
+                            {
+                                tracing::error!(
+                                    "Failed to update state after collab revert. {e:#}"
+                                );
                             }
                         }
+                        Err(error) => {
+                            tracing::error!("Failed at confirming reverting a channel {error:#}");
+                        }
+                    },
+                    Err(err) => {
+                        tracing::error!("Could not confirm collaborative revert {err:#}");
                     }
-                    Err(error) => {
-                        tracing::error!("Failed at confirming reverting a channel  : {error:#}");
-                    }
-                },
-                Err(err) => {
-                    tracing::error!("Could not confirm collaborative revert {err:#}");
                 }
             }
         });
     }
 
     Ok(())
+}
+
+fn update_state_after_collab_revert(
+    sub_channel: SubChannel,
+    execution_price: Decimal,
+) -> Result<()> {
+    let node = NODE.try_get().context("failed to get ln dlc node")?;
+    let positions = db::get_positions()?;
+
+    let position = match positions.first() {
+        Some(position) => {
+            tracing::info!("Channel is reverted before the position got closed successfully.");
+            position
+        }
+        None => {
+            tracing::info!("Channel is reverted before the position got opened successfully.");
+            if let Some(order) = db::maybe_get_order_in_filling()? {
+                order::handler::order_failed(
+                    Some(order.id),
+                    FailureReason::ProposeDlcChannel,
+                    anyhow!("Order failed due collab revert of the channel"),
+                )?;
+            }
+            return Ok(());
+        }
+    };
+
+    let filled_order = match order::handler::order_filled() {
+        Ok(order) => order,
+        Err(_) => {
+            let order = Order {
+                id: uuid::Uuid::new_v4(),
+                leverage: position.leverage,
+                quantity: position.quantity,
+                contract_symbol: position.contract_symbol,
+                direction: position.direction.opposite(),
+                order_type: OrderType::Market,
+                state: OrderState::Filled {
+                    execution_price: execution_price.to_f32().expect("to fit into f32"),
+                },
+                creation_timestamp: OffsetDateTime::now_utc(),
+                order_expiry_timestamp: OffsetDateTime::now_utc(),
+                reason: OrderReason::Expired,
+                stable: position.stable,
+            };
+            db::insert_order(order)?;
+            event::publish(&EventInternal::OrderUpdateNotification(order));
+            order
+        }
+    };
+
+    position::handler::update_position_after_dlc_closure(Some(filled_order))?;
+
+    match db::delete_positions() {
+        Ok(_) => {
+            event::publish(&EventInternal::PositionCloseNotification(
+                ContractSymbol::BtcUsd,
+            ));
+        }
+        Err(error) => {
+            tracing::error!("Could not delete position : {error:#}");
+        }
+    }
+
+    let mut sub_channel = sub_channel;
+    sub_channel.state = SubChannelState::OnChainClosed;
+
+    let node = node.inner.clone();
+
+    node.dlc_manager
+        .get_store()
+        .upsert_sub_channel(&sub_channel)
+        .map_err(|e| anyhow!("{e:#}"))
 }
 
 pub fn get_usable_channel_details() -> Result<Vec<ChannelDetails>> {


### PR DESCRIPTION
- Collaborative revert is not retried once confirmed.
- The dlc channel and order state is cleaned up after a collab revert, allowing the user to continue using the app without having to re-install the app.
- Fixed calculation issue where the amounts were wrong if the dlc got stuck in a state where the ln channel balances have already been updated.
- Considered `unspendable_punishment_reserve` when calculating the trader and coordinators amount.
- Add dialog showing the user that the collab revert was (not) successful
- Fixed minor typos
- Removed dedicated collaborative revert message as it was redundant to the trader message