### PR TITLE
fix: Use rootNavigatorKey context for alert dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Fix missing context when opening alert dialog
+
 ## [1.6.0] - 2023-11-20
 
 - Move backup button to settings

--- a/mobile/lib/util/compare_coordinator_version.dart
+++ b/mobile/lib/util/compare_coordinator_version.dart
@@ -27,7 +27,7 @@ Future<void> compareCoordinatorVersion(bridge.Config config) async {
     if (coordinatorVersion.version > clientVersion) {
       logger.w("Client out of date. Current version: ${clientVersion.toString()}");
       showDialog(
-          context: shellNavigatorKey.currentContext!,
+          context: rootNavigatorKey.currentContext!,
           builder: (context) => AlertDialog(
                   title: const Text("Update available"),
                   content: Text("A new version of 10101 is available: "
@@ -48,7 +48,7 @@ Future<void> compareCoordinatorVersion(bridge.Config config) async {
   } catch (e) {
     logger.e("Error getting coordinator version: ${e.toString()}");
     showDialog(
-        context: shellNavigatorKey.currentContext!,
+        context: rootNavigatorKey.currentContext!,
         builder: (context) => AlertDialog(
                 title: const Text("Cannot reach LSP"),
                 content: const Text("Please check your Internet connection.\n"


### PR DESCRIPTION
This fixes an null error in case the shell is not yet loaded when the dialog should be shown. (also shows the dialog then)