### PR TITLE
chore: Increase next wait time

### DIFF
--- a/crates/tests-e2e/src/test_flow.rs
+++ b/crates/tests-e2e/src/test_flow.rs
@@ -3,7 +3,7 @@
 macro_rules! wait_until {
     ($expr:expr) => {
         // Waiting time for the time on the watch channel before returning error
-        let next_wait_time: std::time::Duration = std::time::Duration::from_secs(60);
+        let next_wait_time: std::time::Duration = std::time::Duration::from_secs(120);
 
         let result = tokio::time::timeout(next_wait_time, async {
             let mut wait_time = std::time::Duration::from_millis(10);


### PR DESCRIPTION
The sub_channel_manager_periodic_check is only running every 30 seconds. Waiting for only 60 seconds has some chances that the force closure was not finalized in time, leaving the sub channel state still in `Closing` when the test fails.

Doubling the timeout should hopefully increase the chances of this test to succeed. Tested here https://github.com/get10101/10101/actions/runs/6944655389/job/18892309832?pr=1619