### PR TITLE
fix: remove one possible panic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2111,7 +2111,7 @@ dependencies = [
 [[package]]
 name = "lightning"
 version = "0.0.117"
-source = "git+https://github.com/p2pderivatives/rust-lightning/?rev=121bc324#121bc324fec54cfb8b0335ec013f596ffc9d6f9f"
+source = "git+https://github.com/bonomat/rust-lightning-p2p-derivatives?rev=e49030e#e49030e785408f0fd4da077f63f8101cc0b2436e"
 dependencies = [
  "bitcoin",
  "musig2",
@@ -2120,7 +2120,7 @@ dependencies = [
 [[package]]
 name = "lightning-background-processor"
 version = "0.0.117"
-source = "git+https://github.com/p2pderivatives/rust-lightning/?rev=121bc324#121bc324fec54cfb8b0335ec013f596ffc9d6f9f"
+source = "git+https://github.com/bonomat/rust-lightning-p2p-derivatives?rev=e49030e#e49030e785408f0fd4da077f63f8101cc0b2436e"
 dependencies = [
  "bitcoin",
  "lightning",
@@ -2144,7 +2144,7 @@ dependencies = [
 [[package]]
 name = "lightning-net-tokio"
 version = "0.0.117"
-source = "git+https://github.com/p2pderivatives/rust-lightning/?rev=121bc324#121bc324fec54cfb8b0335ec013f596ffc9d6f9f"
+source = "git+https://github.com/bonomat/rust-lightning-p2p-derivatives?rev=e49030e#e49030e785408f0fd4da077f63f8101cc0b2436e"
 dependencies = [
  "bitcoin",
  "lightning",
@@ -2154,7 +2154,7 @@ dependencies = [
 [[package]]
 name = "lightning-persister"
 version = "0.0.117"
-source = "git+https://github.com/p2pderivatives/rust-lightning/?rev=121bc324#121bc324fec54cfb8b0335ec013f596ffc9d6f9f"
+source = "git+https://github.com/bonomat/rust-lightning-p2p-derivatives?rev=e49030e#e49030e785408f0fd4da077f63f8101cc0b2436e"
 dependencies = [
  "bitcoin",
  "lightning",
@@ -2164,7 +2164,7 @@ dependencies = [
 [[package]]
 name = "lightning-rapid-gossip-sync"
 version = "0.0.117"
-source = "git+https://github.com/p2pderivatives/rust-lightning/?rev=121bc324#121bc324fec54cfb8b0335ec013f596ffc9d6f9f"
+source = "git+https://github.com/bonomat/rust-lightning-p2p-derivatives?rev=e49030e#e49030e785408f0fd4da077f63f8101cc0b2436e"
 dependencies = [
  "bitcoin",
  "lightning",
@@ -2173,7 +2173,7 @@ dependencies = [
 [[package]]
 name = "lightning-transaction-sync"
 version = "0.0.117"
-source = "git+https://github.com/p2pderivatives/rust-lightning/?rev=121bc324#121bc324fec54cfb8b0335ec013f596ffc9d6f9f"
+source = "git+https://github.com/bonomat/rust-lightning-p2p-derivatives?rev=e49030e#e49030e785408f0fd4da077f63f8101cc0b2436e"
 dependencies = [
  "bdk-macros",
  "bitcoin",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,13 +30,13 @@ dlc = { git = "https://github.com/p2pderivatives/rust-dlc", rev = "69d63e1" }
 p2pd-oracle-client = { git = "https://github.com/p2pderivatives/rust-dlc", rev = "69d63e1" }
 dlc-trie = { git = "https://github.com/p2pderivatives/rust-dlc", rev = "69d63e1" }
 
-# We should usually track the `p2pderivatives/split-tx-experiment[-10101]` branch.
-lightning = { git = "https://github.com/p2pderivatives/rust-lightning/", rev = "121bc324" }
-lightning-background-processor = { git = "https://github.com/p2pderivatives/rust-lightning/", rev = "121bc324" }
-lightning-transaction-sync = { git = "https://github.com/p2pderivatives/rust-lightning/", rev = "121bc324" }
-lightning-net-tokio = { git = "https://github.com/p2pderivatives/rust-lightning/", rev = "121bc324" }
-lightning-persister = { git = "https://github.com/p2pderivatives/rust-lightning/", rev = "121bc324" }
-lightning-rapid-gossip-sync = { git = "https://github.com/p2pderivatives/rust-lightning/", rev = "121bc324" }
+# We should usually track the `p2pderivatives/split-tx-experiment[-10101]` branch. For now we depend on a special fork which removes a panic in rust-lightning
+lightning = { git = "https://github.com/bonomat/rust-lightning-p2p-derivatives", rev = "e49030e" }
+lightning-background-processor = { git = "https://github.com/bonomat/rust-lightning-p2p-derivatives", rev = "e49030e" }
+lightning-transaction-sync = { git = "https://github.com/bonomat/rust-lightning-p2p-derivatives", rev = "e49030e" }
+lightning-net-tokio = { git = "https://github.com/bonomat/rust-lightning-p2p-derivatives", rev = "e49030e" }
+lightning-persister = { git = "https://github.com/bonomat/rust-lightning-p2p-derivatives", rev = "e49030e" }
+lightning-rapid-gossip-sync = { git = "https://github.com/bonomat/rust-lightning-p2p-derivatives", rev = "e49030e" }
 
 rust-bitcoin-coin-selection = { git = "https://github.com/p2pderivatives/rust-bitcoin-coin-selection" }
 


### PR DESCRIPTION
We had an issue where the app would panic because we fell behind in the protocol. This panic has been removed in this commit https://github.com/bonomat/rust-lightning-p2p-derivatives/commit/e49030e785408f0fd4da077f63f8101cc0b2436e.
This commit was built on top of our latest commit https://github.com/p2pderivatives/rust-lightning/commit/121bc324fec54cfb8b0335ec013f596ffc9d6f9f

I didn't feel good about pushing this to our usual fork in https://github.com/p2pderivatives/rust-lightning because it sounds dangerous and hence pushed it onto my own fork. We can drop this again in the future. 

(hopefully) resolves most panics.

Resolves https://github.com/get10101/10101/issues/1911