### PR TITLE
fix(mobile): Make price nullable

### DIFF
--- a/mobile/lib/common/amount_and_fiat_text.dart
+++ b/mobile/lib/common/amount_and_fiat_text.dart
@@ -14,8 +14,8 @@ class AmountAndFiatText extends StatelessWidget {
   Widget build(BuildContext context) {
     return Selector<TradeValuesChangeNotifier, double>(
       selector: (_, provider) {
-        var askPrice = provider.getPrice().ask ?? 0.0;
-        var bidPrice = provider.getPrice().bid ?? 0.0;
+        var askPrice = provider.getPrice()?.ask ?? 0.0;
+        var bidPrice = provider.getPrice()?.bid ?? 0.0;
         var midMarket = (askPrice + bidPrice) / 2;
         return midMarket;
       },

--- a/mobile/lib/features/trade/trade_value_change_notifier.dart
+++ b/mobile/lib/features/trade/trade_value_change_notifier.dart
@@ -17,7 +17,8 @@ class TradeValuesChangeNotifier extends ChangeNotifier implements Subscriber {
   // The trade values are represented as Order domain, because that's essentially what they are
   late final TradeValues _buyTradeValues;
   late final TradeValues _sellTradeValues;
-  late final Price _price;
+
+  Price? _price;
 
   TradeValuesChangeNotifier(this.tradeValuesService, this.channelInfoService) {
     _buyTradeValues = _initOrder(Direction.long);
@@ -106,7 +107,7 @@ class TradeValuesChangeNotifier extends ChangeNotifier implements Subscriber {
     }
   }
 
-  Price getPrice() {
+  Price? getPrice() {
     return _price;
   }
 

--- a/mobile/lib/features/wallet/send/fee_text.dart
+++ b/mobile/lib/features/wallet/send/fee_text.dart
@@ -7,14 +7,15 @@ import 'package:provider/provider.dart';
 
 class FeeText extends StatelessWidget {
   final FeeEstimation fee;
+
   const FeeText({super.key, required this.fee});
 
   @override
   Widget build(BuildContext context) {
     return Selector<TradeValuesChangeNotifier, double>(
       selector: (_, provider) {
-        var askPrice = provider.getPrice().ask ?? 0.0;
-        var bidPrice = provider.getPrice().bid ?? 0.0;
+        var askPrice = provider.getPrice()?.ask ?? 0.0;
+        var bidPrice = provider.getPrice()?.bid ?? 0.0;
         var midMarket = (askPrice + bidPrice) / 2;
         return midMarket;
       },


### PR DESCRIPTION
This was constantly throwing errors in the logs whenever we got a new price as it is not allowed to update a late field multiple times.

```
[VERBOSE-2:dart_vm_initializer.cc(41)] Unhandled Exception: LateInitializationError: Field '_price@1021144427' has already been initialized.
#0      LateError._throwFieldAlreadyInitialized (dart:_internal-patch/internal_patch.dart:192:5)
#1      TradeValuesChangeNotifier._price= (package:get_10101/features/trade/trade_value_change_notifier.dart:20:20)
#2      TradeValuesChangeNotifier.updatePrice (package:get_10101/features/trade/trade_value_change_notifier.dart:102:5)
#3      TradeValuesChangeNotifier.notify (package:get_10101/features/trade/trade_value_change_notifier.dart:119:7)
#4      new EventService.create.<anonymous closure> (package:get_10101/common/application/event_service.dart:21:20)
#5      _RootZone.runUnaryGuarded (dart:async/zone.dart:1594:10)
#6      _BufferingStreamSubscription._sendData (dart:async/stream_impl.dart:339:11)
#7      _BufferingStreamSubscription._add (dart:async/stream_impl.dart:271:7)
#8      _SyncStreamControllerDispatch._sendData (dart:async/stream_controller.dart:<…>
```