### PR TITLE
wip: reproduce timing issue

### DIFF
--- a/coordinator/src/bin/coordinator.rs
+++ b/coordinator/src/bin/coordinator.rs
@@ -49,7 +49,7 @@ use tracing::metadata::LevelFilter;
 const PROCESS_PROMETHEUS_METRICS: Duration = Duration::from_secs(10);
 const PROCESS_INCOMING_DLC_MESSAGES_INTERVAL: Duration = Duration::from_millis(200);
 const EXPIRED_POSITION_SYNC_INTERVAL: Duration = Duration::from_secs(5 * 60);
-const CLOSED_POSITION_SYNC_INTERVAL: Duration = Duration::from_secs(30);
+const CLOSED_POSITION_SYNC_INTERVAL: Duration = Duration::from_secs(1);
 const UNREALIZED_PNL_SYNC_INTERVAL: Duration = Duration::from_secs(10 * 60);
 const CONNECTION_CHECK_INTERVAL: Duration = Duration::from_secs(30);
 

--- a/coordinator/src/node/closed_positions.rs
+++ b/coordinator/src/node/closed_positions.rs
@@ -11,6 +11,7 @@ pub fn sync(node: Node) -> Result<()> {
             .context("Failed to load open and closing positions")?;
 
     for position in open_and_closing_positions {
+        tracing::debug!(position = position.id, "Checking position");
         let temporary_contract_id = match position.temporary_contract_id {
             None => {
                 tracing::trace!(position_id=%position.id, "Position does not have temporary contract id, skipping");
@@ -20,9 +21,13 @@ pub fn sync(node: Node) -> Result<()> {
         };
 
         let contract = match node.inner.get_closed_contract(temporary_contract_id) {
-            Ok(Some(closed_contract)) => closed_contract,
+            Ok(Some(closed_contract)) => {
+                tracing::debug!(position = position.id, "Position closed");
+
+                closed_contract
+            }
             Ok(None) => {
-                tracing::trace!(position_id=%position.id, "Position not closed yet, skipping");
+                tracing::debug!(position_id=%position.id, "Position not closed yet, skipping");
                 continue;
             }
             Err(e) => {


### PR DESCRIPTION
if a position is getting resized we close the current contract and reopen a new one. It might happen that the task  will pick it up in the meantime and set the  to closed. This breaks the renew protocl because we expect the position to be in a certain state/


How to reproduce: 
- start the app
- open position
- resize/add contracts to the position

the task `closed_position` will pick it up and set the position to closed breaking the renew protocol.