### PR TITLE
feat: Add delete network graph in settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Feat: Add delete network graph in settings
+
 ## [1.7.2] - 2023-12-13
 
 - Feat: Receive USD-P via Lightning

--- a/mobile/lib/common/routes.dart
+++ b/mobile/lib/common/routes.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:get_10101/common/global_keys.dart';
 import 'package:get_10101/common/settings/channel_screen.dart';
+import 'package:get_10101/common/settings/delete_network_graph.dart';
 import 'package:get_10101/common/status_screen.dart';
 import 'package:get_10101/features/wallet/domain/destination.dart';
 import 'package:get_10101/features/wallet/send/send_lightning_screen.dart';
@@ -115,6 +116,14 @@ GoRouter createRoutes() {
                 parentNavigatorKey: rootNavigatorKey,
                 builder: (BuildContext context, GoRouterState state) {
                   return const StatusScreen();
+                },
+              ),
+              GoRoute(
+                path: DeleteNetworkGraphScreen.subRouteName,
+                // Use root navigator so the screen overlays the application shell
+                parentNavigatorKey: rootNavigatorKey,
+                builder: (BuildContext context, GoRouterState state) {
+                  return const DeleteNetworkGraphScreen();
                 },
               ),
               GoRoute(

--- a/mobile/lib/common/settings/delete_network_graph.dart
+++ b/mobile/lib/common/settings/delete_network_graph.dart
@@ -1,0 +1,113 @@
+import 'package:flutter/material.dart';
+import 'package:get_10101/common/color.dart';
+import 'package:get_10101/common/custom_app_bar.dart';
+import 'package:get_10101/common/settings/settings_screen.dart';
+import 'package:get_10101/common/snack_bar.dart';
+import 'package:get_10101/ffi.dart' as rust;
+
+class DeleteNetworkGraphScreen extends StatefulWidget {
+  static const route = "${SettingsScreen.route}/$subRouteName";
+  static const subRouteName = "deletenetworkgraph";
+
+  const DeleteNetworkGraphScreen({super.key});
+
+  @override
+  State<DeleteNetworkGraphScreen> createState() => _DeleteNetworkGraphScreenState();
+}
+
+class _DeleteNetworkGraphScreenState extends State<DeleteNetworkGraphScreen> {
+  bool deletedNetworkGraph = false;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: SafeArea(
+        child: Container(
+          padding: const EdgeInsets.only(top: 20, left: 10, right: 10),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              const TenTenOneAppBar(title: "Delete Network Graph"),
+              Container(
+                margin: const EdgeInsets.all(10),
+                child: Column(
+                  children: [
+                    const SizedBox(
+                      height: 20,
+                    ),
+                    const Text(
+                      "If you are having troubles sending a payment, it may help to delete and recreate you network graph.",
+                      style: TextStyle(fontSize: 18, fontWeight: FontWeight.w400),
+                    ),
+                    const SizedBox(height: 30),
+                    Visibility(
+                        visible: deletedNetworkGraph,
+                        replacement: OutlinedButton(
+                            onPressed: () {
+                              final messenger = ScaffoldMessenger.of(context);
+                              try {
+                                rust.api.deleteNetworkGraph();
+                                setState(() => deletedNetworkGraph = true);
+                                showSnackBar(messenger, "Successfully deleted network graph");
+                              } catch (e) {
+                                showSnackBar(
+                                    messenger, "Failed to delete network graph. Error: $e");
+                              }
+                            },
+                            style: ButtonStyle(
+                              fixedSize: MaterialStateProperty.all(const Size(double.infinity, 50)),
+                              iconSize: MaterialStateProperty.all<double>(20.0),
+                              elevation: MaterialStateProperty.all<double>(0),
+                              // this reduces the shade
+                              side: MaterialStateProperty.all(
+                                  const BorderSide(width: 1.0, color: tenTenOnePurple)),
+                              padding: MaterialStateProperty.all<EdgeInsetsGeometry>(
+                                const EdgeInsets.fromLTRB(20, 12, 20, 12),
+                              ),
+                              shape: MaterialStateProperty.all<RoundedRectangleBorder>(
+                                RoundedRectangleBorder(
+                                  borderRadius: BorderRadius.circular(8.0),
+                                ),
+                              ),
+                              backgroundColor: MaterialStateProperty.all<Color>(Colors.transparent),
+                            ),
+                            child: const Row(
+                                mainAxisAlignment: MainAxisAlignment.center,
+                                children: [
+                                  Icon(Icons.delete),
+                                  SizedBox(width: 10),
+                                  Text("Delete Network Graph")
+                                ])),
+                        child: Container(
+                            padding: const EdgeInsets.symmetric(vertical: 10, horizontal: 20),
+                            decoration: BoxDecoration(
+                                border: Border.all(color: tenTenOnePurple),
+                                color: Colors.white,
+                                borderRadius: BorderRadius.circular(10)),
+                            child: Row(
+                              mainAxisAlignment: MainAxisAlignment.start,
+                              children: [
+                                Icon(
+                                  Icons.info_outline,
+                                  color: tenTenOnePurple.shade800,
+                                  size: 22,
+                                ),
+                                const SizedBox(width: 10),
+                                const Text(
+                                  "Restart the app to recreate your\nnetwork graph.",
+                                  softWrap: true,
+                                  overflow: TextOverflow.ellipsis,
+                                  maxLines: 4,
+                                ),
+                              ],
+                            ))),
+                  ],
+                ),
+              )
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/mobile/lib/common/settings/settings_screen.dart
+++ b/mobile/lib/common/settings/settings_screen.dart
@@ -9,6 +9,7 @@ import 'package:get_10101/common/service_status_notifier.dart';
 import 'package:get_10101/common/settings/app_info_screen.dart';
 import 'package:get_10101/common/settings/channel_screen.dart';
 import 'package:get_10101/common/settings/collab_close_screen.dart';
+import 'package:get_10101/common/settings/delete_network_graph.dart';
 import 'package:get_10101/common/settings/force_close_screen.dart';
 import 'package:get_10101/common/settings/share_logs_screen.dart';
 import 'package:get_10101/common/snack_bar.dart';
@@ -214,6 +215,11 @@ class _SettingsScreenState extends State<SettingsScreen> {
                               color: Colors.white, borderRadius: BorderRadius.circular(10)),
                           child: Column(
                             children: [
+                              SettingsClickable(
+                                  icon: Icons.delete,
+                                  title: "Delete Network Graph",
+                                  callBackFunc: () =>
+                                      GoRouter.of(context).push(DeleteNetworkGraphScreen.route)),
                               SettingsClickable(
                                   icon: Icons.close,
                                   title: "Close Channel",

--- a/mobile/native/src/api.rs
+++ b/mobile/native/src/api.rs
@@ -21,6 +21,7 @@ use crate::trade::order::api::Order;
 use crate::trade::position;
 use crate::trade::position::api::Position;
 use crate::trade::users;
+use anyhow::anyhow;
 use anyhow::ensure;
 use anyhow::Context;
 use anyhow::Result;
@@ -30,6 +31,10 @@ use commons::OrderbookRequest;
 use flutter_rust_bridge::frb;
 use flutter_rust_bridge::StreamSink;
 use flutter_rust_bridge::SyncReturn;
+use lightning::util::persist::KVStore;
+use lightning::util::persist::NETWORK_GRAPH_PERSISTENCE_KEY;
+use lightning::util::persist::NETWORK_GRAPH_PERSISTENCE_PRIMARY_NAMESPACE;
+use lightning::util::persist::NETWORK_GRAPH_PERSISTENCE_SECONDARY_NAMESPACE;
 use ln_dlc_node::channel::UserChannelId;
 use rust_decimal::prelude::FromPrimitive;
 use rust_decimal::Decimal;
@@ -239,6 +244,18 @@ pub async fn get_positions() -> Result<Vec<Position>> {
         .collect::<Vec<Position>>();
 
     Ok(positions)
+}
+
+pub fn delete_network_graph() -> Result<()> {
+    crate::state::get_storage()
+        .ln_storage
+        .remove(
+            NETWORK_GRAPH_PERSISTENCE_PRIMARY_NAMESPACE,
+            NETWORK_GRAPH_PERSISTENCE_SECONDARY_NAMESPACE,
+            NETWORK_GRAPH_PERSISTENCE_KEY,
+            false,
+        )
+        .map_err(|e| anyhow!("{e:#}"))
 }
 
 pub fn subscribe(stream: StreamSink<event::api::Event>) {


### PR DESCRIPTION
My mainnet app was not able to send any payments. After deleting and recreating the network graph it was working again. This is certainly not a fix for the payment issues, but it may help as a quick fix for others as well to unblock payments.

<img width="934" alt="Screenshot 2023-12-13 at 17 49 24" src="https://github.com/get10101/10101/assets/382048/3e9a73ac-aa07-4592-978c-18e91b5abe81">
