### PR TITLE
chore: refactor payout curve example

### DIFF
--- a/crates/payout_curve/.gitignore
+++ b/crates/payout_curve/.gitignore
@@ -1,5 +1,6 @@
 examples/payout_curve.png
 examples/*.csv
-src/payout_curve/*.csv
-src/payout_curve/*.png
+*.csv
+*.png
+*.svg
 !src/payout_curve/should_data_offer_short.csv

--- a/crates/payout_curve/examples/payout_curve.gp
+++ b/crates/payout_curve/examples/payout_curve.gp
@@ -1,18 +1,16 @@
 ## Creates a gnuplot diagram fro the payout curve
 
 # Set the terminal to PNG and specify the output file
-set terminal pngcairo enhanced font "Arial,12" size 800,600
+set terminal svg enhanced font "Arial,12" size 800,600
 
-offerer_long_file = "offerer_long.csv"
-offerer_short_file = "offerer_short.csv"
-should_file = "should.csv"
-computed_file = "computed_payout.csv"
-
-# Set the output file name based on the data file
-set output "payout_curve.png"
+discretized_file_long = "discretized_long.csv"
+discretized_file_short = "discretized_short.csv"
+should_file_short = "should_short.csv"
+should_file_long = "should_long.csv"
+computed_file_long = "computed_payout_long.csv"
+computed_file_short = "computed_payout_short.csv"
 
 # Define the labels for the X and Y axes
-set title "Payout Curve BTCUSD"
 set xlabel "Start (in Dollars)"
 set ylabel "Payout (in Bitcoin)"
 
@@ -20,6 +18,8 @@ unset ytics
 unset xtics
 #
 unset colorbox
+
+set key outside
 
 # Define the separator (use semicolon in this case)
 separator = ";"
@@ -38,8 +38,8 @@ set grid ytics
 set grid xtics
 
 # Set the range for the x-axis to 100,000 max
-set xrange [-0.1:80000]
-set yrange [-0.1:1]
+set xrange [-0.05:80000]
+set yrange [-0.05:1.1]
 
 set style line 1 linetype 1 linecolor rgb "blue" lw 5
 set style line 2 linetype 1 linecolor rgb "green" lw 5
@@ -48,9 +48,30 @@ set style line 4 linetype 2 linecolor rgb "violet" lw 2
 set style line 5 linetype 2 linecolor rgb "red" lw 2
 set style line 6 linetype 2 linecolor rgb "orange" lw 2
 
-plot should_file using 1:($2 * conversion_factor) ls 3 with lines title "Should Short", \
-    offerer_short_file using 1:($2 * conversion_factor) ls 2 with lines title "Discretized Short", \
-    should_file using 1:($3 * conversion_factor) ls 4 with lines title "Should Long",  \
-    offerer_long_file using 1:($2 * conversion_factor) ls 1 with lines title "Discretized Long", \
-    computed_file using 1:($2 * conversion_factor) ls 5 title "Computed short", \
-    computed_file using 1:($3 * conversion_factor) ls 6 title "Computed long",
+
+# Set the output file for the first diagram
+set output "payout_curve.svg"
+
+set multiplot layout 2,1 ;
+
+set title "Payout Curve BTCUSD - From Offerer's Perspective (Long)"
+
+plot discretized_file_long using 1:($2 * conversion_factor) ls 1 with lines title "Discretized Long (Offerer)", \
+     discretized_file_long using 1:($3 * conversion_factor) ls 2 with lines title "Discretized Short (Acceptor)", \
+     should_file_long using 1:($2 * conversion_factor) ls 3 with lines title "Should Long (Offerer)",  \
+     should_file_long using 1:($3 * conversion_factor) ls 4 with lines title "Should Short (Acceptor)",  \
+     computed_file_long using 1:($2 * conversion_factor) ls 5 title "Computed Long (Offerer)", \
+     computed_file_long using 1:($3 * conversion_factor) ls 6 title "Computed Short (Acceptor)"
+
+
+# Set the output file for the second diagram
+#set output "payout_curve_offerer_short.png"
+
+set title "Payout Curve BTCUSD - From Offerer's Perspective (Short)"
+
+plot discretized_file_short using 1:($2 * conversion_factor) ls 1 with lines title "Discretized Short (Offerer)", \
+     discretized_file_short using 1:($3 * conversion_factor) ls 2 with lines title "Discretized Long (Acceptor)", \
+     should_file_short using 1:($2 * conversion_factor) ls 3 with lines title "Should Short (Offerer)",  \
+     should_file_short using 1:($3 * conversion_factor) ls 4 with lines title "Should Long (Acceptor)",  \
+     computed_file_short using 1:($2 * conversion_factor) ls 5 title "Computed Short (Offerer)", \
+     computed_file_short using 1:($3 * conversion_factor) ls 6 title "Computed Long (Acceptor)"

--- a/crates/payout_curve/src/lib.rs
+++ b/crates/payout_curve/src/lib.rs
@@ -266,7 +266,7 @@ fn calculate_upper_range_payouts(
             },
             PayoutPoint {
                 event_outcome: BTCUSD_MAX_PRICE,
-                outcome_payout: 0,
+                outcome_payout: fee,
                 extra_precision: 0,
             },
         ),
@@ -597,12 +597,14 @@ mod tests {
         // setup
         // we take 2 BTC so that all tests have nice numbers
         let total_collateral = Amount::ONE_BTC.to_sat() * 2;
+        let fee = 300_000;
+
         let last_payout = PayoutPoint {
             event_outcome: 60_000,
-            outcome_payout: 0,
+            outcome_payout: fee,
             extra_precision: 0,
         };
-        let fee = 300_000;
+
         // act
         let (lower, upper) = calculate_upper_range_payouts(
             Direction::Short,
@@ -614,9 +616,9 @@ mod tests {
 
         // assert
         assert_eq!(lower.event_outcome, last_payout.event_outcome);
-        assert_eq!(lower.outcome_payout, 0);
+        assert_eq!(lower.outcome_payout, fee);
         assert_eq!(upper.event_outcome, BTCUSD_MAX_PRICE);
-        assert_eq!(upper.outcome_payout, 0);
+        assert_eq!(upper.outcome_payout, fee);
 
         if PRINT_CSV {
             let file = File::create("src/payout_curve/upper_range_short.csv").unwrap();
@@ -764,12 +766,12 @@ mod tests {
 
         #[test]
         fn calculating_upper_bound_doesnt_crash_offer_short(total_collateral in 1u64..100_000_000_000, bound in 1u64..100_000) {
+            let fee = 300_000;
             let last_payout = PayoutPoint {
                 event_outcome: bound,
-                outcome_payout: total_collateral,
+                outcome_payout: fee,
                 extra_precision: 0,
             };
-            let fee = 300_000;
 
             // act
             let (lower, upper) =
@@ -779,7 +781,7 @@ mod tests {
             prop_assert_eq!(lower.event_outcome, last_payout.event_outcome);
             prop_assert_eq!(lower.outcome_payout, last_payout.outcome_payout);
             prop_assert_eq!(upper.event_outcome, BTCUSD_MAX_PRICE);
-            prop_assert_eq!(upper.outcome_payout, 0);
+            prop_assert_eq!(upper.outcome_payout, fee);
         }
 
     }


### PR DESCRIPTION
The example now produces a csv file which contains `<price>,<offerer>,<acceptor>`. This is useful to plot the payout for the coordinator(offerer) and trader (acceptor) in a single diagram.

I've also changed the gnuplot file which now produces an SVG so that one can zoom in and see more details.

Note: diagrams below where generated with a fee of 30%
![payout_curve](https://github.com/get10101/10101/assets/224613/12766579-486b-45ed-b292-9cc626422ca7)
