### PR TITLE
Prevent `coordinator::orderbook::trading` task from stopping if getting DB connection times out

### DIFF
--- a/coordinator/src/bin/coordinator.rs
+++ b/coordinator/src/bin/coordinator.rs
@@ -328,12 +328,19 @@ async fn main() -> Result<()> {
     // Start the metrics exporter
     autometrics::prometheus_exporter::init();
 
-    tracing::debug!("listening on http://{}", http_address);
-    axum::Server::bind(&http_address)
-        .serve(app.into_make_service())
-        .await?;
+    tracing::debug!("Listening on http://{}", http_address);
 
-    tracing::trace!("Server has had been launched");
+    match axum::Server::bind(&http_address)
+        .serve(app.into_make_service())
+        .await
+    {
+        Ok(_) => {
+            tracing::info!("HTTP server stopped running");
+        }
+        Err(e) => {
+            tracing::error!("HTTP server stopped running: {e:#}");
+        }
+    }
 
     Ok(())
 }


### PR DESCRIPTION
Fix #1672.

---

Fixing this has made me realise that this is an antipattern that we have (very likely) been running into for a long time. That is,
using a `?` when setting up a spawned task and assuming that it will be handled somewhere.

Here it caused two problems:

1. It stopped a task that we did not want to stop.
2. It failed silently.

In some cases it might be acceptable to stop a task, but we don't want this to happen silently.

I will keep an eye out for this from now on. And I will audit the code base for instances where we use `?` when calling `pool.get()`.