### PR TITLE
feat: Support anchor outputs on ln channels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Enable anchor outputs on ln channels
+
 ## [1.5.1] - 2023-11-16
 
 - Add on-boarding wizard

--- a/crates/ln-dlc-node/src/config.rs
+++ b/crates/ln-dlc-node/src/config.rs
@@ -38,6 +38,8 @@ pub fn app_config() -> UserConfig {
             // We want the coordinator to recover force-close funds as soon as possible. We choose
             // 144 because we can't go any lower according to LDK.
             our_to_self_delay: 144,
+            // enable anchor output support
+            negotiate_anchors_zero_fee_htlc_tx: true,
             ..Default::default()
         },
         channel_handshake_limits: ChannelHandshakeLimits {
@@ -81,6 +83,8 @@ pub fn coordinator_config() -> UserConfig {
             // Our channel peers are allowed to get back their funds ~24 hours after a
             // force-closure.
             our_to_self_delay: 144,
+            // enable anchor output support
+            negotiate_anchors_zero_fee_htlc_tx: true,
             ..Default::default()
         },
         channel_handshake_limits: ChannelHandshakeLimits {
@@ -111,9 +115,9 @@ pub fn coordinator_config() -> UserConfig {
         // This config is needed to forward payments to the 10101 app, which only have private
         // channels with the coordinator.
         accept_forwards_to_priv_channels: true,
-        // The coordinator automatically accepts any inbound channels if they adhere to its channel
-        // preferences.
-        manually_accept_inbound_channels: false,
+        // By enabling anchor outputs, we have to manually check if the provided reserve is
+        // sufficient.
+        manually_accept_inbound_channels: true,
         ..Default::default()
     }
 }

--- a/crates/ln-dlc-node/src/ln/coordinator_event_handler.rs
+++ b/crates/ln-dlc-node/src/ln/coordinator_event_handler.rs
@@ -15,6 +15,7 @@ use crate::storage::TenTenOneStorage;
 use crate::EventHandlerTrait;
 use crate::CONFIRMATION_TARGET;
 use anyhow::anyhow;
+use anyhow::bail;
 use anyhow::ensure;
 use anyhow::Context;
 use anyhow::Result;
@@ -25,6 +26,7 @@ use dlc_manager::subchannel::LNChannelManager;
 use lightning::chain::chaininterface::FeeEstimator;
 use lightning::events::Event;
 use lightning::ln::channelmanager::InterceptId;
+use lightning::ln::features::ChannelTypeFeatures;
 use lightning::ln::PaymentHash;
 use parking_lot::Mutex;
 use rust_decimal::prelude::ToPrimitive;
@@ -33,6 +35,13 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::task::block_in_place;
+
+/// Specifies the minimum reserve required by the counterparty if we are accepting an anchored
+/// channel
+///
+/// TODO(holzeis): This value is chosen arbitrarily, but should cover the on-chain costs for going
+/// on-chain.
+const MIN_COUNTERPARTY_RESERVE_SATS: u64 = 10_000;
 
 /// Event handler for the coordinator node.
 // TODO: Move it out of this crate
@@ -112,7 +121,7 @@ impl<S: TenTenOneStorage + 'static, N: Storage + Send + Sync + 'static> EventHan
                 counterparty_node_id,
                 funding_satoshis,
                 push_msat,
-                ..
+                channel_type,
             } => {
                 handle_open_channel_request(
                     &self.node.channel_manager,
@@ -120,6 +129,7 @@ impl<S: TenTenOneStorage + 'static, N: Storage + Send + Sync + 'static> EventHan
                     funding_satoshis,
                     push_msat,
                     temporary_channel_id,
+                    channel_type,
                 )?;
             }
             Event::PaymentPathSuccessful {
@@ -345,14 +355,36 @@ fn handle_open_channel_request<S: TenTenOneStorage, N: Storage>(
     funding_satoshis: u64,
     push_msat: u64,
     temporary_channel_id: [u8; 32],
+    channel_type: ChannelTypeFeatures,
 ) -> Result<()> {
     let counterparty = counterparty_node_id.to_string();
     tracing::info!(
         counterparty,
         funding_satoshis,
         push_msat,
-        "Accepting open channel request"
+        "Handling open channel request"
     );
+
+    if channel_type.requires_zero_conf() {
+        let reason = "We do not accept zero-conf inbound channels";
+        bail!("Rejecting open channel request. Reason: {reason}");
+    }
+
+    if channel_type.requires_anchors_zero_fee_htlc_tx() {
+        let counterparty_reserve = channel_manager
+            .get_channel_details(&temporary_channel_id)
+            .context("Couldn't find channel by temporary channel id")?
+            .counterparty
+            .unspendable_punishment_reserve;
+        if counterparty_reserve < MIN_COUNTERPARTY_RESERVE_SATS {
+            let reason = format!(
+                "The unspendable counterparty punishment reserve is too small. \
+                Min {MIN_COUNTERPARTY_RESERVE_SATS} sats, got {counterparty_reserve} sats"
+            );
+            bail!("Rejecting open channel request. Reason: {reason}")
+        }
+    }
+
     let user_channel_id = 0;
     channel_manager
         .accept_inbound_channel(
@@ -361,7 +393,7 @@ fn handle_open_channel_request<S: TenTenOneStorage, N: Storage>(
             user_channel_id,
         )
         .map_err(|e| anyhow!("{e:?}"))
-        .context("To be able to accept a 0-conf channel")?;
+        .context("Failed to accept inbound channel")?;
     Ok(())
 }
 

--- a/crates/ln-dlc-node/src/tests/just_in_time_channel/fail_intercepted_htlc.rs
+++ b/crates/ln-dlc-node/src/tests/just_in_time_channel/fail_intercepted_htlc.rs
@@ -169,7 +169,7 @@ async fn fail_intercepted_htlc_if_coordinator_cannot_pay_to_open_jit_channel() {
     payer.connect(coordinator.info).await.unwrap();
     payee.connect(coordinator.info).await.unwrap();
 
-    let payer_outbound_liquidity = 200_000;
+    let payer_outbound_liquidity = 2_000_000;
 
     payer.fund(Amount::ONE_BTC).await.unwrap();
     payer

--- a/crates/tests-e2e/examples/fund.rs
+++ b/crates/tests-e2e/examples/fund.rs
@@ -265,7 +265,7 @@ async fn open_channel(
     post_query(
         "lnd/v1/channels",
         format!(
-            r#"{{"node_pubkey_string":"{}","local_funding_amount":"{}", "min_confs":1 }}"#,
+            r#"{{"node_pubkey_string":"{}","local_funding_amount":"{}", "min_confs":1, "commitment_type": "ANCHORS"}}"#,
             node_info.pubkey,
             amount.to_sat()
         ),


### PR DESCRIPTION
fixes #1596 


Adds anchor outputs to the commitment transaction see below an example of a commitment transaction with anchor outputs.

```
{
    "addresses": [
        "bc1q2zfkaerpl0xe2n0wnkkcxqnj9xx6dac8qnft7kndyxlu8hjpu62qusa7ga",
        "bc1q0jf0ncmpa70frgdkjnkx9khap24yrwgdtjnwx6m4096w7mh2wyns2azzc7",
        "bc1qwgkl04thfchyqctndvvr7w9wc4tdw80078dzdy2cnsnvjdmmrmusapmcl7",
        "bc1q64hyx7qexkzvwa6spwlwek33hwsxy42sty2yeq9vtr5jhkyg68tsyzm68d"
    ],
    "block_height": -1,
    "block_index": -1,
    "confirmations": 0,
    "double_spend": false,
    "fees": 0,
    "hash": "3b94c7ff64af9bbe0821df7e397565a903ae7824e8817ae4b47ef2c878074724",
    "inputs": [
        {
            "age": 0,
            "output_index": 0,
            "prev_hash": "84151c91fd82eee06a0b0b0bf0fb0f0bfdae9915ec5c87b28f86f504f7b49c79",
            "script_type": "empty",
            "sequence": 2160200047
        }
    ],
    "lock_time": 548510010,
    "opt_in_rbf": true,
    "outputs": [
        {
            "addresses": [
                "bc1q2zfkaerpl0xe2n0wnkkcxqnj9xx6dac8qnft7kndyxlu8hjpu62qusa7ga"
            ],
            "script": "002050936ee461fbcd954dee9dad830272298da6f70704d2bf5a6d21bfc3de41e694",
            "script_type": "pay-to-witness-script-hash",
            "value": 330
        },
        {
            "addresses": [
                "bc1q0jf0ncmpa70frgdkjnkx9khap24yrwgdtjnwx6m4096w7mh2wyns2azzc7"
            ],
            "script": "00207c92f9e361ef9e91a1b694ec62dafd0aaa41b90d5ca6e36b757974ef6eea7127",
            "script_type": "pay-to-witness-script-hash",
            "value": 330
        },
        {
            "addresses": [
                "bc1qwgkl04thfchyqctndvvr7w9wc4tdw80078dzdy2cnsnvjdmmrmusapmcl7"
            ],
            "script": "0020722df7d5774e2e4061736b183f38aec556d71deff1da2691589c26c9377b1ef9",
            "script_type": "pay-to-witness-script-hash",
            "value": 90000
        },
        {
            "addresses": [
                "bc1q64hyx7qexkzvwa6spwlwek33hwsxy42sty2yeq9vtr5jhkyg68tsyzm68d"
            ],
            "script": "0020d56e4378193584c777500bbeecda31bba062555059144c80ac58e92bd888d1d7",
            "script_type": "pay-to-witness-script-hash",
            "value": 109056
        }
    ],
    "preference": "low",
    "received": "2023-11-17T07:54:21.743033463Z",
    "relayed_by": "44.197.112.107",
    "size": 443,
    "total": 199716,
    "ver": 2,
    "vin_sz": 1,
    "vout_sz": 4,
    "vsize": 278
}
```
----

Judging from the rust-lightning release notes regarding anchor nodes (copied below). It looks like though it would make sense to upgrade as soon as possible at least to v0.0.117.

### v0.0.118
- Anchor outputs are now properly considered when calculating the amount
available to send in HTLCs. This can prevent force-closes in anchor channels
when sending payments which overflow the available balance (#2674).

### v0.0.117
- Anchor channels which were closed by a counterparty broadcasting its
commitment transaction (i.e. force-closing) would previously not generate a
SpendableOutputs event for our to_remote (i.e. non-HTLC-encumbered)
balance. Those with such balances available should fetch the missing
SpendableOutputDescriptors using the new
ChannelMonitor::get_spendable_outputs method (#2605).

- Anchor channels may result in spurious or missing Balance entries for HTLC
balances (#2610).


#### Security
0.0.117 fixes several loss-of-funds vulnerabilities in anchor output channels,
support for which was added in 0.0.116, in reorg handling, and when accepting
channel(s) from counterparties which are miners.

- When a counterparty broadcasts their latest commitment transaction for a
    channel with anchor outputs, we'd previously fail to build claiming
    transactions against any HTLC outputs in that transaction. This could lead
    to loss of funds if the counterparty is able to eventually claim the HTLC
    after a timeout (#2606).

- Anchor channels HTLC claims on-chain previously spent the entire value of any
    HTLCs as fee, which has now been fixed (#2587).
