### PR TITLE
chore: don't allow more than one dlc-channel per user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Chore: move telegram link into toplevel of settings so that it can be found easier
 - Feat: update coordinator API to show more details on pending channel balance
 - Feat: show dlc-channel balance instead of ln-balance in app and in coordinator's API
+- Chore: don't allow multiple dlc-channels per user
 
 ## [1.7.4] - 2023-12-20
 

--- a/crates/ln-dlc-node/src/node/dlc_channel.rs
+++ b/crates/ln-dlc-node/src/node/dlc_channel.rs
@@ -38,6 +38,19 @@ impl<S: TenTenOneStorage + 'static, N: LnDlcStorage + Sync + Send + 'static> Nod
             "Sending DLC channel offer"
         );
 
+        if let Some(channel) = self
+            .list_dlc_channels()?
+            .iter()
+            .find(|channel| channel.counter_party == counterparty)
+        {
+            tracing::error!(
+                trader_id = %counterparty,
+                existing_channel_id = channel.channel_id.to_hex(),
+                existing_channel_state = %channel.state,
+                "We can't open a new channel because we still have an open dlc-channel");
+            bail!("Cant have more than one dlc channel.");
+        }
+
         spawn_blocking({
             let p2pd_oracles = self.oracles.clone();
 


### PR DESCRIPTION
resolves #1783

If a user tries to open a new position he will just get an error. 
The error message is misleading as it just says `sorry, we couldn't match your order`. 
So I think we should really tackle https://github.com/get10101/10101/issues/1621 soon. 
