### PR TITLE
Update coordinator version in `Cargo.lock`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -663,7 +663,7 @@ dependencies = [
 
 [[package]]
 name = "coordinator"
-version = "1.4.4"
+version = "1.5.0"
 dependencies = [
  "anyhow",
  "atty",


### PR DESCRIPTION
Building locally updates the `Cargo.lock` automatically. I think this should have happened when we updated the coordinator's `Cargo.toml`.