### PR TITLE
fix: make buttons in receive screen not jumpy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - Feat: Add delete network graph in settings
+- Fix: Make switch buttons in receive screen not jumpy
 
 ## [1.7.2] - 2023-12-13
 

--- a/mobile/lib/features/wallet/receive_screen.dart
+++ b/mobile/lib/features/wallet/receive_screen.dart
@@ -558,10 +558,7 @@ class SelectableButton extends StatelessWidget {
             ? MaterialStateProperty.all<Color>(selectedColor.withOpacity(0.05))
             : MaterialStateProperty.all<Color>(Colors.grey.shade200),
       ),
-      icon: Visibility(
-        visible: isSelected,
-        child: Icon(icon, color: isSelected ? selectedColor.withOpacity(1) : Colors.grey),
-      ),
+      icon: Icon(icon, color: isSelected ? selectedColor.withOpacity(1) : Colors.grey),
       label: Text(buttonText,
           style: TextStyle(color: isSelected ? selectedColor.withOpacity(1) : Colors.grey)),
     );


### PR DESCRIPTION
Resolves https://github.com/get10101/10101/issues/1736

I've simply left the icon on both buttons at all times

![image](https://github.com/get10101/10101/assets/224613/435aef39-f348-4909-8005-c0c9cd6565b1)
![image](https://github.com/get10101/10101/assets/224613/b78f8f17-45cb-4175-a807-498dafb5bbea)
