### PR TITLE
fix: Add error handling on failed restore future

### DIFF
--- a/mobile/lib/features/welcome/seed_import_screen.dart
+++ b/mobile/lib/features/welcome/seed_import_screen.dart
@@ -141,9 +141,12 @@ class SeedPhraseImporterState extends State<SeedPhraseImporter> {
                               getSeedFilePath().then((seedPath) {
                                 logger.i("Restoring seed into $seedPath");
 
-                                final restore = api.restoreFromSeedPhrase(
-                                    seedPhrase: seedPhrase, targetSeedFilePath: seedPath);
-
+                                final restore = api
+                                    .restoreFromSeedPhrase(
+                                        seedPhrase: seedPhrase, targetSeedFilePath: seedPath)
+                                    .catchError((error) => showSnackBar(
+                                        ScaffoldMessenger.of(context),
+                                        "Failed to import from seed. $error"));
                                 // TODO(holzeis): Backup preferences and restore email from there.
                                 Preferences.instance.setEmailAddress("restored");
                                 GoRouter.of(context).go(LoadingScreen.route, extra: restore);


### PR DESCRIPTION
Not a perfect fix, but at least it prevents the app from hanging in the loading screen if the seed phrase entered at restore is invalid.