### PR TITLE
feat: Prevent resizing more than the current position quantity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Prevent reducing quantity more than the current position
+
 ## [1.6.1] - 2023-11-21
 
 - Fix missing context when opening alert dialog

--- a/mobile/lib/features/trade/trade_bottom_sheet_tab.dart
+++ b/mobile/lib/features/trade/trade_bottom_sheet_tab.dart
@@ -255,9 +255,13 @@ class _TradeBottomSheetTabState extends State<TradeBottomSheetTab> {
     bool hasPosition = positionChangeNotifier.positions.containsKey(contractSymbol);
 
     double? positionLeverage;
+    int? positionQuantity;
+    Direction? positionDirection;
     if (hasPosition) {
       final position = context.read<PositionChangeNotifier>().positions[contractSymbol];
-      positionLeverage = position!.leverage.leverage;
+      positionLeverage = position?.leverage.leverage;
+      positionQuantity = position?.quantity.toInt;
+      positionDirection = position?.direction;
     }
 
     return Wrap(
@@ -357,6 +361,12 @@ class _TradeBottomSheetTabState extends State<TradeBottomSheetTab> {
                 }
                 if (margin.sats < minTradeMargin.sats) {
                   return "Min margin is ${minTradeMargin.sats}";
+                }
+
+                if (hasPosition &&
+                    quantity.toInt > positionQuantity! &&
+                    direction != positionDirection!) {
+                  return "Can't resize more than $positionQuantity";
                 }
 
                 showCapacityInfo = false;


### PR DESCRIPTION
While working on https://github.com/get10101/10101/issues/1625 I noticed that the way we do a resizing with changing the direction completely can't work the way we have it designed at the moment.

The issue is that we have a bid and an ask price. If we are changing the general direction of our position during resizing we are not using the correct price for the new position.

As a quick fix I've added a simple UI validation rule, that prevents the user from reducing a position further than the current quantity of the position.