### PR TITLE
 fix: allow collab revert even if ln channel is closed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Improve collab revert
+
 ## [1.4.3] - 2023-10-23
 
 - Charge order matching fee through the margin

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -642,7 +642,7 @@ dependencies = [
 
 [[package]]
 name = "coordinator"
-version = "1.4.2"
+version = "1.4.3"
 dependencies = [
  "anyhow",
  "atty",
@@ -1747,7 +1747,7 @@ dependencies = [
 [[package]]
 name = "lightning"
 version = "0.0.114"
-source = "git+https://github.com/p2pderivatives/rust-lightning/?rev=3b69cecf#3b69cecf0db70ae900e85569fe78d8573a5b01b0"
+source = "git+https://github.com/p2pderivatives/rust-lightning/?rev=698be7fb#698be7fb822907e32afbde5144e70f6c9fe48f26"
 dependencies = [
  "bitcoin",
 ]
@@ -1755,7 +1755,7 @@ dependencies = [
 [[package]]
 name = "lightning-background-processor"
 version = "0.0.114"
-source = "git+https://github.com/p2pderivatives/rust-lightning/?rev=3b69cecf#3b69cecf0db70ae900e85569fe78d8573a5b01b0"
+source = "git+https://github.com/p2pderivatives/rust-lightning/?rev=698be7fb#698be7fb822907e32afbde5144e70f6c9fe48f26"
 dependencies = [
  "bitcoin",
  "futures-util",
@@ -1779,7 +1779,7 @@ dependencies = [
 [[package]]
 name = "lightning-net-tokio"
 version = "0.0.114"
-source = "git+https://github.com/p2pderivatives/rust-lightning/?rev=3b69cecf#3b69cecf0db70ae900e85569fe78d8573a5b01b0"
+source = "git+https://github.com/p2pderivatives/rust-lightning/?rev=698be7fb#698be7fb822907e32afbde5144e70f6c9fe48f26"
 dependencies = [
  "bitcoin",
  "lightning",
@@ -1789,7 +1789,7 @@ dependencies = [
 [[package]]
 name = "lightning-persister"
 version = "0.0.114"
-source = "git+https://github.com/p2pderivatives/rust-lightning/?rev=3b69cecf#3b69cecf0db70ae900e85569fe78d8573a5b01b0"
+source = "git+https://github.com/p2pderivatives/rust-lightning/?rev=698be7fb#698be7fb822907e32afbde5144e70f6c9fe48f26"
 dependencies = [
  "bitcoin",
  "libc",
@@ -1800,7 +1800,7 @@ dependencies = [
 [[package]]
 name = "lightning-rapid-gossip-sync"
 version = "0.0.114"
-source = "git+https://github.com/p2pderivatives/rust-lightning/?rev=3b69cecf#3b69cecf0db70ae900e85569fe78d8573a5b01b0"
+source = "git+https://github.com/p2pderivatives/rust-lightning/?rev=698be7fb#698be7fb822907e32afbde5144e70f6c9fe48f26"
 dependencies = [
  "bitcoin",
  "lightning",
@@ -1809,7 +1809,7 @@ dependencies = [
 [[package]]
 name = "lightning-transaction-sync"
 version = "0.0.114"
-source = "git+https://github.com/p2pderivatives/rust-lightning/?rev=3b69cecf#3b69cecf0db70ae900e85569fe78d8573a5b01b0"
+source = "git+https://github.com/p2pderivatives/rust-lightning/?rev=698be7fb#698be7fb822907e32afbde5144e70f6c9fe48f26"
 dependencies = [
  "bdk-macros",
  "bitcoin",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,13 +26,20 @@ dlc-trie = { git = "https://github.com/p2pderivatives/rust-dlc", rev = "9815582"
 simple-wallet = { git = "https://github.com/p2pderivatives/rust-dlc", rev = "9815582" }
 
 # We should usually track the `p2pderivatives/split-tx-experiment[-10101]` branch
-lightning = { git = "https://github.com/p2pderivatives/rust-lightning/", rev = "3b69cecf" }
-lightning-background-processor = { git = "https://github.com/p2pderivatives/rust-lightning/", rev = "3b69cecf" }
-lightning-transaction-sync = { git = "https://github.com/p2pderivatives/rust-lightning/", rev = "3b69cecf" }
-lightning-net-tokio = { git = "https://github.com/p2pderivatives/rust-lightning/", rev = "3b69cecf" }
-lightning-persister = { git = "https://github.com/p2pderivatives/rust-lightning/", rev = "3b69cecf" }
+# Temporary fix: this fork allows us to access the channel monitor's channel_key_ids
+lightning = { git = "https://github.com/p2pderivatives/rust-lightning/", rev = "698be7fb" }
+lightning-background-processor = { git = "https://github.com/p2pderivatives/rust-lightning/", rev = "698be7fb" }
+lightning-transaction-sync = { git = "https://github.com/p2pderivatives/rust-lightning/", rev = "698be7fb" }
+lightning-net-tokio = { git = "https://github.com/p2pderivatives/rust-lightning/", rev = "698be7fb" }
+lightning-persister = { git = "https://github.com/p2pderivatives/rust-lightning/", rev = "698be7fb" }
 
 rust-bitcoin-coin-selection = { git = "https://github.com/p2pderivatives/rust-bitcoin-coin-selection" }
 
 # Waiting for the next release
 xtra = { git = "https://github.com/Restioson/xtra/", rev = "d98393a" }
+
+# lightning = {path = "/Users/bonomat/src/github/p2pderivatives/rust-lightning/lightning"}
+# lightning-background-processor = {path = "/Users/bonomat/src/github/p2pderivatives/rust-lightning/lightning-background-processor"}
+# lightning-transaction-sync = {path = "/Users/bonomat/src/github/p2pderivatives/rust-lightning/lightning-transaction-sync"}
+# lightning-net-tokio = {path = "/Users/bonomat/src/github/p2pderivatives/rust-lightning/lightning-net-tokio"}
+# lightning-persister = {path = "/Users/bonomat/src/github/p2pderivatives/rust-lightning/lightning-persister"}

--- a/coordinator/migrations/2023-10-26-060205_add_funding_details_to_collab_revert/down.sql
+++ b/coordinator/migrations/2023-10-26-060205_add_funding_details_to_collab_revert/down.sql
@@ -1,0 +1,4 @@
+ALTER TABLE collaborative_reverts
+    DROP COLUMN IF EXISTS funding_txid;
+ALTER TABLE collaborative_reverts
+    DROP COLUMN IF EXISTS funding_vout;

--- a/coordinator/migrations/2023-10-26-060205_add_funding_details_to_collab_revert/up.sql
+++ b/coordinator/migrations/2023-10-26-060205_add_funding_details_to_collab_revert/up.sql
@@ -1,0 +1,5 @@
+-- defaults to genesis block tx id
+ALTER TABLE "collaborative_reverts"
+    ADD funding_txid TEXT NOT NULL DEFAULT '4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b';
+ALTER TABLE "collaborative_reverts"
+    ADD funding_vout  INT NOT NULL DEFAULT 0;

--- a/coordinator/src/admin.rs
+++ b/coordinator/src/admin.rs
@@ -11,6 +11,7 @@ use axum::extract::State;
 use axum::Json;
 use bdk::TransactionDetails;
 use bitcoin::secp256k1::PublicKey;
+use bitcoin::OutPoint;
 use coordinator_commons::CollaborativeRevert;
 use dlc_manager::subchannel::SubChannel;
 use lightning_invoice::Invoice;
@@ -160,6 +161,10 @@ pub async fn collaborative_revert(
         AppError::BadRequest("Invalid channel id provided".to_string())
     })?;
 
+    let out_point = OutPoint {
+        txid: revert_params.txid,
+        vout: revert_params.vout,
+    };
     collaborative_revert::notify_user_to_collaboratively_revert(
         revert_params,
         channel_id_string.clone(),
@@ -167,6 +172,7 @@ pub async fn collaborative_revert(
         state.pool.clone(),
         state.node.inner.clone(),
         state.auth_users_notifier.clone(),
+        out_point,
     )
     .await
     .map_err(move |error| {

--- a/coordinator/src/admin.rs
+++ b/coordinator/src/admin.rs
@@ -201,7 +201,7 @@ pub async fn list_peers(State(state): State<Arc<AppState>>) -> Json<Vec<PublicKe
 }
 
 #[derive(Debug, Deserialize)]
-pub struct CloseChanelParams {
+pub struct CloseChannelParams {
     #[serde(default, deserialize_with = "empty_string_as_none")]
     force: Option<bool>,
 }
@@ -287,7 +287,7 @@ pub async fn send_payment(
 #[instrument(skip_all, err(Debug))]
 pub async fn close_channel(
     Path(channel_id_string): Path<String>,
-    Query(params): Query<CloseChanelParams>,
+    Query(params): Query<CloseChannelParams>,
     State(state): State<Arc<AppState>>,
 ) -> Result<(), AppError> {
     let channel_id = hex::decode(channel_id_string.clone())

--- a/coordinator/src/collaborative_revert.rs
+++ b/coordinator/src/collaborative_revert.rs
@@ -116,14 +116,14 @@ pub async fn notify_user_to_collaboratively_revert(
         "Collaborative revert temporary values"
     );
 
-    let coordinator_addrss = node.get_unused_address();
+    let coordinator_address = node.get_unused_address();
     let coordinator_amount = Amount::from_sat(coordinator_amount as u64 - fee / 2);
     let trader_amount = Amount::from_sat(trader_amount - fee / 2);
 
     // TODO: check if trader still has more than dust
     tracing::info!(
         channel_id = channel_id_string,
-        coordinator_address = %coordinator_addrss,
+        coordinator_address = %coordinator_address,
         coordinator_amount = coordinator_amount.to_sat(),
         trader_amount = trader_amount.to_sat(),
         "Proposing collaborative revert");
@@ -134,7 +134,7 @@ pub async fn notify_user_to_collaboratively_revert(
             channel_id,
             trader_pubkey: position.trader,
             price: revert_params.price.to_f32().expect("to fit into f32"),
-            coordinator_address: coordinator_addrss.clone(),
+            coordinator_address: coordinator_address.clone(),
             coordinator_amount_sats: coordinator_amount,
             trader_amount_sats: trader_amount,
             timestamp: OffsetDateTime::now_utc(),
@@ -149,7 +149,7 @@ pub async fn notify_user_to_collaboratively_revert(
             trader_id: position.trader,
             message: Message::CollaborativeRevert {
                 channel_id,
-                coordinator_address: coordinator_addrss,
+                coordinator_address,
                 coordinator_amount,
                 trader_amount,
                 execution_price: revert_params.price,

--- a/coordinator/src/collaborative_revert.rs
+++ b/coordinator/src/collaborative_revert.rs
@@ -152,6 +152,7 @@ pub async fn notify_user_to_collaboratively_revert(
                 coordinator_address: coordinator_addrss,
                 coordinator_amount,
                 trader_amount,
+                execution_price: revert_params.price,
             },
             notification: Some(NotificationKind::CollaborativeRevert),
         })

--- a/coordinator/src/collaborative_revert.rs
+++ b/coordinator/src/collaborative_revert.rs
@@ -2,6 +2,7 @@ use crate::db;
 use crate::db::positions::Position;
 use crate::message::OrderbookMessage;
 use crate::node::storage::NodeStorage;
+use crate::notifications::NotificationKind;
 use crate::position;
 use anyhow::anyhow;
 use anyhow::bail;
@@ -144,7 +145,7 @@ pub async fn notify_user_to_collaboratively_revert(
     // try to notify user
     let sender = auth_users_notifier;
     sender
-        .send(OrderbookMessage::CollaborativeRevert {
+        .send(OrderbookMessage::TraderMessage {
             trader_id: position.trader,
             message: Message::CollaborativeRevert {
                 channel_id,
@@ -152,6 +153,7 @@ pub async fn notify_user_to_collaboratively_revert(
                 coordinator_amount,
                 trader_amount,
             },
+            notification: Some(NotificationKind::CollaborativeRevert),
         })
         .await
         .map_err(|error| anyhow!("Could send message to notify user {error:#}"))?;

--- a/coordinator/src/collaborative_revert.rs
+++ b/coordinator/src/collaborative_revert.rs
@@ -28,7 +28,6 @@ use rust_decimal::prelude::ToPrimitive;
 use std::sync::Arc;
 use time::OffsetDateTime;
 use tokio::sync::mpsc;
-use trade::bitmex_client::Quote;
 
 /// The weight for the collaborative close transaction. It's expected to have 1 input (from the fund
 /// transaction) and 2 outputs, one for each party.
@@ -68,34 +67,36 @@ pub async fn notify_user_to_collaboratively_revert(
         .calculate_settlement_amount(revert_params.price)
         .context("Could not calculate settlement amount")?;
 
-    let pnl = position
-        .calculate_coordinator_pnl(Quote {
-            bid_size: 0,
-            ask_size: 0,
-            bid_price: revert_params.price,
-            ask_price: revert_params.price,
-            symbol: "".to_string(),
-            timestamp: OffsetDateTime::now_utc(),
-        })
-        .context("Could not calculate coordinator pnl")?;
+    let trade_settled = sub_channel.fund_value_satoshis == channel_details.channel_value_satoshis;
 
     // There is no easy way to get the total tx fee for all subchannel transactions, hence, we
     // estimate it. This transaction fee is shared among both users fairly
     let dlc_channel_fee = calculate_dlc_channel_tx_fees(
+        trade_settled,
         sub_channel.fund_value_satoshis,
-        pnl,
         channel_details.inbound_capacity_msat / 1000,
         channel_details.outbound_capacity_msat / 1000,
-        position.trader_margin,
-        position.coordinator_margin,
+        position.trader_margin as u64,
+        position.coordinator_margin as u64,
+        channel_details.unspendable_punishment_reserve.unwrap_or(0),
     )?;
 
     // Coordinator's amount is the total channel's value (fund_value_satoshis) whatever the taker
     // had (inbound_capacity), the taker's PnL (settlement_amount) and the transaction fee
-    let coordinator_amount = sub_channel.fund_value_satoshis as i64
-        - (channel_details.inbound_capacity_msat / 1000) as i64
-        - settlement_amount as i64
-        - (dlc_channel_fee as f64 / 2.0) as i64;
+    let coordinator_amount = match trade_settled {
+        false => {
+            sub_channel.fund_value_satoshis as i64
+                - (channel_details.inbound_capacity_msat / 1000) as i64
+                - settlement_amount as i64
+                - (dlc_channel_fee as f64 / 2.0) as i64
+                - channel_details.unspendable_punishment_reserve.unwrap_or(0) as i64
+        }
+        true => {
+            sub_channel.fund_value_satoshis as i64
+                - (channel_details.inbound_capacity_msat / 1000) as i64
+                - channel_details.unspendable_punishment_reserve.unwrap_or(0) as i64
+        }
+    };
     let trader_amount = sub_channel.fund_value_satoshis - coordinator_amount as u64;
 
     let fee = weight_to_fee(
@@ -164,30 +165,31 @@ pub async fn notify_user_to_collaboratively_revert(
 }
 
 fn calculate_dlc_channel_tx_fees(
-    initial_funding: u64,
-    pnl: i64,
+    trade_settled: bool,
+    sub_channel_sats: u64,
     inbound_capacity: u64,
     outbound_capacity: u64,
-    trader_margin: i64,
-    coordinator_margin: i64,
+    trader_margin: u64,
+    coordinator_margin: u64,
+    reserve: u64,
 ) -> anyhow::Result<u64> {
-    let dlc_tx_fee = initial_funding
+    let mut dlc_tx_fee = sub_channel_sats
         .checked_sub(inbound_capacity)
         .context("could not subtract inbound capacity")?
         .checked_sub(outbound_capacity)
         .context("could not subtract outbound capacity")?
-        .checked_sub(
-            trader_margin
-                .checked_sub(pnl)
-                .context("could not substract pnl")? as u64,
-        )
-        .context("could not subtract trader margin")?
-        .checked_sub(
-            coordinator_margin
-                .checked_add(pnl)
-                .context("could not add pnl")? as u64,
-        )
-        .context("could not subtract coordinator margin")?;
+        .checked_sub(reserve * 2)
+        .context("could not substract the reserve")?;
+
+    if !trade_settled {
+        // the ln channel has not yet been updated so we need to take the margins into account.
+        dlc_tx_fee = dlc_tx_fee
+            .checked_sub(trader_margin)
+            .context("could not subtract trader margin")?
+            .checked_sub(coordinator_margin)
+            .context("could not subtract coordinator margin")?;
+    }
+
     Ok(dlc_tx_fee)
 }
 
@@ -196,17 +198,27 @@ pub mod tests {
     use crate::collaborative_revert::calculate_dlc_channel_tx_fees;
 
     #[test]
-    pub fn calculate_transaction_fee_for_dlc_channel_transactions() {
+    pub fn calculate_transaction_fee_for_dlc_channel_transactions_with_smaller_ln_channel() {
         let total_fee =
-            calculate_dlc_channel_tx_fees(200_000, -4047, 65_450, 85_673, 18_690, 18_690).unwrap();
-        assert_eq!(total_fee, 11_497);
+            calculate_dlc_channel_tx_fees(false, 200_000, 65_450, 85_673, 18_690, 18_690, 1_000)
+                .unwrap();
+        assert_eq!(total_fee, 9_497);
+    }
+
+    #[test]
+    pub fn calculate_transaction_fee_for_dlc_channel_transactions_with_equal_ln_channel() {
+        let total_fee =
+            calculate_dlc_channel_tx_fees(true, 200_000, 84_140, 104_363, 18_690, 18_690, 1_000)
+                .unwrap();
+        assert_eq!(total_fee, 9_497);
     }
 
     #[test]
     pub fn ensure_overflow_being_caught() {
-        assert!(
-            calculate_dlc_channel_tx_fees(200_000, -100, 65_383, 88_330, 180_362, 180_362).is_err()
-        );
+        assert!(calculate_dlc_channel_tx_fees(
+            false, 200_000, 84_140, 104_363, 18_690, 18_690, 1_000
+        )
+        .is_err());
     }
 }
 

--- a/coordinator/src/db/channels.rs
+++ b/coordinator/src/db/channels.rs
@@ -107,6 +107,18 @@ pub(crate) fn update_payment_hash(
     upsert(channel, conn)
 }
 
+pub fn get_by_channel_id(
+    channel_id: String,
+    conn: &mut PgConnection,
+) -> Result<Option<ln_dlc_node::channel::Channel>> {
+    let channel = channels::table
+        .filter(channels::channel_id.eq(channel_id))
+        .first::<Channel>(conn)
+        .optional()?
+        .map(ln_dlc_node::channel::Channel::from);
+    Ok(channel)
+}
+
 pub(crate) fn upsert(channel: Channel, conn: &mut PgConnection) -> Result<()> {
     let affected_rows = diesel::insert_into(channels::table)
         .values(channel.clone())

--- a/coordinator/src/db/collaborative_reverts.rs
+++ b/coordinator/src/db/collaborative_reverts.rs
@@ -2,12 +2,14 @@ use crate::position;
 use crate::position::models::parse_channel_id;
 use crate::schema::collaborative_reverts;
 use anyhow::ensure;
+use anyhow::Context;
 use anyhow::Result;
 use bitcoin::hashes::hex::ToHex;
 use bitcoin::secp256k1::PublicKey;
 use bitcoin::Address;
 use bitcoin::Amount;
 use bitcoin::Denomination;
+use bitcoin::Txid;
 use diesel::prelude::*;
 use diesel::AsChangeset;
 use diesel::Insertable;
@@ -30,6 +32,8 @@ pub(crate) struct CollaborativeRevert {
     pub coordinator_amount_sats: i64,
     pub trader_amount_sats: i64,
     pub timestamp: OffsetDateTime,
+    pub funding_txid: String,
+    pub funding_vout: i32,
 }
 
 #[derive(Insertable, Queryable, AsChangeset, Debug, Clone, PartialEq)]
@@ -114,6 +118,8 @@ impl TryFrom<CollaborativeRevert> for position::models::CollaborativeRevert {
                 Denomination::Satoshi,
             )?,
             timestamp: value.timestamp,
+            txid: Txid::from_str(&value.funding_txid).context("To have valid txid")?,
+            vout: value.funding_vout as u32,
         })
     }
 }

--- a/coordinator/src/db/collaborative_reverts.rs
+++ b/coordinator/src/db/collaborative_reverts.rs
@@ -3,6 +3,7 @@ use crate::position::models::parse_channel_id;
 use crate::schema::collaborative_reverts;
 use anyhow::ensure;
 use anyhow::Result;
+use bitcoin::hashes::hex::ToHex;
 use bitcoin::secp256k1::PublicKey;
 use bitcoin::Address;
 use bitcoin::Amount;
@@ -14,6 +15,7 @@ use diesel::OptionalExtension;
 use diesel::PgConnection;
 use diesel::Queryable;
 use diesel::RunQueryDsl;
+use dlc_manager::ChannelId;
 use std::str::FromStr;
 use time::OffsetDateTime;
 
@@ -68,6 +70,14 @@ pub(crate) fn insert(
         .execute(conn)?;
 
     ensure!(affected_rows > 0, "Could not insert collaborative revert");
+
+    Ok(())
+}
+
+pub(crate) fn delete(conn: &mut PgConnection, channel_id: ChannelId) -> Result<()> {
+    diesel::delete(collaborative_reverts::table)
+        .filter(collaborative_reverts::channel_id.eq(channel_id.to_hex()))
+        .execute(conn)?;
 
     Ok(())
 }

--- a/coordinator/src/orderbook/collaborative_revert.rs
+++ b/coordinator/src/orderbook/collaborative_revert.rs
@@ -4,6 +4,7 @@ use crate::message::OrderbookMessage;
 use anyhow::bail;
 use anyhow::Result;
 use bitcoin::secp256k1::PublicKey;
+use bitcoin::OutPoint;
 use diesel::r2d2::ConnectionManager;
 use diesel::r2d2::Pool;
 use diesel::PgConnection;
@@ -64,6 +65,10 @@ async fn process_pending_collaborative_revert(
                     coordinator_amount: revert.coordinator_amount_sats,
                     trader_amount: revert.trader_amount_sats,
                     execution_price: Decimal::try_from(revert.price).expect("to fit into decimal"),
+                    outpoint: OutPoint {
+                        txid: revert.txid,
+                        vout: revert.vout,
+                    },
                 },
                 notification: None,
             };

--- a/coordinator/src/orderbook/collaborative_revert.rs
+++ b/coordinator/src/orderbook/collaborative_revert.rs
@@ -10,6 +10,7 @@ use diesel::PgConnection;
 use futures::future::RemoteHandle;
 use futures::FutureExt;
 use orderbook_commons::Message;
+use rust_decimal::Decimal;
 use tokio::sync::broadcast;
 use tokio::sync::mpsc;
 
@@ -62,8 +63,9 @@ async fn process_pending_collaborative_revert(
                     coordinator_address: revert.coordinator_address,
                     coordinator_amount: revert.coordinator_amount_sats,
                     trader_amount: revert.trader_amount_sats,
+                    execution_price: Decimal::try_from(revert.price).expect("to fit into decimal"),
                 },
-                notification: None
+                notification: None,
             };
             if let Err(e) = notifier.send(msg).await {
                 bail!("Failed to send notification. Error: {e:#}");

--- a/coordinator/src/orderbook/collaborative_revert.rs
+++ b/coordinator/src/orderbook/collaborative_revert.rs
@@ -55,7 +55,7 @@ async fn process_pending_collaborative_revert(
 
             // Sending no optional push notification as this is only executed if the user just
             // registered on the websocket. So we can assume that the user is still online.
-            let msg = OrderbookMessage::CollaborativeRevert {
+            let msg = OrderbookMessage::TraderMessage {
                 trader_id,
                 message: Message::CollaborativeRevert {
                     channel_id: revert.channel_id,
@@ -63,6 +63,7 @@ async fn process_pending_collaborative_revert(
                     coordinator_amount: revert.coordinator_amount_sats,
                     trader_amount: revert.trader_amount_sats,
                 },
+                notification: None
             };
             if let Err(e) = notifier.send(msg).await {
                 bail!("Failed to send notification. Error: {e:#}");

--- a/coordinator/src/position/models.rs
+++ b/coordinator/src/position/models.rs
@@ -4,6 +4,7 @@ use anyhow::Result;
 use bitcoin::secp256k1::PublicKey;
 use bitcoin::Address;
 use bitcoin::Amount;
+use bitcoin::Txid;
 use dlc_manager::ContractId;
 use orderbook_commons::order_matching_fee_taker;
 use rust_decimal::prelude::ToPrimitive;
@@ -545,6 +546,8 @@ pub struct CollaborativeRevert {
     pub coordinator_amount_sats: Amount,
     pub trader_amount_sats: Amount,
     pub timestamp: OffsetDateTime,
+    pub txid: Txid,
+    pub vout: u32,
 }
 
 pub fn parse_channel_id(channel_id: &str) -> Result<[u8; 32]> {

--- a/coordinator/src/schema.rs
+++ b/coordinator/src/schema.rs
@@ -71,6 +71,8 @@ diesel::table! {
         coordinator_amount_sats -> Int8,
         trader_amount_sats -> Int8,
         timestamp -> Timestamptz,
+        funding_txid -> Text,
+        funding_vout -> Int4,
     }
 }
 

--- a/crates/coordinator-commons/src/lib.rs
+++ b/crates/coordinator-commons/src/lib.rs
@@ -2,6 +2,7 @@ use bdk::bitcoin::secp256k1::ecdsa::Signature;
 use bdk::bitcoin::secp256k1::PublicKey;
 use bdk::bitcoin::Network;
 use bdk::bitcoin::Transaction;
+use bdk::bitcoin::Txid;
 use orderbook_commons::FilledWith;
 use rust_decimal::Decimal;
 use serde::Deserialize;
@@ -376,6 +377,10 @@ pub struct CollaborativeRevert {
     pub price: Decimal,
     /// Fee rate for the closing transaction
     pub fee_rate_sats_vb: u64,
+    /// The UTXO of the funding transaction
+    pub txid: Txid,
+    /// The vout of the funding transaction
+    pub vout: u32,
 }
 
 #[derive(Deserialize, Serialize)]

--- a/crates/ln-dlc-node/src/node/mod.rs
+++ b/crates/ln-dlc-node/src/node/mod.rs
@@ -123,7 +123,7 @@ pub struct Node<S> {
 
     pub peer_manager: Arc<PeerManager>,
     pub channel_manager: Arc<ChannelManager>,
-    chain_monitor: Arc<ChainMonitor>,
+    pub chain_monitor: Arc<ChainMonitor>,
     pub(crate) keys_manager: Arc<CustomKeysManager>,
     pub network_graph: Arc<NetworkGraph>,
     pub fee_rate_estimator: Arc<FeeRateEstimator>,

--- a/crates/orderbook-commons/src/lib.rs
+++ b/crates/orderbook-commons/src/lib.rs
@@ -1,6 +1,7 @@
 use anyhow::Result;
 use bitcoin::Address;
 use bitcoin::Amount;
+use bitcoin::OutPoint;
 use rust_decimal::prelude::ToPrimitive;
 use rust_decimal::Decimal;
 use secp256k1::Message as SecpMessage;
@@ -162,6 +163,7 @@ pub enum Message {
         trader_amount: Amount,
         #[serde(with = "rust_decimal::serde::float")]
         execution_price: Decimal,
+        outpoint: OutPoint,
     },
 }
 

--- a/crates/orderbook-commons/src/lib.rs
+++ b/crates/orderbook-commons/src/lib.rs
@@ -160,6 +160,8 @@ pub enum Message {
         coordinator_amount: Amount,
         #[serde(with = "bitcoin::util::amount::serde::as_sat")]
         trader_amount: Amount,
+        #[serde(with = "rust_decimal::serde::float")]
+        execution_price: Decimal,
     },
 }
 

--- a/mobile/lib/common/collab_revert_change_notifier.dart
+++ b/mobile/lib/common/collab_revert_change_notifier.dart
@@ -1,0 +1,43 @@
+import 'package:flutter/material.dart';
+import 'package:get_10101/bridge_generated/bridge_definitions.dart' as bridge;
+import 'package:get_10101/common/application/event_service.dart';
+import 'package:get_10101/common/domain/background_task.dart';
+import 'package:get_10101/common/global_keys.dart';
+import 'package:get_10101/common/task_status_dialog.dart';
+import 'package:get_10101/logger/logger.dart';
+import 'package:provider/provider.dart';
+
+class CollabRevertChangeNotifier extends ChangeNotifier implements Subscriber {
+  late TaskStatus taskStatus;
+
+  @override
+  void notify(bridge.Event event) {
+    if (event is bridge.Event_BackgroundNotification) {
+      if (event.field0 is! bridge.BackgroundTask_CollabRevert) {
+        // ignoring other kinds of background tasks
+        return;
+      }
+      CollabRevert collabRevert =
+          CollabRevert.fromApi(event.field0 as bridge.BackgroundTask_CollabRevert);
+      logger.d("Received a collab revert channel event. Status: ${collabRevert.taskStatus}");
+
+      taskStatus = collabRevert.taskStatus;
+
+      if (taskStatus == TaskStatus.pending) {
+        // initialize dialog for the pending task
+        showDialog(
+          context: shellNavigatorKey.currentContext!,
+          builder: (context) {
+            TaskStatus status = context.watch<CollabRevertChangeNotifier>().taskStatus;
+            late Widget content = const Text("Your channel has been closed collaboratively!");
+            return TaskStatusDialog(
+                title: "Collaborative Channel Close!", status: status, content: content);
+          },
+        );
+      } else {
+        // notify dialog about changed task status
+        notifyListeners();
+      }
+    }
+  }
+}

--- a/mobile/lib/common/domain/background_task.dart
+++ b/mobile/lib/common/domain/background_task.dart
@@ -63,3 +63,17 @@ class RecoverDlc {
     return bridge.BackgroundTask_RecoverDlc(TaskStatus.apiDummy());
   }
 }
+
+class CollabRevert {
+  final TaskStatus taskStatus;
+
+  CollabRevert({required this.taskStatus});
+
+  static CollabRevert fromApi(bridge.BackgroundTask_CollabRevert collabRevert) {
+    return CollabRevert(taskStatus: TaskStatus.fromApi(collabRevert.field0));
+  }
+
+  static bridge.BackgroundTask apiDummy() {
+    return bridge.BackgroundTask_CollabRevert(TaskStatus.apiDummy());
+  }
+}

--- a/mobile/lib/common/init_service.dart
+++ b/mobile/lib/common/init_service.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:get_10101/common/amount_denomination_change_notifier.dart';
+import 'package:get_10101/common/collab_revert_change_notifier.dart';
 import 'package:get_10101/common/service_status_notifier.dart';
 import 'package:get_10101/common/recover_dlc_change_notifier.dart';
 import 'package:get_10101/features/stable/stable_value_change_notifier.dart';
@@ -58,6 +59,7 @@ List<SingleChildWidget> createProviders(bridge.Config config) {
     ChangeNotifierProvider(create: (context) => RecoverDlcChangeNotifier()),
     ChangeNotifierProvider(create: (context) => PaymentClaimedChangeNotifier()),
     ChangeNotifierProvider(create: (context) => PaymentChangeNotifier()),
+    ChangeNotifierProvider(create: (context) => CollabRevertChangeNotifier()),
     Provider(create: (context) => config),
     Provider(create: (context) => channelInfoService)
   ];
@@ -87,6 +89,7 @@ void subscribeToNotifiers(BuildContext context) {
   final recoverDlcChangeNotifier = context.read<RecoverDlcChangeNotifier>();
   final paymentClaimedChangeNotifier = context.read<PaymentClaimedChangeNotifier>();
   final paymentChangeNotifier = context.read<PaymentChangeNotifier>();
+  final collabRevertChangeNotifier = context.read<CollabRevertChangeNotifier>();
 
   eventService.subscribe(
       orderChangeNotifier, bridge.Event.orderUpdateNotification(Order.apiDummy()));
@@ -132,6 +135,9 @@ void subscribeToNotifiers(BuildContext context) {
 
   eventService.subscribe(paymentChangeNotifier, const bridge.Event.paymentSent());
   eventService.subscribe(paymentChangeNotifier, const bridge.Event.paymentFailed());
+
+  eventService.subscribe(
+      collabRevertChangeNotifier, bridge.Event.backgroundNotification(CollabRevert.apiDummy()));
 
   channelStatusNotifier.subscribe(eventService);
 

--- a/mobile/native/src/db/models.rs
+++ b/mobile/native/src/db/models.rs
@@ -1141,6 +1141,15 @@ impl Channel {
             .first(conn)
             .optional()
     }
+    pub fn get_by_channel_id(
+        conn: &mut SqliteConnection,
+        channel_id: &str,
+    ) -> QueryResult<Option<Channel>> {
+        channels::table
+            .filter(schema::channels::channel_id.eq(channel_id))
+            .first(conn)
+            .optional()
+    }
 
     pub fn get_all(conn: &mut SqliteConnection) -> QueryResult<Vec<Channel>> {
         channels::table.load(conn)

--- a/mobile/native/src/event/api.rs
+++ b/mobile/native/src/event/api.rs
@@ -43,6 +43,8 @@ pub enum BackgroundTask {
     /// The app was started with a dlc channel in an intermediate state. This task is in pending
     /// until the dlc protocol reaches a final state.
     RecoverDlc(TaskStatus),
+    /// The coordinator wants to collaboratively close a ln channel with a stuck position.
+    CollabRevert(TaskStatus),
 }
 
 impl From<EventInternal> for Event {
@@ -141,6 +143,9 @@ impl From<event::BackgroundTask> for BackgroundTask {
             }
             event::BackgroundTask::Rollover(status) => BackgroundTask::Rollover(status.into()),
             event::BackgroundTask::RecoverDlc(status) => BackgroundTask::RecoverDlc(status.into()),
+            event::BackgroundTask::CollabRevert(status) => {
+                BackgroundTask::CollabRevert(status.into())
+            }
         }
     }
 }

--- a/mobile/native/src/event/mod.rs
+++ b/mobile/native/src/event/mod.rs
@@ -49,6 +49,7 @@ pub enum EventInternal {
 pub enum BackgroundTask {
     AsyncTrade(OrderReason),
     Rollover(TaskStatus),
+    CollabRevert(TaskStatus),
     RecoverDlc(TaskStatus),
 }
 

--- a/mobile/native/src/ln_dlc/mod.rs
+++ b/mobile/native/src/ln_dlc/mod.rs
@@ -696,6 +696,7 @@ pub fn collaborative_revert_channel(
     coordinator_address: Address,
     coordinator_amount: Amount,
     trader_amount: Amount,
+    execution_price: Decimal,
 ) -> Result<()> {
     let node = NODE.try_get().context("failed to get ln dlc node")?;
 

--- a/mobile/native/src/orderbook.rs
+++ b/mobile/native/src/orderbook.rs
@@ -179,10 +179,10 @@ pub fn subscribe(
                                     msg @ Message::Authenticated => {
                                         tracing::debug!(?msg, "Skipping message from orderbook");
                                     }
-                                    Message::CollaborativeRevert { channel_id, coordinator_address, coordinator_amount, trader_amount, execution_price } => {
+                                    Message::CollaborativeRevert { channel_id, coordinator_address, coordinator_amount, trader_amount, execution_price, outpoint } => {
                                         tracing::debug!("Received request to revert channel");
                                         event::publish(&EventInternal::BackgroundNotification(BackgroundTask::CollabRevert(TaskStatus::Pending)));
-                                        if let Err(err) = ln_dlc::collaborative_revert_channel(channel_id, coordinator_address, coordinator_amount, trader_amount, execution_price) {
+                                        if let Err(err) = ln_dlc::collaborative_revert_channel(channel_id, coordinator_address, coordinator_amount, trader_amount, execution_price, outpoint) {
                                             event::publish(&EventInternal::BackgroundNotification(BackgroundTask::CollabRevert(TaskStatus::Failed)));
                                             tracing::error!("Could not collaboratively revert channel {err:#}");
                                         } else {


### PR DESCRIPTION
By retrieving the channel signer through the channel monitor we are able to access the fund key of the original ln channel even though ldk closed and removed this channel.

Note: this patch includes a temporary dependency on rust-lightning. This will not be needed anymore once we upgrade to rust-lightning 116 because we can then access the channel keys directly.
Differently said, we might be able to drop this commit completely once we upgrade to rust-lightning 116

Note 2: the api to collab revert has changed: it now needs the funding tx id and vout, e.g. 

```bash
curl -d '{"channel_id":"1be2ef992aaae712cfb74a70da3f5295eb7fcfa711b13483d3c48a3767c446bd", "price":"28394", "fee_rate_sats_vb": 4, "txid": "bc46c467378ac4d38334b111a7cf7feb95523fda704ab7cf12e7aa2a99efe21b", "vout": 1}' -H "Content-Type: application/json" -X POST http://localhost:8000/api/admin/channels/revert
```