### PR TITLE
fix: Add invisible box decorator to settings clickable

### DIFF
--- a/mobile/lib/common/settings/settings_screen.dart
+++ b/mobile/lib/common/settings/settings_screen.dart
@@ -212,6 +212,7 @@ class _SettingsClickableState extends State<SettingsClickable> {
             : setState(() => isMoreInfo = !isMoreInfo);
       },
       child: Container(
+        decoration: BoxDecoration(border: Border.all(color: Colors.white, width: 0.0)),
         padding: const EdgeInsets.all(15),
         child: Row(
           crossAxisAlignment: CrossAxisAlignment.start,


### PR DESCRIPTION
It's weird but adding an invisible box decoration makes the white space clickable.

fixes #1534 