### PR TITLE
Reduce collaborative revert reliance on `ChannelManager`

### DIFF
--- a/coordinator/src/collaborative_revert.rs
+++ b/coordinator/src/collaborative_revert.rs
@@ -8,13 +8,13 @@ use crate::storage::CoordinatorTenTenOneStorage;
 use anyhow::anyhow;
 use anyhow::bail;
 use anyhow::Context;
-use axum::Json;
-use bdk::bitcoin::Transaction;
+use anyhow::Result;
 use bitcoin::hashes::hex::ToHex;
+use bitcoin::secp256k1::ecdsa::Signature;
 use bitcoin::secp256k1::Secp256k1;
 use bitcoin::Amount;
-use coordinator_commons::CollaborativeRevert;
-use coordinator_commons::CollaborativeRevertData;
+use bitcoin::OutPoint;
+use bitcoin::Transaction;
 use diesel::r2d2::ConnectionManager;
 use diesel::r2d2::Pool;
 use diesel::r2d2::PooledConnection;
@@ -25,233 +25,312 @@ use dlc_manager::subchannel::LnDlcChannelSigner;
 use dlc_manager::subchannel::LnDlcSignerProvider;
 use dlc_manager::subchannel::SubChannelState;
 use dlc_manager::Storage;
+use lightning::ln::channelmanager::ChannelDetails;
 use ln_dlc_node::node::Node;
 use orderbook_commons::Message;
 use rust_decimal::prelude::ToPrimitive;
+use rust_decimal::Decimal;
 use std::sync::Arc;
 use time::OffsetDateTime;
 use tokio::sync::mpsc;
 
-/// The weight for the collaborative close transaction. It's expected to have 1 input (from the fund
-/// transaction) and 2 outputs, one for each party.
-/// Note: if either party would have a 0 output, the actual weight will be smaller and we will be
-/// overspending tx fee.
+/// The weight for the collaborative revert transaction. The transaction is expected to have 1 input
+/// (the funding TXO) and 2 outputs, one for each party.
+///
+/// If either party were to _not_ have an output, we would be overestimating the weight of the
+/// transaction and would end up paying higher fees than necessary.
 const COLLABORATIVE_REVERT_TX_WEIGHT: usize = 672;
 
-pub async fn notify_user_to_collaboratively_revert(
-    revert_params: Json<CollaborativeRevert>,
-    channel_id_string: String,
-    channel_id: [u8; 32],
-    pool: Pool<ConnectionManager<PgConnection>>,
+/// Propose collaboratively reverting the channel identified by `channel_id`.
+///
+/// A collaborative revert involves signing a new transaction spending from the funding output
+/// directly. This can be used to circumvent bugs related to position and subchannel state.
+///
+/// This API will only work if LDK still has the [`ChannelDetails`] for the channel. If the
+/// [`ChannelDetails`] are unavailable, use `propose_collaborative_revert_without_channel_details`
+/// instead.
+#[allow(clippy::too_many_arguments)]
+pub async fn propose_collaborative_revert(
     node: Arc<Node<CoordinatorTenTenOneStorage, NodeStorage>>,
-    auth_users_notifier: mpsc::Sender<OrderbookMessage>,
-) -> anyhow::Result<()> {
-    let mut conn = pool.get().context("Could not acquire db lock")?;
-
+    pool: Pool<ConnectionManager<PgConnection>>,
+    sender: mpsc::Sender<OrderbookMessage>,
+    channel_id: [u8; 32],
+    settlement_price: Decimal,
+    fee_rate_sats_vb: u64,
+    funding_txo: OutPoint,
+) -> Result<()> {
     let channel_details = node
         .channel_manager
         .get_channel_details(&channel_id)
-        .context("Could not get channel")?;
-
-    let sub_channels = node
-        .list_dlc_channels()
-        .context("Could not list dlc channels")?;
-
-    let sub_channel = sub_channels
-        .iter()
-        .find(|c| c.channel_id == channel_id)
-        .context("Could not find provided channel")?;
-
-    let position =
-        Position::get_position_by_trader(&mut conn, channel_details.counterparty.node_id, vec![])?
-            .context("Could not load position for channel_id")?;
-
-    let settlement_amount = position
-        .calculate_settlement_amount(revert_params.price)
-        .context("Could not calculate settlement amount")?;
-
-    let trade_settled = sub_channel.fund_value_satoshis == channel_details.channel_value_satoshis;
-
-    // There is no easy way to get the total tx fee for all subchannel transactions, hence, we
-    // estimate it. This transaction fee is shared among both users fairly
-    let dlc_channel_fee = calculate_dlc_channel_tx_fees(
-        trade_settled,
-        sub_channel.fund_value_satoshis,
-        channel_details.inbound_capacity_msat / 1000,
-        channel_details.outbound_capacity_msat / 1000,
-        position.trader_margin as u64,
-        position.coordinator_margin as u64,
-        channel_details.unspendable_punishment_reserve.unwrap_or(0),
+        .context(
+        "Cannot propose collaborative revert without ChannelDetails. Use alternative API instead",
     )?;
 
-    // Coordinator's amount is the total channel's value (fund_value_satoshis) whatever the taker
-    // had (inbound_capacity), the taker's PnL (settlement_amount) and the transaction fee
-    let coordinator_amount = match trade_settled {
-        false => {
-            sub_channel.fund_value_satoshis as i64
-                - (channel_details.inbound_capacity_msat / 1000) as i64
-                - settlement_amount as i64
-                - (dlc_channel_fee as f64 / 2.0) as i64
-                - channel_details.unspendable_punishment_reserve.unwrap_or(0) as i64
+    let mut conn = pool.get().context("Could not acquire DB lock")?;
+
+    let channel_id_hex = channel_id.to_hex();
+
+    let subchannels = node
+        .list_dlc_channels()
+        .context("Could not get list of subchannels")?;
+
+    let subchannel = subchannels
+        .iter()
+        .find(|c| c.channel_id == channel_id)
+        .context("Missing subchannel")?;
+
+    let peer_id = subchannel.counter_party;
+    let fund_txo_sat = subchannel.fund_value_satoshis;
+
+    let unspendable_punishment_reserve_sat =
+        channel_details.counterparty.unspendable_punishment_reserve;
+
+    let (ln_inbound_liquidity_sat, ln_outbound_liquidity_sat) = {
+        let ln_inbound_liquidity_sat =
+            Decimal::from(channel_details.inbound_capacity_msat) / Decimal::ONE_THOUSAND;
+        let ln_inbound_liquidity_sat = ln_inbound_liquidity_sat
+            .to_u64()
+            .expect("inbound liquidity to fit into u64");
+
+        let ln_outbound_liquidity_sat =
+            Decimal::from(channel_details.outbound_capacity_msat) / Decimal::ONE_THOUSAND;
+        let ln_outbound_liquidity_sat = ln_outbound_liquidity_sat
+            .to_u64()
+            .expect("outbound liquidity to fit into u64");
+
+        (ln_inbound_liquidity_sat, ln_outbound_liquidity_sat)
+    };
+
+    let is_channel_split = match channel_details {
+        ChannelDetails {
+            funding_txo: Some(funding_txo),
+            original_funding_outpoint: Some(original_funding_txo),
+            ..
+        } => {
+            // The channel _is_ split if the `original_funding_txo` and the `funding_txo` differ.
+            original_funding_txo != funding_txo
         }
-        true => {
-            sub_channel.fund_value_satoshis as i64
-                - (channel_details.inbound_capacity_msat / 1000) as i64
-                - channel_details.unspendable_punishment_reserve.unwrap_or(0) as i64
+        ChannelDetails {
+            funding_txo: Some(_),
+            original_funding_outpoint: None,
+            ..
+        } => {
+            // The channel is _not_ split if the `original_funding_txo` has not been set.
+            false
+        }
+        ChannelDetails {
+            funding_txo: None, ..
+        } => {
+            bail!("Cannot collaboratively revert channel without funding TXO");
         }
     };
-    let trader_amount = sub_channel.fund_value_satoshis - coordinator_amount as u64;
 
-    let fee = weight_to_fee(
-        COLLABORATIVE_REVERT_TX_WEIGHT,
-        revert_params.fee_rate_sats_vb,
-    )
-    .expect("To be able to calculate constant fee rate");
+    let coordinator_amount = if is_channel_split {
+        let position = Position::get_position_by_trader(&mut conn, peer_id, vec![])?
+            .context("Could not load position for channel_id")?;
 
-    tracing::debug!(
-        coordinator_amount,
-        fund_value_satoshis = sub_channel.fund_value_satoshis,
-        inbound_capacity_msat = channel_details.inbound_capacity_msat,
-        settlement_amount,
-        dlc_channel_fee,
-        inbound_capacity_msat = channel_details.inbound_capacity_msat,
-        outbound_capacity_msat = channel_details.outbound_capacity_msat,
-        trader_margin = position.trader_margin,
-        coordinator_margin = position.coordinator_margin,
-        position_id = position.id,
-        "Collaborative revert temporary values"
-    );
+        // How much the counterparty would get if we were to settle the DLC channel at the
+        // `settlement_price` using the standard subchannel collaborative close protocol.
+        let counterparty_settlement_amount = position
+            .calculate_accept_settlement_amount(settlement_price)
+            .context("Could not calculate settlement amount")?;
+
+        let dlc_channel_reserved_tx_fees = estimate_subchannel_reserved_tx_fees(
+            fund_txo_sat,
+            ln_inbound_liquidity_sat,
+            ln_outbound_liquidity_sat,
+            unspendable_punishment_reserve_sat,
+            position.trader_margin as u64,
+            position.coordinator_margin as u64,
+        )?;
+        let dlc_channel_reserved_tx_fees_per_party = dlc_channel_reserved_tx_fees as f64 / 2.0;
+
+        fund_txo_sat as i64
+            - ln_inbound_liquidity_sat as i64
+            - unspendable_punishment_reserve_sat as i64
+            - counterparty_settlement_amount as i64
+            - dlc_channel_reserved_tx_fees_per_party as i64
+    } else {
+        fund_txo_sat as i64
+            - ln_inbound_liquidity_sat as i64
+            - unspendable_punishment_reserve_sat as i64
+    };
+
+    let trader_amount = subchannel.fund_value_satoshis - coordinator_amount as u64;
+
+    let fee = weight_to_fee(COLLABORATIVE_REVERT_TX_WEIGHT, fee_rate_sats_vb)
+        .expect("To be able to calculate constant fee rate");
 
     let coordinator_address = node.get_unused_address();
     let coordinator_amount = Amount::from_sat(coordinator_amount as u64 - fee / 2);
     let trader_amount = Amount::from_sat(trader_amount - fee / 2);
 
-    // TODO: check if trader still has more than dust
     tracing::info!(
-        channel_id = channel_id_string,
+        channel_id = channel_id_hex,
         coordinator_address = %coordinator_address,
         coordinator_amount = coordinator_amount.to_sat(),
         trader_amount = trader_amount.to_sat(),
-        "Proposing collaborative revert");
+        "Proposing collaborative revert"
+    );
 
     db::collaborative_reverts::insert(
         &mut conn,
         position::models::CollaborativeRevert {
             channel_id,
-            trader_pubkey: position.trader,
-            price: revert_params.price.to_f32().expect("to fit into f32"),
+            trader_pubkey: peer_id,
+            price: settlement_price.to_f32().expect("to fit into f32"),
             coordinator_address: coordinator_address.clone(),
             coordinator_amount_sats: coordinator_amount,
             trader_amount_sats: trader_amount,
             timestamp: OffsetDateTime::now_utc(),
-            txid: revert_params.txid,
-            vout: revert_params.vout,
+            txid: funding_txo.txid,
+            vout: funding_txo.vout,
         },
     )
     .context("Could not insert new collaborative revert")?;
 
-    // try to notify user
-    let sender = auth_users_notifier;
+    // Send collaborative revert proposal to the counterpary.
     sender
         .send(OrderbookMessage::TraderMessage {
-            trader_id: position.trader,
+            trader_id: peer_id,
             message: Message::CollaborativeRevert {
                 channel_id,
                 coordinator_address,
                 coordinator_amount,
                 trader_amount,
-                execution_price: revert_params.price,
+                execution_price: settlement_price,
+                funding_txo,
             },
             notification: Some(NotificationKind::CollaborativeRevert),
         })
         .await
         .map_err(|error| anyhow!("Could send message to notify user {error:#}"))?;
+
     Ok(())
 }
 
-fn calculate_dlc_channel_tx_fees(
-    trade_settled: bool,
-    sub_channel_sats: u64,
-    inbound_capacity: u64,
-    outbound_capacity: u64,
-    trader_margin: u64,
-    coordinator_margin: u64,
-    reserve: u64,
-) -> anyhow::Result<u64> {
-    let mut dlc_tx_fee = sub_channel_sats
-        .checked_sub(inbound_capacity)
-        .context("could not subtract inbound capacity")?
-        .checked_sub(outbound_capacity)
-        .context("could not subtract outbound capacity")?
-        .checked_sub(reserve * 2)
-        .context("could not substract the reserve")?;
+/// Propose collaboratively reverting the channel identified by `channel_id`, without LDK's
+/// [`ChannelDetails`] for said channel.
+///
+/// A collaborative revert involves signing a new transaction spending from the funding output
+/// directly. This can be used to circumvent bugs related to position and subchannel state.
+#[allow(clippy::too_many_arguments)]
+pub async fn propose_collaborative_revert_without_channel_details(
+    node: Arc<Node<CoordinatorTenTenOneStorage, NodeStorage>>,
+    pool: Pool<ConnectionManager<PgConnection>>,
+    sender: mpsc::Sender<OrderbookMessage>,
+    channel_id: [u8; 32],
+    funding_txo: OutPoint,
+    coordinator_amount: u64,
+    fee_rate_sats_vb: u64,
+    // The settlement price is purely informational for the counterparty.
+    settlement_price: Decimal,
+) -> Result<()> {
+    let mut conn = pool.get().context("Could not acquire DB lock")?;
 
-    if !trade_settled {
-        // the ln channel has not yet been updated so we need to take the margins into account.
-        dlc_tx_fee = dlc_tx_fee
-            .checked_sub(trader_margin)
-            .context("could not subtract trader margin")?
-            .checked_sub(coordinator_margin)
-            .context("could not subtract coordinator margin")?;
-    }
+    let channel_id_hex = channel_id.to_hex();
 
-    Ok(dlc_tx_fee)
+    let subchannels = node
+        .list_dlc_channels()
+        .context("Could not get list of subchannels")?;
+
+    let subchannel = subchannels
+        .iter()
+        .find(|c| c.channel_id == channel_id)
+        .context("Missing subchannel")?;
+
+    let peer_id = subchannel.counter_party;
+
+    let trader_amount = subchannel.fund_value_satoshis - coordinator_amount;
+
+    let fee = weight_to_fee(COLLABORATIVE_REVERT_TX_WEIGHT, fee_rate_sats_vb)
+        .expect("To be able to calculate constant fee rate");
+
+    let coordinator_address = node.get_unused_address();
+    let coordinator_amount = Amount::from_sat(coordinator_amount - fee / 2);
+    let trader_amount = Amount::from_sat(trader_amount - fee / 2);
+
+    tracing::info!(
+        channel_id = channel_id_hex,
+        coordinator_address = %coordinator_address,
+        coordinator_amount = coordinator_amount.to_sat(),
+        trader_amount = trader_amount.to_sat(),
+        "Proposing collaborative revert"
+    );
+
+    db::collaborative_reverts::insert(
+        &mut conn,
+        position::models::CollaborativeRevert {
+            channel_id,
+            trader_pubkey: peer_id,
+            price: settlement_price.to_f32().expect("to fit into f32"),
+            coordinator_address: coordinator_address.clone(),
+            coordinator_amount_sats: coordinator_amount,
+            trader_amount_sats: trader_amount,
+            timestamp: OffsetDateTime::now_utc(),
+            txid: funding_txo.txid,
+            vout: funding_txo.vout,
+        },
+    )
+    .context("Could not insert new collaborative revert")?;
+
+    // Send collaborative revert proposal to the counterpary.
+    sender
+        .send(OrderbookMessage::TraderMessage {
+            trader_id: peer_id,
+            message: Message::CollaborativeRevert {
+                channel_id,
+                coordinator_address,
+                coordinator_amount,
+                trader_amount,
+                execution_price: settlement_price,
+                funding_txo,
+            },
+            notification: Some(NotificationKind::CollaborativeRevert),
+        })
+        .await
+        .map_err(|error| anyhow!("Could send message to notify user {error:#}"))?;
+
+    Ok(())
 }
 
-#[cfg(test)]
-pub mod tests {
-    use crate::collaborative_revert::calculate_dlc_channel_tx_fees;
-
-    #[test]
-    pub fn calculate_transaction_fee_for_dlc_channel_transactions_with_smaller_ln_channel() {
-        let total_fee =
-            calculate_dlc_channel_tx_fees(false, 200_000, 65_450, 85_673, 18_690, 18_690, 1_000)
-                .unwrap();
-        assert_eq!(total_fee, 9_497);
-    }
-
-    #[test]
-    pub fn calculate_transaction_fee_for_dlc_channel_transactions_with_equal_ln_channel() {
-        let total_fee =
-            calculate_dlc_channel_tx_fees(true, 200_000, 84_140, 104_363, 18_690, 18_690, 1_000)
-                .unwrap();
-        assert_eq!(total_fee, 9_497);
-    }
-
-    #[test]
-    pub fn ensure_overflow_being_caught() {
-        assert!(calculate_dlc_channel_tx_fees(
-            false, 200_000, 84_140, 104_363, 18_690, 18_690, 1_000
-        )
-        .is_err());
-    }
-}
-
+/// Complete the collaborative revert protocol by:
+///
+/// 1. Verifying the contents of the transaction sent by the counterparty.
+/// 2. Signing the transaction.
+/// 3. Broadcasting the signed transaction.
 pub fn confirm_collaborative_revert(
-    revert_params: &Json<CollaborativeRevertData>,
+    node: Arc<Node<CoordinatorTenTenOneStorage, NodeStorage>>,
     conn: &mut PooledConnection<ConnectionManager<PgConnection>>,
     channel_id: [u8; 32],
-    inner_node: Arc<Node<CoordinatorTenTenOneStorage, NodeStorage>>,
-) -> anyhow::Result<Transaction> {
+    mut revert_transaction: Transaction,
+    counterparty_signature: Signature,
+) -> Result<Transaction> {
     let channel_id_hex = channel_id.to_hex();
 
     tracing::info!(
         channel_id = channel_id_hex,
-        txid = revert_params.transaction.txid().to_string(),
+        txid = revert_transaction.txid().to_string(),
         "Confirming collaborative revert"
     );
 
     // TODO: Check if provided amounts are as expected.
-    if !revert_params
-        .transaction
-        .output
-        .iter()
-        .any(|output| inner_node.wallet().is_mine(&output.script_pubkey).is_ok())
-    {
+    if !revert_transaction.output.iter().any(|output| {
+        match node.wallet().is_mine(&output.script_pubkey) {
+            Ok(is_mine) => is_mine,
+            Err(e) => {
+                tracing::error!(
+                    "Failed to confirm if proposed collaborative revert \
+                     transaction pays to the coordinator: {e:#}"
+                );
+                false
+            }
+        }
+    }) {
         bail!("Proposed collaborative revert transaction doesn't pay the coordinator");
     }
 
-    let subchannels = inner_node
+    let subchannels = node
         .list_dlc_channels()
         .context("Failed to list subchannels")?;
     let subchannel = subchannels
@@ -259,15 +338,10 @@ pub fn confirm_collaborative_revert(
         .find(|c| c.channel_id == channel_id)
         .with_context(|| format!("Could not find subchannel {channel_id_hex}"))?;
 
-    let mut revert_transaction = revert_params.transaction.clone();
-
-    let position = Position::get_position_by_trader(conn, subchannel.counter_party, vec![])?
-        .with_context(|| format!("Could not load position for subchannel {channel_id_hex}"))?;
-
     let own_sig = {
         let channel_keys_id = subchannel
             .channel_keys_id
-            .or(inner_node
+            .or(node
                 .channel_manager
                 .get_channel_details(&subchannel.channel_id)
                 .map(|details| details.channel_keys_id))
@@ -275,7 +349,7 @@ pub fn confirm_collaborative_revert(
                 format!("Could not get channel keys ID for subchannel {channel_id_hex}")
             })?;
 
-        let signer = inner_node
+        let signer = node
             .keys_manager
             .derive_ln_dlc_channel_signer(subchannel.fund_value_satoshis, channel_keys_id);
 
@@ -289,11 +363,14 @@ pub fn confirm_collaborative_revert(
             .context("Could not get own signature for collaborative revert transaction")?
     };
 
+    let position = Position::get_position_by_trader(conn, subchannel.counter_party, vec![])?
+        .with_context(|| format!("Could not load position for subchannel {channel_id_hex}"))?;
+
     dlc::util::finalize_multi_sig_input_transaction(
         &mut revert_transaction,
         vec![
             (subchannel.own_fund_pk, own_sig),
-            (subchannel.counter_fund_pk, revert_params.signature),
+            (subchannel.counter_fund_pk, counterparty_signature),
         ],
         &subchannel.original_funding_redeemscript,
         0,
@@ -303,24 +380,72 @@ pub fn confirm_collaborative_revert(
         txid = revert_transaction.txid().to_string(),
         "Broadcasting collaborative revert transaction"
     );
-    inner_node
-        .wallet()
+    node.wallet()
         .broadcast_transaction(&revert_transaction)
         .context("Could not broadcast transaction")?;
+
+    // TODO: We should probably not modify the state until the transaction has been confirmed.
 
     Position::set_position_to_closed(conn, position.id)
         .context("Could not set position to closed")?;
 
-    let mut sub_channel = subchannel.clone();
+    let mut subchannel = subchannel.clone();
 
-    sub_channel.state = SubChannelState::OnChainClosed;
-    inner_node
-        .sub_channel_manager
+    subchannel.state = SubChannelState::OnChainClosed;
+    node.sub_channel_manager
         .get_dlc_manager()
         .get_store()
-        .upsert_sub_channel(&sub_channel)?;
+        .upsert_sub_channel(&subchannel)?;
 
     db::collaborative_reverts::delete(conn, channel_id)?;
 
     Ok(revert_transaction)
+}
+
+/// Estimate how many sats where reserved to pay for potential transaction fees when creating the
+/// subchannel.
+///
+/// This fee was meant to be split evenly between both parties.
+fn estimate_subchannel_reserved_tx_fees(
+    fund_txo_sat: u64,
+    inbound_capacity: u64,
+    outbound_capacity: u64,
+    reserve: u64,
+    trader_margin: u64,
+    coordinator_margin: u64,
+) -> Result<u64> {
+    let dlc_tx_fee = fund_txo_sat
+        .checked_sub(inbound_capacity)
+        .context("could not subtract inbound capacity")?
+        .checked_sub(outbound_capacity)
+        .context("could not subtract outbound capacity")?
+        .checked_sub(reserve * 2)
+        .context("could not subtract the reserve")?
+        .checked_sub(trader_margin)
+        .context("could not subtract trader margin")?
+        .checked_sub(coordinator_margin)
+        .context("could not subtract coordinator margin")?;
+
+    Ok(dlc_tx_fee)
+}
+
+#[cfg(test)]
+pub mod tests {
+    use super::*;
+
+    #[test]
+    pub fn estimate_subchannel_reserved_tx_fees_test() {
+        let total_fee =
+            estimate_subchannel_reserved_tx_fees(200_000, 65_450, 85_673, 1_000, 18_690, 18_690)
+                .unwrap();
+        assert_eq!(total_fee, 9_497);
+    }
+
+    #[test]
+    pub fn estimate_subchannel_reserved_tx_fees_cannot_overflow() {
+        assert!(estimate_subchannel_reserved_tx_fees(
+            200_000, 84_140, 104_363, 1_000, 18_690, 18_690,
+        )
+        .is_err());
+    }
 }

--- a/coordinator/src/db/collaborative_reverts.rs
+++ b/coordinator/src/db/collaborative_reverts.rs
@@ -1,5 +1,5 @@
+use crate::parse_channel_id;
 use crate::position;
-use crate::position::models::parse_channel_id;
 use crate::schema::collaborative_reverts;
 use anyhow::ensure;
 use anyhow::Context;

--- a/coordinator/src/lib.rs
+++ b/coordinator/src/lib.rs
@@ -1,3 +1,4 @@
+use anyhow::Result;
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
 use axum::response::Response;
@@ -74,4 +75,12 @@ pub fn is_liquidity_sufficient(
     amount_sats: u64,
 ) -> bool {
     balance.get_spendable() >= amount_sats + settings.min_liquidity_threshold_sats
+}
+
+pub fn parse_channel_id(channel_id: &str) -> Result<[u8; 32]> {
+    let channel_id = hex::decode(channel_id)?
+        .try_into()
+        .map_err(|_| anyhow::anyhow!("Could not parse channel ID"))?;
+
+    Ok(channel_id)
 }

--- a/coordinator/src/node.rs
+++ b/coordinator/src/node.rs
@@ -400,7 +400,8 @@ impl Node {
         closing_price: Decimal,
         channel_id: ChannelId,
     ) -> Result<()> {
-        let accept_settlement_amount = position.calculate_settlement_amount(closing_price)?;
+        let accept_settlement_amount =
+            position.calculate_accept_settlement_amount(closing_price)?;
 
         tracing::debug!(
             ?position,

--- a/coordinator/src/position/models.rs
+++ b/coordinator/src/position/models.rs
@@ -1,4 +1,3 @@
-use anyhow::bail;
 use anyhow::Context;
 use anyhow::Result;
 use bitcoin::secp256k1::PublicKey;
@@ -125,7 +124,7 @@ impl Position {
         Ok(pnl)
     }
 
-    pub fn calculate_settlement_amount(&self, closing_price: Decimal) -> Result<u64> {
+    pub fn calculate_accept_settlement_amount(&self, closing_price: Decimal) -> Result<u64> {
         let opening_price = Decimal::try_from(self.average_entry_price)?;
 
         let leverage_long = leverage_long(
@@ -550,14 +549,4 @@ pub struct CollaborativeRevert {
     pub timestamp: OffsetDateTime,
     pub txid: Txid,
     pub vout: u32,
-}
-
-pub fn parse_channel_id(channel_id: &str) -> Result<[u8; 32]> {
-    let channel_id = hex::decode(channel_id)?;
-    match channel_id.try_into() {
-        Ok(channel_id) => Ok(channel_id),
-        Err(_) => {
-            bail!("Could not parse channel id")
-        }
-    }
 }

--- a/crates/coordinator-commons/src/lib.rs
+++ b/crates/coordinator-commons/src/lib.rs
@@ -411,25 +411,49 @@ pub struct OnboardingParam {
     pub liquidity_option_id: i32,
 }
 
+/// The information needed for the coordinator to kickstart the collaborative revert protocol.
 #[derive(Deserialize, Serialize)]
-pub struct CollaborativeRevert {
-    /// Channel to collaboratively close
+pub struct CollaborativeRevertCoordinatorRequest {
+    /// Channel to collaboratively revert.
     pub channel_id: String,
-    /// Price to calculate PnL for trader and coordinator
+    /// Price at which to settle the DLC channel.
     pub price: Decimal,
-    /// Fee rate for the closing transaction
+    /// Fee rate for the collaborative revert transaction.
     pub fee_rate_sats_vb: u64,
-    /// The UTXO of the funding transaction
+    /// The TXID of the LN funding transaction.
     pub txid: Txid,
-    /// The vout of the funding transaction
+    /// The vout corresponding to the funding TXO.
     pub vout: u32,
 }
 
+/// The information needed for the coordinator to kickstart the collaborative revert protocol.
 #[derive(Deserialize, Serialize)]
-pub struct CollaborativeRevertData {
+pub struct CollaborativeRevertCoordinatorExpertRequest {
+    /// Channel to collaboratively revert.
     pub channel_id: String,
-    /// the collaborative closing transaction unsigned
+    /// The TXID of the LN funding transaction.
+    pub txid: Txid,
+    /// The vout corresponding to the funding TXO.
+    pub vout: u32,
+    /// How much the coordinator should get out of the collaborative revert transaction, without
+    /// considering transaction fees.
+    pub coordinator_amount: u64,
+    /// Fee rate for the collaborative revert transaction.
+    pub fee_rate_sats_vb: u64,
+    /// Price at which to settle the DLC channel.
+    ///
+    /// This price is purely informational for the trader, as the caller provides the
+    /// `coordinator_amount` already.
+    pub price: Decimal,
+}
+
+/// The information provided by the trader in response to a collaborative revert proposal.
+#[derive(Deserialize, Serialize)]
+pub struct CollaborativeRevertTraderResponse {
+    /// Channel to collaboratively revert.
+    pub channel_id: String,
+    /// The unsigned collaborative revert transaction.
     pub transaction: Transaction,
-    /// the trader's signature on the provided transaction
+    /// The trader's signature on the collaborative revert transaction.
     pub signature: Signature,
 }

--- a/crates/orderbook-commons/Cargo.toml
+++ b/crates/orderbook-commons/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1"
-bitcoin = "0.29.2"
+bitcoin = { version = "0.29.2", features = ["serde"] }
 lightning = "0.0.116"
 rust_decimal = { version = "1", features = ["serde-with-float"] }
 secp256k1 = { version = "0.24.3", features = ["serde"] }

--- a/crates/orderbook-commons/src/lib.rs
+++ b/crates/orderbook-commons/src/lib.rs
@@ -1,6 +1,7 @@
 use anyhow::Result;
 use bitcoin::Address;
 use bitcoin::Amount;
+use bitcoin::OutPoint;
 use rust_decimal::prelude::ToPrimitive;
 use rust_decimal::Decimal;
 use secp256k1::Message as SecpMessage;
@@ -163,6 +164,7 @@ pub enum Message {
         trader_amount: Amount,
         #[serde(with = "rust_decimal::serde::float")]
         execution_price: Decimal,
+        funding_txo: OutPoint,
     },
 }
 

--- a/crates/payout_curve/tests/integration_proptests.rs
+++ b/crates/payout_curve/tests/integration_proptests.rs
@@ -23,7 +23,7 @@ const PRINT_CSV: bool = false;
 /// taken from a past crash
 #[test]
 fn calculating_payout_curve_doesnt_crash_1() {
-    let initial_price = Decimal::from_u64(26986).expect("to be able to parse price");
+    let initial_price = Decimal::from_u64(26986).unwrap();
     let leverage_trader = 3.0;
     let leverage_coordinator = 3.0;
     let fee = 0;

--- a/crates/tests-e2e/src/app.rs
+++ b/crates/tests-e2e/src/app.rs
@@ -19,21 +19,15 @@ impl AppHandle {
 }
 
 pub async fn run_app(seed_phrase: Option<Vec<String>>) -> AppHandle {
-    let app_dir = TempDir::new().expect("Failed to create temporary directory");
-    let seed_dir = TempDir::new().expect("Failed to create temporary directory");
+    let app_dir = TempDir::new().unwrap();
+    let seed_dir = TempDir::new().unwrap();
     let _app_handle = {
-        let as_string = |dir: &TempDir| {
-            dir.path()
-                .to_str()
-                .expect("Could not convert path to string")
-                .to_string()
-        };
+        let as_string = |dir: &TempDir| dir.path().to_str().unwrap().to_string();
 
         let app_dir = as_string(&app_dir);
         let seed_dir = as_string(&seed_dir);
 
-        native::api::set_config(test_config(), app_dir, seed_dir.clone())
-            .expect("Could not configure app");
+        native::api::set_config(test_config(), app_dir, seed_dir.clone()).unwrap();
 
         if let Some(seed_phrase) = seed_phrase {
             tokio::task::spawn_blocking({
@@ -43,11 +37,11 @@ pub async fn run_app(seed_phrase: Option<Vec<String>>) -> AppHandle {
                         seed_phrase.join(" "),
                         format!("{seed_dir}/regtest/seed"),
                     )
-                    .expect("Failed to restore from seed phrase");
+                    .unwrap();
                 }
             })
             .await
-            .expect("Failed to finish restore from seed phrase");
+            .unwrap();
         }
 
         tokio::task::spawn_blocking(move || {
@@ -56,7 +50,7 @@ pub async fn run_app(seed_phrase: Option<Vec<String>>) -> AppHandle {
                 "".to_string(),
                 native::api::IncludeBacktraceOnPanic::No,
             )
-            .expect("Could not run app")
+            .unwrap()
         })
     };
 

--- a/crates/tests-e2e/src/http.rs
+++ b/crates/tests-e2e/src/http.rs
@@ -4,5 +4,5 @@ pub fn init_reqwest() -> Client {
     Client::builder()
         .timeout(std::time::Duration::from_secs(30))
         .build()
-        .expect("Could not build reqwest client")
+        .unwrap()
 }

--- a/crates/tests-e2e/src/lib.rs
+++ b/crates/tests-e2e/src/lib.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::unwrap_used)]
+
 pub mod app;
 pub mod bitcoind;
 pub mod coordinator;

--- a/crates/tests-e2e/src/setup.rs
+++ b/crates/tests-e2e/src/setup.rs
@@ -28,29 +28,19 @@ impl TestSetup {
         let coordinator = Coordinator::new_local(client.clone());
         assert!(coordinator.is_running().await);
         // ensure coordinator has a free UTXO available
-        let address = coordinator
-            .get_new_address()
-            .await
-            .expect("To be able to get a new address from coordinator");
+        let address = coordinator.get_new_address().await.unwrap();
         let bitcoind = Bitcoind::new_local(client.clone());
         bitcoind
             .send_to_address(&address, Amount::ONE_BTC)
             .await
-            .expect("To be able to send to address");
-        bitcoind.mine(1).await.expect("To be able to mine a block");
-        coordinator
-            .sync_wallet()
-            .await
-            .expect("To be able to sync coordinator wallet");
+            .unwrap();
+        bitcoind.mine(1).await.unwrap();
+        coordinator.sync_wallet().await.unwrap();
 
         let app = run_app(None).await;
 
         assert_eq!(
-            app.rx
-                .wallet_info()
-                .expect("to have wallet info")
-                .balances
-                .lightning,
+            app.rx.wallet_info().unwrap().balances.lightning,
             0,
             "App should start with empty wallet"
         );
@@ -58,14 +48,9 @@ impl TestSetup {
         let fund_amount = 50_000;
         fund_app_with_faucet(&app, &client, fund_amount)
             .await
-            .expect("to be able to fund");
+            .unwrap();
 
-        let ln_balance = app
-            .rx
-            .wallet_info()
-            .expect("to have wallet info")
-            .balances
-            .lightning;
+        let ln_balance = app.rx.wallet_info().unwrap().balances.lightning;
         tracing::info!(%fund_amount, %ln_balance, "Successfully funded app with faucet");
 
         assert!(ln_balance > 0, "App wallet should be funded");
@@ -86,15 +71,15 @@ impl TestSetup {
         let order = dummy_order();
         spawn_blocking({
             let order = order.clone();
-            move || api::submit_order(order).expect("to submit order")
+            move || api::submit_order(order).unwrap()
         })
         .await
-        .expect("to spawn_blocking");
+        .unwrap();
 
         wait_until!(rx.order().is_some());
 
         wait_until!(rx.position().is_some());
-        wait_until!(rx.position().expect("to have position").position_state == PositionState::Open);
+        wait_until!(rx.position().unwrap().position_state == PositionState::Open);
 
         // Wait for coordinator to open position.
         tokio::time::sleep(std::time::Duration::from_secs(10)).await;

--- a/crates/tests-e2e/src/setup.rs
+++ b/crates/tests-e2e/src/setup.rs
@@ -96,7 +96,8 @@ impl TestSetup {
         wait_until!(rx.position().is_some());
         wait_until!(rx.position().expect("to have position").position_state == PositionState::Open);
 
-        tokio::time::sleep(std::time::Duration::from_secs(10)).await; // wait for coordinator to open position
+        // Wait for coordinator to open position.
+        tokio::time::sleep(std::time::Duration::from_secs(10)).await;
 
         setup
     }

--- a/crates/tests-e2e/tests/force_close_position.rs
+++ b/crates/tests-e2e/tests/force_close_position.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::unwrap_used)]
+
 use native::api;
 use tests_e2e::bitcoind::Bitcoind;
 use tests_e2e::coordinator::Coordinator;
@@ -40,13 +42,13 @@ async fn check_for_channel_closed(
     bitcoin: &Bitcoind,
     app_pubkey: &str,
 ) -> bool {
-    bitcoin.mine(100).await.expect("To be able to mine blocks");
+    bitcoin.mine(100).await.unwrap();
     // Let the coordinator catch-up with the blocks
     tokio::time::sleep(std::time::Duration::from_secs(2)).await;
     coordinator
         .get_dlc_channels()
         .await
-        .expect("to be able to retrieve dlc channels from coordinator")
+        .unwrap()
         .iter()
         .any(|chan| {
             chan.counter_party == app_pubkey

--- a/crates/tests-e2e/tests/open_position.rs
+++ b/crates/tests-e2e/tests/open_position.rs
@@ -56,11 +56,5 @@ async fn can_open_position() {
         order.contract_symbol
     );
     assert_eq!(app.rx.position().unwrap().leverage, order.leverage);
-    wait_until!(
-        app.rx
-            .position()
-            .expect("to be receive a position")
-            .position_state
-            == PositionState::Open
-    );
+    wait_until!(app.rx.position().unwrap().position_state == PositionState::Open);
 }

--- a/crates/tests-e2e/tests/restore_from_backup.rs
+++ b/crates/tests-e2e/tests/restore_from_backup.rs
@@ -14,13 +14,7 @@ async fn app_can_be_restored_from_a_backup() -> Result<()> {
 
     let seed_phrase = api::get_seed_phrase();
 
-    let ln_balance = test
-        .app
-        .rx
-        .wallet_info()
-        .expect("to have wallet info")
-        .balances
-        .lightning;
+    let ln_balance = test.app.rx.wallet_info().unwrap().balances.lightning;
 
     // kill the app
     test.app.stop();
@@ -28,22 +22,15 @@ async fn app_can_be_restored_from_a_backup() -> Result<()> {
 
     let app = run_app(Some(seed_phrase.0)).await;
 
-    assert_eq!(
-        app.rx
-            .wallet_info()
-            .expect("to have wallet info")
-            .balances
-            .lightning,
-        ln_balance
-    );
+    assert_eq!(app.rx.wallet_info().unwrap().balances.lightning, ln_balance);
 
-    let positions = spawn_blocking(|| api::get_positions().expect("Failed to get positions"))
+    let positions = spawn_blocking(|| api::get_positions().unwrap())
         .await
         .unwrap();
     assert_eq!(1, positions.len());
 
     // Test if full backup is running without errors
-    spawn_blocking(|| api::full_backup().expect("Failed to run full backup"))
+    spawn_blocking(|| api::full_backup().unwrap())
         .await
         .unwrap();
 

--- a/crates/tests-e2e/tests/rollover_position.rs
+++ b/crates/tests-e2e/tests/rollover_position.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::unwrap_used)]
+
 use bitcoin::Network;
 use native::api;
 use native::trade::position;
@@ -40,7 +42,7 @@ async fn can_rollover_position() {
 }
 
 fn check_rollover_position(app: &AppHandle, new_expiry: OffsetDateTime) -> bool {
-    let position = app.rx.position().expect("position to exist");
+    let position = app.rx.position().unwrap();
     tracing::debug!(
         "expect {:?} to be {:?}",
         position.position_state,

--- a/mobile/native/src/orderbook.rs
+++ b/mobile/native/src/orderbook.rs
@@ -6,9 +6,12 @@ use crate::event::TaskStatus;
 use crate::health::ServiceStatus;
 use crate::ln_dlc;
 use crate::trade::position;
+use anyhow::bail;
+use anyhow::Context;
 use anyhow::Result;
 use bdk::bitcoin::secp256k1::SecretKey;
 use bdk::bitcoin::secp256k1::SECP256K1;
+use bitcoin::hashes::hex::ToHex;
 use futures::TryStreamExt;
 use orderbook_commons::best_current_price;
 use orderbook_commons::Message;
@@ -59,7 +62,11 @@ pub fn subscribe(
                         tracing::debug!("Pruning expired orders");
                         let mut orders = orders.lock();
                         let orders_before_pruning = orders.len();
-                        *orders = orders.iter().filter(|order| order.expiry >= OffsetDateTime::now_utc()).cloned().collect::<Vec<_>>();
+                        *orders = orders
+                            .iter()
+                            .filter(|order| order.expiry >= OffsetDateTime::now_utc())
+                            .cloned()
+                            .collect::<Vec<_>>();
                         let orders_after_pruning = orders.len();
 
                         if orders_after_pruning < orders_before_pruning {
@@ -71,8 +78,12 @@ pub fn subscribe(
                             );
 
                             // Current best price might have changed
-                            if let Err(e) = position::handler::price_update(best_current_price(&orders)) {
-                                tracing::error!("Price update from the orderbook failed. Error: {e:#}");
+                            if let Err(e) =
+                                position::handler::price_update(best_current_price(&orders))
+                            {
+                                tracing::error!(
+                                    "Price update from the orderbook failed. Error: {e:#}"
+                                );
                             }
                         }
                     }
@@ -91,106 +102,18 @@ pub fn subscribe(
             let url = url.clone();
             let authenticate = authenticate;
             let fcm_token = fcm_token.clone();
-            match orderbook_client::subscribe_with_authentication(url, authenticate, fcm_token).await {
+            match orderbook_client::subscribe_with_authentication(url, authenticate, fcm_token)
+                .await
+            {
                 Ok((_, mut stream)) => {
-                    if let Err(e) =
-                        orderbook_status.send(ServiceStatus::Online) {
-                            tracing::warn!("Cannot update orderbook status: {e:#}");
-                        };
+                    if let Err(e) = orderbook_status.send(ServiceStatus::Online) {
+                        tracing::warn!("Cannot update orderbook status: {e:#}");
+                    };
 
-                    let mut cached_best_price : Prices = HashMap::new();
+                    let mut cached_best_price: Prices = HashMap::new();
                     loop {
-                        match stream.try_next().await {
-                            Ok(Some(msg)) => {
-                                let msg = match serde_json::from_str::<Message>(&msg) {
-                                    Ok(msg) => {
-                                        tracing::debug!(%msg, "New message from orderbook");
-                                        msg
-                                    },
-                                    Err(e) => {
-                                        tracing::error!(
-                                            "Could not deserialize message from orderbook. Error: {e:#}"
-                                        );
-                                        continue;
-                                    }
-                                };
-
-                                match msg {
-                                    Message::Rollover(contract_id) => {
-                                        tracing::info!("Received a rollover request from orderbook.");
-                                        event::publish(&EventInternal::BackgroundNotification(BackgroundTask::Rollover(TaskStatus::Pending)));
-
-                                        if let Err(e) = position::handler::rollover(contract_id).await {
-                                            tracing::error!("Failed to rollover dlc. Error: {e:#}");
-                                            event::publish(&EventInternal::BackgroundNotification(BackgroundTask::Rollover(TaskStatus::Failed)));
-                                        }
-                                    },
-                                    Message::AsyncMatch { order, filled_with } => {
-                                        let order_reason = order.clone().order_reason.into();
-                                        tracing::info!(order_id = %order.id, "Received an async match from orderbook. Reason: {order_reason:?}");
-                                        event::publish(&EventInternal::BackgroundNotification(BackgroundTask::AsyncTrade(order_reason)));
-
-                                        if let Err(e) = position::handler::async_trade(order.clone(), filled_with).await {
-                                            tracing::error!(order_id = %order.id, "Failed to process async trade. Error: {e:#}");
-                                        }
-                                    },
-                                    Message::Match(filled) => {
-                                        tracing::info!(order_id = %filled.order_id, "Received match from orderbook");
-
-                                        if let Err(e) = position::handler::trade(filled.clone()).await {
-                                            tracing::error!(order_id = %filled.order_id, "Trade request sent to coordinator failed. Error: {e:#}");
-                                        }
-                                    },
-                                    Message::AllOrders(initial_orders) => {
-                                        let mut orders = orders.lock();
-                                        if !orders.is_empty() {
-                                            tracing::debug!("Received new set of initial orders from orderbook, replacing the previously stored orders");
-                                        }
-                                        else {
-                                            tracing::debug!(?orders, "Received all orders from orderbook");
-                                        }
-                                        *orders = initial_orders;
-                                        update_prices_if_needed(&mut cached_best_price, &orders);
-                                    },
-                                    Message::NewOrder(order) => {
-                                        let mut orders = orders.lock();
-                                        orders.push(order);
-                                        update_prices_if_needed(&mut cached_best_price, &orders);
-                                    }
-                                    Message::DeleteOrder(order_id) => {
-                                        let mut orders = orders.lock();
-                                        let found = remove_order(&mut orders, order_id);
-                                        if !found {
-                                            tracing::warn!(%order_id, "Could not remove non-existing order");
-                                        }
-                                        update_prices_if_needed(&mut cached_best_price, &orders);
-                                    },
-                                    Message::Update(updated_order) => {
-                                        let mut orders = orders.lock();
-                                        let found = remove_order(&mut orders, updated_order.id);
-                                        if !found {
-                                            tracing::warn!(?updated_order, "Update without prior knowledge of order");
-                                        }
-                                        orders.push(updated_order);
-                                        update_prices_if_needed(&mut cached_best_price, &orders);
-                                    },
-                                    msg @ Message::LimitOrderFilledMatches { .. } |
-                                    msg @ Message::InvalidAuthentication(_) |
-                                    msg @ Message::Authenticated => {
-                                        tracing::debug!(?msg, "Skipping message from orderbook");
-                                    }
-                                    Message::CollaborativeRevert { channel_id, coordinator_address, coordinator_amount, trader_amount, execution_price } => {
-                                        tracing::debug!("Received request to revert channel");
-                                        event::publish(&EventInternal::BackgroundNotification(BackgroundTask::CollabRevert(TaskStatus::Pending)));
-                                        if let Err(err) = ln_dlc::collaborative_revert_channel(channel_id, coordinator_address, coordinator_amount, trader_amount, execution_price) {
-                                            event::publish(&EventInternal::BackgroundNotification(BackgroundTask::CollabRevert(TaskStatus::Failed)));
-                                            tracing::error!("Could not collaboratively revert channel {err:#}");
-                                        } else {
-                                            event::publish(&EventInternal::BackgroundNotification(BackgroundTask::CollabRevert(TaskStatus::Success)));
-                                        }
-                                    }
-                                }
-                            }
+                        let msg = match stream.try_next().await {
+                            Ok(Some(msg)) => msg,
                             Ok(None) => {
                                 tracing::warn!("Orderbook WS stream closed");
                                 break;
@@ -199,23 +122,173 @@ pub fn subscribe(
                                 tracing::warn!(%error, "Orderbook WS stream closed with error");
                                 break;
                             }
+                        };
+
+                        if let Err(e) =
+                            handle_orderbook_mesage(orders.clone(), &mut cached_best_price, msg)
+                                .await
+                        {
+                            tracing::error!("Failed to handle event: {e:#}");
                         }
-                    };
-                },
+                    }
+                }
                 Err(e) => {
                     tracing::error!("Could not start up orderbook client: {e:#}");
-                },
+                }
             };
 
-            if let Err(e) =
-            orderbook_status.send(ServiceStatus::Offline) {
+            if let Err(e) = orderbook_status.send(ServiceStatus::Offline) {
                 tracing::warn!("Cannot update orderbook status: {e:#}");
             };
 
             tokio::time::sleep(WS_RECONNECT_TIMEOUT).await;
-            tracing::debug!(?WS_RECONNECT_TIMEOUT, "Reconnecting to orderbook WS after timeout");
+            tracing::debug!(
+                ?WS_RECONNECT_TIMEOUT,
+                "Reconnecting to orderbook WS after timeout"
+            );
         }
     });
+
+    Ok(())
+}
+
+async fn handle_orderbook_mesage(
+    orders: Arc<Mutex<Vec<Order>>>,
+    cached_best_price: &mut Prices,
+    msg: String,
+) -> Result<()> {
+    let msg =
+        serde_json::from_str::<Message>(&msg).context("Could not deserialize orderbook message")?;
+
+    tracing::debug!(%msg, "New orderbook message");
+
+    match msg {
+        Message::Rollover(contract_id) => {
+            tracing::info!("Received a rollover request from orderbook.");
+            event::publish(&EventInternal::BackgroundNotification(
+                BackgroundTask::Rollover(TaskStatus::Pending),
+            ));
+
+            if let Err(e) = position::handler::rollover(contract_id).await {
+                event::publish(&EventInternal::BackgroundNotification(
+                    BackgroundTask::Rollover(TaskStatus::Failed),
+                ));
+
+                bail!("Failed to rollover DLC: {e:#}");
+            }
+        }
+        Message::AsyncMatch { order, filled_with } => {
+            let order_id = order.id;
+            let order_reason = order.clone().order_reason.into();
+
+            tracing::info!(
+                %order_id,
+                "Received an async match from orderbook. Reason: {order_reason:?}"
+            );
+
+            event::publish(&EventInternal::BackgroundNotification(
+                BackgroundTask::AsyncTrade(order_reason),
+            ));
+
+            position::handler::async_trade(order.clone(), filled_with)
+                .await
+                .with_context(|| format!("Failed to process async trade for order {}", order_id))?;
+        }
+        Message::Match(filled) => {
+            let order_id = filled.order_id;
+
+            tracing::info!(%order_id, "Received match from orderbook");
+
+            position::handler::trade(filled.clone())
+                .await
+                .with_context(|| {
+                    format!("Trade request sent to coordinator for order {order_id} failed")
+                })?;
+        }
+        Message::AllOrders(initial_orders) => {
+            let mut orders = orders.lock();
+            if !orders.is_empty() {
+                tracing::debug!(
+                    "Received new set of initial orders from orderbook, \
+                     replacing the previously stored orders"
+                );
+            } else {
+                tracing::debug!(?orders, "Received all orders from orderbook");
+            }
+
+            *orders = initial_orders;
+
+            update_prices_if_needed(cached_best_price, &orders);
+        }
+        Message::NewOrder(order) => {
+            let mut orders = orders.lock();
+            orders.push(order);
+
+            update_prices_if_needed(cached_best_price, &orders);
+        }
+        Message::DeleteOrder(order_id) => {
+            let mut orders = orders.lock();
+
+            let found = remove_order(&mut orders, order_id);
+            if !found {
+                tracing::warn!(%order_id, "Could not remove non-existing order");
+            }
+
+            update_prices_if_needed(cached_best_price, &orders);
+        }
+        Message::Update(updated_order) => {
+            let mut orders = orders.lock();
+
+            let found = remove_order(&mut orders, updated_order.id);
+            if !found {
+                tracing::warn!(?updated_order, "Update without prior knowledge of order");
+            }
+
+            orders.push(updated_order);
+
+            update_prices_if_needed(cached_best_price, &orders);
+        }
+        Message::CollaborativeRevert {
+            channel_id,
+            coordinator_address,
+            coordinator_amount,
+            trader_amount,
+            execution_price,
+            funding_txo,
+        } => {
+            tracing::debug!(
+                channel_id = %channel_id.to_hex(),
+                "Received request to revert channel"
+            );
+
+            event::publish(&EventInternal::BackgroundNotification(
+                BackgroundTask::CollabRevert(TaskStatus::Pending),
+            ));
+
+            if let Err(err) = ln_dlc::collaborative_revert_channel(
+                channel_id,
+                coordinator_address,
+                coordinator_amount,
+                trader_amount,
+                execution_price,
+                funding_txo,
+            ) {
+                event::publish(&EventInternal::BackgroundNotification(
+                    BackgroundTask::CollabRevert(TaskStatus::Failed),
+                ));
+                tracing::error!("Could not collaboratively revert channel: {err:#}");
+            } else {
+                event::publish(&EventInternal::BackgroundNotification(
+                    BackgroundTask::CollabRevert(TaskStatus::Success),
+                ));
+            }
+        }
+        msg @ Message::LimitOrderFilledMatches { .. }
+        | msg @ Message::InvalidAuthentication(_)
+        | msg @ Message::Authenticated => {
+            tracing::debug!(?msg, "Skipping message from orderbook");
+        }
+    };
 
     Ok(())
 }


### PR DESCRIPTION
Fixes #1546.

In situations where the collaborative revert protocol might be useful, it is likely that the channel will have been erased from the `ChannelManager`.

Before this patch we had unavoidable dependencies on the `ChannelManager`, but with this patch we are able to perform the protocol without looking for the relevant `ChannelDetails` via the `ChannelManager`.

---

Currently untested beyond the automatic test! Maybe @bonomat wants to give this a go since he created the original issue and implemented the feature.

---

A large chunk of the diff is formatting and style fixes. I should have split it up, but too late now 😞 