### PR TITLE
fix: Fetch only limit orders

### DIFF
--- a/coordinator/src/orderbook/websocket.rs
+++ b/coordinator/src/orderbook/websocket.rs
@@ -1,6 +1,5 @@
 use crate::db::user;
 use crate::message::NewUserMessage;
-use crate::orderbook;
 use crate::orderbook::db::orders;
 use crate::routes::AppState;
 use axum::extract::ws::Message as WebsocketMessage;
@@ -36,7 +35,7 @@ pub async fn websocket_connection(stream: WebSocket, state: Arc<AppState>) {
         }
     };
 
-    let orders = match orderbook::db::orders::all(&mut conn, false, false) {
+    let orders = match orders::all_limit_orders(&mut conn) {
         Ok(orders) => orders,
         Err(error) => {
             tracing::error!("Could not load all orders from db {error:#}");

--- a/coordinator/src/routes.rs
+++ b/coordinator/src/routes.rs
@@ -20,7 +20,6 @@ use crate::message::NewUserMessage;
 use crate::message::OrderbookMessage;
 use crate::node::Node;
 use crate::orderbook::routes::get_order;
-use crate::orderbook::routes::get_orders;
 use crate::orderbook::routes::post_order;
 use crate::orderbook::routes::put_order;
 use crate::orderbook::routes::websocket_handler;
@@ -134,7 +133,7 @@ pub fn router(
         .route("/api/newaddress", get(get_unused_address))
         .route("/api/node", get(get_node_info))
         .route("/api/invoice", get(get_invoice))
-        .route("/api/orderbook/orders", get(get_orders).post(post_order))
+        .route("/api/orderbook/orders", post(post_order))
         .route(
             "/api/orderbook/orders/:order_id",
             get(get_order).put(put_order),


### PR DESCRIPTION
I am surprised this didn't had a bigger impact, but apparently we where fetching also market orders.