### PR TITLE
fix: fix errors in swap screen

### DIFF
--- a/mobile/lib/features/swap/swap_amount_text_input_form_field.dart
+++ b/mobile/lib/features/swap/swap_amount_text_input_form_field.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:get_10101/common/application/numeric_text_formatter.dart';
-import 'package:get_10101/common/domain/model.dart';
 import 'package:get_10101/common/modal_bottom_sheet_info.dart';
 
 class SwapAmountInputField extends StatefulWidget {
@@ -11,10 +10,9 @@ class SwapAmountInputField extends StatefulWidget {
       this.label,
       this.hint = '',
       this.onChanged,
-      required this.value,
       this.isLoading = false,
       this.infoText,
-      this.controller,
+      required this.controller,
       this.validator,
       this.border,
       this.style,
@@ -23,8 +21,7 @@ class SwapAmountInputField extends StatefulWidget {
       this.hoverColor,
       this.autovalidateMode});
 
-  final TextEditingController? controller;
-  final Amount value;
+  final TextEditingController controller;
   final bool enabled;
   final String? label;
   final TextStyle? style;
@@ -52,7 +49,6 @@ class _SwapAmountInputFieldState extends State<SwapAmountInputField> {
       autovalidateMode: widget.autovalidateMode,
       enabled: widget.enabled,
       controller: widget.controller,
-      initialValue: widget.controller != null ? null : widget.value.formatted(),
       keyboardType: TextInputType.number,
       decoration: InputDecoration(
         border: widget.border,

--- a/mobile/lib/features/swap/swap_bottom_sheet.dart
+++ b/mobile/lib/features/swap/swap_bottom_sheet.dart
@@ -66,6 +66,20 @@ class _StableBottomSheet extends State<SwapBottomSheet> {
   }
 
   @override
+  void initState() {
+    super.initState();
+
+    final stableValuesChangeNotifier = context.read<SwapValuesChangeNotifier>();
+    final tradeValues = stableValuesChangeNotifier.stableValues();
+    updateAmountFields(tradeValues);
+  }
+
+  void updateAmountFields(SwapTradeValues tradeValues) {
+    _usdpController.text = tradeValues.quantity!.formatted();
+    _lnController.text = tradeValues.margin!.formatted();
+  }
+
+  @override
   Widget build(BuildContext context) {
     final stableValuesChangeNotifier = context.watch<SwapValuesChangeNotifier>();
     final tradeValues = stableValuesChangeNotifier.stableValues();
@@ -165,62 +179,50 @@ class _StableBottomSheet extends State<SwapBottomSheet> {
                       final usdpBal = FiatText(amount: usdpBalQuantity);
                       final lnBal = AmountText(amount: Amount(usableBalance));
 
-                      final lnField = Selector<SwapValuesChangeNotifier, Amount>(
-                          selector: (_, provider) =>
-                              provider.stableValues().margin ?? Amount.zero(),
-                          builder: (context, margin, child) {
-                            _lnController.text = tradeValues.margin!.formatted();
+                      final lnField = SwapAmountInputField(
+                        controller: _lnController,
+                        denseNoPad: true,
+                        enabledColor: SwapBottomSheet._offPurple,
+                        hoverColor: SwapBottomSheet._offPurple,
+                        autovalidateMode: AutovalidateMode.always,
+                        style: const TextStyle(
+                          fontSize: 24,
+                          fontWeight: FontWeight.w500,
+                        ),
+                        border: InputBorder.none,
+                        validator: validateLn,
+                        onChanged: (value) {
+                          try {
+                            final margin = Amount.parseAmount(value);
+                            stableValuesChangeNotifier.updateMargin(margin);
+                          } catch (exception) {
+                            stableValuesChangeNotifier.updateMargin(Amount.zero());
+                          }
 
-                            return SwapAmountInputField(
-                              controller: _lnController,
-                              denseNoPad: true,
-                              enabledColor: SwapBottomSheet._offPurple,
-                              hoverColor: SwapBottomSheet._offPurple,
-                              autovalidateMode: AutovalidateMode.always,
-                              style: const TextStyle(
-                                fontSize: 24,
-                                fontWeight: FontWeight.w500,
-                              ),
-                              border: InputBorder.none,
-                              value: margin,
-                              validator: validateLn,
-                              onChanged: (value) {
-                                try {
-                                  final margin = Amount.parseAmount(value);
-                                  stableValuesChangeNotifier.updateMargin(margin);
-                                } catch (exception) {
-                                  stableValuesChangeNotifier.updateMargin(Amount.zero());
-                                }
-                              },
-                            );
-                          });
+                          updateAmountFields(tradeValues);
+                        },
+                      );
 
-                      final usdpField = Selector<SwapValuesChangeNotifier, Amount>(
-                          selector: (_, provider) =>
-                              provider.stableValues().quantity ?? Amount.zero(),
-                          builder: (context, quantity, child) {
-                            _usdpController.text = quantity.formatted();
+                      final usdpField = SwapAmountInputField(
+                        controller: _usdpController,
+                        denseNoPad: true,
+                        enabledColor: SwapBottomSheet._offPurple,
+                        hoverColor: SwapBottomSheet._offPurple,
+                        autovalidateMode: AutovalidateMode.always,
+                        style: const TextStyle(fontSize: 24, fontWeight: FontWeight.w500),
+                        border: InputBorder.none,
+                        onChanged: (value) {
+                          try {
+                            final margin = Amount.parseAmount(value);
+                            stableValuesChangeNotifier.updateQuantity(margin);
+                          } catch (exception) {
+                            stableValuesChangeNotifier.updateQuantity(Amount.zero());
+                          }
 
-                            return SwapAmountInputField(
-                              controller: _usdpController,
-                              denseNoPad: true,
-                              enabledColor: SwapBottomSheet._offPurple,
-                              hoverColor: SwapBottomSheet._offPurple,
-                              autovalidateMode: AutovalidateMode.always,
-                              value: tradeValues.quantity!,
-                              style: const TextStyle(fontSize: 24, fontWeight: FontWeight.w500),
-                              border: InputBorder.none,
-                              onChanged: (value) {
-                                try {
-                                  final margin = Amount.parseAmount(value);
-                                  stableValuesChangeNotifier.updateQuantity(margin);
-                                } catch (exception) {
-                                  stableValuesChangeNotifier.updateQuantity(Amount.zero());
-                                }
-                              },
-                              validator: validateUsdp,
-                            );
-                          });
+                          updateAmountFields(tradeValues);
+                        },
+                        validator: validateUsdp,
+                      );
 
                       const labelStyle = TextStyle(fontSize: 20);
 


### PR DESCRIPTION
Fixes #1711.

I did notice while doing this work the following:
1. Every time we update the margin or quantity, the channel details are fetched again - how often do we actually want this to happen?
2. There are some prices for which the minimum margin given by the validation is 1 sat less than what's actually needed to get a quantity of 1. This is hard to reproduce. Maybe worth opening a ticket for? 