### PR TITLE
Map `SignedChannelState`  to `ChannelStatus` correctly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -827,7 +827,7 @@ dependencies = [
 
 [[package]]
 name = "coordinator"
-version = "1.8.2"
+version = "1.8.3"
 dependencies = [
  "anyhow",
  "atty",

--- a/mobile/native/src/ln_dlc/channel_status.rs
+++ b/mobile/native/src/ln_dlc/channel_status.rs
@@ -80,16 +80,15 @@ impl From<Option<&SignedChannel>> for ChannelStatus {
             None => Self::NotOpen,
             Some(channel) => match channel.state {
                 SignedChannelState::Established { .. } => Self::WithPosition,
-                SignedChannelState::Settled { .. } | SignedChannelState::RenewFinalized { .. } => {
-                    Self::Open
-                }
+                SignedChannelState::Settled { .. } => Self::Open,
                 SignedChannelState::SettledOffered { .. }
                 | SignedChannelState::SettledReceived { .. }
                 | SignedChannelState::SettledAccepted { .. }
                 | SignedChannelState::SettledConfirmed { .. } => Self::Settling,
                 SignedChannelState::RenewOffered { .. }
                 | SignedChannelState::RenewAccepted { .. }
-                | SignedChannelState::RenewConfirmed { .. } => Self::Renewing,
+                | SignedChannelState::RenewConfirmed { .. }
+                | SignedChannelState::RenewFinalized { .. } => Self::Renewing,
                 SignedChannelState::Closing { .. }
                 | SignedChannelState::CollaborativeCloseOffered { .. } => Self::Closing,
             },


### PR DESCRIPTION
I think it's correct to assume that a `Established` channel is one that has a position. But a `RenewFinalized` channel is still pending
completion of the renew protocol and will eventually transition back to `Established`.

This behaviour can be seen in our `can_open_and_settle_offchain` test in the `ln-dlc-node` crate.