### PR TITLE
Load persisted `rust-dlc` `ChainMonitor` whenever possible 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - Allow to drain on-chain wallet by sending amount `0`.
+- Load persisted `rust-dlc` `ChainMonitor` on restart.
 
 ## [1.4.4] - 2023-10-28
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1041,7 +1041,7 @@ dependencies = [
 [[package]]
 name = "dlc"
 version = "0.4.0"
-source = "git+https://github.com/p2pderivatives/rust-dlc?rev=d1e08a0#d1e08a0e8269c3dfb75d673beebc0fac87d58236"
+source = "git+https://github.com/p2pderivatives/rust-dlc?rev=4e104b4#4e104b4db197ae9014065c4ee0b03021fc29f848"
 dependencies = [
  "bitcoin",
  "miniscript 8.0.0",
@@ -1053,7 +1053,7 @@ dependencies = [
 [[package]]
 name = "dlc-manager"
 version = "0.4.0"
-source = "git+https://github.com/p2pderivatives/rust-dlc?rev=d1e08a0#d1e08a0e8269c3dfb75d673beebc0fac87d58236"
+source = "git+https://github.com/p2pderivatives/rust-dlc?rev=4e104b4#4e104b4db197ae9014065c4ee0b03021fc29f848"
 dependencies = [
  "async-trait",
  "bitcoin",
@@ -1069,7 +1069,7 @@ dependencies = [
 [[package]]
 name = "dlc-messages"
 version = "0.4.0"
-source = "git+https://github.com/p2pderivatives/rust-dlc?rev=d1e08a0#d1e08a0e8269c3dfb75d673beebc0fac87d58236"
+source = "git+https://github.com/p2pderivatives/rust-dlc?rev=4e104b4#4e104b4db197ae9014065c4ee0b03021fc29f848"
 dependencies = [
  "bitcoin",
  "dlc",
@@ -1082,7 +1082,7 @@ dependencies = [
 [[package]]
 name = "dlc-sled-storage-provider"
 version = "0.1.0"
-source = "git+https://github.com/p2pderivatives/rust-dlc?rev=d1e08a0#d1e08a0e8269c3dfb75d673beebc0fac87d58236"
+source = "git+https://github.com/p2pderivatives/rust-dlc?rev=4e104b4#4e104b4db197ae9014065c4ee0b03021fc29f848"
 dependencies = [
  "bitcoin",
  "dlc-manager",
@@ -1096,7 +1096,7 @@ dependencies = [
 [[package]]
 name = "dlc-trie"
 version = "0.4.0"
-source = "git+https://github.com/p2pderivatives/rust-dlc?rev=d1e08a0#d1e08a0e8269c3dfb75d673beebc0fac87d58236"
+source = "git+https://github.com/p2pderivatives/rust-dlc?rev=4e104b4#4e104b4db197ae9014065c4ee0b03021fc29f848"
 dependencies = [
  "bitcoin",
  "dlc",
@@ -2524,7 +2524,7 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 [[package]]
 name = "p2pd-oracle-client"
 version = "0.1.0"
-source = "git+https://github.com/p2pderivatives/rust-dlc?rev=d1e08a0#d1e08a0e8269c3dfb75d673beebc0fac87d58236"
+source = "git+https://github.com/p2pderivatives/rust-dlc?rev=4e104b4#4e104b4db197ae9014065c4ee0b03021fc29f848"
 dependencies = [
  "chrono",
  "dlc-manager",
@@ -3460,7 +3460,7 @@ dependencies = [
 [[package]]
 name = "simple-wallet"
 version = "0.1.0"
-source = "git+https://github.com/p2pderivatives/rust-dlc?rev=d1e08a0#d1e08a0e8269c3dfb75d673beebc0fac87d58236"
+source = "git+https://github.com/p2pderivatives/rust-dlc?rev=4e104b4#4e104b4db197ae9014065c4ee0b03021fc29f848"
 dependencies = [
  "bitcoin",
  "dlc",


### PR DESCRIPTION
Fixes #1547.

If we cannot load it because the deserialisation fails, we introduce a workaround that ensures that we can overwrite it and move on with the `DlcManager` initialisation.

This is generally not safe, but it unblocks us for the time being. We should nevertheless remove the workaround as soon as most users have updated to this patch.