### PR TITLE
fix: parse bitcoin to Bitcoin network

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -827,7 +827,7 @@ dependencies = [
 
 [[package]]
 name = "coordinator"
-version = "1.7.4"
+version = "1.8.0"
 dependencies = [
  "anyhow",
  "atty",

--- a/mobile/native/src/config/api.rs
+++ b/mobile/native/src/config/api.rs
@@ -68,6 +68,7 @@ pub fn parse_network(network: &str) -> Network {
         "signet" => Network::Signet,
         "testnet" => Network::Testnet,
         "mainnet" => Network::Bitcoin,
+        "bitcoin" => Network::Bitcoin,
         _ => Network::Regtest,
     }
 }


### PR DESCRIPTION
we use differently name for bitcoin mainnet. Instead of trying to unify all different writing we convert the most common ones

fixes https://github.com/get10101/10101/issues/1881