### PR TITLE
chore: Reduce websocket reconnect timeout to 200ms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Fix: Reduce websocket reconnect timeout to 200ms
+
 ## [1.6.6] - 2023-12-01
 
 - Fix: Add backwards-compatibility of `ChainMonitor`s created before version 1.5.0

--- a/crates/commons/src/message.rs
+++ b/crates/commons/src/message.rs
@@ -79,7 +79,7 @@ impl Display for Message {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Message::AllOrders(_) => {
-                write!(f, "AllOrdere")
+                write!(f, "AllOrders")
             }
             Message::LimitOrderFilledMatches { .. } => {
                 write!(f, "LimitOrderFilledMatches")

--- a/mobile/native/src/orderbook.rs
+++ b/mobile/native/src/orderbook.rs
@@ -257,6 +257,9 @@ async fn handle_orderbook_mesage(
 
             *orders = initial_orders;
 
+            // if we receive a full set of new orders, we can clear the cached best price as it is
+            // outdated information.
+            cached_best_price.clear();
             update_prices_if_needed(cached_best_price, &orders);
         }
         Message::NewOrder(order) => {

--- a/mobile/native/src/state.rs
+++ b/mobile/native/src/state.rs
@@ -1,8 +1,10 @@
 use crate::config::ConfigInternal;
 use crate::ln_dlc::node::Node;
+use crate::logger::LogEntry;
 use crate::storage::TenTenOneNodeStorage;
 use anyhow::Result;
 use commons::OrderbookRequest;
+use flutter_rust_bridge::StreamSink;
 use ln_dlc_node::seed::Bip39Seed;
 use parking_lot::RwLock;
 use state::Storage;
@@ -21,6 +23,7 @@ static SEED: Storage<RwLock<Bip39Seed>> = Storage::new();
 static STORAGE: Storage<RwLock<TenTenOneNodeStorage>> = Storage::new();
 static RUNTIME: Storage<Runtime> = Storage::new();
 static WEBSOCKET: Storage<RwLock<Sender<OrderbookRequest>>> = Storage::new();
+static LOG_STREAM_SINK: Storage<RwLock<Arc<StreamSink<LogEntry>>>> = Storage::new();
 
 pub fn set_config(config: ConfigInternal) {
     match CONFIG.try_get() {
@@ -112,4 +115,17 @@ pub fn get_websocket() -> Sender<OrderbookRequest> {
 
 pub fn try_get_websocket() -> Option<Sender<OrderbookRequest>> {
     WEBSOCKET.try_get().map(|w| w.read().clone())
+}
+
+pub fn set_log_stream_sink(sink: Arc<StreamSink<LogEntry>>) {
+    match LOG_STREAM_SINK.try_get() {
+        Some(l) => *l.write() = sink,
+        None => {
+            LOG_STREAM_SINK.set(RwLock::new(sink));
+        }
+    }
+}
+
+pub fn try_get_log_stream_sink() -> Option<Arc<StreamSink<LogEntry>>> {
+    LOG_STREAM_SINK.try_get().map(|l| l.read().clone())
 }


### PR DESCRIPTION
This was originally increased to ensure that a rollover is not failing if the app is open and the coordinator restarts while moving into the rollover window, as the rollover will fail.

However, this is a very edge case, that shouldn't happen very often and even if it's happening. The rollover will simply timeout and finish on the next restart of the app without any errors.

Reducing this timeout to 200ms gives the app a more ready feeling as the app will not wait 5s before reconnect and thus fetching the latest limit orders to get a price.