### PR TITLE
fix: Spawn backup tasks from static tokio runtime

### DIFF
--- a/coordinator/src/admin.rs
+++ b/coordinator/src/admin.rs
@@ -291,7 +291,6 @@ pub async fn send_payment(
         .node
         .inner
         .pay_invoice(&invoice, None)
-        .await
         .map_err(|e| AppError::InternalServerError(format!("{e:#}")))?;
 
     Ok(())
@@ -316,7 +315,6 @@ pub async fn close_channel(
         .node
         .inner
         .close_channel(channel_id, params.force.unwrap_or_default())
-        .await
         .map_err(|e| AppError::InternalServerError(format!("{e:#}")))?;
 
     Ok(())

--- a/crates/ln-dlc-node/src/node/ln_channel.rs
+++ b/crates/ln-dlc-node/src/node/ln_channel.rs
@@ -6,7 +6,6 @@ use anyhow::Context;
 use anyhow::Result;
 use bitcoin::secp256k1::PublicKey;
 use lightning::ln::channelmanager::ChannelDetails;
-use tokio::task::spawn_blocking;
 
 impl<S: TenTenOneStorage + 'static, N: Storage + Sync + Send + 'static> Node<S, N> {
     /// Initiates the open private channel protocol.
@@ -59,7 +58,7 @@ impl<S: TenTenOneStorage + 'static, N: Storage + Sync + Send + 'static> Node<S, 
             .collect()
     }
 
-    pub async fn close_channel(&self, channel_id: [u8; 32], force_close: bool) -> Result<()> {
+    pub fn close_channel(&self, channel_id: [u8; 32], force_close: bool) -> Result<()> {
         let channel_id_str = hex::encode(channel_id);
 
         let channels = self.channel_manager.list_channels();
@@ -69,15 +68,15 @@ impl<S: TenTenOneStorage + 'static, N: Storage + Sync + Send + 'static> Node<S, 
             .with_context(|| format!("Cannot close non-existent channel {channel_id_str}"))?;
 
         if force_close {
-            self.force_close_channel(channel).await?;
+            self.force_close_channel(channel)?;
         } else {
-            self.collab_close_channel(channel).await?;
+            self.collab_close_channel(channel)?;
         }
 
         Ok(())
     }
 
-    async fn collab_close_channel(&self, channel: &ChannelDetails) -> Result<()> {
+    fn collab_close_channel(&self, channel: &ChannelDetails) -> Result<()> {
         let channel_id = channel.channel_id;
         let channel_id_str = hex::encode(channel_id);
         let peer = channel.counterparty.node_id;
@@ -89,17 +88,16 @@ impl<S: TenTenOneStorage + 'static, N: Storage + Sync + Send + 'static> Node<S, 
                 format!("Could not collaboratively close LN channel {channel_id_str}: must close DLC channel first")
             })?;
 
-        spawn_blocking({
-            let channel_manager = self.channel_manager.clone();
-            move || channel_manager.close_channel(&channel_id, &peer)
-        })
-        .await?
-        .map_err(|e| anyhow!("Could not collaboratively close channel {channel_id_str}: {e:?}"))?;
+        self.channel_manager
+            .close_channel(&channel_id, &peer)
+            .map_err(|e| {
+                anyhow!("Could not collaboratively close channel {channel_id_str}: {e:?}")
+            })?;
 
         Ok(())
     }
 
-    pub(crate) async fn force_close_channel(&self, channel: &ChannelDetails) -> Result<()> {
+    pub(crate) fn force_close_channel(&self, channel: &ChannelDetails) -> Result<()> {
         let channel_id = channel.channel_id;
         let channel_id_str = hex::encode(channel_id);
         let peer = channel.counterparty.node_id;
@@ -115,22 +113,14 @@ impl<S: TenTenOneStorage + 'static, N: Storage + Sync + Send + 'static> Node<S, 
                 %peer,
                 "Initiating force-closure of LN-DLC channel"
             );
-
-            spawn_blocking({
-                let sub_channel_manager = self.sub_channel_manager.clone();
-                move || sub_channel_manager.force_close_sub_channel(&channel_id)
-            })
-            .await?
-            .map_err(|e| anyhow!("Failed to initiate force-close: {e:#}"))?
+            self.sub_channel_manager
+                .force_close_sub_channel(&channel_id)
+                .map_err(|e| anyhow!("Failed to initiate force-close: {e:#}"))?
         } else {
             tracing::info!(channel_id = %hex::encode(channel_id), %peer, "Force-closing LN channel");
-
-            spawn_blocking({
-                let channel_manager = self.channel_manager.clone();
-                move || channel_manager.force_close_broadcasting_latest_txn(&channel_id, &peer)
-            })
-            .await?
-            .map_err(|e| anyhow!("Could not force-close channel {channel_id_str}: {e:?}"))?;
+            self.channel_manager
+                .force_close_broadcasting_latest_txn(&channel_id, &peer)
+                .map_err(|e| anyhow!("Could not force-close channel {channel_id_str}: {e:?}"))?;
         };
 
         Ok(())

--- a/crates/ln-dlc-node/src/tests/dlc/non_collaborative_settlement.rs
+++ b/crates/ln-dlc-node/src/tests/dlc/non_collaborative_settlement.rs
@@ -49,10 +49,7 @@ async fn force_close_ln_dlc_channel() {
 
     // Act
 
-    coordinator
-        .force_close_channel(&channel_details)
-        .await
-        .unwrap();
+    coordinator.force_close_channel(&channel_details).unwrap();
 
     // Need 288 confirmations on the split transaction to be able to publish the glue and buffer
     // transactions

--- a/crates/ln-dlc-node/src/tests/just_in_time_channel/create.rs
+++ b/crates/ln-dlc-node/src/tests/just_in_time_channel/create.rs
@@ -153,7 +153,7 @@ async fn fail_to_open_jit_channel_with_fee_rate_over_max() {
         )
         .unwrap();
 
-    payer.pay_invoice(&invoice, None).await.unwrap();
+    payer.pay_invoice(&invoice, None).unwrap();
 
     // Assert
 
@@ -208,7 +208,7 @@ async fn open_jit_channel_with_disconnected_payee() {
         )
         .unwrap();
 
-    payer.pay_invoice(&invoice, None).await.unwrap();
+    payer.pay_invoice(&invoice, None).unwrap();
 
     // We wait a little bit until reconnecting to simulate a pending JIT channel on the coordinator
     tokio::time::sleep(Duration::from_secs(5)).await;
@@ -308,11 +308,12 @@ pub(crate) async fn send_interceptable_payment(
         "Invoice amount larger than maximum inbound HTLC in payer-coordinator channel"
     );
 
-    payer.pay_invoice(&invoice, None).await?;
+    payer.pay_invoice(&invoice, None).unwrap();
 
     payee
         .wait_for_payment_claimed(invoice.payment_hash())
-        .await?;
+        .await
+        .unwrap();
 
     // Assert
 
@@ -391,11 +392,12 @@ pub(crate) async fn send_payment(
         "Invoice amount larger than maximum inbound HTLC in payer-coordinator channel"
     );
 
-    payer.pay_invoice(&invoice, None).await?;
+    payer.pay_invoice(&invoice, None).unwrap();
 
     payee
         .wait_for_payment_claimed(invoice.payment_hash())
-        .await?;
+        .await
+        .unwrap();
 
     // Assert
 

--- a/crates/ln-dlc-node/src/tests/just_in_time_channel/fail_intercepted_htlc.rs
+++ b/crates/ln-dlc-node/src/tests/just_in_time_channel/fail_intercepted_htlc.rs
@@ -58,7 +58,7 @@ async fn fail_intercepted_htlc_if_coordinator_cannot_reconnect_to_payee() {
     payee.disconnect(coordinator.info);
     tokio::time::sleep(Duration::from_secs(1)).await;
 
-    payer.pay_invoice(&invoice, None).await.unwrap();
+    payer.pay_invoice(&invoice, None).unwrap();
 
     // Assert
 
@@ -128,7 +128,7 @@ async fn fail_intercepted_htlc_if_connection_lost_after_funding_tx_generated() {
 
     // Act
 
-    payer.pay_invoice(&invoice, None).await.unwrap();
+    payer.pay_invoice(&invoice, None).unwrap();
 
     tokio::time::timeout(Duration::from_secs(30), async {
         loop {
@@ -204,7 +204,7 @@ async fn fail_intercepted_htlc_if_coordinator_cannot_pay_to_open_jit_channel() {
         )
         .unwrap();
 
-    payer.pay_invoice(&invoice, None).await.unwrap();
+    payer.pay_invoice(&invoice, None).unwrap();
 
     // Assert
 

--- a/crates/ln-dlc-node/src/tests/multi_hop_payment.rs
+++ b/crates/ln-dlc-node/src/tests/multi_hop_payment.rs
@@ -64,7 +64,7 @@ async fn multi_hop_payment() {
         invoice_amount_sat,
     );
 
-    payer.pay_invoice(&invoice, None).await.unwrap();
+    payer.pay_invoice(&invoice, None).unwrap();
 
     payee
         .wait_for_payment_claimed(invoice.payment_hash())

--- a/crates/ln-dlc-node/src/tests/single_hop_payment.rs
+++ b/crates/ln-dlc-node/src/tests/single_hop_payment.rs
@@ -36,7 +36,7 @@ async fn single_hop_payment() {
         .create_invoice(invoice_amount, "".to_string(), 180)
         .unwrap();
 
-    payer.pay_invoice(&invoice, None).await.unwrap();
+    payer.pay_invoice(&invoice, None).unwrap();
 
     payee
         .wait_for_payment_claimed(invoice.payment_hash())

--- a/maker/src/routes.rs
+++ b/maker/src/routes.rs
@@ -256,7 +256,6 @@ pub async fn pay_invoice(
     state
         .node
         .pay_invoice(&invoice, None)
-        .await
         .map_err(|e| AppError::InternalServerError(format!("Could not pay invoice {e:#}")))?;
     Ok(())
 }

--- a/mobile/native/src/api.rs
+++ b/mobile/native/src/api.rs
@@ -290,13 +290,11 @@ pub fn get_unused_address() -> SyncReturn<String> {
 }
 
 pub fn close_channel() -> Result<()> {
-    let runtime = crate::state::get_or_create_tokio_runtime()?;
-    runtime.block_on(async { ln_dlc::close_channel(false).await })
+    ln_dlc::close_channel(false)
 }
 
 pub fn force_close_channel() -> Result<()> {
-    let runtime = crate::state::get_or_create_tokio_runtime()?;
-    runtime.block_on(async { ln_dlc::close_channel(true).await })
+    ln_dlc::close_channel(true)
 }
 
 /// Returns channel info if we have a channel available already

--- a/mobile/native/src/api.rs
+++ b/mobile/native/src/api.rs
@@ -277,7 +277,7 @@ pub fn run(
 
     db::init_db(&config::get_data_dir(), get_network())?;
 
-    let runtime = ln_dlc::get_or_create_tokio_runtime()?;
+    let runtime = crate::state::get_or_create_tokio_runtime()?;
     ln_dlc::run(seed_dir, runtime)?;
 
     let (_health, tx) = health::Health::new(runtime);
@@ -290,12 +290,12 @@ pub fn get_unused_address() -> SyncReturn<String> {
 }
 
 pub fn close_channel() -> Result<()> {
-    let runtime = ln_dlc::get_or_create_tokio_runtime()?;
+    let runtime = crate::state::get_or_create_tokio_runtime()?;
     runtime.block_on(async { ln_dlc::close_channel(false).await })
 }
 
 pub fn force_close_channel() -> Result<()> {
-    let runtime = ln_dlc::get_or_create_tokio_runtime()?;
+    let runtime = crate::state::get_or_create_tokio_runtime()?;
     runtime.block_on(async { ln_dlc::close_channel(true).await })
 }
 
@@ -409,7 +409,7 @@ pub enum SendPayment {
 }
 
 pub fn send_payment(payment: SendPayment) -> Result<()> {
-    let runtime = ln_dlc::get_or_create_tokio_runtime()?;
+    let runtime = crate::state::get_or_create_tokio_runtime()?;
     runtime.block_on(async { ln_dlc::send_payment(payment).await })
 }
 

--- a/mobile/native/src/ln_dlc/mod.rs
+++ b/mobile/native/src/ln_dlc/mod.rs
@@ -77,7 +77,6 @@ use ln_dlc_node::CONFIRMATION_TARGET;
 use orderbook_commons::RouteHintHop;
 use rust_decimal::prelude::ToPrimitive;
 use rust_decimal::Decimal;
-use state::Storage;
 use std::net::IpAddr;
 use std::net::Ipv4Addr;
 use std::net::SocketAddr;
@@ -141,7 +140,7 @@ pub async fn refresh_wallet_info() -> Result<()> {
 
     // Spawn into the blocking thread pool of the dedicated backend runtime to avoid blocking the UI
     // thread.
-    let runtime = get_or_create_tokio_runtime()?;
+    let runtime = crate::state::get_or_create_tokio_runtime()?;
     runtime.spawn_blocking(move || {
         if let Err(e) = wallet.sync() {
             tracing::error!("Manually triggered on-chain sync failed: {e:#}");
@@ -234,19 +233,6 @@ pub fn get_funding_transaction(channel_id: &ChannelId) -> Result<Txid> {
     };
 
     Ok(funding_transaction)
-}
-
-/// Lazily creates a multi threaded runtime with the the number of worker threads corresponding to
-/// the number of available cores.
-pub fn get_or_create_tokio_runtime() -> Result<&'static Runtime> {
-    static RUNTIME: Storage<Runtime> = Storage::new();
-
-    if RUNTIME.try_get().is_none() {
-        let runtime = Runtime::new()?;
-        RUNTIME.set(runtime);
-    }
-
-    Ok(RUNTIME.get())
 }
 
 /// Gets the 10101 node storage, initializes the storage if not found yet.
@@ -736,7 +722,7 @@ pub fn collaborative_revert_channel(
     };
 
     let client = reqwest_client();
-    let runtime = get_or_create_tokio_runtime()?;
+    let runtime = crate::state::get_or_create_tokio_runtime()?;
     runtime.spawn({
         let subchannel = subchannel.clone();
         async move {
@@ -884,7 +870,7 @@ pub fn max_channel_value() -> Result<Amount> {
 // TODO(holzeis): We might want to consider caching the lsp config, as this shouldn't change too
 // often and even if, I guess we can live with the user having to restart to get the newest configs?
 fn fetch_lsp_config() -> Result<LspConfig, Error> {
-    let runtime = get_or_create_tokio_runtime()?;
+    let runtime = crate::state::get_or_create_tokio_runtime()?;
     runtime.block_on(async {
         let client = reqwest_client();
         let response = client
@@ -938,7 +924,7 @@ pub fn create_onboarding_invoice(
     amount_sats: u64,
     fee_sats: u64,
 ) -> Result<Bolt11Invoice> {
-    let runtime = get_or_create_tokio_runtime()?;
+    let runtime = crate::state::get_or_create_tokio_runtime()?;
 
     runtime.block_on(async {
         let node = crate::state::get_node();

--- a/mobile/native/src/ln_dlc/mod.rs
+++ b/mobile/native/src/ln_dlc/mod.rs
@@ -615,15 +615,14 @@ pub fn get_unused_address() -> String {
         .to_string()
 }
 
-pub async fn close_channel(is_force_close: bool) -> Result<()> {
+pub fn close_channel(is_force_close: bool) -> Result<()> {
     let node = crate::state::try_get_node().context("failed to get ln dlc node")?;
 
     let channels = node.inner.list_channels();
     let channel_details = channels.first().context("No channel to close")?;
 
     node.inner
-        .close_channel(channel_details.channel_id, is_force_close)
-        .await?;
+        .close_channel(channel_details.channel_id, is_force_close)?;
 
     Ok(())
 }
@@ -1013,8 +1012,7 @@ pub async fn send_payment(payment: SendPayment) -> Result<()> {
             let invoice = Bolt11Invoice::from_str(&invoice)?;
             crate::state::get_node()
                 .inner
-                .pay_invoice(&invoice, amount)
-                .await?;
+                .pay_invoice(&invoice, amount)?;
         }
         SendPayment::OnChain { address, amount } => {
             let address = Address::from_str(&address)?;


### PR DESCRIPTION
Reverts the changes from https://github.com/get10101/10101/pull/1599 and https://github.com/get10101/10101/pull/1602 and uses the static tokio runtime to spawn the backup tasks.