### PR TITLE
fix: Remove unneeded fixed width from total balance

### DIFF
--- a/mobile/lib/features/wallet/balance.dart
+++ b/mobile/lib/features/wallet/balance.dart
@@ -44,7 +44,6 @@ class Balance extends StatelessWidget {
                     fontWeight: FontWeight.bold,
                   )),
               const Icon(Icons.currency_bitcoin, size: 28, color: tenTenOnePurple),
-              const SizedBox(width: 16)
             ],
           ),
           const SizedBox(


### PR DESCRIPTION
This was shifting the total balance annoyingly to the left, which made it not centered on the screen.

left: before, right: after (the lines are the same length)

![Screenshot 2023-12-06 at 11 42 15](https://github.com/get10101/10101/assets/382048/bb05fbc0-4cce-4b86-8b8b-bb1bc8cabbec)