### PR TITLE
fix: Only print counterparty pubkey from rollover

### DIFF
--- a/coordinator/src/node/rollover.rs
+++ b/coordinator/src/node/rollover.rs
@@ -202,7 +202,7 @@ impl Node {
         let contract = self.inner.get_contract_by_dlc_channel_id(dlc_channel_id)?;
         let rollover = Rollover::new(contract, network)?;
 
-        tracing::debug!(?rollover, "Rollover dlc channel");
+        tracing::debug!(node_id=%rollover.counterparty_pubkey, "Rollover dlc channel");
 
         let contract_input: ContractInput = rollover.clone().into();
 


### PR DESCRIPTION
The message also included the payout function which spammed the logs.