### PR TITLE
chore: Set background of scaffold on new wallet

### DIFF
--- a/mobile/lib/features/welcome/new_wallet_screen.dart
+++ b/mobile/lib/features/welcome/new_wallet_screen.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/services.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 import 'package:get_10101/common/color.dart';
 import 'package:get_10101/common/global_keys.dart';
@@ -28,121 +29,129 @@ class _NewWalletScreenState extends State<NewWalletScreen> {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-        body: ScrollableSafeArea(
-            child: Form(
-      key: _formKey,
-      child: Container(
-        color: Colors.white,
-        padding: const EdgeInsets.all(20.0),
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          crossAxisAlignment: CrossAxisAlignment.center,
-          children: <Widget>[
-            const Spacer(),
-            Center(
-              child: Image.asset('assets/10101_logo_icon.png', width: 150, height: 150),
-            ),
-            const Spacer(),
-            Column(children: [
-              SizedBox(
-                width: 250,
-                child: ElevatedButton(
-                    // TODO: block the button until the backend is started
-                    onPressed: buttonsDisabled
-                        ? null
-                        : () async {
-                            setState(() {
-                              buttonsDisabled = true;
-                            });
-                            final seedPath = await getSeedFilePath();
-                            await api.initNewMnemonic(targetSeedFilePath: seedPath).then((value) {
-                              GoRouter.of(context).go(LoadingScreen.route);
-                            }).catchError((error) {
-                              logger.e("Could not create seed", error: error);
-                              showSnackBar(ScaffoldMessenger.of(rootNavigatorKey.currentContext!),
-                                  "Failed to create seed: $error");
-                            });
+    return AnnotatedRegion<SystemUiOverlayStyle>(
+      value: SystemUiOverlayStyle.dark,
+      child: Scaffold(
+          backgroundColor: Colors.white,
+          body: ScrollableSafeArea(
+              child: Form(
+            key: _formKey,
+            child: Container(
+              color: Colors.white,
+              padding: const EdgeInsets.all(20.0),
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                crossAxisAlignment: CrossAxisAlignment.center,
+                children: <Widget>[
+                  const Spacer(),
+                  Center(
+                    child: Image.asset('assets/10101_logo_icon.png', width: 150, height: 150),
+                  ),
+                  const Spacer(),
+                  Column(children: [
+                    SizedBox(
+                      width: 250,
+                      child: ElevatedButton(
+                          // TODO: block the button until the backend is started
+                          onPressed: buttonsDisabled
+                              ? null
+                              : () async {
+                                  setState(() {
+                                    buttonsDisabled = true;
+                                  });
+                                  final seedPath = await getSeedFilePath();
+                                  await api
+                                      .initNewMnemonic(targetSeedFilePath: seedPath)
+                                      .then((value) {
+                                    GoRouter.of(context).go(LoadingScreen.route);
+                                  }).catchError((error) {
+                                    logger.e("Could not create seed", error: error);
+                                    showSnackBar(
+                                        ScaffoldMessenger.of(rootNavigatorKey.currentContext!),
+                                        "Failed to create seed: $error");
+                                  });
 
-                            // In case there was an error and we did not go forward, we want to be able to click the button again.
-                            setState(() {
-                              buttonsDisabled = false;
-                            });
-                          },
-                    style: ButtonStyle(
-                      padding: MaterialStateProperty.all<EdgeInsets>(const EdgeInsets.all(15)),
-                      backgroundColor: MaterialStateProperty.all<Color>(tenTenOnePurple),
-                      shape: MaterialStateProperty.all<RoundedRectangleBorder>(
-                        RoundedRectangleBorder(
-                          borderRadius: BorderRadius.circular(18.0),
-                          side: const BorderSide(color: tenTenOnePurple),
+                                  // In case there was an error and we did not go forward, we want to be able to click the button again.
+                                  setState(() {
+                                    buttonsDisabled = false;
+                                  });
+                                },
+                          style: ButtonStyle(
+                            padding:
+                                MaterialStateProperty.all<EdgeInsets>(const EdgeInsets.all(15)),
+                            backgroundColor: MaterialStateProperty.all<Color>(tenTenOnePurple),
+                            shape: MaterialStateProperty.all<RoundedRectangleBorder>(
+                              RoundedRectangleBorder(
+                                borderRadius: BorderRadius.circular(10.0),
+                                side: const BorderSide(color: tenTenOnePurple),
+                              ),
+                            ),
+                          ),
+                          child: const Wrap(
+                            children: <Widget>[
+                              Icon(
+                                FontAwesomeIcons.vault,
+                                color: Colors.white,
+                                size: 24.0,
+                              ),
+                              SizedBox(
+                                width: 10,
+                              ),
+                              Text(
+                                "Create wallet",
+                                style: TextStyle(fontSize: 20, color: Colors.white),
+                              ),
+                            ],
+                          )),
+                    ),
+                    const SizedBox(height: 20),
+                    SizedBox(
+                      width: 250,
+                      child: ElevatedButton(
+                        onPressed: buttonsDisabled
+                            ? null
+                            : () {
+                                setState(() {
+                                  buttonsDisabled = true;
+                                  GoRouter.of(context).go(SeedPhraseImporter.route);
+                                  buttonsDisabled = false;
+                                });
+                              },
+                        style: ButtonStyle(
+                          padding: MaterialStateProperty.all<EdgeInsets>(const EdgeInsets.all(15)),
+                          backgroundColor: MaterialStateProperty.all<Color>(Colors.white),
+                          shape: MaterialStateProperty.all<RoundedRectangleBorder>(
+                            RoundedRectangleBorder(
+                              borderRadius: BorderRadius.circular(10.0),
+                              side: const BorderSide(color: tenTenOnePurple),
+                            ),
+                          ),
+                        ),
+                        child: const Wrap(
+                          children: <Widget>[
+                            Icon(
+                              FontAwesomeIcons.download,
+                              color: tenTenOnePurple,
+                              size: 24.0,
+                            ),
+                            SizedBox(
+                              width: 10,
+                            ),
+                            Text(
+                              "Restore wallet",
+                              style: TextStyle(
+                                  fontSize: 20, color: Colors.black), // Set the text color to black
+                            ),
+                          ],
                         ),
                       ),
-                    ),
-                    child: const Wrap(
-                      children: <Widget>[
-                        Icon(
-                          FontAwesomeIcons.vault,
-                          color: Colors.white,
-                          size: 24.0,
-                        ),
-                        SizedBox(
-                          width: 10,
-                        ),
-                        Text(
-                          "Create wallet",
-                          style: TextStyle(fontSize: 20, color: Colors.white),
-                        ),
-                      ],
-                    )),
+                    )
+                  ]),
+                ],
               ),
-              const SizedBox(height: 20),
-              SizedBox(
-                width: 250,
-                child: ElevatedButton(
-                  onPressed: buttonsDisabled
-                      ? null
-                      : () {
-                          setState(() {
-                            buttonsDisabled = true;
-                            GoRouter.of(context).go(SeedPhraseImporter.route);
-                            buttonsDisabled = false;
-                          });
-                        },
-                  style: ButtonStyle(
-                    padding: MaterialStateProperty.all<EdgeInsets>(const EdgeInsets.all(15)),
-                    backgroundColor: MaterialStateProperty.all<Color>(Colors.white),
-                    shape: MaterialStateProperty.all<RoundedRectangleBorder>(
-                      RoundedRectangleBorder(
-                        borderRadius: BorderRadius.circular(18.0),
-                        side: const BorderSide(color: tenTenOnePurple),
-                      ),
-                    ),
-                  ),
-                  child: const Wrap(
-                    children: <Widget>[
-                      Icon(
-                        FontAwesomeIcons.download,
-                        color: tenTenOnePurple,
-                        size: 24.0,
-                      ),
-                      SizedBox(
-                        width: 10,
-                      ),
-                      Text(
-                        "Restore wallet",
-                        style: TextStyle(
-                            fontSize: 20, color: Colors.black), // Set the text color to black
-                      ),
-                    ],
-                  ),
-                ),
-              )
-            ]),
-          ],
-        ),
-      ),
-    )));
+            ),
+          ))),
+    );
   }
 
   @override


### PR DESCRIPTION
- set background of scaffold to white to match the rest of the screen
- use dark status bar, needs to be done here again since it is not in the shell route.
- reduced the button border radius from 18 to 10.


![Screenshot 2023-10-27 at 09 43 09](https://github.com/get10101/10101/assets/382048/264b8f1e-5a64-4e0a-97de-a962f528e70f)
