### PR TITLE
fix: Do not call periodic check twice

### DIFF
--- a/crates/ln-dlc-node/src/node/mod.rs
+++ b/crates/ln-dlc-node/src/node/mod.rs
@@ -883,11 +883,9 @@ fn manage_dlc_manager<S: TenTenOneStorage + 'static, N: Storage + Sync + Send + 
             loop {
                 tracing::trace!("Started periodic dlc manager check");
                 let now = Instant::now();
+
                 if let Err(e) = dlc_manager.periodic_chain_monitor() {
                     tracing::error!("Failed to perform periodic chain monitor check: {e:#}");
-                };
-                if let Err(e) = dlc_manager.periodic_check() {
-                    tracing::error!("Failed to perform periodic check: {e:#}");
                 };
 
                 tracing::trace!(


### PR DESCRIPTION
The periodic check is already called in a loop by the `sub_channel_manager_periodic_check`. I don't see a reason to do it multiple times.

Also finalizing a force-closure with the `period_check` called from the manager lead to a panic, when trying to get the attestations from the oracle.

fixes #1586 