### PR TITLE
fix: Handle error on channel receive

### DIFF
--- a/coordinator/src/orderbook/async_match.rs
+++ b/coordinator/src/orderbook/async_match.rs
@@ -20,6 +20,7 @@ use orderbook_commons::OrderReason;
 use orderbook_commons::OrderState;
 use time::OffsetDateTime;
 use tokio::sync::broadcast;
+use tokio::sync::broadcast::error::RecvError;
 use tokio::sync::mpsc;
 
 pub fn monitor(
@@ -31,17 +32,28 @@ pub fn monitor(
 ) -> RemoteHandle<Result<()>> {
     let mut user_feed = tx_user_feed.subscribe();
     let (fut, remote_handle) = async move {
-        while let Ok(new_user_msg) = user_feed.recv().await {
-            tokio::spawn({
-                let mut conn = pool.get()?;
-                let notifier = notifier.clone();
-                async move {
-                    tracing::debug!(trader_id=%new_user_msg.new_user, "Checking if the user needs to be notified about pending matches");
-                    if let Err(e) = process_pending_match(&mut conn, notifier, new_user_msg.new_user, network, oracle_pk).await {
-                        tracing::error!("Failed to process pending match. Error: {e:#}");
-                    }
+        loop {
+            match user_feed.recv().await {
+                Ok(new_user_msg) => {
+                    tokio::spawn({
+                        let mut conn = pool.get()?;
+                        let notifier = notifier.clone();
+                        async move {
+                            tracing::debug!(trader_id=%new_user_msg.new_user, "Checking if the user needs to be notified about pending matches");
+                            if let Err(e) = process_pending_match(&mut conn, notifier, new_user_msg.new_user, network, oracle_pk).await {
+                                tracing::error!("Failed to process pending match. Error: {e:#}");
+                            }
+                        }
+                    });
                 }
-            });
+                Err(RecvError::Closed) => {
+                    tracing::error!("New user message sender died! Channel closed.");
+                    break;
+                }
+                Err(RecvError::Lagged(skip)) => tracing::warn!(%skip,
+                        "Lagging behind on new user message."
+                    ),
+            }
         }
         Ok(())
     }.remote_handle();


### PR DESCRIPTION
Without that fixed we would have simply broke out of the loop and the task completed.

Note, the capacity of a 100 should have been enough, and it doesn't look like the channel got closed. Hopefully we learn more by logging errors when receiving a message from the channel.

fixes #1646 