### PR TITLE
Reduce linking time by using Rust "unit" tests in `tests-e2e`

### DIFF
--- a/crates/tests-e2e/src/lib.rs
+++ b/crates/tests-e2e/src/lib.rs
@@ -1,5 +1,8 @@
 #![allow(clippy::unwrap_used)]
 
+#[cfg(test)]
+mod tests;
+
 pub mod app;
 pub mod bitcoind;
 pub mod coordinator;

--- a/crates/tests-e2e/src/test_flow.rs
+++ b/crates/tests-e2e/src/test_flow.rs
@@ -3,7 +3,7 @@
 macro_rules! wait_until {
     ($expr:expr) => {
         // Waiting time for the time on the watch channel before returning error
-        let next_wait_time: std::time::Duration = std::time::Duration::from_secs(120);
+        let next_wait_time = std::time::Duration::from_secs(120);
 
         let result = tokio::time::timeout(next_wait_time, async {
             let mut wait_time = std::time::Duration::from_millis(10);

--- a/crates/tests-e2e/src/tests.rs
+++ b/crates/tests-e2e/src/tests.rs
@@ -1,0 +1,12 @@
+mod basic;
+mod close_position;
+mod collaborative_revert_position;
+mod collaborative_revert_position_without_channel_details;
+mod force_close_position;
+mod maker;
+mod open_position;
+mod receive_payment_when_open_position;
+mod resize_position;
+mod restore_from_backup;
+mod rollover_position;
+mod send_payment_when_open_position;

--- a/crates/tests-e2e/src/tests/basic.rs
+++ b/crates/tests-e2e/src/tests/basic.rs
@@ -1,11 +1,11 @@
+use crate::app::run_app;
+use crate::bitcoind::Bitcoind;
+use crate::coordinator::Coordinator;
+use crate::fund::fund_app_with_faucet;
+use crate::http::init_reqwest;
+use crate::logger::init_tracing;
 use anyhow::Result;
 use bitcoin::Amount;
-use tests_e2e::app::run_app;
-use tests_e2e::bitcoind::Bitcoind;
-use tests_e2e::coordinator::Coordinator;
-use tests_e2e::fund::fund_app_with_faucet;
-use tests_e2e::http::init_reqwest;
-use tests_e2e::logger::init_tracing;
 
 #[tokio::test]
 #[ignore = "need to be run with 'just e2e' command"]

--- a/crates/tests-e2e/src/tests/close_position.rs
+++ b/crates/tests-e2e/src/tests/close_position.rs
@@ -1,8 +1,8 @@
+use crate::setup;
+use crate::setup::dummy_order;
+use crate::wait_until;
 use native::api;
 use native::trade::position::PositionState;
-use tests_e2e::setup;
-use tests_e2e::setup::dummy_order;
-use tests_e2e::wait_until;
 use tokio::task::spawn_blocking;
 
 #[tokio::test]

--- a/crates/tests-e2e/src/tests/collaborative_revert_position.rs
+++ b/crates/tests-e2e/src/tests/collaborative_revert_position.rs
@@ -1,13 +1,11 @@
-#![allow(clippy::unwrap_used)]
-
+use crate::bitcoind::Bitcoind;
+use crate::coordinator::Coordinator;
+use crate::setup;
+use crate::wait_until;
 use bitcoin::Txid;
 use coordinator::admin::Balance;
 use native::api;
 use std::str::FromStr;
-use tests_e2e::bitcoind::Bitcoind;
-use tests_e2e::coordinator::Coordinator;
-use tests_e2e::setup;
-use tests_e2e::wait_until;
 use tokio::task::block_in_place;
 
 // TODO: We should check that the on-chain balances have increased by the _expected amount_ for

--- a/crates/tests-e2e/src/tests/collaborative_revert_position_without_channel_details.rs
+++ b/crates/tests-e2e/src/tests/collaborative_revert_position_without_channel_details.rs
@@ -1,14 +1,12 @@
-#![allow(clippy::unwrap_used)]
-
+use crate::bitcoind::Bitcoind;
+use crate::coordinator::Coordinator;
+use crate::setup;
+use crate::wait_until;
 use bitcoin::Txid;
 use coordinator::admin::Balance;
 use native::api;
 use rust_decimal_macros::dec;
 use std::str::FromStr;
-use tests_e2e::bitcoind::Bitcoind;
-use tests_e2e::coordinator::Coordinator;
-use tests_e2e::setup;
-use tests_e2e::wait_until;
 use tokio::task::block_in_place;
 
 // TODO: We should check that the on-chain balances have increased by the _expected amount_ for

--- a/crates/tests-e2e/src/tests/force_close_position.rs
+++ b/crates/tests-e2e/src/tests/force_close_position.rs
@@ -1,11 +1,9 @@
-#![allow(clippy::unwrap_used)]
-
+use crate::bitcoind::Bitcoind;
+use crate::coordinator::Coordinator;
+use crate::coordinator::SubChannelState;
+use crate::setup;
+use crate::wait_until;
 use native::api;
-use tests_e2e::bitcoind::Bitcoind;
-use tests_e2e::coordinator::Coordinator;
-use tests_e2e::coordinator::SubChannelState;
-use tests_e2e::setup;
-use tests_e2e::wait_until;
 
 #[tokio::test]
 #[ignore = "need to be run with 'just e2e' command"]

--- a/crates/tests-e2e/src/tests/maker.rs
+++ b/crates/tests-e2e/src/tests/maker.rs
@@ -1,12 +1,12 @@
+use crate::bitcoind::Bitcoind;
+use crate::coordinator::Coordinator;
+use crate::http::init_reqwest;
+use crate::logger::init_tracing;
+use crate::maker::Maker;
+use crate::wait_until;
 use anyhow::Result;
 use bitcoin::Amount;
 use std::time::Duration;
-use tests_e2e::bitcoind::Bitcoind;
-use tests_e2e::coordinator::Coordinator;
-use tests_e2e::http::init_reqwest;
-use tests_e2e::logger::init_tracing;
-use tests_e2e::maker::Maker;
-use tests_e2e::wait_until;
 
 #[tokio::test]
 #[ignore = "need to be run with 'just e2e' command"]

--- a/crates/tests-e2e/src/tests/open_position.rs
+++ b/crates/tests-e2e/src/tests/open_position.rs
@@ -1,3 +1,5 @@
+use crate::setup::TestSetup;
+use crate::wait_until;
 use native::api;
 use native::api::ContractSymbol;
 use native::health::Service;
@@ -5,8 +7,6 @@ use native::health::ServiceStatus;
 use native::trade::order::api::NewOrder;
 use native::trade::order::api::OrderType;
 use native::trade::position::PositionState;
-use tests_e2e::setup::TestSetup;
-use tests_e2e::wait_until;
 use tokio::task::spawn_blocking;
 
 fn dummy_order() -> NewOrder {

--- a/crates/tests-e2e/src/tests/receive_payment_when_open_position.rs
+++ b/crates/tests-e2e/src/tests/receive_payment_when_open_position.rs
@@ -1,6 +1,6 @@
+use crate::setup;
+use crate::wait_until;
 use native::api;
-use tests_e2e::setup;
-use tests_e2e::wait_until;
 use tokio::task::spawn_blocking;
 
 #[tokio::test]

--- a/crates/tests-e2e/src/tests/resize_position.rs
+++ b/crates/tests-e2e/src/tests/resize_position.rs
@@ -1,11 +1,11 @@
+use crate::setup::TestSetup;
+use crate::wait_until;
 use native::api;
 use native::api::ContractSymbol;
 use native::api::Direction;
 use native::trade::order::api::NewOrder;
 use native::trade::order::api::OrderType;
 use native::trade::position::PositionState;
-use tests_e2e::setup::TestSetup;
-use tests_e2e::wait_until;
 use tokio::task::spawn_blocking;
 
 #[tokio::test]

--- a/crates/tests-e2e/src/tests/restore_from_backup.rs
+++ b/crates/tests-e2e/src/tests/restore_from_backup.rs
@@ -1,10 +1,10 @@
+use crate::app::run_app;
+use crate::logger::init_tracing;
+use crate::setup;
+use crate::setup::dummy_order;
+use crate::wait_until;
 use native::api;
 use native::trade::position::PositionState;
-use tests_e2e::app::run_app;
-use tests_e2e::logger::init_tracing;
-use tests_e2e::setup;
-use tests_e2e::setup::dummy_order;
-use tests_e2e::wait_until;
 use tokio::task::spawn_blocking;
 
 #[tokio::test]

--- a/crates/tests-e2e/src/tests/rollover_position.rs
+++ b/crates/tests-e2e/src/tests/rollover_position.rs
@@ -1,12 +1,10 @@
-#![allow(clippy::unwrap_used)]
-
+use crate::app::AppHandle;
+use crate::setup;
+use crate::wait_until;
 use bitcoin::Network;
 use native::api;
 use native::trade::position;
 use position::PositionState;
-use tests_e2e::app::AppHandle;
-use tests_e2e::setup;
-use tests_e2e::wait_until;
 use time::OffsetDateTime;
 
 #[tokio::test]

--- a/crates/tests-e2e/src/tests/send_payment_when_open_position.rs
+++ b/crates/tests-e2e/src/tests/send_payment_when_open_position.rs
@@ -1,7 +1,7 @@
+use crate::setup;
+use crate::wait_until;
 use native::api;
 use native::api::SendPayment;
-use tests_e2e::setup;
-use tests_e2e::wait_until;
 use tokio::task::spawn_blocking;
 
 #[tokio::test]


### PR DESCRIPTION
Rust "unit" tests are just tests that are located next to the code. By putting the e2e tests next to the auxiliary code in the `tests-e2e` crate, we avoid re-linking and building a separate binary for each e2e test.

Advice taken from this blog post[^1], which we already applied to the `ln-dlc-node` crate.

[^1]: https://matklad.github.io/2021/02/27/delete-cargo-integration-tests.html.

---

I was motivated to do this because linking the tests was failing for me locally. My theory is that my linker gave up having to do linking for so many test binaries.