### PR TITLE
Instruct maker to send random probes every minute

### DIFF
--- a/crates/ln-dlc-node/src/lib.rs
+++ b/crates/ln-dlc-node/src/lib.rs
@@ -23,7 +23,6 @@ use lightning_net_tokio::SocketDescriptor;
 use ln_dlc_wallet::LnDlcWallet;
 use std::fmt;
 use std::sync::Arc;
-use std::sync::Mutex;
 use time::OffsetDateTime;
 
 mod dlc_custom_signer;
@@ -81,7 +80,7 @@ pub type PeerManager<S, N> = lightning::ln::peer_handler::PeerManager<
 pub(crate) type Router = DefaultRouter<
     Arc<NetworkGraph>,
     Arc<TracingLogger>,
-    Arc<Mutex<Scorer>>,
+    Arc<std::sync::RwLock<Scorer>>,
     ProbabilisticScoringFeeParameters,
     Scorer,
 >;

--- a/crates/ln-dlc-node/src/ln/probes.rs
+++ b/crates/ln-dlc-node/src/ln/probes.rs
@@ -30,10 +30,12 @@ impl Probes {
 
                 tracing::debug!(%payment_id, ?old_status, ?new_status, "Updated probe");
             }
-            Entry::Vacant(entry) => {
-                entry.insert(Some(new_status.clone()));
-
-                tracing::debug!(%payment_id, ?new_status, "Updating unregistered probe");
+            Entry::Vacant(_) => {
+                tracing::trace!(
+                    %payment_id,
+                    ?new_status,
+                    "Ignoring update about unregistered probe"
+                );
             }
         }
     }

--- a/crates/ln-dlc-node/src/node/mod.rs
+++ b/crates/ln-dlc-node/src/node/mod.rs
@@ -145,7 +145,7 @@ pub struct Node<S: TenTenOneStorage, N: Storage> {
     pub network_graph: Arc<NetworkGraph>,
     pub fee_rate_estimator: Arc<FeeRateEstimator>,
 
-    logger: Arc<TracingLogger>,
+    pub logger: Arc<TracingLogger>,
 
     pub info: NodeInfo,
     pub(crate) fake_channel_payments: FakeChannelPaymentRequests,
@@ -173,7 +173,7 @@ pub struct Node<S: TenTenOneStorage, N: Storage> {
     gossip_source: Arc<GossipSource>,
     pub(crate) alias: String,
     pub(crate) announcement_addresses: Vec<SocketAddress>,
-    scorer: Arc<std::sync::RwLock<Scorer>>,
+    pub scorer: Arc<std::sync::RwLock<Scorer>>,
     esplora_server_url: String,
     esplora_client: Arc<NodeEsploraClient>,
     pub pending_channel_opening_fee_rates: Arc<parking_lot::Mutex<HashMap<PublicKey, FeeRate>>>,

--- a/crates/ln-dlc-node/src/node/mod.rs
+++ b/crates/ln-dlc-node/src/node/mod.rs
@@ -59,7 +59,6 @@ use std::io::BufReader;
 use std::net::SocketAddr;
 use std::path::Path;
 use std::sync::Arc;
-use std::sync::Mutex;
 use std::time::Duration;
 use std::time::Instant;
 use std::time::SystemTime;
@@ -174,7 +173,7 @@ pub struct Node<S: TenTenOneStorage, N: Storage> {
     gossip_source: Arc<GossipSource>,
     pub(crate) alias: String,
     pub(crate) announcement_addresses: Vec<SocketAddress>,
-    scorer: Arc<Mutex<Scorer>>,
+    scorer: Arc<std::sync::RwLock<Scorer>>,
     esplora_server_url: String,
     esplora_client: Arc<NodeEsploraClient>,
     pub pending_channel_opening_fee_rates: Arc<parking_lot::Mutex<HashMap<PublicKey, FeeRate>>>,
@@ -346,7 +345,7 @@ impl<S: TenTenOneStorage + 'static, N: Storage + Sync + Send + 'static> Node<S, 
         };
 
         let scorer_path = data_dir.join("scorer");
-        let scorer = Arc::new(Mutex::new(read_scorer(
+        let scorer = Arc::new(std::sync::RwLock::new(read_scorer(
             scorer_path.as_path(),
             network_graph.clone(),
             logger.clone(),
@@ -670,7 +669,7 @@ fn spawn_background_processor<S: TenTenOneStorage + 'static, N: Storage + Sync +
     persister: Arc<S>,
     event_handler: impl EventHandlerTrait + 'static,
     gossip_source: Arc<GossipSource>,
-    scorer: Arc<Mutex<Scorer>>,
+    scorer: Arc<std::sync::RwLock<Scorer>>,
     mobile_interruptable_platform: bool,
 ) -> RemoteHandle<()> {
     tracing::info!("Starting background processor");

--- a/maker/src/bin/maker.rs
+++ b/maker/src/bin/maker.rs
@@ -16,6 +16,7 @@ use maker::metrics;
 use maker::metrics::init_meter;
 use maker::orderbook_ws;
 use maker::position;
+use maker::probing::send_payment_probes_regularly;
 use maker::routes::router;
 use maker::run_migration;
 use maker::storage::MakerTenTenOneStorage;
@@ -193,6 +194,8 @@ async fn main() -> Result<()> {
     )
     .spawn_supervised_connection();
 
+    tokio::spawn(send_payment_probes_regularly(node.clone()));
+
     let app = router(
         node,
         exporter,
@@ -222,6 +225,7 @@ async fn main() -> Result<()> {
 
     Ok(())
 }
+
 fn reqwest_client() -> reqwest::Client {
     reqwest::Client::builder()
         .timeout(std::time::Duration::from_secs(30))

--- a/maker/src/lib.rs
+++ b/maker/src/lib.rs
@@ -16,6 +16,7 @@ pub mod logger;
 pub mod metrics;
 pub mod orderbook_ws;
 pub mod position;
+pub mod probing;
 pub mod routes;
 pub mod schema;
 pub mod storage;

--- a/maker/src/probing.rs
+++ b/maker/src/probing.rs
@@ -1,0 +1,122 @@
+use anyhow::Context;
+use anyhow::Result;
+use bitcoin::secp256k1::PublicKey;
+use lightning::routing::gossip::ReadOnlyNetworkGraph;
+use lightning::routing::router::PaymentParameters;
+use lightning::routing::router::RouteParameters;
+use lightning::routing::router::ScorerAccountingForInFlightHtlcs;
+use lightning::routing::scoring::ProbabilisticScoringFeeParameters;
+use ln_dlc_node::node::Node;
+use ln_dlc_node::node::Storage;
+use ln_dlc_node::storage::TenTenOneStorage;
+use rand::thread_rng;
+use rand::Rng;
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::task::spawn_blocking;
+
+const MAX_AMOUNT_MSAT: u64 = 500_000_000;
+
+const FINAL_CLTV_EXPIRY_DELTA: u32 = 144;
+
+const MAX_PATH_COUNT: u8 = 1;
+
+pub async fn send_payment_probes_regularly<
+    S: TenTenOneStorage + 'static,
+    N: Storage + Sync + Send + 'static,
+>(
+    node: Arc<Node<S, N>>,
+) {
+    let mut interval = tokio::time::interval(Duration::from_secs(60));
+    loop {
+        interval.tick().await;
+        if let Err(e) = spawn_blocking({
+            let node = node.clone();
+            move || send_random_probe(&node)
+        })
+        .await
+        .expect("task to complete")
+        {
+            tracing::error!("Failed to send payment probe: {e:#}");
+        }
+    }
+}
+
+fn send_random_probe<S: TenTenOneStorage + 'static, N: Storage + Sync + Send + 'static>(
+    node: &Node<S, N>,
+) -> Result<()> {
+    let random_node = match random_node(node.network_graph.read_only())? {
+        Some(node) => node,
+        None => {
+            tracing::warn!("No probe to send with empty network graph");
+            return Ok(());
+        }
+    };
+
+    let random_amount_msat = thread_rng().gen_range(0..MAX_AMOUNT_MSAT);
+
+    send_probe(node, random_node, random_amount_msat);
+
+    Ok(())
+}
+
+fn send_probe<S: TenTenOneStorage + 'static, N: Storage + Sync + Send + 'static>(
+    node: &Node<S, N>,
+    recipient: PublicKey,
+    amount_msat: u64,
+) {
+    let channel_manager = &node.channel_manager;
+    let scorer = &node.scorer;
+
+    let usable_channels = channel_manager.list_usable_channels();
+    let usable_channels = usable_channels.iter().collect::<Vec<_>>();
+
+    let route_parameters = {
+        let mut payment_params =
+            PaymentParameters::from_node_id(recipient, FINAL_CLTV_EXPIRY_DELTA);
+        payment_params.max_path_count = MAX_PATH_COUNT;
+
+        RouteParameters::from_payment_params_and_value(payment_params, amount_msat)
+    };
+
+    let scorer = scorer.read().expect("to be able to acquire read lock");
+    let in_flight_htlcs = channel_manager.compute_inflight_htlcs();
+    let inflight_scorer = ScorerAccountingForInFlightHtlcs::new(&scorer, &in_flight_htlcs);
+
+    let route_res = lightning::routing::router::find_route(
+        &channel_manager.get_our_node_id(),
+        &route_parameters,
+        &node.network_graph,
+        Some(&usable_channels),
+        node.logger.clone(),
+        &inflight_scorer,
+        &ProbabilisticScoringFeeParameters::default(),
+        &[32; 32],
+    );
+    if let Ok(route) = route_res {
+        for path in route.paths {
+            let _ = channel_manager.send_probe(path);
+        }
+    }
+}
+
+fn random_node(network_graph: ReadOnlyNetworkGraph) -> Result<Option<PublicKey>> {
+    let nodes = network_graph.nodes();
+    let n_nodes = nodes.len();
+
+    if n_nodes == 0 {
+        return Ok(None);
+    }
+
+    let random_index = thread_rng().gen_range(0..n_nodes);
+
+    let random_node = nodes
+        .unordered_iter()
+        .nth(random_index)
+        .expect("node at index")
+        .0
+        .as_pubkey()
+        .context("Cannot convert node ID to public key")?;
+
+    Ok(Some(random_node))
+}


### PR DESCRIPTION
Fix #1632.

As the maker sends random probes through the coordinator and collects the results, the maker's scorer will get updated over time.

We can then share the scorer file with other peers connected to the coordinator (10101 apps), which should improve their payment experience.

This last part is not included in this PR because I want to see how this works in production before we actually support the app pulling the maker's scorer file.

---

Based on this [patch](https://git.bitcoin.ninja/index.cgi?p=ldk-sample;a=blobdiff;f=src/main.rs;h=1d6edb45006a70d53e8a3d466dd9968c3c8d1dfb;hp=6480805d92759eed4d90407ada06a3f6eb7f202f;hb=f47b6f50b85ef3770173cc8e4bcddd3662cb5d5e;hpb=37da86a8a1a3294f991657ecca49c19e7c2b043d) shared by Matt from LDK.