### PR TITLE
feat: configurable fee for sending on chain

### DIFF
--- a/mobile/lib/common/amount_and_fiat_text.dart
+++ b/mobile/lib/common/amount_and_fiat_text.dart
@@ -1,0 +1,29 @@
+import 'package:flutter/material.dart';
+import 'package:get_10101/common/amount_text.dart';
+import 'package:get_10101/common/domain/model.dart';
+import 'package:get_10101/common/fiat_text.dart';
+import 'package:get_10101/features/swap/swap_value_change_notifier.dart';
+import 'package:provider/provider.dart';
+
+class AmountAndFiatText extends StatelessWidget {
+  final Amount amount;
+
+  const AmountAndFiatText({super.key, required this.amount});
+
+  @override
+  Widget build(BuildContext context) {
+    return Selector<SwapValuesChangeNotifier, double>(
+      selector: (_, provider) => provider.stableValues().price ?? 1.0,
+      builder: (BuildContext context, double price, Widget? child) =>
+          Column(crossAxisAlignment: CrossAxisAlignment.end, children: [
+        AmountText(amount: amount, textStyle: const TextStyle(fontSize: 17)),
+        Wrap(children: [
+          Text("~", style: TextStyle(color: Colors.grey.shade700, fontSize: 15)),
+          FiatText(
+              amount: amount.btc / price,
+              textStyle: TextStyle(color: Colors.grey.shade700, fontSize: 15))
+        ])
+      ]),
+    );
+  }
+}

--- a/mobile/lib/common/amount_input_modalised.dart
+++ b/mobile/lib/common/amount_input_modalised.dart
@@ -69,7 +69,6 @@ void _showModal(BuildContext context, BtcOrFiat type, int? amount, void Function
     String? Function(String?)? validator) {
   showEditModal<void>(
     context: context,
-    height: 200,
     builder: (BuildContext context, _) => EnterAmountModal(
         amount: amount, onSetAmount: onSetAmount, validator: validator, type: type),
   );

--- a/mobile/lib/common/amount_input_modalised.dart
+++ b/mobile/lib/common/amount_input_modalised.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:get_10101/common/edit_modal.dart';
 import 'package:go_router/go_router.dart';
 import 'package:intl/intl.dart';
 import 'package:get_10101/common/amount_text.dart';
@@ -66,43 +67,12 @@ class AmountInputModalisedField extends StatelessWidget {
 
 void _showModal(BuildContext context, BtcOrFiat type, int? amount, void Function(int?) onSetAmount,
     String? Function(String?)? validator) {
-  showModalBottomSheet<void>(
-      shape: const RoundedRectangleBorder(
-        borderRadius: BorderRadius.vertical(
-          top: Radius.circular(20),
-        ),
-      ),
-      clipBehavior: Clip.antiAlias,
-      isScrollControlled: true,
-      useRootNavigator: true,
-      context: context,
-      builder: (BuildContext context) {
-        return SafeArea(
-            child: Padding(
-                padding: EdgeInsets.only(bottom: MediaQuery.of(context).viewInsets.bottom),
-                // the GestureDetector ensures that we can close the keyboard by tapping into the modal
-                child: GestureDetector(
-                  onTap: () {
-                    FocusScopeNode currentFocus = FocusScope.of(context);
-
-                    if (!currentFocus.hasPrimaryFocus) {
-                      currentFocus.unfocus();
-                    }
-                  },
-                  child: SingleChildScrollView(
-                    child: SizedBox(
-                      // TODO: Find a way to make height dynamic depending on the children size
-                      // This is needed because otherwise the keyboard does not push the sheet up correctly
-                      height: 200,
-                      child: EnterAmountModal(
-                          amount: amount,
-                          onSetAmount: onSetAmount,
-                          validator: validator,
-                          type: type),
-                    ),
-                  ),
-                )));
-      });
+  showEditModal<void>(
+    context: context,
+    height: 200,
+    builder: (BuildContext context, _) => EnterAmountModal(
+        amount: amount, onSetAmount: onSetAmount, validator: validator, type: type),
+  );
 }
 
 class EnterAmountModal extends StatefulWidget {

--- a/mobile/lib/common/amount_text_input_form_field.dart
+++ b/mobile/lib/common/amount_text_input_form_field.dart
@@ -4,20 +4,26 @@ import 'package:get_10101/common/application/numeric_text_formatter.dart';
 import 'package:get_10101/common/domain/model.dart';
 import 'package:get_10101/common/modal_bottom_sheet_info.dart';
 
-class AmountInputField extends StatefulWidget {
+class AmountInputField extends StatelessWidget {
+  /// If `decoration` is passed, then `isLoading`, `hint`, `label`, `infoText`,
+  /// and `isLoading` are overriden.
   const AmountInputField(
       {super.key,
       this.enabled = true,
-      required this.label,
+      this.label = '',
       this.hint = '',
       this.onChanged,
       required this.value,
       this.isLoading = false,
       this.infoText,
       this.controller,
-      this.validator});
+      this.validator,
+      this.decoration,
+      this.style,
+      this.onTap});
 
   final TextEditingController? controller;
+  final TextStyle? style;
   final Amount value;
   final bool enabled;
   final String label;
@@ -25,46 +31,45 @@ class AmountInputField extends StatefulWidget {
   final String? infoText;
   final bool isLoading;
   final Function(String)? onChanged;
+  final Function()? onTap;
+  final InputDecoration? decoration;
 
   final String? Function(String?)? validator;
 
   @override
-  State<AmountInputField> createState() => _AmountInputFieldState();
-}
-
-class _AmountInputFieldState extends State<AmountInputField> {
-  @override
   Widget build(BuildContext context) {
     return TextFormField(
-      style: const TextStyle(color: Colors.black87),
-      enabled: widget.enabled,
-      controller: widget.controller,
-      initialValue: widget.controller != null ? null : widget.value.formatted(),
+      style: style ?? const TextStyle(color: Colors.black87),
+      enabled: enabled,
+      controller: controller,
+      initialValue: controller != null ? null : value.formatted(),
       keyboardType: TextInputType.number,
-      decoration: InputDecoration(
-        border: const OutlineInputBorder(),
-        hintText: widget.hint,
-        labelText: widget.label,
-        labelStyle: const TextStyle(color: Colors.black87),
-        filled: true,
-        fillColor: widget.enabled ? Colors.white : Colors.grey[50],
-        errorStyle: TextStyle(
-          color: Colors.red[900],
-        ),
-        suffixIcon: widget.isLoading
-            ? const CircularProgressIndicator()
-            : widget.infoText != null
-                ? ModalBottomSheetInfo(closeButtonText: "Back", child: Text(widget.infoText!))
-                : null,
-      ),
+      decoration: decoration ??
+          InputDecoration(
+            border: const OutlineInputBorder(),
+            hintText: hint,
+            labelText: label,
+            labelStyle: const TextStyle(color: Colors.black87),
+            filled: true,
+            fillColor: enabled ? Colors.white : Colors.grey[50],
+            errorStyle: TextStyle(
+              color: Colors.red[900],
+            ),
+            suffixIcon: isLoading
+                ? const CircularProgressIndicator()
+                : infoText != null
+                    ? ModalBottomSheetInfo(closeButtonText: "Back", child: Text(infoText!))
+                    : null,
+          ),
       inputFormatters: <TextInputFormatter>[
         FilteringTextInputFormatter.digitsOnly,
         NumericTextFormatter()
       ],
-      onChanged: (value) => {if (widget.onChanged != null) widget.onChanged!(value)},
+      onChanged: (value) => {if (onChanged != null) onChanged!(value)},
+      onTap: onTap,
       validator: (value) {
-        if (widget.validator != null) {
-          return widget.validator!(value);
+        if (validator != null) {
+          return validator!(value);
         }
 
         return null;

--- a/mobile/lib/common/edit_modal.dart
+++ b/mobile/lib/common/edit_modal.dart
@@ -1,0 +1,44 @@
+import 'package:flutter/material.dart';
+
+/// Show a modal designed to allow the user to edit a form field with a keyboard.
+/// It is dismissible.
+Future<T?> showEditModal<T>(
+    {required BuildContext context,
+    required double height,
+    required Widget Function(BuildContext context, Function(T?) setVal) builder}) {
+  T? val;
+
+  return showModalBottomSheet<T>(
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(
+          top: Radius.circular(20),
+        ),
+      ),
+      clipBehavior: Clip.antiAlias,
+      isScrollControlled: true,
+      useRootNavigator: true,
+      context: context,
+      builder: (BuildContext context) {
+        return SafeArea(
+            child: Padding(
+                padding: EdgeInsets.only(bottom: MediaQuery.of(context).viewInsets.bottom),
+                // the GestureDetector ensures that we can close the keyboard by tapping into the modal
+                child: GestureDetector(
+                  onTap: () {
+                    FocusScopeNode currentFocus = FocusScope.of(context);
+
+                    if (!currentFocus.hasPrimaryFocus) {
+                      currentFocus.unfocus();
+                    }
+                  },
+                  child: SingleChildScrollView(
+                    child: SizedBox(
+                      // TODO: Find a way to make height dynamic depending on the children size
+                      // This is needed because otherwise the keyboard does not push the sheet up correctly
+                      height: height,
+                      child: builder(context, (newVal) => val = newVal),
+                    ),
+                  ),
+                )));
+      }).then((res) => res ?? val);
+}

--- a/mobile/lib/common/edit_modal.dart
+++ b/mobile/lib/common/edit_modal.dart
@@ -19,26 +19,28 @@ Future<T?> showEditModal<T>(
       useRootNavigator: true,
       context: context,
       builder: (BuildContext context) {
-        return SafeArea(
-            child: Padding(
-                padding: EdgeInsets.only(bottom: MediaQuery.of(context).viewInsets.bottom),
-                // the GestureDetector ensures that we can close the keyboard by tapping into the modal
-                child: GestureDetector(
-                  onTap: () {
-                    FocusScopeNode currentFocus = FocusScope.of(context);
+        return Container(
+            decoration: const BoxDecoration(color: Colors.white),
+            child: SafeArea(
+                child: Padding(
+                    padding: EdgeInsets.only(bottom: MediaQuery.of(context).viewInsets.bottom),
+                    // the GestureDetector ensures that we can close the keyboard by tapping into the modal
+                    child: GestureDetector(
+                      onTap: () {
+                        FocusScopeNode currentFocus = FocusScope.of(context);
 
-                    if (!currentFocus.hasPrimaryFocus) {
-                      currentFocus.unfocus();
-                    }
-                  },
-                  child: SingleChildScrollView(
-                    child: SizedBox(
-                      // TODO: Find a way to make height dynamic depending on the children size
-                      // This is needed because otherwise the keyboard does not push the sheet up correctly
-                      height: height,
-                      child: builder(context, (newVal) => val = newVal),
-                    ),
-                  ),
-                )));
+                        if (!currentFocus.hasPrimaryFocus) {
+                          currentFocus.unfocus();
+                        }
+                      },
+                      child: SingleChildScrollView(
+                        child: SizedBox(
+                          // TODO: Find a way to make height dynamic depending on the children size
+                          // This is needed because otherwise the keyboard does not push the sheet up correctly
+                          height: height,
+                          child: builder(context, (newVal) => val = newVal),
+                        ),
+                      ),
+                    ))));
       }).then((res) => res ?? val);
 }

--- a/mobile/lib/common/edit_modal.dart
+++ b/mobile/lib/common/edit_modal.dart
@@ -4,7 +4,6 @@ import 'package:flutter/material.dart';
 /// It is dismissible.
 Future<T?> showEditModal<T>(
     {required BuildContext context,
-    required double height,
     required Widget Function(BuildContext context, Function(T?) setVal) builder}) {
   T? val;
 
@@ -34,10 +33,7 @@ Future<T?> showEditModal<T>(
                         }
                       },
                       child: SingleChildScrollView(
-                        child: SizedBox(
-                          // TODO: Find a way to make height dynamic depending on the children size
-                          // This is needed because otherwise the keyboard does not push the sheet up correctly
-                          height: height,
+                        child: IntrinsicHeight(
                           child: builder(context, (newVal) => val = newVal),
                         ),
                       ),

--- a/mobile/lib/common/intersperse.dart
+++ b/mobile/lib/common/intersperse.dart
@@ -1,0 +1,15 @@
+extension Intersperse<T> on Iterable<T> {
+  Iterable<T> intersperse(T separator) sync* {
+    final it = iterator;
+    if (it.moveNext()) {
+      yield it.current;
+      while (it.moveNext()) {
+        yield separator;
+        yield it.current;
+      }
+    }
+  }
+
+  List<T> intersperseList(T separator, {bool growable = true}) =>
+      intersperse(separator).toList(growable: growable);
+}

--- a/mobile/lib/features/swap/swap_bottom_sheet.dart
+++ b/mobile/lib/features/swap/swap_bottom_sheet.dart
@@ -3,6 +3,7 @@ import 'dart:math';
 
 import 'package:bitcoin_icons/bitcoin_icons.dart';
 import 'package:flutter/material.dart';
+import 'package:get_10101/common/amount_and_fiat_text.dart';
 import 'package:get_10101/common/amount_text.dart';
 import 'package:get_10101/features/swap/swap_amount_text_input_form_field.dart';
 import 'package:get_10101/common/application/lsp_change_notifier.dart';
@@ -391,26 +392,6 @@ class _SwapTile extends StatelessWidget {
   }
 }
 
-class _AmountAndFiatText extends StatelessWidget {
-  final Amount amount;
-
-  const _AmountAndFiatText({required this.amount});
-
-  @override
-  Widget build(BuildContext context) {
-    return Selector<SwapValuesChangeNotifier, double>(
-      selector: (_, provider) => provider.stableValues().price ?? 1.0,
-      builder: (BuildContext context, double price, Widget? child) => Column(children: [
-        AmountText(amount: amount, textStyle: const TextStyle(fontSize: 17)),
-        Wrap(children: [
-          const Text("~", style: TextStyle(color: Colors.grey)),
-          FiatText(amount: amount.btc / price, textStyle: TextStyle(color: Colors.grey.shade700))
-        ])
-      ]),
-    );
-  }
-}
-
 class _SwapBalanceText extends StatelessWidget {
   final Widget balance;
 
@@ -497,7 +478,7 @@ void _showConfirmSheet(BuildContext context, SwapTradeValues tradeValues,
                           ...divider,
                           ValueDataRow(
                               type: ValueType.widget,
-                              value: _AmountAndFiatText(amount: tradeValues.fee ?? Amount(0)),
+                              value: AmountAndFiatText(amount: tradeValues.fee ?? Amount(0)),
                               label: "Swap fees:",
                               labelTextStyle: labelStyle),
                         ]),

--- a/mobile/lib/features/wallet/application/wallet_service.dart
+++ b/mobile/lib/features/wallet/application/wallet_service.dart
@@ -1,6 +1,8 @@
 import 'package:get_10101/common/domain/model.dart';
 import 'package:flutter_rust_bridge/flutter_rust_bridge.dart';
+import 'package:get_10101/features/wallet/domain/confirmation_target.dart';
 import 'package:get_10101/features/wallet/domain/destination.dart';
+import 'package:get_10101/features/wallet/domain/fee.dart';
 import 'package:get_10101/features/wallet/domain/share_payment_request.dart';
 import 'package:get_10101/features/wallet/domain/wallet_type.dart';
 import 'package:get_10101/ffi.dart' as rust;
@@ -76,22 +78,45 @@ class WalletService {
     }
   }
 
-  Future<void> sendPayment(Destination destination, Amount? amount) async {
-    logger.i("Sending payment of $amount");
+  Future<Map<ConfirmationTarget, int>> calculateFeesForOnChain(
+      String address, Amount amount) async {
+    final Map<ConfirmationTarget, int> map = {};
 
-    rust.SendPayment payment;
-    switch (destination.getWalletType()) {
-      case WalletType.lightning:
-        payment = rust.SendPayment_Lightning(invoice: destination.raw, amount: amount?.sats);
-      case WalletType.onChain:
-        payment = rust.SendPayment_OnChain(address: destination.raw, amount: amount!.sats);
-      default:
-        throw Exception("unsupported wallet type: ${destination.getWalletType().name}");
+    final fees = await rust.api.calculateAllFeesForOnChain(address: address, amount: amount.sats);
+    for (int i = 0; i < ConfirmationTarget.values.length; i++) {
+      map[ConfirmationTarget.values[i]] = fees[i].toInt();
     }
-    await rust.api.sendPayment(payment: payment);
+
+    return map;
+  }
+
+  Future<int> estimateFeeMsat(Destination destination, Amount? amount, Fee? fee) async {
+    return switch (fee) {
+      null ||
+      PriorityFee() =>
+        await rust.api.sendPreflightProbe(payment: _createPayment(destination, amount, fee: fee)),
+      CustomFee() => fee.amount.sats * 1000,
+    };
+  }
+
+  Future<void> sendPayment(Destination destination, Amount? amount, {Fee? fee}) async {
+    logger.i("Sending payment of $amount");
+    await rust.api.sendPayment(payment: _createPayment(destination, amount, fee: fee));
   }
 
   String getUnusedAddress() {
     return rust.api.getUnusedAddress();
+  }
+}
+
+rust.SendPayment _createPayment(Destination destination, Amount? amount, {Fee? fee}) {
+  switch (destination.getWalletType()) {
+    case WalletType.lightning:
+      return rust.SendPayment_Lightning(invoice: destination.raw, amount: amount?.sats);
+    case WalletType.onChain:
+      return rust.SendPayment_OnChain(
+          address: destination.raw, amount: amount!.sats, fee: fee!.toAPI());
+    default:
+      throw Exception("unsupported wallet type: ${destination.getWalletType().name}");
   }
 }

--- a/mobile/lib/features/wallet/application/wallet_service.dart
+++ b/mobile/lib/features/wallet/application/wallet_service.dart
@@ -3,6 +3,7 @@ import 'package:flutter_rust_bridge/flutter_rust_bridge.dart';
 import 'package:get_10101/features/wallet/domain/confirmation_target.dart';
 import 'package:get_10101/features/wallet/domain/destination.dart';
 import 'package:get_10101/features/wallet/domain/fee.dart';
+import 'package:get_10101/features/wallet/domain/fee_estimate.dart';
 import 'package:get_10101/features/wallet/domain/share_payment_request.dart';
 import 'package:get_10101/features/wallet/domain/wallet_type.dart';
 import 'package:get_10101/ffi.dart' as rust;
@@ -78,13 +79,13 @@ class WalletService {
     }
   }
 
-  Future<Map<ConfirmationTarget, int>> calculateFeesForOnChain(
+  Future<Map<ConfirmationTarget, FeeEstimation>> calculateFeesForOnChain(
       String address, Amount amount) async {
-    final Map<ConfirmationTarget, int> map = {};
+    final Map<ConfirmationTarget, FeeEstimation> map = {};
 
     final fees = await rust.api.calculateAllFeesForOnChain(address: address, amount: amount.sats);
     for (int i = 0; i < ConfirmationTarget.values.length; i++) {
-      map[ConfirmationTarget.values[i]] = fees[i].toInt();
+      map[ConfirmationTarget.values[i]] = FeeEstimation.fromAPI(fees[i]);
     }
 
     return map;

--- a/mobile/lib/features/wallet/domain/confirmation_target.dart
+++ b/mobile/lib/features/wallet/domain/confirmation_target.dart
@@ -1,0 +1,55 @@
+import 'package:get_10101/ffi.dart' as rust;
+
+enum ConfirmationTarget {
+  minimum,
+  background,
+  normal,
+  highPriority;
+
+  static ConfirmationTarget fromAPI(rust.ConfirmationTarget target) {
+    return switch (target) {
+      rust.ConfirmationTarget.Background => background,
+      rust.ConfirmationTarget.Normal => normal,
+      rust.ConfirmationTarget.HighPriority => highPriority,
+      rust.ConfirmationTarget.Minimum => minimum,
+    };
+  }
+
+  static const List<ConfirmationTarget> options = [
+    ConfirmationTarget.background,
+    ConfirmationTarget.normal,
+    ConfirmationTarget.highPriority,
+  ];
+
+  @override
+  String toString() {
+    return switch (this) {
+      minimum => "Minimum",
+      background => "Background",
+      normal => "Normal",
+      highPriority => "High Priority",
+    };
+  }
+
+  // TODO(restioson): are these correct?
+  String toTimeEstimate() {
+    return switch (this) {
+      ConfirmationTarget.minimum => "eventually",
+      // LDK says 'within the next day or so'
+      ConfirmationTarget.background => "~1 day",
+      // LDK says 'within the next 12-24 blocks'
+      ConfirmationTarget.normal => "~2-4 hours",
+      // LDK says 'within the next few blocks'
+      ConfirmationTarget.highPriority => "~10-30 min",
+    };
+  }
+
+  rust.ConfirmationTarget toAPI() {
+    return switch (this) {
+      minimum => rust.ConfirmationTarget.Minimum,
+      background => rust.ConfirmationTarget.Background,
+      normal => rust.ConfirmationTarget.Normal,
+      highPriority => rust.ConfirmationTarget.HighPriority,
+    };
+  }
+}

--- a/mobile/lib/features/wallet/domain/fee.dart
+++ b/mobile/lib/features/wallet/domain/fee.dart
@@ -1,0 +1,32 @@
+import 'package:get_10101/common/domain/model.dart';
+import 'package:get_10101/features/wallet/domain/confirmation_target.dart';
+import 'package:get_10101/ffi.dart' as rust;
+
+sealed class Fee {
+  String get name;
+  rust.Fee toAPI();
+}
+
+class PriorityFee implements Fee {
+  final ConfirmationTarget priority;
+
+  PriorityFee(this.priority);
+
+  @override
+  String get name => priority.toString();
+
+  @override
+  rust.Fee toAPI() => rust.Fee_Priority(priority.toAPI());
+}
+
+class CustomFee implements Fee {
+  final Amount amount;
+
+  CustomFee({required this.amount});
+
+  @override
+  String get name => "Custom";
+
+  @override
+  rust.Fee toAPI() => rust.Fee_Custom(sats: amount.sats);
+}

--- a/mobile/lib/features/wallet/domain/fee_estimate.dart
+++ b/mobile/lib/features/wallet/domain/fee_estimate.dart
@@ -1,0 +1,12 @@
+import 'package:get_10101/ffi.dart' as rust;
+import 'package:get_10101/common/domain/model.dart';
+
+class FeeEstimation {
+  final Amount perVbyte;
+  final Amount total;
+
+  FeeEstimation({required this.perVbyte, required this.total});
+
+  static FeeEstimation fromAPI(rust.FeeEstimation fee) =>
+      FeeEstimation(perVbyte: Amount(fee.satsPerVbyte), total: Amount(fee.totalSats));
+}

--- a/mobile/lib/features/wallet/send/fee_picker.dart
+++ b/mobile/lib/features/wallet/send/fee_picker.dart
@@ -32,7 +32,6 @@ class _FeePickerState extends State<FeePicker> {
 
   Future<Fee?> _showModal(BuildContext context) => showEditModal<Fee?>(
       context: context,
-      height: 700,
       builder: (BuildContext context, setVal) => Theme(
             data: Theme.of(context).copyWith(
                 textTheme:

--- a/mobile/lib/features/wallet/send/fee_picker.dart
+++ b/mobile/lib/features/wallet/send/fee_picker.dart
@@ -1,0 +1,236 @@
+import 'package:flutter/material.dart';
+import 'package:get_10101/common/amount_and_fiat_text.dart';
+import 'package:get_10101/common/amount_text.dart';
+import 'package:get_10101/common/amount_text_input_form_field.dart';
+import 'package:get_10101/common/color.dart';
+import 'package:get_10101/common/domain/model.dart';
+import 'package:get_10101/common/edit_modal.dart';
+import 'package:get_10101/common/intersperse.dart';
+import 'package:get_10101/features/wallet/domain/confirmation_target.dart';
+import 'package:get_10101/features/wallet/domain/fee.dart';
+
+class FeePicker extends StatefulWidget {
+  final void Function(Fee) onChange;
+  final Fee initialSelection;
+
+  const FeePicker(
+      {super.key, this.feeAmounts, required this.onChange, required this.initialSelection});
+  final Map<ConfirmationTarget, int>? feeAmounts;
+
+  @override
+  State<StatefulWidget> createState() => _FeePickerState();
+}
+
+class _FeePickerState extends State<FeePicker> {
+  late Fee _fee;
+
+  @override
+  void initState() {
+    super.initState();
+    _fee = widget.initialSelection;
+  }
+
+  Future<Fee?> _showModal(BuildContext context) => showEditModal<Fee?>(
+      context: context,
+      height: 700,
+      builder: (BuildContext context, setVal) => Theme(
+            data: Theme.of(context).copyWith(
+                textTheme:
+                    const TextTheme(labelMedium: TextStyle(fontSize: 16, color: Colors.black)),
+                colorScheme: Theme.of(context).colorScheme.copyWith(background: Colors.white)),
+            child: _FeePickerModal(
+                feeAmounts: widget.feeAmounts, initialSelection: _fee, setVal: setVal),
+          ));
+
+  @override
+  Widget build(BuildContext context) {
+    int feeSats = switch (_fee) {
+      PriorityFee() => widget.feeAmounts?[(_fee as PriorityFee).priority] ?? -1,
+      CustomFee() => (_fee as CustomFee).amount.sats,
+    };
+
+    final fees = switch (feeSats) {
+      -1 => const SizedBox.square(dimension: 24, child: CircularProgressIndicator()),
+      int() => AmountAndFiatText(amount: Amount(feeSats))
+    };
+
+    return ElevatedButton(
+        onPressed: () {
+          _showModal(context).then((val) {
+            setState(() => _fee = val ?? _fee);
+            widget.onChange(_fee);
+          });
+        },
+        style: ElevatedButton.styleFrom(
+          minimumSize: const Size(20, 50),
+          shadowColor: Colors.transparent,
+          backgroundColor: Colors.orange.shade300.withOpacity(0.1),
+          foregroundColor: Colors.black,
+          textStyle: const TextStyle(),
+          shape: RoundedRectangleBorder(
+              side: BorderSide(color: Colors.grey.shade200),
+              borderRadius: BorderRadius.circular(10)),
+          padding: const EdgeInsets.only(left: 25, top: 25, bottom: 25, right: 10),
+        ),
+        child: Row(
+          children: [
+            Text(_fee.name, style: const TextStyle(fontSize: 16)),
+            const Spacer(),
+            fees,
+            const SizedBox(width: 5),
+            const Icon(Icons.arrow_drop_down_outlined, size: 36),
+          ],
+        ));
+  }
+}
+
+class _FeePickerModal extends StatefulWidget {
+  final Fee initialSelection;
+  final Map<ConfirmationTarget, int>? feeAmounts;
+  final void Function(Fee?) setVal;
+
+  const _FeePickerModal({this.feeAmounts, required this.initialSelection, required this.setVal});
+
+  @override
+  State<StatefulWidget> createState() => _FeePickerModalState();
+}
+
+class _FeePickerModalState extends State<_FeePickerModal> {
+  late Fee selected;
+  final TextEditingController _controller = TextEditingController();
+  final _formKey = GlobalKey<FormState>();
+
+  @override
+  void initState() {
+    super.initState();
+    selected = widget.initialSelection;
+
+    if (selected is CustomFee) {
+      _controller.text = (selected as CustomFee).amount.formatted();
+    }
+  }
+
+  Widget buildTile(ConfirmationTarget target) {
+    Widget fee = switch (widget.feeAmounts) {
+      Map() => AmountAndFiatText(amount: Amount(widget.feeAmounts![target]!)),
+      null => const SizedBox.square(dimension: 24, child: CircularProgressIndicator()),
+    };
+
+    bool isSelected = selected is PriorityFee && (selected as PriorityFee).priority == target;
+
+    return TextButton(
+      onPressed: () => setValue(PriorityFee(target)),
+      style: TextButton.styleFrom(foregroundColor: Colors.orange.shade300.withOpacity(0.1)),
+      child: DefaultTextStyle(
+        style: Theme.of(context).textTheme.labelMedium!,
+        child: Padding(
+          padding: const EdgeInsets.all(20),
+          child: Row(
+            children: [
+              SizedBox.square(
+                  dimension: 22,
+                  child: Visibility(
+                      visible: isSelected,
+                      child: const Icon(Icons.check, size: 22, color: Colors.black))),
+              const SizedBox(width: 8),
+              Column(crossAxisAlignment: CrossAxisAlignment.start, children: [
+                Text(target.toString()),
+                Text(target.toTimeEstimate(), style: const TextStyle(color: Color(0xff878787))),
+              ]),
+              const Spacer(),
+              fee,
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  void setValue(Fee fee) => setState(() {
+        selected = fee;
+        widget.setVal(selected);
+      });
+
+  void setCustomValue({String? val}) {
+    val = val ?? _controller.text;
+    if (validateCustomValue(val) == null) {
+      setValue(CustomFee(amount: Amount.parseAmount(val)));
+    }
+  }
+
+  int get minFee => widget.feeAmounts?[ConfirmationTarget.minimum] ?? 0;
+
+  String? validateCustomValue(String? val) {
+    if (val == null) {
+      return "Enter a value";
+    }
+
+    final amt = Amount.parseAmount(val);
+
+    if (minFee > amt.sats) {
+      return "The minimum fee to broadcast the transaction is ${formatSats(Amount(minFee))}.";
+    }
+
+    return null;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        const SizedBox(height: 20),
+        ...ConfirmationTarget.options
+            .map(buildTile)
+            .intersperse(const Divider(height: 0.5, thickness: 0.5)),
+        const SizedBox(height: 25),
+        const Padding(
+          padding: EdgeInsets.only(left: 25, bottom: 10),
+          child: Text("Custom", style: TextStyle(color: Colors.grey)),
+        ),
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 25),
+          child: Form(
+            key: _formKey,
+            autovalidateMode: AutovalidateMode.onUserInteraction,
+            child: AmountInputField(
+                controller: _controller,
+                onChanged: (val) => setCustomValue(val: val),
+                validator: validateCustomValue,
+                onTap: () => setCustomValue(),
+                style: const TextStyle(color: Colors.black, fontSize: 20),
+                decoration: InputDecoration(
+                    hintText: minFee.toString(),
+                    border: OutlineInputBorder(
+                        borderSide: BorderSide.none, borderRadius: BorderRadius.circular(10)),
+                    fillColor: const Color(0xfff4f4f4),
+                    filled: true,
+                    errorStyle: TextStyle(
+                      color: Colors.red[900],
+                    ),
+                    errorMaxLines: 3,
+                    suffix: const Text(
+                      "sats",
+                      style: TextStyle(fontSize: 16, color: Color(0xff878787)),
+                    )),
+                value: Amount(1)),
+          ),
+        ),
+        const SizedBox(height: 25),
+        Padding(
+          padding: const EdgeInsets.all(20),
+          child: OutlinedButton(
+              onPressed: () => Navigator.pop(context, selected),
+              style: OutlinedButton.styleFrom(
+                  padding: EdgeInsets.zero,
+                  side: const BorderSide(color: tenTenOnePurple),
+                  shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12))),
+              child: const Padding(
+                padding: EdgeInsets.all(16.0),
+                child: Text("Done", style: TextStyle(fontWeight: FontWeight.normal, fontSize: 20)),
+              )),
+        )
+      ],
+    );
+  }
+}

--- a/mobile/lib/features/wallet/send/fee_text.dart
+++ b/mobile/lib/features/wallet/send/fee_text.dart
@@ -1,0 +1,29 @@
+import 'package:flutter/material.dart';
+import 'package:get_10101/common/amount_text.dart';
+import 'package:get_10101/common/fiat_text.dart';
+import 'package:get_10101/features/swap/swap_value_change_notifier.dart';
+import 'package:get_10101/features/wallet/domain/fee_estimate.dart';
+import 'package:provider/provider.dart';
+
+class FeeText extends StatelessWidget {
+  final FeeEstimation fee;
+  const FeeText({super.key, required this.fee});
+
+  @override
+  Widget build(BuildContext context) {
+    return Selector<SwapValuesChangeNotifier, double>(
+      selector: (_, provider) => provider.stableValues().price ?? 1.0,
+      builder: (BuildContext context, double price, Widget? child) =>
+          Column(crossAxisAlignment: CrossAxisAlignment.end, children: [
+        Text("${formatSats(fee.perVbyte)}/vbyte", style: const TextStyle(fontSize: 17)),
+        AmountText(amount: fee.total, textStyle: const TextStyle(fontSize: 15)),
+        Wrap(children: [
+          Text("~", style: TextStyle(color: Colors.grey.shade700, fontSize: 15)),
+          FiatText(
+              amount: fee.total.btc / price,
+              textStyle: TextStyle(color: Colors.grey.shade700, fontSize: 15))
+        ])
+      ]),
+    );
+  }
+}

--- a/mobile/lib/features/wallet/send/send_onchain_screen.dart
+++ b/mobile/lib/features/wallet/send/send_onchain_screen.dart
@@ -7,8 +7,11 @@ import 'package:get_10101/common/domain/model.dart';
 import 'package:get_10101/common/scrollable_safe_area.dart';
 import 'package:get_10101/features/wallet/application/util.dart';
 import 'package:get_10101/features/wallet/application/wallet_service.dart';
+import 'package:get_10101/features/wallet/domain/confirmation_target.dart';
 import 'package:get_10101/features/wallet/domain/destination.dart';
+import 'package:get_10101/features/wallet/domain/fee.dart';
 import 'package:get_10101/features/wallet/send/confirm_payment_modal.dart';
+import 'package:get_10101/features/wallet/send/fee_picker.dart';
 import 'package:get_10101/features/wallet/wallet_change_notifier.dart';
 import 'package:get_10101/features/wallet/wallet_screen.dart';
 import 'package:provider/provider.dart';
@@ -31,6 +34,9 @@ class _SendOnChainScreenState extends State<SendOnChainScreen> {
   ChannelInfo? channelInfo;
 
   Amount _amount = Amount.zero();
+  Fee _fee = PriorityFee(ConfirmationTarget.normal);
+  Map<ConfirmationTarget, int>? _feeAmounts;
+  late WalletService _walletService;
 
   final TextEditingController _controller = TextEditingController();
 
@@ -38,8 +44,8 @@ class _SendOnChainScreenState extends State<SendOnChainScreen> {
   void initState() {
     super.initState();
     final ChannelInfoService channelInfoService = context.read<ChannelInfoService>();
-    final WalletService walletService = context.read<WalletChangeNotifier>().service;
-    init(channelInfoService, walletService);
+    _walletService = context.read<WalletChangeNotifier>().service;
+    init(channelInfoService);
   }
 
   @override
@@ -48,9 +54,13 @@ class _SendOnChainScreenState extends State<SendOnChainScreen> {
     _controller.dispose();
   }
 
-  Future<void> init(ChannelInfoService channelInfoService, WalletService walletService) async {
+  Future<void> init(ChannelInfoService channelInfoService) async {
     channelInfo = await channelInfoService.getChannelInfo();
+    final fees = await _walletService.calculateFeesForOnChain(
+        widget.destination.address, widget.destination.amount);
+
     setState(() {
+      _feeAmounts = fees;
       _amount = widget.destination.amount;
       _controller.text = _amount.formatted();
     });
@@ -68,6 +78,7 @@ class _SendOnChainScreenState extends State<SendOnChainScreen> {
         body: ScrollableSafeArea(
           child: Form(
             key: _formKey,
+            autovalidateMode: AutovalidateMode.always,
             child: SafeArea(
               child: GestureDetector(
                 onTap: () => FocusManager.instance.primaryFocus?.unfocus(),
@@ -132,7 +143,12 @@ class _SendOnChainScreenState extends State<SendOnChainScreen> {
                               return "Amount cannot be negative";
                             }
 
-                            if (amount.sats > balance.sats) {
+                            final fee = switch (_fee) {
+                              PriorityFee() => _feeAmounts?[(_fee as PriorityFee).priority] ?? 0,
+                              CustomFee() => (_fee as CustomFee).amount.sats,
+                            };
+
+                            if (amount.sats + fee > balance.sats) {
                               return "Not enough funds.";
                             }
 
@@ -163,6 +179,11 @@ class _SendOnChainScreenState extends State<SendOnChainScreen> {
                                       _amount = Amount.parseAmount(value);
                                       _controller.text = _amount.formatted();
                                     });
+
+                                    _walletService
+                                        .calculateFeesForOnChain(
+                                            widget.destination.address, _amount)
+                                        .then((fees) => setState(() => _feeAmounts = fees));
                                   },
                                 ),
                                 Visibility(
@@ -241,13 +262,21 @@ class _SendOnChainScreenState extends State<SendOnChainScreen> {
                         ])
                       ]),
                     ),
+                    const SizedBox(height: 20),
+                    const Text("Select Network Fee", style: TextStyle(fontSize: 16)),
+                    const SizedBox(height: 10),
+                    FeePicker(
+                      initialSelection: _fee,
+                      feeAmounts: _feeAmounts,
+                      onChange: (target) => setState(() => _fee = target),
+                    ),
                     const Spacer(),
                     SizedBox(
                       width: MediaQuery.of(context).size.width * 0.9,
                       child: ElevatedButton(
                           onPressed: (_formKey.currentState?.validate() ?? false)
                               ? () => showConfirmPaymentModal(
-                                  context, widget.destination, false, _amount, _amount)
+                                  context, widget.destination, false, _amount, _amount, fee: _fee)
                               : null,
                           style: ButtonStyle(
                               padding:

--- a/mobile/lib/features/wallet/send/send_onchain_screen.dart
+++ b/mobile/lib/features/wallet/send/send_onchain_screen.dart
@@ -10,6 +10,7 @@ import 'package:get_10101/features/wallet/application/wallet_service.dart';
 import 'package:get_10101/features/wallet/domain/confirmation_target.dart';
 import 'package:get_10101/features/wallet/domain/destination.dart';
 import 'package:get_10101/features/wallet/domain/fee.dart';
+import 'package:get_10101/features/wallet/domain/fee_estimate.dart';
 import 'package:get_10101/features/wallet/send/confirm_payment_modal.dart';
 import 'package:get_10101/features/wallet/send/fee_picker.dart';
 import 'package:get_10101/features/wallet/wallet_change_notifier.dart';
@@ -35,7 +36,7 @@ class _SendOnChainScreenState extends State<SendOnChainScreen> {
 
   Amount _amount = Amount.zero();
   Fee _fee = PriorityFee(ConfirmationTarget.normal);
-  Map<ConfirmationTarget, int>? _feeAmounts;
+  Map<ConfirmationTarget, FeeEstimation>? _feeEstimates;
   late WalletService _walletService;
 
   final TextEditingController _controller = TextEditingController();
@@ -60,7 +61,7 @@ class _SendOnChainScreenState extends State<SendOnChainScreen> {
         widget.destination.address, widget.destination.amount);
 
     setState(() {
-      _feeAmounts = fees;
+      _feeEstimates = fees;
       _amount = widget.destination.amount;
       _controller.text = _amount.formatted();
     });
@@ -144,7 +145,8 @@ class _SendOnChainScreenState extends State<SendOnChainScreen> {
                             }
 
                             final fee = switch (_fee) {
-                              PriorityFee() => _feeAmounts?[(_fee as PriorityFee).priority] ?? 0,
+                              PriorityFee() =>
+                                _feeEstimates?[(_fee as PriorityFee).priority]?.total.sats ?? 0,
                               CustomFee() => (_fee as CustomFee).amount.sats,
                             };
 
@@ -183,7 +185,7 @@ class _SendOnChainScreenState extends State<SendOnChainScreen> {
                                     _walletService
                                         .calculateFeesForOnChain(
                                             widget.destination.address, _amount)
-                                        .then((fees) => setState(() => _feeAmounts = fees));
+                                        .then((fees) => setState(() => _feeEstimates = fees));
                                   },
                                 ),
                                 Visibility(
@@ -267,7 +269,7 @@ class _SendOnChainScreenState extends State<SendOnChainScreen> {
                     const SizedBox(height: 10),
                     FeePicker(
                       initialSelection: _fee,
-                      feeAmounts: _feeAmounts,
+                      feeEstimates: _feeEstimates,
                       onChange: (target) => setState(() => _fee = target),
                     ),
                     const Spacer(),

--- a/mobile/native/src/ln_dlc/mod.rs
+++ b/mobile/native/src/ln_dlc/mod.rs
@@ -1,4 +1,5 @@
 use crate::api;
+use crate::api::Fee;
 use crate::api::PaymentFlow;
 use crate::api::SendPayment;
 use crate::api::Status;
@@ -52,6 +53,7 @@ use commons::RouteHintHop;
 use commons::TradeParams;
 use itertools::chain;
 use itertools::Itertools;
+use lightning::chain::chaininterface::ConfirmationTarget;
 use lightning::events::Event;
 use lightning::ln::channelmanager::ChannelDetails;
 use lightning::ln::ChannelId;
@@ -851,8 +853,12 @@ pub fn get_usable_channel_details() -> Result<Vec<ChannelDetails>> {
 }
 
 pub fn get_fee_rate() -> Result<FeeRate> {
+    get_fee_rate_for_target(CONFIRMATION_TARGET)
+}
+
+pub fn get_fee_rate_for_target(target: ConfirmationTarget) -> Result<FeeRate> {
     let node = state::try_get_node().context("failed to get ln dlc node")?;
-    Ok(node.inner.ldk_wallet().get_fee_rate(CONFIRMATION_TARGET))
+    Ok(node.inner.ldk_wallet().get_fee_rate(target))
 }
 
 /// Returns channel value or zero if there is no channel yet.
@@ -1051,32 +1057,49 @@ pub async fn send_payment(payment: SendPayment) -> Result<()> {
                 }
             }
         }
-        SendPayment::OnChain { address, amount } => {
+        SendPayment::OnChain {
+            address,
+            amount,
+            fee,
+        } => {
             let address = Address::from_str(&address)?;
-            state::get_node().inner.send_to_address(&address, amount)?;
+            state::get_node()
+                .inner
+                .send_to_address(&address, amount, fee.into())?;
         }
     }
     Ok(())
 }
 
 pub async fn estimate_payment_fee_msat(payment: SendPayment) -> Result<u64> {
-    let (invoice, amount) = match payment {
-        SendPayment::Lightning { invoice, amount } => (invoice, amount),
-        SendPayment::OnChain { .. } => {
-            // TODO: Let the type system handle this.
-            unreachable!("Cannot estimate payment fee for on-chain payment");
+    match payment {
+        SendPayment::Lightning { invoice, amount } => {
+            let invoice = Bolt11Invoice::from_str(&invoice)?;
+            let amount = amount.map(Amount::from_sat);
+
+            state::get_node()
+                .inner
+                .estimate_payment_fee_msat(invoice, amount, Duration::from_secs(10))
+                .await
         }
-    };
+        SendPayment::OnChain {
+            address,
+            amount,
+            fee,
+        } => {
+            let address = address.parse()?;
 
-    let invoice = Bolt11Invoice::from_str(&invoice)?;
-    let amount = amount.map(Amount::from_sat);
+            let fee = match fee {
+                Fee::Priority(target) => state::get_node()
+                    .inner
+                    .calculate_fee(&address, amount, target.into())?
+                    .to_sat(),
+                Fee::Custom { sats } => sats,
+            };
 
-    let fee = state::get_node()
-        .inner
-        .estimate_payment_fee_msat(invoice, amount, Duration::from_secs(10))
-        .await?;
-
-    Ok(fee)
+            Ok(fee * 1000)
+        }
+    }
 }
 
 pub async fn trade(trade_params: TradeParams) -> Result<(), (FailureReason, Error)> {


### PR DESCRIPTION
Fixes #1290, fixes #1177. Additionally, fees will be shown on the confirmation screen for lightning payments, too (though this would be easy to disable). This also includes a fix to setting the amount on the on-chain screen.

Before this is merged, I'd appreciate if someone can check if opening the keyboard correctly pushes up the drawer - I am not sure if this is the case as I can't compile for android anymore.

Some screenshots of the current UI - not at all the final state, just what I'm using for testing. Presented simply for an indicator of functional progress.
![image](https://github.com/get10101/10101/assets/6688948/5ae597d7-4508-4f75-8495-34739c68b11b)

When selecting
![image](https://github.com/get10101/10101/assets/6688948/fa2ac3f1-4b63-4246-9265-31be0364aa4c)

On summary page
![image](https://github.com/get10101/10101/assets/6688948/93c3b17a-665a-4fae-8743-24755d01e13c)


To do:
- [x] Show estimated fee in selection
- [x] Show estimated fee in confirmation swipe
- [x] Make it look like the Figma
    - [x] Select box
    - [x] Summary page
- [x] Fix fee estimate with no balance
- [x] absolute sats vs sats/vbyte conundrum