### PR TITLE
Fix overflow in `rust-miniscript` for iOS and Android builds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -321,7 +321,7 @@ dependencies = [
  "getrandom",
  "js-sys",
  "log",
- "miniscript 9.0.1",
+ "miniscript 9.0.2",
  "rand",
  "serde",
  "serde_json",
@@ -1132,7 +1132,7 @@ version = "0.4.0"
 source = "git+https://github.com/p2pderivatives/rust-dlc?rev=145cf6e#145cf6ef153035ac0d93d22f22051e49d678eee5"
 dependencies = [
  "bitcoin",
- "miniscript 8.0.0",
+ "miniscript 8.0.2",
  "secp256k1-sys",
  "secp256k1-zkp",
  "serde",
@@ -2287,18 +2287,18 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniscript"
-version = "8.0.0"
+version = "8.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f4975078076f0b7b914a3044ad7432d2a7fcec38edb855afdc672e24ca35b69"
+checksum = "e5f536c4b9b0868b37f4fb276758831fa93401f1fadc03447607f06ef4c72ee1"
 dependencies = [
  "bitcoin",
 ]
 
 [[package]]
 name = "miniscript"
-version = "9.0.1"
+version = "9.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9601439f168c13bdc5bf84349c2e61c815be4a4dcebe8c4ff4af58f4e8a6d20"
+checksum = "e5b106477a0709e2da253e5559ba4ab20a272f8577f1eefff72f3a905b5d35f5"
 dependencies = [
  "bitcoin",
  "serde",


### PR DESCRIPTION
By bumping our two miniscript versions to later patch releases which include the fix backported from `miniscript:10`.

We were only hitting this when [building for Android and iOS](https://github.com/get10101/10101/actions/runs/7086216992), since this merge commit: 3615e5bd.

---

Related issue: https://github.com/rust-bitcoin/rust-miniscript/issues/549.