### PR TITLE
Allow app trader to resize open position

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2386,6 +2386,7 @@ dependencies = [
  "reqwest",
  "rusqlite",
  "rust_decimal",
+ "rust_decimal_macros",
  "secp256k1-zkp",
  "serde",
  "serde_json",

--- a/coordinator/migrations/2023-10-25-120015_add_fee_to_channel/up.sql
+++ b/coordinator/migrations/2023-10-25-120015_add_fee_to_channel/up.sql
@@ -1,4 +1,3 @@
--- Your SQL goes here
 ALTER TABLE channels ADD COLUMN "fee_sats" BIGINT DEFAULT null;
 
 ALTER TABLE

--- a/coordinator/migrations/2023-11-07-073206_add_expiry_timestamp_to_trades/down.sql
+++ b/coordinator/migrations/2023-11-07-073206_add_expiry_timestamp_to_trades/down.sql
@@ -1,0 +1,6 @@
+ALTER TABLE trades
+DROP COLUMN dlc_expiry_timestamp;
+
+-- Note: There is no down migration for removing the `Resizing`
+-- variant that was added to `PositionState_Type` because it is not
+-- feasible to remove enum variants in the db!

--- a/coordinator/migrations/2023-11-07-073206_add_expiry_timestamp_to_trades/up.sql
+++ b/coordinator/migrations/2023-11-07-073206_add_expiry_timestamp_to_trades/up.sql
@@ -1,0 +1,5 @@
+ALTER TABLE trades
+ADD COLUMN dlc_expiry_timestamp timestamp WITH TIME ZONE;
+
+ALTER TYPE "PositionState_Type"
+ADD VALUE IF NOT EXISTS 'Resizing';

--- a/coordinator/src/db/custom_types.rs
+++ b/coordinator/src/db/custom_types.rs
@@ -45,6 +45,7 @@ impl ToSql<PositionStateType, Pg> for PositionState {
             PositionState::Closing => out.write_all(b"Closing")?,
             PositionState::Closed => out.write_all(b"Closed")?,
             PositionState::Rollover => out.write_all(b"Rollover")?,
+            PositionState::Resizing => out.write_all(b"Resizing")?,
         }
         Ok(IsNull::No)
     }
@@ -57,6 +58,7 @@ impl FromSql<PositionStateType, Pg> for PositionState {
             b"Closing" => Ok(PositionState::Closing),
             b"Closed" => Ok(PositionState::Closed),
             b"Rollover" => Ok(PositionState::Rollover),
+            b"Resizing" => Ok(PositionState::Resizing),
             _ => Err("Unrecognized enum variant".into()),
         }
     }

--- a/coordinator/src/node/closed_positions.rs
+++ b/coordinator/src/node/closed_positions.rs
@@ -41,7 +41,12 @@ pub fn sync(node: Node) -> Result<()> {
             position.id,
             contract.pnl,
         ) {
-            tracing::error!(position_id=%position.id, temporary_contract_id=%temporary_contract_id.to_hex(), pnl=%contract.pnl, "Failed to set position to closed: {e:#}")
+            tracing::error!(
+                position_id=%position.id,
+                temporary_contract_id=%temporary_contract_id.to_hex(),
+                pnl=%contract.pnl,
+                "Failed to set position to closed: {e:#}"
+            )
         }
     }
 

--- a/coordinator/src/node/resize.rs
+++ b/coordinator/src/node/resize.rs
@@ -1,0 +1,364 @@
+use crate::db;
+use crate::node::compute_relative_contracts;
+use crate::node::decimal_from_f32;
+use crate::node::f32_from_decimal;
+use crate::node::Node;
+use crate::payout_curve;
+use crate::payout_curve::create_rounding_interval;
+use crate::position::models::PositionState;
+use crate::trade::models::NewTrade;
+use anyhow::Context;
+use anyhow::Result;
+use bitcoin::hashes::hex::ToHex;
+use bitcoin::secp256k1::PublicKey;
+use coordinator_commons::TradeParams;
+use diesel::PgConnection;
+use dlc_manager::contract::contract_input::ContractInput;
+use dlc_manager::contract::contract_input::ContractInputInfo;
+use dlc_manager::contract::contract_input::OracleInput;
+use dlc_manager::ChannelId;
+use orderbook_commons::order_matching_fee_taker;
+use rust_decimal::prelude::Signed;
+use rust_decimal::prelude::ToPrimitive;
+use rust_decimal::Decimal;
+use rust_decimal::RoundingStrategy;
+use trade::cfd::calculate_long_liquidation_price;
+use trade::cfd::calculate_margin;
+use trade::cfd::calculate_short_liquidation_price;
+use trade::Direction;
+
+impl Node {
+    pub async fn resize_position(
+        &self,
+        conn: &mut PgConnection,
+        channel_id: ChannelId,
+        trade_params: &TradeParams,
+    ) -> Result<()> {
+        let channel_id_hex = channel_id.to_hex();
+        let peer_id = trade_params.pubkey;
+
+        let position = db::positions::Position::get_position_by_trader(
+            conn,
+            peer_id,
+            vec![PositionState::Open],
+        )?
+        .with_context(|| {
+            format!("Failed to find open position for channel {channel_id_hex} with peer {peer_id}")
+        })?;
+
+        tracing::info!(
+            ?position,
+            ?trade_params,
+            channel_id = %channel_id_hex,
+            peer_id = %peer_id,
+            "Resizing position",
+        );
+
+        // We start the position resizing by proposing a collaborative settlement of the existing
+        // DLC channel _as if nothing had happened_. That is, the `accept_settlement_amount` is
+        // equal to the amount the accept party originally put into the contract.
+        //
+        // TODO: Use subchannel resize protocol to ensure atomicity, simplify the implementation and
+        // improve UX.
+        {
+            // The position.trader_margin has already been subtracted the previous order-matching
+            // fee, so we don't have to touch this.
+            let unchanged_accept_settlement_amount = position.trader_margin as u64;
+
+            self.inner
+                .propose_dlc_channel_collaborative_settlement(
+                    channel_id,
+                    unchanged_accept_settlement_amount,
+                )
+                .await?;
+
+            // The protocol will continue once we have processed the `CloseFinalize` message. Then
+            // we will have to propose the creation of a _new_ DLC channel.
+        };
+
+        // This is pretty meaningless as documented in `NewTrade`.
+        let margin_coordinator = {
+            let leverage_coordinator = self.coordinator_leverage_for_trade(&peer_id)?;
+
+            margin_coordinator(trade_params, leverage_coordinator) as i64
+        };
+
+        let execution_price = trade_params
+            .average_execution_price()
+            .to_f32()
+            .expect("To fit into f32");
+
+        db::trades::insert(
+            conn,
+            NewTrade {
+                position_id: position.id,
+                contract_symbol: position.contract_symbol,
+                trader_pubkey: position.trader,
+                quantity: trade_params.quantity,
+                trader_leverage: trade_params.leverage,
+                coordinator_margin: margin_coordinator,
+                direction: trade_params.direction,
+                average_price: execution_price,
+                dlc_expiry_timestamp: Some(trade_params.filled_with.expiry_timestamp),
+            },
+        )?;
+
+        db::positions::Position::set_open_position_to_resizing(conn, position.trader.to_string())?;
+
+        Ok(())
+    }
+
+    pub fn continue_position_resizing(&self, peer_id: PublicKey) -> Result<()> {
+        let mut conn = self.pool.get()?;
+
+        // If we have a `Resizing` position, we must be in the middle of the resizing protocol.
+        // We have just finished closing the existing channel and are now ready to propose the
+        // creation of the new one.
+        if let Some(old_position) = db::positions::Position::get_position_by_trader(
+            &mut conn,
+            peer_id,
+            vec![PositionState::Resizing],
+        )? {
+            let channel_details = self.get_counterparty_channel(peer_id)?;
+
+            tracing::info!(
+                channel_id = %channel_details.channel_id.to_hex(),
+                peer_id = %peer_id,
+                "Found resizing position corresponding to channel that was just closed"
+            );
+
+            let trade = db::trades::get_latest_for_position(&mut conn, old_position.id)?
+                .context("No trade for resized position")?;
+
+            // Compute absolute contracts using formula.
+            let (total_contracts, direction) = {
+                let contracts_before_relative = compute_relative_contracts(
+                    decimal_from_f32(old_position.quantity),
+                    &old_position.direction,
+                );
+                let contracts_trade_relative =
+                    compute_relative_contracts(decimal_from_f32(trade.quantity), &trade.direction);
+
+                let total_contracts_relative = contracts_before_relative + contracts_trade_relative;
+
+                let direction = if total_contracts_relative.signum() == Decimal::ONE {
+                    Direction::Long
+                } else {
+                    Direction::Short
+                };
+
+                let total_contracts = total_contracts_relative.abs();
+
+                (total_contracts, direction)
+            };
+
+            let average_execution_price = compute_average_execution_price(
+                old_position.average_entry_price,
+                trade.average_price,
+                old_position.quantity,
+                trade.quantity,
+                old_position.direction,
+                trade.direction,
+            );
+
+            // NOTE: Leverage does not change with new orders!
+            let leverage_trader = decimal_from_f32(old_position.trader_leverage);
+            let leverage_coordinator = decimal_from_f32(old_position.coordinator_leverage);
+
+            let margin_coordinator = compute_margin(
+                total_contracts,
+                leverage_coordinator,
+                average_execution_price,
+            );
+            let margin_trader =
+                compute_margin(total_contracts, leverage_trader, average_execution_price);
+
+            let liquidation_price_trader =
+                compute_liquidation_price(leverage_trader, average_execution_price, &direction);
+            let expiry_timestamp = trade
+                .dlc_expiry_timestamp
+                .context("No expiry timestamp for resizing trade")?;
+
+            let stable = old_position.stable
+                && leverage_trader == Decimal::ONE
+                && direction == Direction::Short;
+
+            let total_contracts = f32_from_decimal(total_contracts);
+            let leverage_coordinator = f32_from_decimal(leverage_coordinator);
+            let leverage_trader = f32_from_decimal(leverage_trader);
+
+            let contract_input = {
+                let fee_rate = self.settings.blocking_read().contract_tx_fee_rate;
+
+                let contract_symbol = old_position.contract_symbol;
+                let maturity_time = expiry_timestamp.unix_timestamp();
+                let event_id = format!("{contract_symbol}{maturity_time}");
+
+                let total_collateral = margin_coordinator + margin_trader;
+
+                let coordinator_direction = direction.opposite();
+
+                // Apply the order-matching fee. The fee from the previous iteration of the
+                // position should have already been cashed into the
+                // coordinator's side of the Lightning channel when first
+                // closing the DLC channel.
+                //
+                // Here we only need to charge for executing the order.
+                let fee =
+                    order_matching_fee_taker(trade.quantity, decimal_from_f32(trade.average_price))
+                        .to_sat();
+
+                let contract_descriptor = payout_curve::build_contract_descriptor(
+                    average_execution_price,
+                    margin_coordinator,
+                    margin_trader,
+                    leverage_coordinator,
+                    leverage_trader,
+                    coordinator_direction,
+                    fee,
+                    create_rounding_interval(total_collateral),
+                    total_contracts,
+                    contract_symbol,
+                )
+                .context("Could not build contract descriptor")?;
+
+                tracing::info!(
+                    channel_id = %channel_details.channel_id.to_hex(),
+                    peer_id = %peer_id,
+                    event_id,
+                    "Proposing DLC channel as part of position resizing"
+                );
+
+                ContractInput {
+                    offer_collateral: margin_coordinator - fee,
+                    // the accepting party has do bring in additional margin for the fees
+                    accept_collateral: margin_trader + fee,
+                    fee_rate,
+                    contract_infos: vec![ContractInputInfo {
+                        contract_descriptor,
+                        oracles: OracleInput {
+                            public_keys: vec![self.inner.oracle_pk()],
+                            event_id,
+                            threshold: 1,
+                        },
+                    }],
+                }
+            };
+
+            tokio::spawn({
+                let node = self.inner.clone();
+                async move {
+                    if let Err(e) = node
+                        .propose_dlc_channel(channel_details.clone(), contract_input)
+                        .await
+                    {
+                        tracing::error!(
+                            channel_id = %channel_details.channel_id.to_hex(),
+                            peer_id = %peer_id,
+                            "Failed to propose DLC channel as part of position resizing: {e:#}"
+                        );
+                        return;
+                    }
+
+                    let temporary_contract_id = match node
+                        .get_temporary_contract_id_by_sub_channel_id(channel_details.channel_id)
+                    {
+                        Ok(temporary_contract_id) => temporary_contract_id,
+                        Err(e) => {
+                            tracing::error!(
+                                channel_id = %channel_details.channel_id.to_hex(),
+                                "Unable to extract temporary contract id: {e:#}"
+                            );
+                            return;
+                        }
+                    };
+
+                    // TODO: We are too eager to update the position as the protocol is not quite
+                    // done. We should use a separate table that holds all the information needed to
+                    // update the position once the resize protocol is actually done.
+                    if let Err(e) = db::positions::Position::update_resized_position(
+                        &mut conn,
+                        old_position.trader.to_string(),
+                        total_contracts,
+                        direction.into(),
+                        leverage_coordinator,
+                        leverage_trader,
+                        margin_coordinator as i64,
+                        margin_trader as i64,
+                        f32_from_decimal(average_execution_price),
+                        f32_from_decimal(liquidation_price_trader),
+                        expiry_timestamp,
+                        temporary_contract_id,
+                        stable,
+                    ) {
+                        tracing::error!(
+                            channel_id = %channel_details.channel_id.to_hex(),
+                            "Failed to update resized position: {e:#}"
+                        )
+                    }
+                }
+            });
+        }
+
+        Ok(())
+    }
+}
+
+fn margin_coordinator(trade_params: &TradeParams, coordinator_leverage: f32) -> u64 {
+    calculate_margin(
+        trade_params.average_execution_price(),
+        trade_params.quantity,
+        coordinator_leverage,
+    )
+}
+
+fn compute_margin(
+    total_contracts: Decimal,
+    leverage: Decimal,
+    average_execution_price: Decimal,
+) -> u64 {
+    let margin_btc = total_contracts / (leverage * average_execution_price);
+
+    let margin_btc = margin_btc
+        .abs()
+        .round_dp_with_strategy(8, RoundingStrategy::MidpointAwayFromZero)
+        .to_f64()
+        .expect("margin to fit into f64");
+
+    bitcoin::Amount::from_btc(margin_btc)
+        .expect("margin to fit into Amount")
+        .to_sat()
+}
+
+fn compute_average_execution_price(
+    starting_average_execution_price: f32,
+    trade_execution_price: f32,
+    starting_contracts: f32,
+    trade_contracts: f32,
+    starting_direction: Direction,
+    trade_direction: Direction,
+) -> Decimal {
+    let starting_average_execution_price = decimal_from_f32(starting_average_execution_price);
+
+    let trade_execution_price = decimal_from_f32(trade_execution_price);
+
+    let starting_contracts = decimal_from_f32(starting_contracts);
+    let starting_contracts_relative =
+        compute_relative_contracts(starting_contracts, &starting_direction);
+
+    let trade_contracts = decimal_from_f32(trade_contracts);
+    let trade_contracts_relative = compute_relative_contracts(trade_contracts, &trade_direction);
+
+    let total_contracts_relative = starting_contracts_relative + trade_contracts_relative;
+
+    total_contracts_relative
+        / (starting_contracts_relative / starting_average_execution_price
+            + trade_contracts_relative / trade_execution_price)
+}
+
+fn compute_liquidation_price(leverage: Decimal, price: Decimal, direction: &Direction) -> Decimal {
+    match direction {
+        Direction::Long => calculate_long_liquidation_price(leverage, price),
+        Direction::Short => calculate_short_liquidation_price(leverage, price),
+    }
+}

--- a/coordinator/src/payout_curve.rs
+++ b/coordinator/src/payout_curve.rs
@@ -11,12 +11,14 @@ use dlc_manager::payout_curve::RoundingInterval;
 use dlc_manager::payout_curve::RoundingIntervals;
 use payout_curve::ROUNDING_PERCENT;
 use rust_decimal::Decimal;
+use tracing::instrument;
 use trade::ContractSymbol;
 use trade::Direction;
 
 /// Builds the contract descriptor from the point of view of the coordinator.
 ///
 /// It's the direction of the coordinator because the coordinator is always proposing
+#[instrument]
 #[allow(clippy::too_many_arguments)]
 pub fn build_contract_descriptor(
     initial_price: Decimal,
@@ -33,6 +35,8 @@ pub fn build_contract_descriptor(
     if symbol != ContractSymbol::BtcUsd {
         bail!("We only support BTCUSD at the moment. For other symbols we will need a different payout curve");
     }
+
+    tracing::info!("Building contract descriptor");
 
     Ok(ContractDescriptor::Numerical(NumericalDescriptor {
         payout_function: build_inverse_payout_function(

--- a/coordinator/src/position/models.rs
+++ b/coordinator/src/position/models.rs
@@ -28,6 +28,7 @@ pub struct NewPosition {
     pub coordinator_margin: i64,
     pub expiry_timestamp: OffsetDateTime,
     pub temporary_contract_id: ContractId,
+    pub coordinator_leverage: f32,
     pub trader_margin: i64,
     pub stable: bool,
 }
@@ -35,9 +36,9 @@ pub struct NewPosition {
 #[derive(Clone, PartialEq, Debug)]
 pub enum PositionState {
     Open,
-    /// The position is in the process of being closed
+    /// The position is in the process of being closed.
     ///
-    /// Once the position is being close the closing price is known.
+    /// Once the position is being closed the closing price is known.
     Closing {
         closing_price: f32,
     },
@@ -45,6 +46,7 @@ pub enum PositionState {
         pnl: i64,
     },
     Rollover,
+    Resizing,
 }
 
 /// The position acts as an aggregate of one contract of one user.

--- a/coordinator/src/schema.rs
+++ b/coordinator/src/schema.rs
@@ -236,6 +236,7 @@ diesel::table! {
         average_price -> Float4,
         timestamp -> Timestamptz,
         fee_payment_hash -> Text,
+        dlc_expiry_timestamp -> Nullable<Timestamptz>,
     }
 }
 

--- a/coordinator/src/trade/models.rs
+++ b/coordinator/src/trade/models.rs
@@ -11,9 +11,11 @@ pub struct NewTrade {
     pub trader_pubkey: PublicKey,
     pub quantity: f32,
     pub trader_leverage: f32,
+    // TODO: Consider removing this since it doesn't make sense with all kinds of trades.
     pub coordinator_margin: i64,
     pub direction: Direction,
     pub average_price: f32,
+    pub dlc_expiry_timestamp: Option<OffsetDateTime>,
 }
 
 #[derive(Debug)]
@@ -24,9 +26,14 @@ pub struct Trade {
     pub trader_pubkey: PublicKey,
     pub quantity: f32,
     pub trader_leverage: f32,
+    // TODO: Consider removing this since it doesn't make sense with all kinds of trades.
     pub collateral: i64,
     pub direction: Direction,
     pub average_price: f32,
+    // We need this for position resizing so that we can set up the DLC channel using the expiry
+    // timestamp specified in the `TradeParams`. It should probably go in a different table since
+    // it's not part of the trade model.
+    pub dlc_expiry_timestamp: Option<OffsetDateTime>,
     pub timestamp: OffsetDateTime,
     pub fee_payment_hash: PaymentHash,
 }

--- a/crates/coordinator-commons/src/lib.rs
+++ b/crates/coordinator-commons/src/lib.rs
@@ -19,7 +19,7 @@ use trade::Direction;
 /// Emitted by the orderbook when a match is found.
 /// Both trading parties will receive trade params and then request trade execution with said trade
 /// parameters from the coordinator.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct TradeParams {
     /// The identity of the trader
     pub pubkey: PublicKey,

--- a/crates/orderbook-commons/src/lib.rs
+++ b/crates/orderbook-commons/src/lib.rs
@@ -210,7 +210,7 @@ impl Display for Message {
 ///
 /// The match defines the execution price and the quantity to be used of the order with the
 /// corresponding order id.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct Match {
     /// The id of the match
     pub id: Uuid,
@@ -254,7 +254,7 @@ impl From<Matches> for Match {
 /// This emitted for one of the trader's order, i.e. the `order_id` matches one of the orders that
 /// the trader submitted to the orderbook. The matches define how this order was filled.
 /// This information is used to request trade execution with the coordinator.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct FilledWith {
     /// The id of the order defined by the orderbook
     ///

--- a/crates/tests-e2e/tests/close_position.rs
+++ b/crates/tests-e2e/tests/close_position.rs
@@ -22,6 +22,7 @@ async fn can_collab_close_position() {
         .unwrap();
 
     wait_until!(test.app.rx.position().unwrap().position_state == PositionState::Closing);
+    wait_until!(test.app.rx.position_close().is_some());
 
-    // TODO: Assert that the position is closed in the app and the coordinator
+    // TODO: Assert that the position is closed in the coordinator
 }

--- a/crates/tests-e2e/tests/resize_position.rs
+++ b/crates/tests-e2e/tests/resize_position.rs
@@ -1,0 +1,172 @@
+use native::api;
+use native::api::ContractSymbol;
+use native::api::Direction;
+use native::trade::order::api::NewOrder;
+use native::trade::order::api::OrderType;
+use native::trade::position::PositionState;
+use tests_e2e::setup::TestSetup;
+use tests_e2e::wait_until;
+use tokio::task::spawn_blocking;
+
+#[tokio::test]
+#[ignore = "need to be run with 'just e2e' command"]
+async fn can_resize_position() {
+    let test = TestSetup::new_after_funding().await;
+    let app = &test.app;
+
+    // Buy 10 => 10 Long.
+
+    let opening_market_order = NewOrder {
+        leverage: 2.0,
+        contract_symbol: ContractSymbol::BtcUsd,
+        direction: Direction::Long,
+        quantity: 10.0,
+        order_type: Box::new(OrderType::Market),
+        stable: false,
+    };
+
+    spawn_blocking({
+        let order = opening_market_order.clone();
+        move || api::submit_order(order).unwrap()
+    })
+    .await
+    .unwrap();
+
+    // Wait until the position has been created.
+    wait_until!(app
+        .rx
+        .position()
+        .map(|pos| pos.position_state == PositionState::Open && pos.quantity == 10.0)
+        .unwrap_or(false));
+
+    // Sell 5 => 5 Long.
+
+    let resize_market_order = NewOrder {
+        leverage: 2.0,
+        contract_symbol: ContractSymbol::BtcUsd,
+        direction: Direction::Short,
+        quantity: 5.0,
+        order_type: Box::new(OrderType::Market),
+        stable: false,
+    };
+
+    spawn_blocking({
+        let order = resize_market_order.clone();
+        move || api::submit_order(order).unwrap()
+    })
+    .await
+    .unwrap();
+
+    wait_until!(app
+        .rx
+        .position()
+        .map(|pos| pos.position_state == PositionState::Resizing)
+        .unwrap_or(false));
+
+    wait_until!(app
+        .rx
+        .position()
+        .map(|pos| pos.position_state == PositionState::Open && pos.quantity == 5.0)
+        .unwrap_or(false));
+
+    let position = app.rx.position().unwrap();
+
+    assert_eq!(position.direction, Direction::Long);
+    assert_eq!(position.contract_symbol, ContractSymbol::BtcUsd);
+    assert_eq!(position.leverage, 2.0);
+
+    // Sell 10 => 5 Short.
+
+    let resize_market_order = NewOrder {
+        leverage: 2.0,
+        contract_symbol: ContractSymbol::BtcUsd,
+        direction: Direction::Short,
+        quantity: 10.0,
+        order_type: Box::new(OrderType::Market),
+        stable: false,
+    };
+
+    spawn_blocking({
+        let order = resize_market_order.clone();
+        move || api::submit_order(order).unwrap()
+    })
+    .await
+    .unwrap();
+
+    wait_until!(app
+        .rx
+        .position()
+        .map(|pos| pos.position_state == PositionState::Resizing)
+        .unwrap_or(false));
+
+    // Wait until the position has been resized.
+    wait_until!(app
+        .rx
+        .position()
+        .map(|pos| pos.position_state == PositionState::Open && pos.direction == Direction::Short)
+        .unwrap_or(false));
+
+    let position = app.rx.position().unwrap();
+
+    assert_eq!(position.quantity, 5.0);
+    assert_eq!(position.contract_symbol, ContractSymbol::BtcUsd);
+    assert_eq!(position.leverage, 2.0);
+
+    // Sell 5 => 10 Short.
+
+    let resize_market_order = NewOrder {
+        leverage: 2.0,
+        contract_symbol: ContractSymbol::BtcUsd,
+        direction: Direction::Short,
+        quantity: 5.0,
+        order_type: Box::new(OrderType::Market),
+        stable: false,
+    };
+
+    spawn_blocking({
+        let order = resize_market_order.clone();
+        move || api::submit_order(order).unwrap()
+    })
+    .await
+    .unwrap();
+
+    wait_until!(app
+        .rx
+        .position()
+        .map(|pos| pos.position_state == PositionState::Resizing)
+        .unwrap_or(false));
+
+    // Wait until the position has been resized.
+    wait_until!(app
+        .rx
+        .position()
+        .map(|pos| pos.position_state == PositionState::Open && pos.quantity == 10.0)
+        .unwrap_or(false));
+
+    let position = app.rx.position().unwrap();
+
+    assert_eq!(position.direction, Direction::Short);
+    assert_eq!(position.contract_symbol, ContractSymbol::BtcUsd);
+    assert_eq!(position.leverage, 2.0);
+
+    // Buy 10 => 0 contracts.
+
+    let resize_market_order = NewOrder {
+        leverage: 2.0,
+        contract_symbol: ContractSymbol::BtcUsd,
+        direction: Direction::Long,
+        quantity: 10.0,
+        order_type: Box::new(OrderType::Market),
+        stable: false,
+    };
+
+    spawn_blocking({
+        let order = resize_market_order.clone();
+        move || api::submit_order(order).unwrap()
+    })
+    .await
+    .unwrap();
+
+    wait_until!(app.rx.position().unwrap().position_state == PositionState::Closing);
+    wait_until!(app.rx.position_close().is_some());
+}

--- a/crates/trade/src/lib.rs
+++ b/crates/trade/src/lib.rs
@@ -3,7 +3,6 @@ use rust_decimal::Decimal;
 use serde::Deserialize;
 use serde::Serialize;
 use std::fmt;
-use std::fmt::Formatter;
 use std::str::FromStr;
 
 pub mod bitmex_client;
@@ -34,6 +33,17 @@ impl Direction {
             Direction::Long => Direction::Short,
             Direction::Short => Direction::Long,
         }
+    }
+}
+
+impl fmt::Display for Direction {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let s = match self {
+            Direction::Long => "Long",
+            Direction::Short => "Short",
+        };
+
+        s.fmt(f)
     }
 }
 
@@ -69,7 +79,7 @@ impl FromStr for ContractSymbol {
 }
 
 impl fmt::Display for ContractSymbol {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let symbol = match self {
             ContractSymbol::BtcUsd => "btcusd",
         };

--- a/mobile/lib/features/trade/domain/position.dart
+++ b/mobile/lib/features/trade/domain/position.dart
@@ -14,6 +14,7 @@ enum PositionState {
   static PositionState fromApi(bridge.PositionState positionState) {
     switch (positionState) {
       case bridge.PositionState.Open:
+      case bridge.PositionState.Resizing:
         return PositionState.open;
       case bridge.PositionState.Closing:
         return PositionState.closing;

--- a/mobile/lib/features/wallet/domain/wallet_history.dart
+++ b/mobile/lib/features/wallet/domain/wallet_history.dart
@@ -67,7 +67,9 @@ abstract class WalletHistoryItemData {
           timestamp: timestamp,
           orderId: type.orderId,
           fee: Amount(type.feeSat),
-          pnl: type.pnl != null ? Amount(type.pnl!) : null);
+          pnl: type.pnl != null ? Amount(type.pnl!) : null,
+          direction: type.direction,
+          contracts: type.contracts);
     }
 
     rust.WalletHistoryItemType_Lightning type =
@@ -144,6 +146,8 @@ class TradeData extends WalletHistoryItemData {
   final String orderId;
   final Amount fee;
   final Amount? pnl;
+  final String direction;
+  final int contracts;
 
   TradeData(
       {required super.flow,
@@ -152,7 +156,9 @@ class TradeData extends WalletHistoryItemData {
       required super.timestamp,
       required this.fee,
       this.pnl,
-      required this.orderId});
+      required this.orderId,
+      required this.direction,
+      required this.contracts});
 
   @override
   WalletHistoryItem toWidget() {

--- a/mobile/lib/features/wallet/wallet_history_item.dart
+++ b/mobile/lib/features/wallet/wallet_history_item.dart
@@ -381,12 +381,7 @@ class TradeHistoryItem extends WalletHistoryItem {
 
   @override
   String getTitle() {
-    switch (data.flow) {
-      case PaymentFlow.inbound:
-        return "Closed position";
-      case PaymentFlow.outbound:
-        return "Opened position";
-    }
+    return "${data.direction} ${data.contracts} contracts";
   }
 
   @override

--- a/mobile/native/Cargo.toml
+++ b/mobile/native/Cargo.toml
@@ -34,6 +34,7 @@ parking_lot = { version = "0.12.1" }
 reqwest = { version = "0.11", default-features = false, features = ["json", "stream"] }
 rusqlite = { version = "0.29.0", features = ["backup", "bundled"] }
 rust_decimal = { version = "1", features = ["serde-with-float"] }
+rust_decimal_macros = "1"
 serde = { version = "1.0.152", features = ["serde_derive"] }
 serde_json = "1"
 state = "0.5.3"

--- a/mobile/native/migrations/2023-11-10-014928_add_trades/down.sql
+++ b/mobile/native/migrations/2023-11-10-014928_add_trades/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE "trades";

--- a/mobile/native/migrations/2023-11-10-014928_add_trades/up.sql
+++ b/mobile/native/migrations/2023-11-10-014928_add_trades/up.sql
@@ -1,0 +1,12 @@
+CREATE TABLE IF NOT EXISTS trades (
+    id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+    order_id TEXT NOT NULL,
+    contract_symbol TEXT NOT NULL,
+    contracts FLOAT NOT NULL,
+    direction TEXT NOT NULL,
+    trade_cost_sat BIGINT NOT NULL,
+    fee_sat BIGINT NOT NULL,
+    pnl_sat BIGINT,
+    price FLOAT NOT NULL,
+    timestamp BIGINT NOT NULL
+)

--- a/mobile/native/src/api.rs
+++ b/mobile/native/src/api.rs
@@ -95,6 +95,8 @@ pub enum WalletHistoryItemType {
         order_id: String,
         fee_sat: u64,
         pnl: Option<i64>,
+        contracts: u64,
+        direction: String,
     },
 }
 

--- a/mobile/native/src/calculations/mod.rs
+++ b/mobile/native/src/calculations/mod.rs
@@ -25,9 +25,12 @@ pub fn calculate_pnl(
     leverage: f32,
     direction: Direction,
 ) -> Result<i64> {
+    // FIXME: We can no longer assume that the coordinator always has the same leverage! It needs to
+    // be passed in as an argument. Unfortunately the coordinator leverage is not passed around at
+    // the moment. Perhaps we should add it to the `TradeParams`.
     let (long_leverage, short_leverage) = match direction {
-        Direction::Long => (leverage, 1.0),
-        Direction::Short => (1.0, leverage),
+        Direction::Long => (leverage, 2.0),
+        Direction::Short => (2.0, leverage),
     };
 
     let opening_price = Decimal::try_from(opening_price).expect("price to fit into decimal");

--- a/mobile/native/src/db/custom_types.rs
+++ b/mobile/native/src/db/custom_types.rs
@@ -180,6 +180,7 @@ impl ToSql<Text, Sqlite> for PositionState {
             PositionState::Open => "Open",
             PositionState::Closing => "Closing",
             PositionState::Rollover => "Rollover",
+            PositionState::Resizing => "Resizing",
         };
         out.set_value(text);
         Ok(IsNull::No)
@@ -194,6 +195,7 @@ impl FromSql<Text, Sqlite> for PositionState {
             "Open" => Ok(PositionState::Open),
             "Closing" => Ok(PositionState::Closing),
             "Rollover" => Ok(PositionState::Rollover),
+            "Resizing" => Ok(PositionState::Resizing),
             _ => Err("Unrecognized enum variant".into()),
         };
     }

--- a/mobile/native/src/ln_dlc/recover_rollover.rs
+++ b/mobile/native/src/ln_dlc/recover_rollover.rs
@@ -1,5 +1,6 @@
 use crate::ln_dlc::node::Node;
 use anyhow::Result;
+use bitcoin::hashes::hex::ToHex;
 use ln_dlc_node::node::rust_dlc_manager::channel::signed_channel::SignedChannelState;
 use ln_dlc_node::node::rust_dlc_manager::channel::Channel;
 use ln_dlc_node::node::rust_dlc_manager::Storage;
@@ -7,51 +8,65 @@ use ln_dlc_node::node::rust_dlc_manager::Storage;
 impl Node {
     /// Checks and recovers from a potential stuck rollover.
     pub async fn recover_rollover(&self) -> Result<()> {
-        tracing::debug!("Checking if dlc channel got stuck in rollover.");
+        tracing::debug!("Checking if DLC channel got stuck during rollover");
+
         let channels = self.inner.channel_manager.list_channels();
         let channel_details = match channels.first() {
             Some(channel_details) => channel_details,
             None => {
-                tracing::debug!("No channel found. All good!");
+                tracing::debug!("No need to recover rollover: no LN channel found");
                 return Ok(());
             }
         };
 
-        let dlc_channels = self.inner.dlc_manager.get_store().get_sub_channels()?;
-        let dlc_channel = dlc_channels
+        let subchannels = self.inner.dlc_manager.get_store().get_sub_channels()?;
+        let subchannel = match subchannels
             .iter()
-            .find(|dlc_channel| dlc_channel.channel_id == channel_details.channel_id);
-
-        let dlc_channel = match dlc_channel {
-            Some(dlc_channel) => dlc_channel,
+            .find(|dlc_channel| dlc_channel.channel_id == channel_details.channel_id)
+        {
+            Some(subchannel) => subchannel,
             None => {
-                tracing::debug!("No dlc channel found. All good!");
+                tracing::debug!("No need to recover rollover: no subchannel found");
                 return Ok(());
             }
         };
 
-        let dlc_channel_id = match dlc_channel.get_dlc_channel_id(0) {
+        let channel_id_hex = subchannel.channel_id.to_hex();
+
+        let dlc_channel_id = match subchannel.get_dlc_channel_id(0) {
             Some(dlc_channel_id) => dlc_channel_id,
             None => {
-                tracing::warn!(channel_id=%hex::encode(dlc_channel.channel_id), "Couldn't get a dlc channel id for a dlc channel");
+                tracing::debug!(
+                    channel_id=%channel_id_hex,
+                    "Cannot consider subchannel for rollover recovery without DLC channel ID"
+                );
                 return Ok(());
             }
         };
 
-        let channel = self
+        let dlc_channel_id_hex = dlc_channel_id.to_hex();
+
+        let dlc_channel = self
             .inner
             .dlc_manager
             .get_store()
             .get_channel(&dlc_channel_id)?;
 
-        let signed_channel = match channel {
+        let signed_channel = match dlc_channel {
             Some(Channel::Signed(signed_channel)) => signed_channel,
-            Some(channel) => {
-                tracing::warn!(dlc_channel_id=%hex::encode(dlc_channel_id), "Found channel in unexpected state. Expected: Signed, Found: {channel:?}");
+            Some(_) => {
+                tracing::debug!(
+                    channel_id=%channel_id_hex,
+                    "No need to recover rollover: DLC channel not signed"
+                );
                 return Ok(());
             }
             None => {
-                tracing::warn!(dlc_channel_id=%hex::encode(dlc_channel_id), "Couldn't find channel");
+                tracing::warn!(
+                    channel_id=%channel_id_hex,
+                    dlc_channel_id=%dlc_channel_id_hex,
+                    "Expected DLC channel associated with subchannel not found"
+                );
                 return Ok(());
             }
         };
@@ -62,13 +77,24 @@ impl Node {
             | SignedChannelState::RenewConfirmed { .. }
             | SignedChannelState::RenewFinalized { .. } => {
                 let state = ln_dlc_node::node::signed_channel_state_name(&signed_channel);
-                tracing::warn!(state, "Found signed channel contract in an intermediate state. Rolling back, expecting coordinator to retry rollover!");
+
+                tracing::warn!(
+                    state,
+                    "Found signed DLC channel in an intermediate rollover state. \
+                     Rolling back and expecting coordinator to retry rollover"
+                );
+
                 self.inner.rollback_channel(&signed_channel)?;
             }
             _ => {
-                tracing::debug!(signed_channel_state=%signed_channel.state, "Channel is not in an intermediate rollover state. All good.")
+                tracing::debug!(
+                    signed_channel_state=%signed_channel.state,
+                    "No need to recover rollover: DLC channel is not in an \
+                     intermediate rollover state"
+                )
             }
         }
+
         Ok(())
     }
 }

--- a/mobile/native/src/schema.rs
+++ b/mobile/native/src/schema.rs
@@ -80,6 +80,21 @@ diesel::table! {
 }
 
 diesel::table! {
+    trades (id) {
+        id -> Integer,
+        order_id -> Text,
+        contract_symbol -> Text,
+        contracts -> Float,
+        direction -> Text,
+        trade_cost_sat -> BigInt,
+        fee_sat -> BigInt,
+        pnl_sat -> Nullable<BigInt>,
+        price -> Float,
+        timestamp -> BigInt,
+    }
+}
+
+diesel::table! {
     transactions (txid) {
         txid -> Text,
         fee -> BigInt,
@@ -95,5 +110,6 @@ diesel::allow_tables_to_appear_in_same_query!(
     payments,
     positions,
     spendable_outputs,
+    trades,
     transactions,
 );

--- a/mobile/native/src/trade/mod.rs
+++ b/mobile/native/src/trade/mod.rs
@@ -1,3 +1,42 @@
+use bitcoin::Amount;
+use bitcoin::SignedAmount;
+use rust_decimal::Decimal;
+use time::OffsetDateTime;
+use trade::ContractSymbol;
+use trade::Direction;
+use uuid::Uuid;
+
 pub mod order;
 pub mod position;
 pub mod users;
+
+/// A trade is an event that moves funds between the Lightning wallet and a DLC channel.
+///
+/// Every trade is associated with a single market order, but an order can be associated with
+/// multiple trades.
+///
+/// If an order changes the direction of the underlying position, it must be split into _two_
+/// trades: one to close the original position and another one to open the new position in the
+/// opposite direction. We do so to keep the model as simple as possible.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Trade {
+    /// The executed order which resulted in this trade.
+    pub order_id: Uuid,
+    pub contract_symbol: ContractSymbol,
+    pub contracts: Decimal,
+    /// Direction of the associated order.
+    pub direction: Direction,
+    /// How many coins were moved between the Lightning wallet and the DLC channel.
+    ///
+    /// A positive value indicates that the money moved out of the Lightning wallet; a negative
+    /// value indicates that the money moved into the Lightning wallet.
+    pub trade_cost: SignedAmount,
+    pub fee: Amount,
+    /// If a position was reduced or closed because of this trade, how profitable it was.
+    ///
+    /// Set to [`None`] if the position was extended.
+    pub pnl: Option<SignedAmount>,
+    /// The price at which the associated order was executed.
+    pub price: Decimal,
+    pub timestamp: OffsetDateTime,
+}

--- a/mobile/native/src/trade/order/mod.rs
+++ b/mobile/native/src/trade/order/mod.rs
@@ -13,7 +13,7 @@ mod orderbook_client;
 // When naming this the same as `api_model::order::OrderType` the generated code somehow uses
 // `trade::OrderType` and contains errors, hence different name is used.
 // This is likely a bug in frb.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub enum OrderType {
     Market,
     Limit { price: f32 },
@@ -147,6 +147,8 @@ impl Order {
                 Some(execution_price)
             }
             _ => {
+                // TODO: The caller should decide how to handle this. Always logging an error is
+                // weird.
                 tracing::error!("Executed price not known in state {:?}", self.state);
                 None
             }

--- a/mobile/native/src/trade/position/api.rs
+++ b/mobile/native/src/trade/position/api.rs
@@ -26,7 +26,6 @@ pub enum PositionState {
     /// Transitions:
     /// Open->Closing
     Closing,
-
     /// The position is in rollover
     ///
     /// This is a technical intermediate state indicating that a rollover is currently in progress.
@@ -34,6 +33,11 @@ pub enum PositionState {
     /// Transitions:
     /// Open->Rollover
     Rollover,
+    /// The position is being resized.
+    ///
+    /// Transitions:
+    /// Open->Resizing.
+    Resizing,
 }
 
 #[frb]
@@ -57,6 +61,7 @@ impl From<position::PositionState> for PositionState {
             position::PositionState::Open => PositionState::Open,
             position::PositionState::Closing => PositionState::Closing,
             position::PositionState::Rollover => PositionState::Rollover,
+            position::PositionState::Resizing => PositionState::Resizing,
         }
     }
 }

--- a/mobile/native/src/trade/position/handler.rs
+++ b/mobile/native/src/trade/position/handler.rs
@@ -1,4 +1,3 @@
-use crate::calculations::calculate_liquidation_price;
 use crate::db;
 use crate::event;
 use crate::event::EventInternal;
@@ -7,16 +6,17 @@ use crate::trade::order;
 use crate::trade::order::Order;
 use crate::trade::order::OrderState;
 use crate::trade::order::OrderType;
+use crate::trade::position::compute_relative_contracts;
 use crate::trade::position::Position;
 use crate::trade::position::PositionState;
 use anyhow::bail;
-use anyhow::ensure;
 use anyhow::Context;
 use anyhow::Result;
 use coordinator_commons::TradeParams;
 use orderbook_commons::FilledWith;
 use orderbook_commons::Prices;
 use rust_decimal::prelude::ToPrimitive;
+use rust_decimal::Decimal;
 use time::OffsetDateTime;
 use trade::ContractSymbol;
 
@@ -45,6 +45,28 @@ pub async fn trade(filled: FilledWith) -> Result<()> {
         .expect("to fit into f32");
     order::handler::order_filling(order.id, execution_price)
         .context("Could not update order to filling")?;
+
+    // If we have a position _and_ the order is not closing the position (i.e. the contracts between
+    // position and order do not match), we must be resizing the position.
+
+    if let Some(Position {
+        quantity,
+        position_state: PositionState::Open,
+        direction,
+        contract_symbol,
+        ..
+    }) = get_positions()?.first()
+    {
+        let position_contracts_relative = compute_relative_contracts(*quantity, *direction);
+        let trade_contracts_relative =
+            compute_relative_contracts(trade_params.quantity, trade_params.direction);
+
+        if *contract_symbol == trade_params.contract_symbol
+            && position_contracts_relative + trade_contracts_relative != Decimal::ZERO
+        {
+            set_position_state(PositionState::Resizing)?;
+        }
+    }
 
     if let Err((reason, e)) = ln_dlc::trade(trade_params).await {
         order::handler::order_failed(Some(order.id), reason, e)
@@ -127,16 +149,16 @@ pub fn update_position_after_order_submitted(submitted_order: &Order) -> Result<
     Ok(())
 }
 
-/// Returns the position that would be closed by submitted, if there is any
+/// If the submitted order would close the current [`Position`], return the [`position`].
 pub fn get_position_matching_order(order: &Order) -> Result<Option<Position>> {
-    Ok(if let Some(position) = db::get_positions()?.first() {
-        // closing the position
-        ensure!(position.direction == order.direction.opposite()
-                && position.quantity == order.quantity, "Currently not possible to extend or reduce a position, you can only close the position with a counter-order");
-        Some(position.clone())
-    } else {
-        None
-    })
+    match db::get_positions()?.first() {
+        Some(position)
+            if position.direction != order.direction && position.quantity == order.quantity =>
+        {
+            Ok(Some(position.clone()))
+        }
+        _ => Ok(None),
+    }
 }
 
 /// Sets the position to the given state
@@ -172,39 +194,53 @@ pub fn update_position_after_dlc_creation(
     collateral: u64,
     expiry: OffsetDateTime,
 ) -> Result<()> {
-    ensure!(
-        db::get_positions()?.is_empty(),
-        "Cannot create a position if one is already open"
-    );
+    let (position, trades) = match db::get_positions()?.first() {
+        None => {
+            tracing::debug!(
+                order = ?filled_order,
+                %collateral,
+                "Creating position after DLC channel creation"
+            );
 
-    tracing::debug!(order = ?filled_order, %collateral, "Creating position after DLC channel creation");
+            let (position, trade) = Position::new_open(filled_order, collateral, expiry);
 
-    let average_entry_price = filled_order.execution_price().unwrap_or(0.0);
+            tracing::info!(?trade, ?position, "Position created");
 
-    let have_a_position = Position {
-        leverage: filled_order.leverage,
-        quantity: filled_order.quantity,
-        contract_symbol: filled_order.contract_symbol,
-        direction: filled_order.direction,
-        average_entry_price,
-        // TODO: Is it correct to use the average entry price to calculate the liquidation
-        // price? -> What would that mean in the UI if we already have a
-        // position and trade?
-        liquidation_price: calculate_liquidation_price(
-            average_entry_price,
-            filled_order.leverage,
-            filled_order.direction,
-        ),
-        // TODO: Remove the PnL, that has to be calculated in the UI
-        position_state: PositionState::Open,
-        collateral,
-        expiry,
-        updated: OffsetDateTime::now_utc(),
-        created: OffsetDateTime::now_utc(),
-        stable: filled_order.stable,
+            db::insert_position(position.clone())?;
+
+            (position, vec![trade])
+        }
+        Some(
+            position @ Position {
+                position_state: PositionState::Resizing,
+                ..
+            },
+        ) => {
+            tracing::info!("Calculating new position after DLC channel has been resized");
+
+            let (position, trades) =
+                position
+                    .clone()
+                    .apply_order(filled_order, expiry, collateral)?;
+
+            let position = position.context("Resized position has vanished")?;
+
+            db::update_position(position.clone())?;
+
+            (position, trades)
+        }
+        Some(position) => {
+            bail!(
+                "Cannot resize position in state {:?}",
+                position.position_state
+            );
+        }
     };
 
-    let position = db::insert_position(have_a_position)?;
+    for trade in trades {
+        db::insert_trade(trade)?;
+    }
+
     event::publish(&EventInternal::PositionUpdateNotification(position));
 
     Ok(())
@@ -214,8 +250,44 @@ pub fn update_position_after_dlc_creation(
 pub fn update_position_after_dlc_closure(filled_order: Option<Order>) -> Result<()> {
     tracing::debug!(?filled_order, "Removing position after DLC channel closure");
 
-    if db::get_positions()?.is_empty() {
-        tracing::warn!("No position to remove");
+    let position = match db::get_positions()?.as_slice() {
+        [position] => position.clone(),
+        [position, ..] => {
+            tracing::warn!("Found more than one position. Taking the first one");
+            position.clone()
+        }
+        [] => {
+            tracing::warn!("No position to remove");
+            return Ok(());
+        }
+    };
+
+    if let Some(filled_order) = filled_order {
+        tracing::debug!(
+            ?position,
+            ?filled_order,
+            "Calculating closing trades for position"
+        );
+
+        // After closing the DLC channel we do not need to update the position's expiry anymore.
+        let expiry = position.expiry;
+        // The collateral is 0 since the DLC channel has been closed.
+        let actual_collateral = 0;
+        let (new_position, trades) =
+            position.apply_order(filled_order, expiry, actual_collateral)?;
+
+        tracing::debug!(?trades, "Calculated closing trades");
+
+        if let Some(new_position) = new_position {
+            tracing::warn!(
+                ?new_position,
+                "Expected computed position to vanish after applying closing order"
+            );
+        }
+
+        for trade in trades {
+            db::insert_trade(trade)?;
+        }
     }
 
     db::delete_positions()?;

--- a/mobile/native/src/trade/position/mod.rs
+++ b/mobile/native/src/trade/position/mod.rs
@@ -1,3 +1,19 @@
+use crate::calculations::calculate_liquidation_price;
+use crate::calculations::calculate_pnl;
+use crate::trade::order::Order;
+use crate::trade::order::OrderState;
+use crate::trade::order::OrderType;
+use crate::trade::Trade;
+use anyhow::bail;
+use anyhow::ensure;
+use anyhow::Result;
+use bitcoin::Amount;
+use bitcoin::SignedAmount;
+use orderbook_commons::order_matching_fee_taker;
+use rust_decimal::prelude::FromPrimitive;
+use rust_decimal::prelude::ToPrimitive;
+use rust_decimal::Decimal;
+use rust_decimal::RoundingStrategy;
 use time::OffsetDateTime;
 use trade::ContractSymbol;
 use trade::Direction;
@@ -28,7 +44,6 @@ pub enum PositionState {
     /// Transitions:
     /// Open->Closing
     Closing,
-
     /// The position is in rollover
     ///
     /// This is a technical intermediate state indicating that a rollover is currently in progress.
@@ -36,6 +51,11 @@ pub enum PositionState {
     /// Transitions:
     /// Open->Rollover
     Rollover,
+    /// The position is being resized.
+    ///
+    /// Transitions:
+    /// Open->Resizing.
+    Resizing,
 }
 
 #[derive(Debug, Clone)]
@@ -52,4 +72,864 @@ pub struct Position {
     pub updated: OffsetDateTime,
     pub created: OffsetDateTime,
     pub stable: bool,
+}
+
+impl Position {
+    /// Construct a new open position from an initial [`OrderState::Filled`] order.
+    pub fn new_open(
+        order: Order,
+        actual_collateral_sat: u64,
+        expiry: OffsetDateTime,
+    ) -> (Self, Trade) {
+        let now_timestamp = OffsetDateTime::now_utc();
+
+        let average_entry_price = order.execution_price().expect("order to be filled");
+
+        let liquidation_price =
+            calculate_liquidation_price(average_entry_price, order.leverage, order.direction);
+
+        let contracts = decimal_from_f32(order.quantity);
+
+        {
+            let leverage = decimal_from_f32(order.leverage);
+            let average_entry_price = decimal_from_f32(average_entry_price);
+
+            let expected_collateral_btc = contracts / (leverage * average_entry_price);
+            let expected_collateral_btc = expected_collateral_btc
+                .round_dp_with_strategy(8, RoundingStrategy::MidpointAwayFromZero)
+                .to_f64()
+                .expect("collateral to fit into f64");
+
+            let calculated_collateral_sat = Amount::from_btc(expected_collateral_btc)
+                .expect("collateral to fit into Amount")
+                .to_sat();
+
+            debug_assert!(actual_collateral_sat == calculated_collateral_sat);
+
+            if actual_collateral_sat != calculated_collateral_sat {
+                tracing::debug!(
+                    actual_sat = %actual_collateral_sat,
+                    expected_sat = %calculated_collateral_sat,
+                    "Actual DLC collateral for new position different to calculated"
+                );
+            }
+        }
+
+        let position = Self {
+            leverage: order.leverage,
+            quantity: order.quantity,
+            contract_symbol: order.contract_symbol,
+            direction: order.direction,
+            average_entry_price,
+            liquidation_price,
+            position_state: PositionState::Open,
+            collateral: actual_collateral_sat,
+            expiry,
+            updated: now_timestamp,
+            created: now_timestamp,
+            stable: order.stable,
+        };
+
+        let average_entry_price = decimal_from_f32(average_entry_price);
+        let fee = order_matching_fee_taker(order.quantity, average_entry_price);
+
+        let trade = Trade {
+            order_id: order.id,
+            contract_symbol: order.contract_symbol,
+            contracts,
+            direction: order.direction,
+            trade_cost: SignedAmount::from_sat(actual_collateral_sat as i64),
+            fee,
+            pnl: None,
+            price: average_entry_price,
+            timestamp: now_timestamp,
+        };
+
+        (position, trade)
+    }
+
+    pub fn apply_order(
+        self,
+        order: Order,
+        expiry: OffsetDateTime,
+        actual_collateral_sat: u64,
+    ) -> Result<(Option<Self>, Vec<Trade>)> {
+        match order {
+            Order {
+                state: OrderState::Filled { .. } | OrderState::Filling { .. },
+                ..
+            } => {}
+            _ => bail!("Cannot apply order that is not filling or filled"),
+        };
+
+        ensure!(
+            self.contract_symbol == order.contract_symbol,
+            "Cannot apply order to position if contract symbol does not match"
+        );
+
+        ensure!(
+            order.order_type == OrderType::Market,
+            "Cannot apply limit order to position"
+        );
+
+        let mut trades = Vec::new();
+        let position = self.apply_order_recursive(order, expiry, &mut trades)?;
+
+        {
+            let calculated_collateral_sat =
+                position.as_ref().map(|p| p.collateral).unwrap_or_default();
+
+            if actual_collateral_sat != calculated_collateral_sat {
+                tracing::debug!(
+                    actual_sat = %actual_collateral_sat,
+                    calculated_sat = %calculated_collateral_sat,
+                    "Actual DLC collateral for position different to calculated"
+                );
+            }
+        }
+
+        Ok((position, trades))
+    }
+
+    /// Apply an [`Order`] to the [`Position`] recursively until the order is fully applied. Each
+    /// application of the order can (1) reduce the position, (2) reduce the position down to zero
+    /// contracts or (3) increase the position. By combining (2) and (3) through recursion we are
+    /// able to apply orders which change the direction of the position.
+    ///
+    /// NOTE: The order's leverage is ignored when applying an order to an existing position. It
+    /// does not seem to make much sense to allow a trader to both change the number and/or
+    /// direction of contracts (the point of creating a new order) _and_ to change the leverage.
+    /// Also, it's not so straightforward to calculate combined leverages, particularly when
+    /// reducing a position.
+    ///
+    /// TODO: This highlights the fact that orders really shouldn't have a leverage associated with
+    /// them!
+    fn apply_order_recursive(
+        self,
+        order: Order,
+        expiry: OffsetDateTime,
+        trades: &mut Vec<Trade>,
+    ) -> Result<Option<Self>> {
+        // The order has been fully applied.
+        if order.quantity == 0.0 {
+            // The position has vanished.
+            if self.quantity == 0.0 {
+                return Ok(None);
+            }
+            // What is left of the position after fully applying the order.
+            else {
+                return Ok(Some(self));
+            }
+        }
+
+        let now_timestamp = OffsetDateTime::now_utc();
+
+        let order_id = order.id;
+
+        let starting_contracts = decimal_from_f32(self.quantity);
+        let starting_leverage = decimal_from_f32(self.leverage);
+        let starting_average_execution_price = decimal_from_f32(self.average_entry_price);
+
+        let order_contracts = decimal_from_f32(order.quantity);
+        let order_execution_price = decimal_from_f32(
+            order
+                .execution_price()
+                .expect("order to have an execution price"),
+        );
+
+        // If the directions differ (and the position has contracts!) we must reduce the position
+        // (first).
+        let (position, order, trade): (Position, Order, Trade) = if self.quantity != 0.0
+            && order.direction != self.direction
+        {
+            let contract_diff = self.quantity - order.quantity;
+
+            // Reduce position and order to 0.
+            if contract_diff == 0.0 {
+                let fee = order_matching_fee_taker(order.quantity, order_execution_price);
+
+                let trade_cost = {
+                    let margin_before_btc =
+                        starting_contracts / (starting_leverage * starting_average_execution_price);
+
+                    let margin_before_btc = margin_before_btc
+                        .round_dp_with_strategy(8, RoundingStrategy::MidpointAwayFromZero)
+                        .to_f64()
+                        .expect("margin to fit into f64");
+
+                    // `margin_before_btc` is a positive number so we have to make it negative so
+                    // that reducing the position results in a negative `trade_cost` i.e. money into
+                    // the Lightning wallet.
+                    SignedAmount::from_btc(-margin_before_btc)
+                        .expect("margin to fit into SignedAmount")
+                };
+
+                let pnl = {
+                    let pnl = calculate_pnl(
+                        self.average_entry_price,
+                        trade::Price {
+                            bid: order_execution_price,
+                            ask: order_execution_price,
+                        },
+                        order.quantity,
+                        self.leverage,
+                        self.direction,
+                    )?;
+                    SignedAmount::from_sat(pnl)
+                };
+
+                let trade = Trade {
+                    order_id,
+                    contract_symbol: order.contract_symbol,
+                    contracts: order_contracts,
+                    direction: order.direction,
+                    trade_cost,
+                    fee,
+                    pnl: Some(pnl),
+                    price: order_execution_price,
+                    timestamp: now_timestamp,
+                };
+
+                let position = Position {
+                    quantity: 0.0,
+                    ..self
+                };
+
+                let order = Order {
+                    quantity: 0.0,
+                    ..order
+                };
+
+                (position, order, trade)
+            }
+            // Reduce position and consume entire order.
+            else if contract_diff.is_sign_positive() {
+                let starting_contracts_relative =
+                    compute_relative_contracts(self.quantity, self.direction);
+                let order_contracts_relative =
+                    compute_relative_contracts(order.quantity, order.direction);
+                let total_contracts_relative =
+                    starting_contracts_relative + order_contracts_relative;
+
+                let updated_average_execution_price = total_contracts_relative
+                    / (starting_contracts_relative / starting_average_execution_price
+                        + order_contracts_relative / order_execution_price);
+
+                let updated_collateral = {
+                    let updated_collateral_btc = total_contracts_relative
+                        / (starting_leverage * updated_average_execution_price);
+
+                    let updated_collateral_btc = updated_collateral_btc
+                        .abs()
+                        .round_dp_with_strategy(8, RoundingStrategy::MidpointAwayFromZero)
+                        .to_f64()
+                        .expect("collateral to fit into f64");
+
+                    Amount::from_btc(updated_collateral_btc)
+                        .expect("collateral to fit into Amount")
+                        .to_sat()
+                };
+
+                let updated_liquidation_price = calculate_liquidation_price(
+                    f32_from_decimal(updated_average_execution_price),
+                    f32_from_decimal(starting_leverage),
+                    self.direction,
+                );
+
+                let stable = self.stable && order.stable && self.direction == Direction::Short;
+
+                let position = Position {
+                    leverage: f32_from_decimal(starting_leverage),
+                    quantity: contract_diff,
+                    contract_symbol: self.contract_symbol,
+                    direction: self.direction,
+                    average_entry_price: f32_from_decimal(updated_average_execution_price),
+                    liquidation_price: updated_liquidation_price,
+                    position_state: PositionState::Open,
+                    collateral: updated_collateral,
+                    expiry,
+                    updated: now_timestamp,
+                    created: self.created,
+                    stable,
+                };
+
+                let fee = order_matching_fee_taker(order.quantity, order_execution_price);
+
+                // The difference between the margin before the trade and the margin after the
+                // trade determines how much money we move between the DLC channel and the
+                // Lightning channel.
+                let trade_cost = {
+                    let margin_before_btc = starting_contracts_relative.abs()
+                        / (starting_leverage * starting_average_execution_price);
+
+                    let margin_after_btc = total_contracts_relative.abs()
+                        / (starting_leverage * updated_average_execution_price);
+
+                    let margin_diff_btc = (margin_after_btc.abs() - margin_before_btc.abs())
+                        .abs()
+                        .round_dp_with_strategy(8, RoundingStrategy::MidpointAwayFromZero)
+                        .to_f64()
+                        .expect("margin to fit into f64");
+
+                    // `margin_change_btc` is a positive number since we calculated it using `abs`.
+                    // Because this is the result of applying an order that reduces the position we
+                    // want `trade_cost` to be negative so we add the negative sign.
+                    SignedAmount::from_btc(-margin_diff_btc)
+                        .expect("margin to fit into SignedAmount")
+                };
+
+                let pnl = {
+                    let pnl = calculate_pnl(
+                        self.average_entry_price,
+                        trade::Price {
+                            bid: order_execution_price,
+                            ask: order_execution_price,
+                        },
+                        order.quantity,
+                        self.leverage,
+                        self.direction,
+                    )?;
+                    SignedAmount::from_sat(pnl)
+                };
+
+                let trade = Trade {
+                    order_id,
+                    contract_symbol: self.contract_symbol,
+                    contracts: order_contracts_relative.abs(),
+                    direction: order.direction,
+                    trade_cost,
+                    fee,
+                    pnl: Some(pnl),
+                    price: order_execution_price,
+                    timestamp: now_timestamp,
+                };
+
+                let order = Order {
+                    quantity: 0.0,
+                    ..order
+                };
+
+                (position, order, trade)
+            }
+            // Reduce position to 0, with leftover order.
+            else {
+                let leftover_order_contracts = contract_diff.abs();
+
+                // This trade only includes the fee for the part of the other that was applied
+                // thus far.
+                let fee = order_matching_fee_taker(self.quantity, order_execution_price);
+
+                let trade_cost = {
+                    let margin_before_btc =
+                        starting_contracts / (starting_leverage * starting_average_execution_price);
+
+                    let margin_before_btc = margin_before_btc
+                        .abs()
+                        .round_dp_with_strategy(8, RoundingStrategy::MidpointAwayFromZero)
+                        .to_f64()
+                        .expect("margin to fit into f64");
+
+                    // `margin_before_btc` is a positive number so we have to make it negative so
+                    // that reducing the position results in a negative `trade_cost` i.e. money into
+                    // the Lightning wallet.
+                    SignedAmount::from_btc(-margin_before_btc)
+                        .expect("margin to fit into SignedAmount")
+                };
+
+                let pnl = {
+                    let pnl = calculate_pnl(
+                        self.average_entry_price,
+                        trade::Price {
+                            bid: order_execution_price,
+                            ask: order_execution_price,
+                        },
+                        self.quantity,
+                        self.leverage,
+                        self.direction,
+                    )?;
+                    SignedAmount::from_sat(pnl)
+                };
+
+                let trade = Trade {
+                    order_id,
+                    contract_symbol: order.contract_symbol,
+                    contracts: starting_contracts,
+                    direction: order.direction,
+                    trade_cost,
+                    fee,
+                    pnl: Some(pnl),
+                    price: order_execution_price,
+                    timestamp: now_timestamp,
+                };
+
+                let position = Position {
+                    quantity: 0.0,
+
+                    ..self
+                };
+
+                // Reduce the order without vanishing it.
+                let order = Order {
+                    quantity: leftover_order_contracts,
+                    ..order
+                };
+
+                (position, order, trade)
+            }
+        }
+        // If the directions agree or the position has no contracts we must increase the position.
+        else {
+            let starting_contracts_relative =
+                compute_relative_contracts(self.quantity, self.direction);
+            let order_contracts_relative =
+                compute_relative_contracts(order.quantity, order.direction);
+            let total_contracts_relative = starting_contracts_relative + order_contracts_relative;
+
+            let updated_average_execution_price = total_contracts_relative
+                / (starting_contracts_relative / starting_average_execution_price
+                    + order_contracts_relative / order_execution_price);
+
+            let updated_liquidation_price = calculate_liquidation_price(
+                f32_from_decimal(updated_average_execution_price),
+                f32_from_decimal(starting_leverage),
+                self.direction,
+            );
+
+            let updated_collateral = {
+                let updated_collateral_btc = total_contracts_relative
+                    / (starting_leverage * updated_average_execution_price);
+
+                let updated_collateral_btc = updated_collateral_btc
+                    .abs()
+                    .round_dp_with_strategy(8, RoundingStrategy::MidpointAwayFromZero)
+                    .to_f64()
+                    .expect("collateral to fit into f64");
+
+                Amount::from_btc(updated_collateral_btc)
+                    .expect("collateral to fit into Amount")
+                    .to_sat()
+            };
+
+            let stable = self.stable && order.stable && self.direction == Direction::Short;
+
+            let position = Position {
+                leverage: f32_from_decimal(starting_leverage),
+                quantity: f32_from_decimal(total_contracts_relative.abs()),
+                contract_symbol: self.contract_symbol,
+                direction: order.direction,
+                average_entry_price: f32_from_decimal(updated_average_execution_price),
+                liquidation_price: updated_liquidation_price,
+                position_state: PositionState::Open,
+                collateral: updated_collateral,
+                expiry,
+                updated: now_timestamp,
+                created: self.created,
+                stable,
+            };
+
+            let fee = order_matching_fee_taker(order.quantity, order_execution_price);
+
+            // The difference between the margin before the trade and the margin after the
+            // trade determines how much money we move between the DLC channel and the
+            // Lightning channel.
+            let trade_cost = {
+                let margin_before_btc = starting_contracts_relative.abs()
+                    / (starting_leverage * starting_average_execution_price);
+
+                let margin_after_btc = total_contracts_relative.abs()
+                    / (starting_leverage * updated_average_execution_price);
+
+                let margin_diff_btc = (margin_after_btc - margin_before_btc)
+                    .round_dp_with_strategy(8, RoundingStrategy::MidpointAwayFromZero)
+                    .to_f64()
+                    .expect("margin to fit into f64");
+
+                SignedAmount::from_btc(margin_diff_btc).expect("margin to fit into SignedAmount")
+            };
+
+            let trade = Trade {
+                order_id,
+                contract_symbol: order.contract_symbol,
+                contracts: order_contracts,
+                direction: order.direction,
+                trade_cost,
+                fee,
+                pnl: None,
+                price: order_execution_price,
+                timestamp: now_timestamp,
+            };
+
+            let order = Order {
+                quantity: 0.0,
+                ..order
+            };
+
+            (position, order, trade)
+        };
+
+        trades.push(trade);
+
+        position.apply_order_recursive(order, expiry, trades)
+    }
+}
+
+#[track_caller]
+fn decimal_from_f32(float: f32) -> Decimal {
+    Decimal::from_f32(float).expect("f32 to fit into Decimal")
+}
+
+#[track_caller]
+fn f32_from_decimal(decimal: Decimal) -> f32 {
+    decimal.to_f32().expect("Decimal to fit into f32")
+}
+
+/// Compute the number of contracts for the [`Order`] relative to its [`Direction`].
+fn compute_relative_contracts(contracts: f32, direction: Direction) -> Decimal {
+    let contracts = decimal_from_f32(contracts)
+        // We round to 2 decimal places to avoid slight differences between opening and
+        // closing orders.
+        .round_dp_with_strategy(2, RoundingStrategy::MidpointAwayFromZero);
+
+    match direction {
+        Direction::Long => contracts,
+        Direction::Short => -contracts,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::trade::order::OrderReason;
+    use rust_decimal_macros::dec;
+    use uuid::Uuid;
+
+    #[test]
+    fn open_position() {
+        let now = OffsetDateTime::now_utc();
+
+        let dlc_collateral = 78_125;
+
+        let order = Order {
+            id: Uuid::new_v4(),
+            leverage: 1.0,
+            quantity: 25.0,
+            contract_symbol: ContractSymbol::BtcUsd,
+            direction: Direction::Short,
+            order_type: OrderType::Market,
+            state: OrderState::Filled {
+                execution_price: 32_000.0,
+            },
+            creation_timestamp: now,
+            order_expiry_timestamp: now,
+            reason: OrderReason::Manual,
+            stable: true,
+        };
+
+        let (position, opening_trade) = Position::new_open(order, dlc_collateral, now);
+
+        assert_eq!(position.leverage, 1.0);
+        assert_eq!(position.quantity, 25.0);
+        assert_eq!(position.contract_symbol, position.contract_symbol);
+        assert_eq!(position.direction, order.direction);
+        assert_eq!(position.average_entry_price, 32_000.0);
+        assert_eq!(position.liquidation_price, 1_048_575.0);
+        assert_eq!(position.position_state, PositionState::Open);
+        assert_eq!(position.collateral, 78_125);
+        assert!(position.stable);
+
+        assert_eq!(opening_trade.order_id, order.id);
+        assert_eq!(opening_trade.contract_symbol, order.contract_symbol);
+        assert_eq!(opening_trade.contracts, dec!(25));
+        assert_eq!(opening_trade.direction, order.direction);
+        assert_eq!(opening_trade.trade_cost, SignedAmount::from_sat(78_125));
+        assert_eq!(opening_trade.fee, Amount::from_sat(234));
+        assert_eq!(opening_trade.pnl, None);
+        assert_eq!(
+            opening_trade.price,
+            decimal_from_f32(order.execution_price().unwrap())
+        );
+    }
+
+    #[test]
+    fn close_position() {
+        let now = OffsetDateTime::now_utc();
+
+        let position = Position {
+            leverage: 2.0,
+            quantity: 10.0,
+            contract_symbol: ContractSymbol::BtcUsd,
+            direction: Direction::Long,
+            average_entry_price: 36_469.5,
+            liquidation_price: 24_313.0,
+            position_state: PositionState::Open,
+            collateral: 13_710,
+            expiry: now,
+            updated: now,
+            created: now,
+            stable: false,
+        };
+
+        let order = Order {
+            id: Uuid::new_v4(),
+            leverage: 2.0,
+            quantity: 10.0,
+            contract_symbol: ContractSymbol::BtcUsd,
+            direction: Direction::Short,
+            order_type: OrderType::Market,
+            state: OrderState::Filled {
+                execution_price: 36_401.5,
+            },
+            creation_timestamp: now,
+            order_expiry_timestamp: now,
+            reason: OrderReason::Manual,
+            stable: false,
+        };
+
+        // The DLC channel has been closed.
+        let dlc_collateral_after_resize = 0;
+        let (updated_position, trades) = position
+            .apply_order(order, now, dlc_collateral_after_resize)
+            .unwrap();
+
+        assert!(updated_position.is_none());
+
+        let closing_trade = match trades.as_slice() {
+            [closing_trade] => closing_trade,
+            trades => panic!("Unexpected number of trades: {}", trades.len()),
+        };
+
+        assert_eq!(closing_trade.order_id, order.id);
+        assert_eq!(closing_trade.contract_symbol, order.contract_symbol);
+        assert_eq!(closing_trade.contracts, Decimal::TEN);
+        assert_eq!(closing_trade.direction, order.direction);
+        assert_eq!(closing_trade.trade_cost, SignedAmount::from_sat(-13_710));
+        assert_eq!(closing_trade.fee, Amount::from_sat(82));
+        assert_eq!(closing_trade.pnl, Some(SignedAmount::from_sat(-51)));
+        assert_eq!(
+            closing_trade.price,
+            decimal_from_f32(order.execution_price().unwrap())
+        );
+    }
+
+    #[test]
+    fn extend_position() {
+        let now = OffsetDateTime::now_utc();
+
+        let position = Position {
+            leverage: 2.0,
+            quantity: 10.0,
+            contract_symbol: ContractSymbol::BtcUsd,
+            direction: Direction::Long,
+            average_entry_price: 36_469.5,
+            liquidation_price: 24_313.0,
+            position_state: PositionState::Resizing,
+            collateral: 13_710,
+            expiry: now,
+            updated: now,
+            created: now,
+            stable: false,
+        };
+
+        let order = Order {
+            id: Uuid::new_v4(),
+            leverage: 2.0,
+            quantity: 5.0,
+            contract_symbol: ContractSymbol::BtcUsd,
+            direction: Direction::Long,
+            order_type: OrderType::Market,
+            state: OrderState::Filled {
+                execution_price: 36_401.5,
+            },
+            creation_timestamp: now,
+            order_expiry_timestamp: now,
+            reason: OrderReason::Manual,
+            stable: false,
+        };
+
+        let dlc_collateral_after_resize = 20_578;
+        let (updated_position, trades) = position
+            .clone()
+            .apply_order(order, now, dlc_collateral_after_resize)
+            .unwrap();
+        let updated_position = updated_position.unwrap();
+
+        assert_eq!(updated_position.leverage, 2.0);
+        assert_eq!(updated_position.quantity, 15.0);
+        assert_eq!(updated_position.contract_symbol, position.contract_symbol);
+        assert_eq!(updated_position.direction, position.direction);
+        assert_eq!(updated_position.average_entry_price, 36_446.805);
+        assert_eq!(updated_position.liquidation_price, 24297.873);
+        assert_eq!(updated_position.position_state, PositionState::Open);
+        assert_eq!(updated_position.collateral, 20_578);
+        assert!(!updated_position.stable);
+
+        let trade = match trades.as_slice() {
+            [trade] => trade,
+            trades => panic!("Unexpected number of trades: {}", trades.len()),
+        };
+
+        assert_eq!(trade.order_id, order.id);
+        assert_eq!(trade.contract_symbol, order.contract_symbol);
+        assert_eq!(trade.contracts, dec!(5));
+        assert_eq!(trade.direction, order.direction);
+        assert_eq!(trade.trade_cost, SignedAmount::from_sat(6_868));
+        assert_eq!(trade.fee, Amount::from_sat(41));
+        assert_eq!(trade.pnl, None);
+        assert_eq!(
+            trade.price,
+            decimal_from_f32(order.execution_price().unwrap())
+        );
+    }
+
+    #[test]
+    fn reduce_position() {
+        let now = OffsetDateTime::now_utc();
+
+        let position = Position {
+            leverage: 2.0,
+            quantity: 10.0,
+            contract_symbol: ContractSymbol::BtcUsd,
+            direction: Direction::Long,
+            average_entry_price: 36_469.5,
+            liquidation_price: 24_313.0,
+            position_state: PositionState::Resizing,
+            collateral: 13_710,
+            expiry: now,
+            updated: now,
+            created: now,
+            stable: false,
+        };
+
+        let order = Order {
+            id: Uuid::new_v4(),
+            leverage: 2.0,
+            quantity: 5.0,
+            contract_symbol: ContractSymbol::BtcUsd,
+            direction: Direction::Short,
+            order_type: OrderType::Market,
+            state: OrderState::Filled {
+                execution_price: 36_401.5,
+            },
+            creation_timestamp: now,
+            order_expiry_timestamp: now,
+            reason: OrderReason::Manual,
+            stable: false,
+        };
+
+        let dlc_collateral_after_resize = 6_842;
+        let (updated_position, trades) = position
+            .clone()
+            .apply_order(order, now, dlc_collateral_after_resize)
+            .unwrap();
+        let updated_position = updated_position.unwrap();
+
+        assert_eq!(updated_position.leverage, 2.0);
+        assert_eq!(updated_position.quantity, 5.0);
+        assert_eq!(updated_position.contract_symbol, position.contract_symbol);
+        assert_eq!(updated_position.direction, position.direction);
+        assert_eq!(updated_position.average_entry_price, 36_537.754);
+        assert_eq!(updated_position.liquidation_price, 24_358.5);
+        assert_eq!(updated_position.position_state, PositionState::Open);
+        assert_eq!(updated_position.collateral, 6_842);
+        assert!(!updated_position.stable);
+
+        let trade = match trades.as_slice() {
+            [trade] => trade,
+            trades => panic!("Unexpected number of trades: {}", trades.len()),
+        };
+
+        assert_eq!(trade.order_id, order.id);
+        assert_eq!(trade.contract_symbol, order.contract_symbol);
+        assert_eq!(trade.contracts, dec!(5));
+        assert_eq!(trade.direction, order.direction);
+        assert_eq!(trade.trade_cost, SignedAmount::from_sat(-6_868));
+        assert_eq!(trade.fee, Amount::from_sat(41));
+        assert_eq!(trade.pnl, Some(SignedAmount::from_sat(-26)));
+        assert_eq!(
+            trade.price,
+            decimal_from_f32(order.execution_price().unwrap())
+        );
+    }
+
+    #[test]
+    fn resize_position_from_long_to_short() {
+        let now = OffsetDateTime::now_utc();
+
+        let position = Position {
+            leverage: 2.0,
+            quantity: 10.0,
+            contract_symbol: ContractSymbol::BtcUsd,
+            direction: Direction::Long,
+            average_entry_price: 36_469.5,
+            liquidation_price: 24_313.0,
+            position_state: PositionState::Resizing,
+            collateral: 13_710,
+            expiry: now,
+            updated: now,
+            created: now,
+            stable: false,
+        };
+
+        let order = Order {
+            id: Uuid::new_v4(),
+            leverage: 2.0,
+            quantity: 20.0,
+            contract_symbol: ContractSymbol::BtcUsd,
+            direction: Direction::Short,
+            order_type: OrderType::Market,
+            state: OrderState::Filled {
+                execution_price: 36_401.5,
+            },
+            creation_timestamp: now,
+            order_expiry_timestamp: now,
+            reason: OrderReason::Manual,
+            stable: false,
+        };
+
+        let dlc_collateral_after_resize = 13_736;
+        let (updated_position, trades) = position
+            .clone()
+            .apply_order(order, now, dlc_collateral_after_resize)
+            .unwrap();
+        let updated_position = updated_position.unwrap();
+
+        assert_eq!(updated_position.leverage, 2.0);
+        assert_eq!(updated_position.quantity, 10.0);
+        assert_eq!(updated_position.contract_symbol, position.contract_symbol);
+        assert_eq!(updated_position.direction, order.direction);
+        assert_eq!(updated_position.average_entry_price, 36_401.5);
+        assert_eq!(updated_position.liquidation_price, 24_267.666);
+        assert_eq!(updated_position.position_state, PositionState::Open);
+        assert_eq!(updated_position.collateral, 13_736);
+        assert!(!updated_position.stable);
+
+        let (closing_trade, opening_trade) = match trades.as_slice() {
+            [closing_trade, opening_trade] => (closing_trade, opening_trade),
+            trades => panic!("Unexpected number of trades: {}", trades.len()),
+        };
+
+        assert_eq!(closing_trade.order_id, order.id);
+        assert_eq!(closing_trade.contract_symbol, order.contract_symbol);
+        assert_eq!(closing_trade.contracts, Decimal::TEN);
+        assert_eq!(closing_trade.direction, order.direction);
+        assert_eq!(closing_trade.trade_cost, SignedAmount::from_sat(-13_710));
+        assert_eq!(closing_trade.fee, Amount::from_sat(82));
+        assert_eq!(closing_trade.pnl, Some(SignedAmount::from_sat(-51)));
+        assert_eq!(
+            closing_trade.price,
+            decimal_from_f32(order.execution_price().unwrap())
+        );
+
+        assert_eq!(opening_trade.order_id, order.id);
+        assert_eq!(opening_trade.contract_symbol, order.contract_symbol);
+        assert_eq!(opening_trade.contracts, Decimal::TEN);
+        assert_eq!(opening_trade.direction, order.direction);
+        assert_eq!(opening_trade.trade_cost, SignedAmount::from_sat(13_736));
+        assert_eq!(opening_trade.fee, Amount::from_sat(82));
+        assert_eq!(opening_trade.pnl, None);
+        assert_eq!(
+            opening_trade.price,
+            decimal_from_f32(order.execution_price().unwrap())
+        );
+    }
 }


### PR DESCRIPTION
Fixes #1543.

Test is passing, but a few things left to do:

- [x] Update app position fields when we set the position state from `Resizing` back to `Open`. For instance, the number of contracts needs to be updated!
- [x] Ensure that app trader can keep trading after resizing. Write a test for this.
- [x] Probably a few more things 😁 

---

A video[^1] with a lot of minor bugs, but it "works" and the entry in the trade history at the end appears to be correct:

https://github.com/get10101/10101/assets/9418575/04c74c51-f9ef-4a91-80a6-22a5df16ea8e


[^1]: This is still the old video, I'll update it tomorrow. It looks better, so you can check out the PR if you want!
