### PR TITLE
Replace speed dial with 3 buttons

### DIFF
--- a/mobile/lib/features/wallet/wallet_screen.dart
+++ b/mobile/lib/features/wallet/wallet_screen.dart
@@ -1,14 +1,12 @@
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_speed_dial/flutter_speed_dial.dart';
+import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 import 'package:get_10101/common/channel_status_notifier.dart';
 import 'package:get_10101/features/wallet/balance.dart';
 import 'package:get_10101/features/wallet/receive_screen.dart';
 import 'package:get_10101/features/wallet/onboarding/onboarding_screen.dart';
 import 'package:get_10101/features/wallet/send/send_screen.dart';
 import 'package:get_10101/features/wallet/wallet_change_notifier.dart';
-import 'package:get_10101/features/wallet/wallet_theme.dart';
-import 'package:get_10101/util/send_receive_icons.dart';
 import 'package:go_router/go_router.dart';
 import 'package:provider/provider.dart';
 
@@ -24,7 +22,7 @@ class WalletScreen extends StatelessWidget {
 
     final hasChannel = context.watch<ChannelStatusNotifier>().hasChannel();
 
-    WalletTheme theme = Theme.of(context).extension<WalletTheme>()!;
+    ButtonStyle balanceButtonStyle = balanceActionButtonStyle();
 
     return Scaffold(
       body: RefreshIndicator(
@@ -40,16 +38,80 @@ class WalletScreen extends StatelessWidget {
             children: [
               const Balance(),
               const SizedBox(height: 10.0),
-              if (walletChangeNotifier.lightning().sats == 0)
-                Container(
+              Container(
                   margin: const EdgeInsets.only(left: 4, right: 4),
-                  child: ElevatedButton(
-                    onPressed: () {
-                      context.go(OnboardingScreen.route);
-                    },
-                    child: const Text("Fund Wallet"),
-                  ),
-                ),
+                  child: Row(children: [
+                    Expanded(
+                      child: ElevatedButton(
+                        style: balanceButtonStyle,
+                        // Additionally checking the Lightning balance here, as when
+                        // hot reloading the app the channel info appears to be
+                        // unknown.
+                        onPressed: () => context.go(
+                            (hasChannel || walletChangeNotifier.lightning().sats > 0)
+                                ? ReceiveScreen.route
+                                : OnboardingScreen.route),
+                        child: const Row(
+                          mainAxisAlignment: MainAxisAlignment.center,
+                          children: [
+                            Icon(
+                              FontAwesomeIcons.arrowDown,
+                              size: 14,
+                            ),
+                            SizedBox(width: 10),
+                            Text(
+                              'Receive',
+                              style: TextStyle(fontSize: 14, fontWeight: FontWeight.normal),
+                            )
+                          ],
+                        ),
+                      ),
+                    ),
+                    const SizedBox(width: 10.0),
+                    Expanded(
+                      child: ElevatedButton(
+                        style: balanceButtonStyle,
+                        onPressed: () {
+                          // TODO: Take me to the Lightning-USDp swap screen.
+                        },
+                        child: const Row(
+                          mainAxisAlignment: MainAxisAlignment.center,
+                          children: [
+                            Icon(
+                              FontAwesomeIcons.rotate,
+                              size: 14,
+                            ),
+                            SizedBox(width: 10),
+                            Text(
+                              'Swap',
+                              style: TextStyle(fontSize: 14, fontWeight: FontWeight.normal),
+                            )
+                          ],
+                        ),
+                      ),
+                    ),
+                    const SizedBox(width: 10.0),
+                    Expanded(
+                      child: ElevatedButton(
+                        style: balanceButtonStyle,
+                        onPressed: () => GoRouter.of(context).go(SendScreen.route),
+                        child: const Row(
+                          mainAxisAlignment: MainAxisAlignment.center,
+                          children: [
+                            Icon(
+                              FontAwesomeIcons.arrowUp,
+                              size: 14,
+                            ),
+                            SizedBox(width: 10),
+                            Text(
+                              'Send',
+                              style: TextStyle(fontSize: 14, fontWeight: FontWeight.normal),
+                            )
+                          ],
+                        ),
+                      ),
+                    )
+                  ])),
               const SizedBox(
                 height: 5,
               ),
@@ -74,36 +136,22 @@ class WalletScreen extends StatelessWidget {
           ),
         ),
       ),
-      floatingActionButton: SpeedDial(
-        icon: SendReceiveIcons.sendReceive,
-        iconTheme: const IconThemeData(size: 20),
-        activeIcon: Icons.close,
-        buttonSize: const Size(56.0, 56.0),
-        visible: true,
-        closeManually: false,
-        curve: Curves.bounceIn,
-        overlayColor: theme.dividerColor,
-        overlayOpacity: 0.5,
-        elevation: 8.0,
-        shape: const CircleBorder(),
-        children: [
-          SpeedDialChild(
-            child: const Icon(SendReceiveIcons.receive, size: 20.0),
-            label: 'Receive',
-            labelStyle: const TextStyle(fontSize: 18.0),
-            // additionally checking the lightning balance here, as when hot reloading the app the channel info appears to be unknown.
-            onTap: () => context.go((hasChannel || walletChangeNotifier.lightning().sats > 0)
-                ? ReceiveScreen.route
-                : OnboardingScreen.route),
-          ),
-          SpeedDialChild(
-            child: const Icon(SendReceiveIcons.sendWithQr, size: 24.0),
-            label: 'Send',
-            labelStyle: const TextStyle(fontSize: 18.0),
-            onTap: () => GoRouter.of(context).go(SendScreen.route),
-          ),
-        ],
-      ),
+    );
+  }
+
+  ButtonStyle balanceActionButtonStyle() {
+    ColorScheme greyScheme = ColorScheme.fromSwatch(primarySwatch: Colors.grey);
+
+    return IconButton.styleFrom(
+      foregroundColor: Colors.black,
+      backgroundColor: Colors.grey.shade200,
+      disabledBackgroundColor: greyScheme.onSurface.withOpacity(0.12),
+      elevation: 0,
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8.0)),
+      hoverColor: greyScheme.onPrimary.withOpacity(0.08),
+      focusColor: greyScheme.onPrimary.withOpacity(0.12),
+      highlightColor: greyScheme.onPrimary.withOpacity(0.12),
+      visualDensity: const VisualDensity(horizontal: 0.0, vertical: 1.0),
     );
   }
 }

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -438,14 +438,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.78.0"
-  flutter_speed_dial:
-    dependency: "direct main"
-    description:
-      name: flutter_speed_dial
-      sha256: "698a037274a66dbae8697c265440e6acb6ab6cae9ac5f95c749e7944d8f28d41"
-      url: "https://pub.dev"
-    source: hosted
-    version: "7.0.0"
   flutter_svg:
     dependency: "direct main"
     description:

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -10,7 +10,6 @@ dependencies:
   cupertino_icons: ^1.0.5
   ffi: ^2.0.2
   flutter_rust_bridge: ^1.78.0
-  flutter_speed_dial: ^7.0.0
   meta: ^1.8.0
   go_router: ^9.0.0
   flutter_native_splash: ^2.2.19


### PR DESCRIPTION
Fixes #1515.
Fixes https://github.com/get10101/10101/issues/1678.

https://github.com/get10101/10101/assets/9418575/4820fb6e-8b7f-43c3-9aa3-19a9d3c80a9c

---

- Choose a speficic style for the new buttons that diverges from the `WalletTheme`. This is purely subjective, I'm just proposing something (temporary) here. I also went for no icons, since I didn't like any of the options readily available. _I'm happy to change everything related to the styles._

- Remove fund button since the now always-visible `Receive` button serves the same purpose.