### PR TITLE
feat: Recover from pending offer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Feat: made sure that rollover works with dlc-channels
 - Fix: correctly remember reserved utxos and don't accidentally double spend
 - Feat: Allow recovering from a stuck protocol state by resending last outbound dlc message on connect
+- Feat: Allow continuing from an offered dlc channel state (offered, settle offered and collab close offered)
 
 ## [1.7.4] - 2023-12-20
 

--- a/coordinator/src/node.rs
+++ b/coordinator/src/node.rs
@@ -688,7 +688,7 @@ impl Node {
 
                         // TODO(bonomat): we should verify that the proposed amount is acceptable
                         self.inner
-                            .accept_dlc_channel_collaborative_close(close_offer.channel_id)?;
+                            .accept_dlc_channel_collaborative_close(&close_offer.channel_id)?;
                     }
                     ChannelMessage::Accept(accept_channel) => {
                         let channel_id_hex_string = accept_channel.temporary_channel_id.to_hex();

--- a/crates/ln-dlc-node/src/node/dlc_channel.rs
+++ b/crates/ln-dlc-node/src/node/dlc_channel.rs
@@ -266,27 +266,27 @@ impl<S: TenTenOneStorage + 'static, N: LnDlcStorage + Sync + Send + 'static> Nod
         .await?
     }
 
-    pub fn accept_dlc_channel_collaborative_close(&self, channel_id: DlcChannelId) -> Result<()> {
+    pub fn accept_dlc_channel_collaborative_close(&self, channel_id: &DlcChannelId) -> Result<()> {
         let channel_id_hex = hex::encode(channel_id);
 
         tracing::info!(channel_id = %channel_id_hex, "Accepting DLC channel collaborative close offer");
 
         let dlc_manager = self.dlc_manager.clone();
-        dlc_manager.accept_collaborative_close(&channel_id)?;
+        dlc_manager.accept_collaborative_close(channel_id)?;
 
         Ok(())
     }
 
     pub fn accept_dlc_channel_collaborative_settlement(
         &self,
-        channel_id: DlcChannelId,
+        channel_id: &DlcChannelId,
     ) -> Result<()> {
         let channel_id_hex = hex::encode(channel_id);
 
         tracing::info!(channel_id = %channel_id_hex, "Accepting DLC channel collaborative settlement");
 
         let dlc_manager = self.dlc_manager.clone();
-        let (settle_offer, counterparty_pk) = dlc_manager.accept_settle_offer(&channel_id)?;
+        let (settle_offer, counterparty_pk) = dlc_manager.accept_settle_offer(channel_id)?;
 
         self.event_handler.publish(NodeEvent::SendDlcMessage {
             peer: counterparty_pk,

--- a/crates/ln-dlc-node/src/tests/dlc_channel.rs
+++ b/crates/ln-dlc-node/src/tests/dlc_channel.rs
@@ -50,7 +50,7 @@ async fn can_open_and_collaboratively_close_channel() {
 
     tracing::debug!("Accepting collaborative close offer");
 
-    app.accept_dlc_channel_collaborative_close(coordinator_signed_channel.channel_id)
+    app.accept_dlc_channel_collaborative_close(&coordinator_signed_channel.channel_id)
         .unwrap();
 
     wait_until(Duration::from_secs(10), || async {
@@ -312,7 +312,7 @@ async fn setup_channel_with_position() -> (
     .unwrap();
 
     tracing::debug!("Accepting settle offer and waiting for being settled...");
-    app.accept_dlc_channel_collaborative_settlement(app_signed_channel.channel_id)
+    app.accept_dlc_channel_collaborative_settlement(&app_signed_channel.channel_id)
         .unwrap();
 
     wait_until(Duration::from_secs(10), || async {

--- a/mobile/native/src/ln_dlc/node.rs
+++ b/mobile/native/src/ln_dlc/node.rs
@@ -193,6 +193,11 @@ impl Node {
                         )
                     })?;
 
+                {
+                    let mut conn = db::connection()?;
+                    db::dlc_messages::DlcMessage::insert(&mut conn, inbound_msg)?;
+                }
+
                 match channel_msg {
                     ChannelMessage::Offer(offer) => {
                         let action = decide_subchannel_offer_action(
@@ -296,11 +301,6 @@ impl Node {
                         ));
                     }
                     _ => (),
-                }
-
-                {
-                    let mut conn = db::connection()?;
-                    db::dlc_messages::DlcMessage::insert(&mut conn, inbound_msg)?;
                 }
 
                 resp

--- a/mobile/native/src/ln_dlc/node.rs
+++ b/mobile/native/src/ln_dlc/node.rs
@@ -205,7 +205,7 @@ impl Node {
                     }
                     ChannelMessage::SettleOffer(offer) => {
                         self.inner
-                            .accept_dlc_channel_collaborative_settlement(offer.channel_id)
+                            .accept_dlc_channel_collaborative_settlement(&offer.channel_id)
                             .with_context(|| {
                                 format!(
                                     "Failed to accept DLC channel close offer for channel {}",


### PR DESCRIPTION
Checks on `on_connect` if the current dlc channel status is in offered.

- `OfferedChannel`: Automatically tries to accept the offer, if that fails the offer is attempted to be rejected. I think we do not need to check the maturity date outside of accepting the offer as the offer will fail anyways if the maturity date is in the past. If so we are continuing with rejecting the dlc channel offer.
- `SignedChannel(state: SettledReceived)`: Automatically accept the offer to close the position (settle the dlc channel)
- `SignedChannel(state: CollaborativeCloseOffered)`: Automatically accept the offer to collab close the dlc channel.

### Future work
- `SignedChannel(state: RenewOffered)`: To be addressed with #1791 .
- Add plausibility checks before automatically accepting any offer.