### PR TITLE
feat: show dlc-channel balance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Chore: move telegram link into toplevel of settings so that it can be found easier
 - Feat: update coordinator API to show more details on pending channel balance
+- Feat: show dlc-channel balance instead of ln-balance in app and in coordinator's API
 
 ## [1.7.4] - 2023-12-20
 

--- a/coordinator/src/admin.rs
+++ b/coordinator/src/admin.rs
@@ -31,7 +31,7 @@ use tracing::instrument;
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Balance {
-    pub offchain: u64,
+    pub lightning: u64,
     pub onchain: u64,
 }
 
@@ -44,7 +44,7 @@ pub async fn get_balance(State(state): State<Arc<AppState>>) -> Result<Json<Bala
             })?;
 
         Ok(Json(Balance {
-            offchain: offchain.available(),
+            lightning: offchain.available(),
             onchain: onchain.confirmed,
         }))
     })

--- a/crates/fund/src/coordinator.rs
+++ b/crates/fund/src/coordinator.rs
@@ -22,7 +22,7 @@ pub struct InvoiceParams {
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Balance {
-    pub offchain: u64,
+    pub dlc_channel: u64,
     pub onchain: u64,
 }
 

--- a/crates/tests-e2e/tests/maker.rs
+++ b/crates/tests-e2e/tests/maker.rs
@@ -56,7 +56,7 @@ async fn maker_can_open_channel_to_coordinator_and_send_payment() -> Result<()> 
         balance_maker_after_channel
     );
 
-    let balance_coordinator_after_channel = coordinator.get_balance().await?.offchain;
+    let balance_coordinator_after_channel = coordinator.get_balance().await?.lightning;
 
     let payment_amount = 100_000;
     let invoice = coordinator.create_invoice(Some(payment_amount)).await?;
@@ -64,11 +64,11 @@ async fn maker_can_open_channel_to_coordinator_and_send_payment() -> Result<()> 
     maker.pay_invoice(invoice).await?;
 
     wait_until!(
-        coordinator.get_balance().await.unwrap().offchain > balance_coordinator_after_channel
+        coordinator.get_balance().await.unwrap().lightning > balance_coordinator_after_channel
     );
 
     let balance_maker_after_payment = maker.get_balance().await?.offchain;
-    let balance_coordinator_after_payment = coordinator.get_balance().await?.offchain;
+    let balance_coordinator_after_payment = coordinator.get_balance().await?.lightning;
 
     assert_eq!(
         balance_maker_after_channel - payment_amount,

--- a/mobile/lib/features/swap/swap_bottom_sheet.dart
+++ b/mobile/lib/features/swap/swap_bottom_sheet.dart
@@ -118,12 +118,11 @@ class _StableBottomSheet extends State<SwapBottomSheet> {
                       Amount channelReserve = channelInfo?.reserve ?? initialReserve;
                       int totalReserve = channelReserve.sats + tradeFeeReserve.sats;
 
-                      int usableBalance = max(walletInfo.balances.lightning.sats - totalReserve, 0);
+                      int usableBalance = max(walletInfo.balances.offChain.sats - totalReserve, 0);
                       // the assumed balance of the counterparty based on the channel and our balance
                       // this is needed to make sure that the counterparty can fulfil the trade
                       int counterpartyUsableBalance = max(
-                          channelCapacity.sats -
-                              (walletInfo.balances.lightning.sats + totalReserve),
+                          channelCapacity.sats - (walletInfo.balances.offChain.sats + totalReserve),
                           0);
 
                       final usdpBalQuantity = widget.position?.quantity.asDouble() ?? 0.0;

--- a/mobile/lib/features/trade/trade_bottom_sheet_tab.dart
+++ b/mobile/lib/features/trade/trade_bottom_sheet_tab.dart
@@ -141,12 +141,12 @@ class _TradeBottomSheetTabState extends State<TradeBottomSheetTab> {
                     positionChangeNotifier.marginUsableForTrade(direction).sats;
 
                 int usableBalance = max(
-                    walletInfo.balances.lightning.sats + usableMarginInPosition - totalReserve, 0);
+                    walletInfo.balances.offChain.sats + usableMarginInPosition - totalReserve, 0);
 
                 // The assumed balance of the counterparty based on the channel and our balance. This
                 // is needed to make sure that the counterparty can fulfil the trade.
                 int counterpartyUsableBalance = max(
-                    channelCapacity.sats - (walletInfo.balances.lightning.sats + totalReserve), 0);
+                    channelCapacity.sats - (walletInfo.balances.offChain.sats + totalReserve), 0);
                 int maxMargin = usableBalance;
 
                 children = <Widget>[

--- a/mobile/lib/features/wallet/balance_row.dart
+++ b/mobile/lib/features/wallet/balance_row.dart
@@ -28,7 +28,7 @@ class _BalanceRowState extends State<BalanceRow> with SingleTickerProviderStateM
             mainAxisAlignment: MainAxisAlignment.center,
             crossAxisAlignment: CrossAxisAlignment.center,
             children: [
-              Text(walletChangeNotifier.lightning().formatted(),
+              Text(walletChangeNotifier.offChain().formatted(),
                   style: const TextStyle(
                       fontSize: 30, color: Colors.white, fontWeight: FontWeight.bold)),
               const Text(" sats",

--- a/mobile/lib/features/wallet/domain/wallet_balances.dart
+++ b/mobile/lib/features/wallet/domain/wallet_balances.dart
@@ -2,7 +2,7 @@ import 'package:get_10101/common/domain/model.dart';
 
 class WalletBalances {
   Amount onChain;
-  Amount lightning;
+  Amount offChain;
 
-  WalletBalances({required this.onChain, required this.lightning});
+  WalletBalances({required this.onChain, required this.offChain});
 }

--- a/mobile/lib/features/wallet/domain/wallet_info.dart
+++ b/mobile/lib/features/wallet/domain/wallet_info.dart
@@ -11,14 +11,14 @@ class WalletInfo {
   WalletInfo.fromApi(rust.WalletInfo walletInfo)
       : balances = WalletBalances(
             onChain: Amount(walletInfo.balances.onChain),
-            lightning: Amount(walletInfo.balances.lightning)),
+            offChain: Amount(walletInfo.balances.offChain)),
         history = walletInfo.history.map((item) {
           return WalletHistoryItemData.fromApi(item);
         }).toList();
 
   static rust.WalletInfo apiDummy() {
     return rust.WalletInfo(
-      balances: const rust.Balances(onChain: -1, lightning: -1),
+      balances: const rust.Balances(onChain: -1, offChain: -1),
       history: List.empty(growable: false),
     );
   }

--- a/mobile/lib/features/wallet/send/send_lightning_screen.dart
+++ b/mobile/lib/features/wallet/send/send_lightning_screen.dart
@@ -90,7 +90,7 @@ class _SendLightningScreenState extends State<SendLightningScreen> {
     final formatter = NumberFormat("#,###,##0.00", "en");
 
     final usdpBalance = positionChangeNotifier.getStableUSDAmountInFiat();
-    final lightningBalance = getLightningBalance();
+    final offChainBalance = getOffChainBalance();
 
     return GestureDetector(
       onTap: () => FocusManager.instance.primaryFocus?.unfocus(),
@@ -151,7 +151,7 @@ class _SendLightningScreenState extends State<SendLightningScreen> {
                       maintainState: true,
                       visible: !_payWithUsdp,
                       child: buildSatsForm(
-                          tradeValuesChangeNotifier, lightningBalance.$1, lightningBalance.$2))),
+                          tradeValuesChangeNotifier, offChainBalance.$1, offChainBalance.$2))),
               Container(
                 margin: const EdgeInsets.only(left: 40, right: 40),
                 child: Visibility(
@@ -216,7 +216,7 @@ class _SendLightningScreenState extends State<SendLightningScreen> {
                                     Text("Lightning", style: TextStyle(fontSize: 18))
                                   ]),
                               const SizedBox(height: 5),
-                              Text(lightningBalance.$2.toString(), textAlign: TextAlign.start),
+                              Text(offChainBalance.$2.toString(), textAlign: TextAlign.start),
                             ])),
                       ),
                     ),
@@ -467,12 +467,12 @@ class _SendLightningScreenState extends State<SendLightningScreen> {
     );
   }
 
-  (Amount, Amount) getLightningBalance() {
+  (Amount, Amount) getOffChainBalance() {
     final walletInfo = context.read<WalletChangeNotifier>().walletInfo;
     final ChannelInfoService channelInfoService = context.read<ChannelInfoService>();
     Amount initialReserve = channelInfoService.getInitialReserve();
     int channelReserve = channelInfo?.reserve.sats ?? initialReserve.sats;
-    int balance = walletInfo.balances.lightning.sats;
+    int balance = walletInfo.balances.offChain.sats;
 
     return (Amount(balance), Amount(max(balance - channelReserve, 0)));
   }

--- a/mobile/lib/features/wallet/wallet_change_notifier.dart
+++ b/mobile/lib/features/wallet/wallet_change_notifier.dart
@@ -12,7 +12,7 @@ import 'package:get_10101/features/wallet/domain/wallet_info.dart';
 class WalletChangeNotifier extends ChangeNotifier implements Subscriber {
   final WalletService service;
   WalletInfo walletInfo = WalletInfo(
-    balances: WalletBalances(onChain: Amount(0), lightning: Amount(0)),
+    balances: WalletBalances(onChain: Amount(0), offChain: Amount(0)),
     history: List.empty(),
   );
   bool syncing = true;
@@ -40,11 +40,11 @@ class WalletChangeNotifier extends ChangeNotifier implements Subscriber {
     await service.refreshWalletInfo();
   }
 
-  Amount total() => Amount(onChain().sats + lightning().sats);
+  Amount total() => Amount(onChain().sats + offChain().sats);
 
   Amount onChain() => walletInfo.balances.onChain;
 
-  Amount lightning() => walletInfo.balances.lightning;
+  Amount offChain() => walletInfo.balances.offChain;
 
   @override
   void notify(bridge.Event event) {

--- a/mobile/lib/features/wallet/wallet_screen.dart
+++ b/mobile/lib/features/wallet/wallet_screen.dart
@@ -43,7 +43,7 @@ class WalletScreen extends StatelessWidget {
                     Expanded(
                       child: SecondaryActionButton(
                         onPressed: () {
-                          context.go((hasChannel || walletChangeNotifier.lightning().sats > 0)
+                          context.go((hasChannel || walletChangeNotifier.offChain().sats > 0)
                               ? ReceiveScreen.route
                               :
                               // TODO: we should have a dedicated on-boarding screen for on-boarding with on-chain funds

--- a/mobile/native/src/api.rs
+++ b/mobile/native/src/api.rs
@@ -80,7 +80,7 @@ pub struct WalletInfo {
 #[derive(Clone, Debug, Default)]
 pub struct Balances {
     pub on_chain: u64,
-    pub lightning: u64,
+    pub off_chain: u64,
 }
 
 /// Assembles the wallet info and publishes wallet info update event.

--- a/mobile/native/src/ln_dlc/node.rs
+++ b/mobile/native/src/ln_dlc/node.rs
@@ -81,7 +81,7 @@ impl From<Balances> for crate::api::Balances {
     fn from(value: Balances) -> Self {
         Self {
             on_chain: value.on_chain,
-            lightning: value.off_chain,
+            off_chain: value.off_chain,
         }
     }
 }
@@ -98,11 +98,11 @@ impl Node {
 
     pub fn get_wallet_balances(&self) -> Result<Balances> {
         let on_chain = self.inner.get_on_chain_balance()?.confirmed;
-        let off_chain = self.inner.get_ldk_balance().available();
+        let off_chain = self.inner.get_usable_dlc_channel_balance()?;
 
         Ok(Balances {
             on_chain,
-            off_chain,
+            off_chain: off_chain.to_sat(),
         })
     }
 

--- a/mobile/test/trade_test.dart
+++ b/mobile/test/trade_test.dart
@@ -151,7 +151,7 @@ void main() {
 
     // We have to pretend that we have a balance, because otherwise the trade bottom sheet validation will not allow us to go to the confirmation screen
     walletChangeNotifier.update(WalletInfo(
-        balances: WalletBalances(onChain: Amount(0), lightning: Amount(10000)), history: []));
+        balances: WalletBalances(onChain: Amount(0), offChain: Amount(10000)), history: []));
 
     await tester.pumpAndSettle();
 


### PR DESCRIPTION
resolves https://github.com/get10101/10101/issues/1780

Off-chain balance only shows the `available` balance, i.e. after opening a position, the off-chain balance will be `0` because all the amounts are locked in the position.

See video

https://github.com/get10101/10101/assets/224613/e2e0f8da-1009-468d-98e4-5ade94b54f4e

In this video the price has been fixed so that the user does not make any profit nor loss which showed this bug: https://github.com/get10101/10101/issues/1799 and this one https://github.com/get10101/10101/issues/1800
