### PR TITLE
fix: Check for channel closed by counterparty

### DIFF
--- a/crates/tests-e2e/src/coordinator.rs
+++ b/crates/tests-e2e/src/coordinator.rs
@@ -47,6 +47,7 @@ pub enum SubChannelState {
     Signed,
     Closing,
     OnChainClosed,
+    CounterOnChainClosed,
     // We don't care about other states for now
     #[serde(other)]
     Other,

--- a/crates/tests-e2e/tests/force_close_position.rs
+++ b/crates/tests-e2e/tests/force_close_position.rs
@@ -49,6 +49,8 @@ async fn check_for_channel_closed(
         .expect("to be able to retrieve dlc channels from coordinator")
         .iter()
         .any(|chan| {
-            chan.counter_party == app_pubkey && chan.state == SubChannelState::OnChainClosed
+            chan.counter_party == app_pubkey
+                && (chan.state == SubChannelState::OnChainClosed
+                    || chan.state == SubChannelState::CounterOnChainClosed)
         })
 }


### PR DESCRIPTION
I couldn't reproduce it locally, but it looks like the test sometimes fails as the counterparty was faster to broadcast the force-close transaction. That would result into a different sub channel state `SubChannelState::CounterOnChainClosed` which is never satisfied in our tests.

Logs from a failed test
`
2023-11-20T08:58:38.762568Z DEBUG ln_dlc_node::ln::event_handler: Received event event=ChannelClosed { channel_id: [128, 51, 43, 129, 47, 105, 245, 153, 151, 161, 145, 195, 201, 127, 71, 17, 80, 225, 87, 102, 210, 250, 85, 157, 98, 146, 203, 176, 165, 124, 246, 25], user_channel_id: 227848002640833202195941678669145496055, reason: HolderForceClosed }
`

Logs from a successful test
`
2023-11-20T09:40:36.121962Z DEBUG ln_dlc_node::ln::event_handler: Received event event=ChannelClosed { channel_id: [125, 11, 239, 31, 34, 165, 14, 11, 214, 195, 35, 197, 23, 245, 175, 191, 6, 115, 234, 156, 205, 30, 99, 223, 87, 194, 97, 134, 72, 111, 35, 39], user_channel_id: 137255084321847532753912677717785221346, reason: CounterpartyForceClosed { peer_msg: UntrustedString("Channel force-closed") } }
`