### PR TITLE
fix: allow collab revert even if ln channel is closed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1747,7 +1747,7 @@ dependencies = [
 [[package]]
 name = "lightning"
 version = "0.0.114"
-source = "git+https://github.com/p2pderivatives/rust-lightning/?rev=3b69cecf#3b69cecf0db70ae900e85569fe78d8573a5b01b0"
+source = "git+https://github.com/p2pderivatives/rust-lightning/?rev=698be7fb#698be7fb822907e32afbde5144e70f6c9fe48f26"
 dependencies = [
  "bitcoin",
 ]
@@ -1755,7 +1755,7 @@ dependencies = [
 [[package]]
 name = "lightning-background-processor"
 version = "0.0.114"
-source = "git+https://github.com/p2pderivatives/rust-lightning/?rev=3b69cecf#3b69cecf0db70ae900e85569fe78d8573a5b01b0"
+source = "git+https://github.com/p2pderivatives/rust-lightning/?rev=698be7fb#698be7fb822907e32afbde5144e70f6c9fe48f26"
 dependencies = [
  "bitcoin",
  "futures-util",
@@ -1779,7 +1779,7 @@ dependencies = [
 [[package]]
 name = "lightning-net-tokio"
 version = "0.0.114"
-source = "git+https://github.com/p2pderivatives/rust-lightning/?rev=3b69cecf#3b69cecf0db70ae900e85569fe78d8573a5b01b0"
+source = "git+https://github.com/p2pderivatives/rust-lightning/?rev=698be7fb#698be7fb822907e32afbde5144e70f6c9fe48f26"
 dependencies = [
  "bitcoin",
  "lightning",
@@ -1789,7 +1789,7 @@ dependencies = [
 [[package]]
 name = "lightning-persister"
 version = "0.0.114"
-source = "git+https://github.com/p2pderivatives/rust-lightning/?rev=3b69cecf#3b69cecf0db70ae900e85569fe78d8573a5b01b0"
+source = "git+https://github.com/p2pderivatives/rust-lightning/?rev=698be7fb#698be7fb822907e32afbde5144e70f6c9fe48f26"
 dependencies = [
  "bitcoin",
  "libc",
@@ -1800,7 +1800,7 @@ dependencies = [
 [[package]]
 name = "lightning-rapid-gossip-sync"
 version = "0.0.114"
-source = "git+https://github.com/p2pderivatives/rust-lightning/?rev=3b69cecf#3b69cecf0db70ae900e85569fe78d8573a5b01b0"
+source = "git+https://github.com/p2pderivatives/rust-lightning/?rev=698be7fb#698be7fb822907e32afbde5144e70f6c9fe48f26"
 dependencies = [
  "bitcoin",
  "lightning",
@@ -1809,7 +1809,7 @@ dependencies = [
 [[package]]
 name = "lightning-transaction-sync"
 version = "0.0.114"
-source = "git+https://github.com/p2pderivatives/rust-lightning/?rev=3b69cecf#3b69cecf0db70ae900e85569fe78d8573a5b01b0"
+source = "git+https://github.com/p2pderivatives/rust-lightning/?rev=698be7fb#698be7fb822907e32afbde5144e70f6c9fe48f26"
 dependencies = [
  "bdk-macros",
  "bitcoin",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,11 +26,12 @@ dlc-trie = { git = "https://github.com/p2pderivatives/rust-dlc", rev = "9815582"
 simple-wallet = { git = "https://github.com/p2pderivatives/rust-dlc", rev = "9815582" }
 
 # We should usually track the `p2pderivatives/split-tx-experiment[-10101]` branch
-lightning = { git = "https://github.com/p2pderivatives/rust-lightning/", rev = "3b69cecf" }
-lightning-background-processor = { git = "https://github.com/p2pderivatives/rust-lightning/", rev = "3b69cecf" }
-lightning-transaction-sync = { git = "https://github.com/p2pderivatives/rust-lightning/", rev = "3b69cecf" }
-lightning-net-tokio = { git = "https://github.com/p2pderivatives/rust-lightning/", rev = "3b69cecf" }
-lightning-persister = { git = "https://github.com/p2pderivatives/rust-lightning/", rev = "3b69cecf" }
+# Temporary fix: this fork allows us to access the channel monitor's channel_key_ids
+lightning = { git = "https://github.com/p2pderivatives/rust-lightning/", rev = "698be7fb" }
+lightning-background-processor = { git = "https://github.com/p2pderivatives/rust-lightning/", rev = "698be7fb" }
+lightning-transaction-sync = { git = "https://github.com/p2pderivatives/rust-lightning/", rev = "698be7fb" }
+lightning-net-tokio = { git = "https://github.com/p2pderivatives/rust-lightning/", rev = "698be7fb" }
+lightning-persister = { git = "https://github.com/p2pderivatives/rust-lightning/", rev = "698be7fb" }
 
 rust-bitcoin-coin-selection = { git = "https://github.com/p2pderivatives/rust-bitcoin-coin-selection" }
 

--- a/coordinator/migrations/2023-10-26-060205_add_funding_details_to_collab_revert/down.sql
+++ b/coordinator/migrations/2023-10-26-060205_add_funding_details_to_collab_revert/down.sql
@@ -1,0 +1,4 @@
+ALTER TABLE collaborative_reverts
+    DROP COLUMN IF EXISTS funding_txid;
+ALTER TABLE collaborative_reverts
+    DROP COLUMN IF EXISTS funding_vout;

--- a/coordinator/migrations/2023-10-26-060205_add_funding_details_to_collab_revert/up.sql
+++ b/coordinator/migrations/2023-10-26-060205_add_funding_details_to_collab_revert/up.sql
@@ -1,0 +1,5 @@
+-- defaults to genesis block tx id
+ALTER TABLE "collaborative_reverts"
+    ADD funding_txid TEXT NOT NULL DEFAULT '4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b';
+ALTER TABLE "collaborative_reverts"
+    ADD funding_vout  INT NOT NULL DEFAULT 0;

--- a/coordinator/src/collaborative_revert.rs
+++ b/coordinator/src/collaborative_revert.rs
@@ -137,6 +137,8 @@ pub async fn notify_user_to_collaboratively_revert(
             coordinator_amount_sats: coordinator_amount,
             trader_amount_sats: trader_amount,
             timestamp: OffsetDateTime::now_utc(),
+            txid: revert_params.txid,
+            vout: revert_params.vout,
         },
     )
     .context("Could not insert new collaborative revert")?;

--- a/coordinator/src/db/channels.rs
+++ b/coordinator/src/db/channels.rs
@@ -107,6 +107,18 @@ pub(crate) fn update_payment_hash(
     upsert(channel, conn)
 }
 
+pub fn get_by_channel_id(
+    channel_id: String,
+    conn: &mut PgConnection,
+) -> Result<Option<ln_dlc_node::channel::Channel>> {
+    let channel = channels::table
+        .filter(channels::channel_id.eq(channel_id))
+        .first::<Channel>(conn)
+        .optional()?
+        .map(ln_dlc_node::channel::Channel::from);
+    Ok(channel)
+}
+
 pub(crate) fn upsert(channel: Channel, conn: &mut PgConnection) -> Result<()> {
     let affected_rows = diesel::insert_into(channels::table)
         .values(channel.clone())

--- a/coordinator/src/db/collaborative_reverts.rs
+++ b/coordinator/src/db/collaborative_reverts.rs
@@ -2,11 +2,13 @@ use crate::position;
 use crate::position::models::parse_channel_id;
 use crate::schema::collaborative_reverts;
 use anyhow::ensure;
+use anyhow::Context;
 use anyhow::Result;
 use bitcoin::secp256k1::PublicKey;
 use bitcoin::Address;
 use bitcoin::Amount;
 use bitcoin::Denomination;
+use bitcoin::Txid;
 use diesel::prelude::*;
 use diesel::AsChangeset;
 use diesel::Insertable;
@@ -28,6 +30,8 @@ pub(crate) struct CollaborativeRevert {
     pub coordinator_amount_sats: i64,
     pub trader_amount_sats: i64,
     pub timestamp: OffsetDateTime,
+    pub funding_txid: String,
+    pub funding_vout: i32,
 }
 
 #[derive(Insertable, Queryable, AsChangeset, Debug, Clone, PartialEq)]
@@ -104,6 +108,8 @@ impl TryFrom<CollaborativeRevert> for position::models::CollaborativeRevert {
                 Denomination::Satoshi,
             )?,
             timestamp: value.timestamp,
+            txid: Txid::from_str(&value.funding_txid).context("To have valid txid")?,
+            vout: value.funding_vout as u32,
         })
     }
 }

--- a/coordinator/src/position/models.rs
+++ b/coordinator/src/position/models.rs
@@ -4,6 +4,7 @@ use anyhow::Result;
 use bitcoin::secp256k1::PublicKey;
 use bitcoin::Address;
 use bitcoin::Amount;
+use bitcoin::Txid;
 use dlc_manager::ContractId;
 use orderbook_commons::order_matching_fee_taker;
 use rust_decimal::prelude::ToPrimitive;
@@ -545,6 +546,8 @@ pub struct CollaborativeRevert {
     pub coordinator_amount_sats: Amount,
     pub trader_amount_sats: Amount,
     pub timestamp: OffsetDateTime,
+    pub txid: Txid,
+    pub vout: u32,
 }
 
 pub fn parse_channel_id(channel_id: &str) -> Result<[u8; 32]> {

--- a/coordinator/src/schema.rs
+++ b/coordinator/src/schema.rs
@@ -71,6 +71,8 @@ diesel::table! {
         coordinator_amount_sats -> Int8,
         trader_amount_sats -> Int8,
         timestamp -> Timestamptz,
+        funding_txid -> Text,
+        funding_vout -> Int4,
     }
 }
 

--- a/crates/coordinator-commons/src/lib.rs
+++ b/crates/coordinator-commons/src/lib.rs
@@ -2,6 +2,7 @@ use bdk::bitcoin::secp256k1::ecdsa::Signature;
 use bdk::bitcoin::secp256k1::PublicKey;
 use bdk::bitcoin::Network;
 use bdk::bitcoin::Transaction;
+use bdk::bitcoin::Txid;
 use orderbook_commons::FilledWith;
 use rust_decimal::Decimal;
 use serde::Deserialize;
@@ -376,6 +377,10 @@ pub struct CollaborativeRevert {
     pub price: Decimal,
     /// Fee rate for the closing transaction
     pub fee_rate_sats_vb: u64,
+    /// The UTXO of the funding transaction
+    pub txid: Txid,
+    /// The vout of the funding transaction
+    pub vout: u32,
 }
 
 #[derive(Deserialize, Serialize)]

--- a/crates/ln-dlc-node/src/node/mod.rs
+++ b/crates/ln-dlc-node/src/node/mod.rs
@@ -123,8 +123,8 @@ pub struct Node<S> {
 
     pub peer_manager: Arc<PeerManager>,
     pub channel_manager: Arc<ChannelManager>,
-    chain_monitor: Arc<ChainMonitor>,
-    pub(crate) keys_manager: Arc<CustomKeysManager>,
+    pub chain_monitor: Arc<ChainMonitor>,
+    pub keys_manager: Arc<CustomKeysManager>,
     pub network_graph: Arc<NetworkGraph>,
     pub fee_rate_estimator: Arc<FeeRateEstimator>,
 

--- a/mobile/native/src/db/models.rs
+++ b/mobile/native/src/db/models.rs
@@ -1072,6 +1072,15 @@ impl Channel {
             .first(conn)
             .optional()
     }
+    pub fn get_by_channel_id(
+        conn: &mut SqliteConnection,
+        channel_id: &str,
+    ) -> QueryResult<Option<Channel>> {
+        channels::table
+            .filter(schema::channels::channel_id.eq(channel_id))
+            .first(conn)
+            .optional()
+    }
 
     pub fn get_all(conn: &mut SqliteConnection) -> QueryResult<Vec<Channel>> {
         channels::table.load(conn)


### PR DESCRIPTION
By retrieving the channel signer through the channel monitor we are able to access the fund key of the original ln channel even though ldk closed and removed this channel.

Note: this patch includes a temporary dependency on rust-lightning. This will not be needed anymore once we upgrade to rust-lightning 116 because we can then access the channel keys directly.
Differently said, we might be able to drop this commit completely once we upgrade to rust-lightning 116

Note 2: the api to collab revert has changed: it now needs the funding tx id and vout, e.g. 

```bash
curl -d '{"channel_id":"1be2ef992aaae712cfb74a70da3f5295eb7fcfa711b13483d3c48a3767c446bd", "price":"28394", "fee_rate_sats_vb": 4, "txid": "bc46c467378ac4d38334b111a7cf7feb95523fda704ab7cf12e7aa2a99efe21b", "vout": 1}' -H "Content-Type: application/json" -X POST http://localhost:8000/api/admin/channels/revert
```