### PR TITLE
Add endpoint to force-close LN-DLC channel

### DIFF
--- a/coordinator/src/admin.rs
+++ b/coordinator/src/admin.rs
@@ -558,6 +558,26 @@ pub async fn close_channel(
 }
 
 #[instrument(skip_all, err(Debug))]
+pub async fn force_close_ln_dlc_channel(
+    Path(channel_id_string): Path<String>,
+    State(state): State<Arc<AppState>>,
+) -> Result<(), AppError> {
+    let channel_id = parse_channel_id(&channel_id_string)
+        .map_err(|_| AppError::BadRequest("Provided channel ID was invalid".to_string()))?;
+
+    tracing::info!(channel_id = %channel_id_string, "Attempting to force-close Lightning channel");
+
+    let is_force_close = true;
+    state
+        .node
+        .inner
+        .close_channel(channel_id, is_force_close)
+        .map_err(|e| AppError::InternalServerError(format!("{e:#}")))?;
+
+    Ok(())
+}
+
+#[instrument(skip_all, err(Debug))]
 pub async fn sign_message(
     Path(msg): Path<String>,
     State(state): State<Arc<AppState>>,

--- a/coordinator/src/routes.rs
+++ b/coordinator/src/routes.rs
@@ -1,6 +1,7 @@
 use crate::admin::close_channel;
 use crate::admin::collaborative_revert;
 use crate::admin::connect_to_peer;
+use crate::admin::force_close_ln_dlc_channel;
 use crate::admin::get_balance;
 use crate::admin::get_fee_rate_estimation;
 use crate::admin::get_utxos;
@@ -156,6 +157,10 @@ pub fn router(
         .route("/api/admin/wallet/utxos", get(get_utxos))
         .route("/api/admin/channels", get(list_channels).post(open_channel))
         .route("/api/admin/channels/:channel_id", delete(close_channel))
+        .route(
+            "/api/admin/ln-dlc-channels/:channel_id",
+            delete(force_close_ln_dlc_channel),
+        )
         .route("/api/admin/peers", get(list_peers))
         .route("/api/admin/send_payment/:invoice", post(send_payment))
         .route("/api/admin/dlc_channels", get(list_dlc_channels))


### PR DESCRIPTION
We may need this until all LN-DLC channels are closed. This serves as a less efficient alternative to collaborative revert, as it doesn't require cooperation with the counterparty and it _may_ work when either party lacks all the data needed to perform the collaborative revert protocol.

---

I manually tested this by opening an LN-DLC channel (with a position) on version 1.7.4 and force-closing it using the same coordinator but updated to this branch. I've verified that the LN money is claimed on both sides after mining sufficient blocks. The DLC money is a bit more finicky because we have to mess with the expiry time, but given that this was already tested and that we haven't changed any of that code and that it was tested in `ln-dlc-node` on version 1.7.4, I don't see any risk.