### PR TITLE
Revert a `rust-lightning` patch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1915,7 +1915,7 @@ dependencies = [
 [[package]]
 name = "lightning"
 version = "0.0.117"
-source = "git+https://github.com/p2pderivatives/rust-lightning/?rev=08c0c5fd#08c0c5fd00721af410d4e56b172175afa3f6a4fa"
+source = "git+https://github.com/p2pderivatives/rust-lightning/?rev=121bc324#121bc324fec54cfb8b0335ec013f596ffc9d6f9f"
 dependencies = [
  "bitcoin",
  "musig2",
@@ -1924,7 +1924,7 @@ dependencies = [
 [[package]]
 name = "lightning-background-processor"
 version = "0.0.117"
-source = "git+https://github.com/p2pderivatives/rust-lightning/?rev=08c0c5fd#08c0c5fd00721af410d4e56b172175afa3f6a4fa"
+source = "git+https://github.com/p2pderivatives/rust-lightning/?rev=121bc324#121bc324fec54cfb8b0335ec013f596ffc9d6f9f"
 dependencies = [
  "bitcoin",
  "lightning",
@@ -1948,7 +1948,7 @@ dependencies = [
 [[package]]
 name = "lightning-net-tokio"
 version = "0.0.117"
-source = "git+https://github.com/p2pderivatives/rust-lightning/?rev=08c0c5fd#08c0c5fd00721af410d4e56b172175afa3f6a4fa"
+source = "git+https://github.com/p2pderivatives/rust-lightning/?rev=121bc324#121bc324fec54cfb8b0335ec013f596ffc9d6f9f"
 dependencies = [
  "bitcoin",
  "lightning",
@@ -1958,7 +1958,7 @@ dependencies = [
 [[package]]
 name = "lightning-persister"
 version = "0.0.117"
-source = "git+https://github.com/p2pderivatives/rust-lightning/?rev=08c0c5fd#08c0c5fd00721af410d4e56b172175afa3f6a4fa"
+source = "git+https://github.com/p2pderivatives/rust-lightning/?rev=121bc324#121bc324fec54cfb8b0335ec013f596ffc9d6f9f"
 dependencies = [
  "bitcoin",
  "lightning",
@@ -1968,7 +1968,7 @@ dependencies = [
 [[package]]
 name = "lightning-rapid-gossip-sync"
 version = "0.0.117"
-source = "git+https://github.com/p2pderivatives/rust-lightning/?rev=08c0c5fd#08c0c5fd00721af410d4e56b172175afa3f6a4fa"
+source = "git+https://github.com/p2pderivatives/rust-lightning/?rev=121bc324#121bc324fec54cfb8b0335ec013f596ffc9d6f9f"
 dependencies = [
  "bitcoin",
  "lightning",
@@ -1977,7 +1977,7 @@ dependencies = [
 [[package]]
 name = "lightning-transaction-sync"
 version = "0.0.117"
-source = "git+https://github.com/p2pderivatives/rust-lightning/?rev=08c0c5fd#08c0c5fd00721af410d4e56b172175afa3f6a4fa"
+source = "git+https://github.com/p2pderivatives/rust-lightning/?rev=121bc324#121bc324fec54cfb8b0335ec013f596ffc9d6f9f"
 dependencies = [
  "bdk-macros",
  "bitcoin",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,12 +29,12 @@ p2pd-oracle-client = { git = "https://github.com/p2pderivatives/rust-dlc", rev =
 dlc-trie = { git = "https://github.com/p2pderivatives/rust-dlc", rev = "145cf6e" }
 
 # We should usually track the `p2pderivatives/split-tx-experiment[-10101]` branch.
-lightning = { git = "https://github.com/p2pderivatives/rust-lightning/", rev = "08c0c5fd" }
-lightning-background-processor = { git = "https://github.com/p2pderivatives/rust-lightning/", rev = "08c0c5fd" }
-lightning-transaction-sync = { git = "https://github.com/p2pderivatives/rust-lightning/", rev = "08c0c5fd" }
-lightning-net-tokio = { git = "https://github.com/p2pderivatives/rust-lightning/", rev = "08c0c5fd" }
-lightning-persister = { git = "https://github.com/p2pderivatives/rust-lightning/", rev = "08c0c5fd" }
-lightning-rapid-gossip-sync = { git = "https://github.com/p2pderivatives/rust-lightning/", rev = "08c0c5fd" }
+lightning = { git = "https://github.com/p2pderivatives/rust-lightning/", rev = "121bc324" }
+lightning-background-processor = { git = "https://github.com/p2pderivatives/rust-lightning/", rev = "121bc324" }
+lightning-transaction-sync = { git = "https://github.com/p2pderivatives/rust-lightning/", rev = "121bc324" }
+lightning-net-tokio = { git = "https://github.com/p2pderivatives/rust-lightning/", rev = "121bc324" }
+lightning-persister = { git = "https://github.com/p2pderivatives/rust-lightning/", rev = "121bc324" }
+lightning-rapid-gossip-sync = { git = "https://github.com/p2pderivatives/rust-lightning/", rev = "121bc324" }
 
 rust-bitcoin-coin-selection = { git = "https://github.com/p2pderivatives/rust-bitcoin-coin-selection" }
 

--- a/crates/ln-dlc-node/src/node/dlc_channel.rs
+++ b/crates/ln-dlc-node/src/node/dlc_channel.rs
@@ -127,6 +127,8 @@ impl<S: TenTenOneStorage + 'static, N: LnDlcStorage + Sync + Send + 'static> Nod
             Message::SubChannel(SubChannelMessage::Accept(accept_sub_channel)),
         );
 
+        tracing::info!(channel_id = %channel_id_hex, "Sent DLC channel accept message");
+
         Ok(())
     }
 

--- a/mobile/native/src/logger.rs
+++ b/mobile/native/src/logger.rs
@@ -28,7 +28,7 @@ pub fn log_base_directives(env: EnvFilter, level: LevelFilter) -> Result<EnvFilt
         .add_directive("sled=warn".parse()?)
         .add_directive("bdk=warn".parse()?) // bdk is quite spamy on debug
         .add_directive("lightning_transaction_sync=warn".parse()?)
-        .add_directive("lightning::ln::peer_handler=debug".parse()?)
+        .add_directive("lightning::ln::peer_handler=trace".parse()?)
         .add_directive("lightning=trace".parse()?)
         .add_directive("ureq=info".parse()?);
     Ok(filter)


### PR DESCRIPTION
This _may_ be a fix for https://github.com/get10101/10101/issues/1697.

This is the reverting patch: https://github.com/lightningdevkit/rust-lightning/commit/121bc324.