### PR TITLE
chore: Add default features to bitcoin dependency

### DIFF
--- a/crates/trade/Cargo.toml
+++ b/crates/trade/Cargo.toml
@@ -8,7 +8,7 @@ description = "A common library for the shared model and functions for trading"
 
 [dependencies]
 anyhow = "1"
-bitcoin = { version = "0.29", default-features = false }
+bitcoin = "0.29"
 reqwest = { version = "0.11", default-features = false, features = ["json"] }
 rust_decimal = { version = "1", features = ["serde-with-float"] }
 rust_decimal_macros = "1"


### PR DESCRIPTION
Otherwise running the cfd test run into the following error

```
error: at least one of the `std` or `no-std` features must be enabled
  --> /Users/holzeis/.cargo/registry/src/index.crates.io-6f17d22bba15001f/bitcoin-0.29.2/src/lib.rs:47:1
   |
47 | compile_error!("at least one of the `std` or `no-std` features must be enabled");
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```