### PR TITLE
fix: Skip refreshing the lightning wallet on startup

### DIFF
--- a/mobile/lib/backend.dart
+++ b/mobile/lib/backend.dart
@@ -53,6 +53,8 @@ Future<void> runBackend(BuildContext context) async {
 
   String fcmToken = '';
   try {
+    // TODO(holzeis): Fetching the fcm token takes up to 2 seconds. Given that we this is not changing
+    // frequently, we should not block everytime when starting the app to wait on this.
     fcmToken = await FirebaseMessaging.instance.getToken() ?? '';
   } catch (e) {
     logger.e("Failed to get FCM token $e");

--- a/mobile/lib/backend.dart
+++ b/mobile/lib/backend.dart
@@ -3,7 +3,6 @@ import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:get_10101/features/trade/order_change_notifier.dart';
 import 'package:get_10101/features/trade/position_change_notifier.dart';
-import 'package:get_10101/features/wallet/wallet_change_notifier.dart';
 import 'package:get_10101/ffi.dart' as rust;
 import 'package:get_10101/bridge_generated/bridge_definitions.dart' as bridge;
 import 'package:get_10101/util/environment.dart';
@@ -49,7 +48,6 @@ Future<void> fullBackup() async {
 Future<void> runBackend(BuildContext context) async {
   final orderChangeNotifier = context.read<OrderChangeNotifier>();
   final positionChangeNotifier = context.read<PositionChangeNotifier>();
-  final walletChangeNotifier = context.read<WalletChangeNotifier>();
 
   final seedDir = (await getApplicationSupportDirectory()).path;
 
@@ -65,7 +63,6 @@ Future<void> runBackend(BuildContext context) async {
   // these notifiers depend on the backend running
   await orderChangeNotifier.initialize();
   await positionChangeNotifier.initialize();
-  await walletChangeNotifier.refreshLightningWallet();
 }
 
 Future<void> _startBackend({seedDir, fcmToken}) async {


### PR DESCRIPTION
This is already done at startup. Also, this additional await apparently impacts the startup performance. I assume its because a bdk lock is required somewhere which has to wait for the on-chain sync.