### PR TITLE
fix: Create certs as 1000 user

### DIFF
--- a/webapp/Dockerfile
+++ b/webapp/Dockerfile
@@ -10,11 +10,12 @@ RUN apt-get update && \
     apt-get install sqlite3 -y && \
     apt-get install ca-certificates openssl -y
 
+RUN mkdir -p webapp/certs
 
-RUN mkdir certs
-
-RUN cd certs && \
+RUN cd webapp/certs && \
     openssl req -x509 -newkey rsa:4096 -keyout key.pem -out cert.pem -sha256 -days 3650 -nodes -subj "/C=XX/ST=StateName/L=CityName/O=CompanyName/OU=CompanySectionName/CN=CommonNameOrHostname"
+
+RUN chown -R 1000:1000 webapp/certs
 
 USER 1000
 


### PR DESCRIPTION
Also generates the certs on the default path so that the certs directory doesn't have to be set if the default certs should be used.


tested locally with the following
```
mkdir data

docker run \
  --name webapp \
  --rm \
  -v ./data:/data \
  -p 3001:3001 -it \
ghcr.io/holzeis/webapp:0.1.2  \
  --coordinator-endpoint=021025118ede915d626f7da184d75af7281dca965dd91a06993cf9d21fe4ca54e5@34.89.166.156:9045 \
  --data-dir=/data \
  --esplora=http://api.10101.finance:3000 \
  mainnet
```