### PR TITLE
Use correct direction when computing settlement

### DIFF
--- a/coordinator/src/node.rs
+++ b/coordinator/src/node.rs
@@ -220,12 +220,6 @@ impl Node {
     ) -> Result<()> {
         let peer_id = trade_params.pubkey;
 
-        tracing::info!(
-            %peer_id,
-            order_id = %trade_params.filled_with.order_id,
-            ?trade_params, "Opening DLC channel and position"
-        );
-
         let leverage_trader = trade_params.leverage;
         let leverage_coordinator = self.coordinator_leverage_for_trade(&trade_params.pubkey)?;
 
@@ -241,6 +235,17 @@ impl Node {
         let initial_price = trade_params.filled_with.average_execution_price();
 
         let coordinator_direction = trade_params.direction.opposite();
+
+        tracing::info!(
+            %peer_id,
+            order_id = %trade_params.filled_with.order_id,
+            ?trade_params,
+            leverage_coordinator,
+            margin_coordinator_sat = %margin_coordinator,
+            margin_trader_sat = %margin_trader,
+            order_matching_fee_sat = %order_matching_fee,
+            "Opening DLC channel and position"
+        );
 
         let contract_descriptor = payout_curve::build_contract_descriptor(
             initial_price,
@@ -374,6 +379,18 @@ impl Node {
                     margin_trader, order_matching_fee, trader_dlc_channel_collateral
                 )
             })?;
+
+        tracing::debug!(
+            %peer_id,
+            order_id = %trade_params.filled_with.order_id,
+            leverage_coordinator,
+            margin_coordinator_sat = %margin_coordinator,
+            margin_trader_sat = %margin_trader,
+            coordinator_collateral_reserve_sat = %coordinator_collateral_reserve,
+            trader_collateral_reserve_sat = %trader_collateral_reserve,
+            order_matching_fee_sat = %order_matching_fee,
+            "DLC channel update parameters"
+        );
 
         let contract_descriptor = payout_curve::build_contract_descriptor(
             initial_price,

--- a/coordinator/src/position/models.rs
+++ b/coordinator/src/position/models.rs
@@ -156,13 +156,14 @@ impl Position {
             self.coordinator_leverage,
         );
 
+        let coordinator_direction = self.direction.opposite();
         calculate_coordinator_settlement_amount(
             opening_price,
             closing_price,
             self.quantity,
             leverage_long,
             leverage_short,
-            self.direction,
+            coordinator_direction,
         )
     }
 
@@ -436,6 +437,105 @@ mod tests {
     use super::*;
     use rust_decimal_macros::dec;
     use std::str::FromStr;
+
+    #[test]
+    fn position_calculate_coordinator_settlement_amount() {
+        let position = Position {
+            id: 0,
+            contract_symbol: ContractSymbol::BtcUsd,
+            trader_leverage: 2.0,
+            quantity: 100.0,
+            direction: Direction::Long,
+            average_entry_price: 40_000.0,
+            liquidation_price: 20_000.0,
+            position_state: PositionState::Open,
+            coordinator_margin: 125_000,
+            creation_timestamp: OffsetDateTime::now_utc(),
+            expiry_timestamp: OffsetDateTime::now_utc(),
+            update_timestamp: OffsetDateTime::now_utc(),
+            trader: PublicKey::from_str(
+                "02bd998ebd176715fe92b7467cf6b1df8023950a4dd911db4c94dfc89cc9f5a655",
+            )
+            .unwrap(),
+            coordinator_leverage: 2.0,
+            temporary_contract_id: None,
+            closing_price: None,
+            trader_margin: 125_000,
+            stable: false,
+        };
+
+        let coordinator_settlement_amount = position
+            .calculate_coordinator_settlement_amount(dec!(39_000))
+            .unwrap();
+
+        assert_eq!(coordinator_settlement_amount, 132_179);
+    }
+
+    #[test]
+    fn position_calculate_coordinator_settlement_amount_trader_leverage_3() {
+        let position = Position {
+            id: 0,
+            contract_symbol: ContractSymbol::BtcUsd,
+            trader_leverage: 3.0,
+            quantity: 100.0,
+            direction: Direction::Long,
+            average_entry_price: 40_000.0,
+            liquidation_price: 20_000.0,
+            position_state: PositionState::Open,
+            coordinator_margin: 125_000,
+            creation_timestamp: OffsetDateTime::now_utc(),
+            expiry_timestamp: OffsetDateTime::now_utc(),
+            update_timestamp: OffsetDateTime::now_utc(),
+            trader: PublicKey::from_str(
+                "02bd998ebd176715fe92b7467cf6b1df8023950a4dd911db4c94dfc89cc9f5a655",
+            )
+            .unwrap(),
+            coordinator_leverage: 2.0,
+            temporary_contract_id: None,
+            closing_price: None,
+            trader_margin: 125_000,
+            stable: false,
+        };
+
+        let coordinator_settlement_amount = position
+            .calculate_coordinator_settlement_amount(dec!(39_000))
+            .unwrap();
+
+        assert_eq!(coordinator_settlement_amount, 132_179);
+    }
+
+    #[test]
+    fn position_calculate_coordinator_settlement_amount_coordinator_leverage_3() {
+        let position = Position {
+            id: 0,
+            contract_symbol: ContractSymbol::BtcUsd,
+            trader_leverage: 2.0,
+            quantity: 100.0,
+            direction: Direction::Long,
+            average_entry_price: 40_000.0,
+            liquidation_price: 20_000.0,
+            position_state: PositionState::Open,
+            coordinator_margin: 125_000,
+            creation_timestamp: OffsetDateTime::now_utc(),
+            expiry_timestamp: OffsetDateTime::now_utc(),
+            update_timestamp: OffsetDateTime::now_utc(),
+            trader: PublicKey::from_str(
+                "02bd998ebd176715fe92b7467cf6b1df8023950a4dd911db4c94dfc89cc9f5a655",
+            )
+            .unwrap(),
+            coordinator_leverage: 3.0,
+            temporary_contract_id: None,
+            closing_price: None,
+            trader_margin: 125_000,
+            stable: false,
+        };
+
+        let coordinator_settlement_amount = position
+            .calculate_coordinator_settlement_amount(dec!(39_000))
+            .unwrap();
+
+        assert_eq!(coordinator_settlement_amount, 90_512);
+    }
 
     // Basic sanity tests. Verify the effect of the price moving on the computed settlement amount.
 


### PR DESCRIPTION
All the tests I ran locally where with a fixed price, so of course this only showed up in an environment where the price can actually change.

This also highlighted the fact that we were missing some tests, so I added them.

Fixes https://github.com/get10101/10101/issues/1840.