### PR TITLE
feat: Support multiple oracles

### DIFF
--- a/.github/workflows/build-release-binaries.yml
+++ b/.github/workflows/build-release-binaries.yml
@@ -36,8 +36,8 @@ jobs:
       coordinator_port_http: 80
       network: mainnet
       tag: ${{ github.ref_name }}
-      oracle_endpoint: https://oracle.holzeis.me
-      oracle_pubkey: 16f88cf7d21e6c0f46bcbc983a4e3b19726c6c98858cc31c83551a88fde171c0
+      oracle_endpoint: http://oracle.10101.finance
+      oracle_pubkey: 93051f54feefdb4765492a85139c436d4857e2e331a360c89a16d6bc02ba9cd0
       fastlane_developer_app_identifier: finance.get10101.app
       fastlane_provisioning_profile_specifier: match AppStore finance.get10101.app 1692208014
       app_scheme: Runner
@@ -54,5 +54,5 @@ jobs:
       coordinator_p2p_endpoint: 022ae8dbec1caa4dac93f07f2ebf5ad7a5dd08d375b79f11095e81b065c2155156@46.17.98.29:9045
       coordinator_port_http: 80
       network: mainnet
-      oracle_endpoint: https://oracle.holzeis.me
-      oracle_pubkey: 16f88cf7d21e6c0f46bcbc983a4e3b19726c6c98858cc31c83551a88fde171c0
+      oracle_endpoint: http://oracle.10101.finance
+      oracle_pubkey: 93051f54feefdb4765492a85139c436d4857e2e331a360c89a16d6bc02ba9cd0

--- a/coordinator/src/bin/coordinator.rs
+++ b/coordinator/src/bin/coordinator.rs
@@ -1,5 +1,6 @@
 use anyhow::Context;
 use anyhow::Result;
+use bitcoin::XOnlyPublicKey;
 use coordinator::backup::SledBackup;
 use coordinator::cli::Opts;
 use coordinator::logger;
@@ -37,6 +38,7 @@ use std::backtrace::Backtrace;
 use std::net::IpAddr;
 use std::net::Ipv4Addr;
 use std::net::SocketAddr;
+use std::str::FromStr;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::broadcast;
@@ -124,7 +126,11 @@ async fn main() -> Result<()> {
         seed,
         ephemeral_randomness,
         settings.ln_dlc.clone(),
-        opts.get_oracle_info().into(),
+        opts.get_oracle_infos()
+            .into_iter()
+            .map(|o| o.into())
+            .collect(),
+        XOnlyPublicKey::from_str(&opts.oracle_pubkey).expect("valid public key"),
     )?);
 
     let event_handler = CoordinatorEventHandler::new(node.clone(), Some(node_event_sender));

--- a/coordinator/src/bin/coordinator.rs
+++ b/coordinator/src/bin/coordinator.rs
@@ -226,12 +226,14 @@ async fn main() -> Result<()> {
         tx_price_feed.clone(),
         auth_users_notifier.clone(),
         network,
+        node.inner.oracle_pubkey,
     );
     let _handle = async_match::monitor(
         pool.clone(),
         tx_user_feed.clone(),
         auth_users_notifier.clone(),
         network,
+        node.inner.oracle_pubkey,
     );
     let _handle = rollover::monitor(
         pool.clone(),

--- a/coordinator/src/node.rs
+++ b/coordinator/src/node.rs
@@ -294,7 +294,7 @@ impl Node {
         // The contract input to be used for setting up the trade between the trader and the
         // coordinator
         let event_id = format!("{contract_symbol}{maturity_time}");
-        tracing::debug!(event_id, "Proposing dlc channel");
+        tracing::debug!(event_id, oracle=%self.inner.oracle_pubkey, "Proposing dlc channel");
         let contract_input = ContractInput {
             offer_collateral: margin_coordinator - fee,
             // the accepting party has do bring in additional margin for the fees
@@ -303,7 +303,7 @@ impl Node {
             contract_infos: vec![ContractInputInfo {
                 contract_descriptor,
                 oracles: OracleInput {
-                    public_keys: vec![self.inner.oracle_pk()],
+                    public_keys: vec![self.inner.oracle_pubkey],
                     event_id,
                     threshold: 1,
                 },

--- a/coordinator/src/node.rs
+++ b/coordinator/src/node.rs
@@ -294,7 +294,7 @@ impl Node {
         // The contract input to be used for setting up the trade between the trader and the
         // coordinator
         let event_id = format!("{contract_symbol}{maturity_time}");
-        tracing::debug!(event_id, oracle=%self.inner.oracle_pubkey, "Proposing dlc channel");
+        tracing::debug!(event_id, oracle=%trade_params.filled_with.oracle_pk, "Proposing dlc channel");
         let contract_input = ContractInput {
             offer_collateral: margin_coordinator - fee,
             // the accepting party has do bring in additional margin for the fees
@@ -303,7 +303,7 @@ impl Node {
             contract_infos: vec![ContractInputInfo {
                 contract_descriptor,
                 oracles: OracleInput {
-                    public_keys: vec![self.inner.oracle_pubkey],
+                    public_keys: vec![trade_params.filled_with.oracle_pk],
                     event_id,
                     threshold: 1,
                 },

--- a/coordinator/src/node/resize.rs
+++ b/coordinator/src/node/resize.rs
@@ -237,7 +237,7 @@ impl Node {
                     contract_infos: vec![ContractInputInfo {
                         contract_descriptor,
                         oracles: OracleInput {
-                            public_keys: vec![self.inner.oracle_pk()],
+                            public_keys: vec![self.inner.oracle_pubkey],
                             event_id,
                             threshold: 1,
                         },

--- a/crates/ln-dlc-node/src/node/oracle.rs
+++ b/crates/ln-dlc-node/src/node/oracle.rs
@@ -23,7 +23,11 @@ impl From<OracleInfo> for P2PDOracleClient {
 }
 
 impl<S: TenTenOneStorage, N: Storage> Node<S, N> {
-    pub fn oracle_pk(&self) -> XOnlyPublicKey {
-        self.oracle.get_public_key()
+    pub fn oracle_pk(&self) -> Vec<XOnlyPublicKey> {
+        self.oracles
+            .clone()
+            .into_iter()
+            .map(|oracle| oracle.get_public_key())
+            .collect()
     }
 }

--- a/crates/ln-dlc-node/src/tests/dlc/create.rs
+++ b/crates/ln-dlc-node/src/tests/dlc/create.rs
@@ -61,7 +61,7 @@ pub async fn create_dlc_channel(
 ) -> Result<()> {
     // Act
 
-    let oracle_pk = offer_node.oracle_pk();
+    let oracle_pk = *offer_node.oracle_pk().first().unwrap();
     let contract_input =
         dummy_contract_input(app_dlc_collateral, coordinator_dlc_collateral, oracle_pk);
 

--- a/crates/ln-dlc-node/src/tests/dlc/dlc_setup_with_reconnects.rs
+++ b/crates/ln-dlc-node/src/tests/dlc/dlc_setup_with_reconnects.rs
@@ -49,7 +49,7 @@ async fn reconnecting_during_dlc_channel_setup() {
 
     // Act
 
-    let oracle_pk = app.oracle_pk();
+    let oracle_pk = *app.oracle_pk().first().unwrap();
     let contract_input = dummy_contract_input(20_000, 20_000, oracle_pk);
 
     app.propose_dlc_channel(channel_details.clone(), contract_input)
@@ -402,7 +402,7 @@ async fn can_lose_connection_before_processing_subchannel_accept() {
         .await
         .unwrap();
 
-    let oracle_pk = app.oracle_pk();
+    let oracle_pk = *app.oracle_pk().first().unwrap();
     let contract_input =
         dummy_contract_input(coordinator_dlc_collateral, app_dlc_collateral, oracle_pk);
 

--- a/crates/ln-dlc-node/src/tests/load/coordinator.rs
+++ b/crates/ln-dlc-node/src/tests/load/coordinator.rs
@@ -165,7 +165,7 @@ impl Coordinator {
             filled_with: FilledWith {
                 order_id,
                 expiry_timestamp,
-                oracle_pk: app.oracle_pk(),
+                oracle_pk: *app.oracle_pk().first().unwrap(),
                 matches: vec![Match {
                     order_id: Uuid::new_v4(),
                     quantity: Decimal::from_f32(quantity).unwrap(),

--- a/crates/ln-dlc-node/src/tests/mod.rs
+++ b/crates/ln-dlc-node/src/tests/mod.rs
@@ -191,7 +191,8 @@ impl Node<TenTenOneInMemoryStorage, InMemoryStore> {
             seed,
             ephemeral_randomness,
             settings,
-            oracle.into(),
+            vec![oracle.into()],
+            XOnlyPublicKey::from_str(ORACLE_PUBKEY)?,
         )?;
         let node = Arc::new(node);
 

--- a/maker/src/bin/maker.rs
+++ b/maker/src/bin/maker.rs
@@ -98,7 +98,8 @@ async fn main() -> Result<()> {
         seed,
         ephemeral_randomness,
         LnDlcNodeSettings::default(),
-        opts.get_oracle_info().into(),
+        vec![opts.get_oracle_info().into()],
+        opts.get_oracle_info().public_key,
     )?);
 
     let event_handler = EventHandler::new(node.clone());

--- a/mobile/native/src/ln_dlc/mod.rs
+++ b/mobile/native/src/ln_dlc/mod.rs
@@ -198,7 +198,7 @@ pub async fn update_node_settings(settings: LnDlcNodeSettings) {
 }
 
 pub fn get_oracle_pubkey() -> XOnlyPublicKey {
-    crate::state::get_node().inner.oracle_pk()
+    crate::state::get_node().inner.oracle_pubkey
 }
 
 pub fn get_funding_transaction(channel_id: &ChannelId) -> Result<Txid> {
@@ -304,7 +304,8 @@ pub fn run(seed_dir: String, runtime: &Runtime) -> Result<()> {
             seed,
             ephemeral_randomness,
             LnDlcNodeSettings::default(),
-            config::get_oracle_info().into(),
+            vec![config::get_oracle_info().into()],
+            config::get_oracle_info().public_key,
         )?;
         let node = Arc::new(node);
 


### PR DESCRIPTION
This is a preparation step allowing the coordinator to accept multiple oracles as argument, to be able to force-close outdated positions, that have not been migrated to the new oracle.

The oracle_pubkey defines what oracle to be used for proposing new dlc channels

related to https://github.com/get10101/cloud-conf/issues/233

----

The oracle data is passed to the coordinator arguments like that

```
--oracle [pubkey1]@[host1] --oracle [pubkey2]@[host2] --oracle_pubkey [pubkey2]
```

This will tell the coordinator to build 2 oracle clients and use the second to for dlc channel proposals.