### PR TITLE
Smarter coin selection for DLC funding transaction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -414,6 +414,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bdk_coin_select"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd50028fb9c48ce062859565fc59974cd1ee614f8db1c4bfc8c094ef1ffe6ff6"
+
+[[package]]
 name = "bech32"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2209,6 +2215,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "bdk",
+ "bdk_coin_select",
  "bip39",
  "bitcoin",
  "dlc",

--- a/crates/ln-dlc-node/Cargo.toml
+++ b/crates/ln-dlc-node/Cargo.toml
@@ -10,6 +10,7 @@ description = "A common interface for using Lightning and DLC channels side-by-s
 anyhow = { version = "1", features = ["backtrace"] }
 async-trait = "0.1.71"
 bdk = { version = "0.28.0", default-features = false, features = ["key-value-db", "use-esplora-blocking", "std"] }
+bdk_coin_select = "0.2.0"
 bip39 = { version = "2", features = ["rand_core"] }
 bitcoin = "0.29.2"
 dlc = { version = "0.4.0" }

--- a/crates/ln-dlc-node/src/ldk_node_wallet.rs
+++ b/crates/ln-dlc-node/src/ldk_node_wallet.rs
@@ -179,7 +179,11 @@ where
         Ok(utxos)
     }
 
-    pub fn get_utxos_for_amount(&self, amount: u64, lock_utxos: bool) -> Result<Vec<Utxo>> {
+    pub fn get_utxos_for_dlc_funding_transaction(
+        &self,
+        amount: u64,
+        lock_utxos: bool,
+    ) -> Result<Vec<Utxo>> {
         let utxos = self.get_utxos()?;
         // get temporarily reserved utxo from in-memory storage
         let mut reserved_outpoints = self.locked_outpoints.lock();

--- a/crates/ln-dlc-node/src/ldk_node_wallet.rs
+++ b/crates/ln-dlc-node/src/ldk_node_wallet.rs
@@ -20,7 +20,6 @@ use bitcoin::psbt::PartiallySignedTransaction;
 use bitcoin::Address;
 use bitcoin::Amount;
 use bitcoin::BlockHash;
-use bitcoin::Network;
 use bitcoin::OutPoint;
 use bitcoin::Script;
 use bitcoin::Transaction;
@@ -180,12 +179,7 @@ where
         Ok(utxos)
     }
 
-    pub fn get_utxos_for_amount(
-        &self,
-        amount: u64,
-        lock_utxos: bool,
-        network: Network,
-    ) -> Result<Vec<Utxo>> {
+    pub fn get_utxos_for_amount(&self, amount: u64, lock_utxos: bool) -> Result<Vec<Utxo>> {
         let utxos = self.get_utxos()?;
         // get temporarily reserved utxo from in-memory storage
         let mut reserved_outpoints = self.locked_outpoints.lock();
@@ -204,8 +198,11 @@ where
                 utxo: Utxo {
                     tx_out: x.txout.clone(),
                     outpoint: x.outpoint,
-                    address: Address::from_script(&x.txout.script_pubkey, network)
-                        .expect("to be a valid address"),
+                    address: Address::from_script(
+                        &x.txout.script_pubkey,
+                        self.bdk_lock().network(),
+                    )
+                    .expect("to be a valid address"),
                     redeem_script: Default::default(),
                     reserved: false,
                 },

--- a/crates/ln-dlc-node/src/ldk_node_wallet.rs
+++ b/crates/ln-dlc-node/src/ldk_node_wallet.rs
@@ -166,6 +166,10 @@ where
             .address)
     }
 
+    pub(crate) fn get_new_address(&self) -> Result<Address> {
+        Ok(self.bdk_lock().get_address(AddressIndex::New)?.address)
+    }
+
     pub fn is_mine(&self, script: &Script) -> Result<bool> {
         Ok(self.bdk_lock().is_mine(script)?)
     }

--- a/crates/ln-dlc-node/src/ln_dlc_wallet.rs
+++ b/crates/ln-dlc-node/src/ln_dlc_wallet.rs
@@ -280,7 +280,7 @@ impl<S: TenTenOneStorage, N: Storage> dlc_manager::Wallet for LnDlcWallet<S, N> 
             .ldk_wallet()
             .get_utxos_for_amount(amount, lock_utxos)
             .map_err(|error| {
-                Error::InvalidState(format!("Could not find utxos for mount {error:?}"))
+                Error::InvalidState(format!("Could not find utxos for amount: {error:?}"))
             })?;
         if utxos.is_empty() {
             return Err(Error::InvalidState(

--- a/crates/ln-dlc-node/src/ln_dlc_wallet.rs
+++ b/crates/ln-dlc-node/src/ln_dlc_wallet.rs
@@ -278,12 +278,12 @@ impl<S: TenTenOneStorage, N: Storage> dlc_manager::Wallet for LnDlcWallet<S, N> 
     fn get_utxos_for_amount(
         &self,
         amount: u64,
-        _: Option<u64>,
+        fee_rate: Option<u64>,
         lock_utxos: bool,
     ) -> Result<Vec<Utxo>, Error> {
         let utxos = self
             .ldk_wallet()
-            .get_utxos_for_dlc_funding_transaction(amount, lock_utxos)
+            .get_utxos_for_dlc_funding_transaction(amount, fee_rate, lock_utxos)
             .map_err(|error| {
                 Error::InvalidState(format!("Could not find utxos for amount: {error:?}"))
             })?;

--- a/crates/ln-dlc-node/src/ln_dlc_wallet.rs
+++ b/crates/ln-dlc-node/src/ln_dlc_wallet.rs
@@ -122,6 +122,10 @@ impl<S: TenTenOneStorage, N: Storage> LnDlcWallet<S, N> {
         self.address_cache.read().clone()
     }
 
+    pub fn new_address(&self) -> Result<Address> {
+        self.ldk_wallet().get_new_address()
+    }
+
     pub fn is_mine(&self, script: &Script) -> Result<bool> {
         self.ldk_wallet().is_mine(script)
     }

--- a/crates/ln-dlc-node/src/ln_dlc_wallet.rs
+++ b/crates/ln-dlc-node/src/ln_dlc_wallet.rs
@@ -278,7 +278,7 @@ impl<S: TenTenOneStorage, N: Storage> dlc_manager::Wallet for LnDlcWallet<S, N> 
     ) -> Result<Vec<Utxo>, Error> {
         let utxos = self
             .ldk_wallet()
-            .get_utxos_for_amount(amount, lock_utxos, self.network)
+            .get_utxos_for_amount(amount, lock_utxos)
             .map_err(|error| {
                 Error::InvalidState(format!("Could not find utxos for mount {error:?}"))
             })?;

--- a/crates/ln-dlc-node/src/ln_dlc_wallet.rs
+++ b/crates/ln-dlc-node/src/ln_dlc_wallet.rs
@@ -270,6 +270,7 @@ impl<S: TenTenOneStorage, N: Storage> dlc_manager::Wallet for LnDlcWallet<S, N> 
         Ok(sk)
     }
 
+    // This is only used to create the funding transaction of a DLC or a DLC channel.
     fn get_utxos_for_amount(
         &self,
         amount: u64,
@@ -278,7 +279,7 @@ impl<S: TenTenOneStorage, N: Storage> dlc_manager::Wallet for LnDlcWallet<S, N> 
     ) -> Result<Vec<Utxo>, Error> {
         let utxos = self
             .ldk_wallet()
-            .get_utxos_for_amount(amount, lock_utxos)
+            .get_utxos_for_dlc_funding_transaction(amount, lock_utxos)
             .map_err(|error| {
                 Error::InvalidState(format!("Could not find utxos for amount: {error:?}"))
             })?;

--- a/crates/ln-dlc-node/src/ln_dlc_wallet.rs
+++ b/crates/ln-dlc-node/src/ln_dlc_wallet.rs
@@ -282,11 +282,7 @@ impl<S: TenTenOneStorage, N: Storage> dlc_manager::Wallet for LnDlcWallet<S, N> 
             .map_err(|error| {
                 Error::InvalidState(format!("Could not find utxos for amount: {error:?}"))
             })?;
-        if utxos.is_empty() {
-            return Err(Error::InvalidState(
-                "Not enough UTXOs for amount".to_string(),
-            ));
-        }
+
         Ok(utxos)
     }
 

--- a/crates/ln-dlc-node/src/node/wallet.rs
+++ b/crates/ln-dlc-node/src/node/wallet.rs
@@ -59,6 +59,12 @@ impl<S: TenTenOneStorage, N: Storage> Node<S, N> {
         self.wallet.unused_address()
     }
 
+    pub fn get_new_address(&self) -> Result<Address> {
+        self.wallet
+            .new_address()
+            .context("Failed to get new address")
+    }
+
     pub fn get_blockchain_height(&self) -> Result<u64> {
         self.wallet
             .get_blockchain_height()

--- a/crates/tests-e2e/src/bitcoind.rs
+++ b/crates/tests-e2e/src/bitcoind.rs
@@ -5,6 +5,7 @@ use bitcoin::Amount;
 use reqwest::Client;
 use reqwest::Response;
 use serde::Deserialize;
+use serde_json::json;
 use std::time::Duration;
 
 /// A wrapper over the bitcoind HTTP API
@@ -27,12 +28,7 @@ impl Bitcoind {
 
     /// Instructs `bitcoind` to generate to address.
     pub async fn mine(&self, n: u16) -> Result<()> {
-        #[derive(Deserialize, Debug)]
-        struct BitcoindResponse {
-            result: String,
-        }
-
-        let response: BitcoindResponse = self
+        let response: GetNewAddressResponse = self
             .client
             .post(&self.host)
             .body(r#"{"jsonrpc": "1.0", "method": "getnewaddress", "params": []}"#.to_string())
@@ -75,6 +71,106 @@ impl Bitcoind {
         Ok(response)
     }
 
+    pub async fn send_multiple_utxos_to_address<F>(
+        &self,
+        address_fn: F,
+        utxo_amount: Amount,
+        n_utxos: u64,
+    ) -> Result<()>
+    where
+        F: Fn() -> Address,
+    {
+        let total_amount = utxo_amount * n_utxos;
+
+        let response: ListUnspentResponse = self
+            .client
+            .post(&self.host)
+            .body(r#"{"jsonrpc": "1.0", "method": "listunspent", "params": []}"#)
+            .send()
+            .await?
+            .json()
+            .await?;
+
+        let utxo = response
+            .result
+            .iter()
+            // We try to find one UTXO that can cover the whole transaction. We could cover the
+            // amount with multiple UTXOs too, but this is simpler and will probably succeed.
+            .find(|utxo| utxo.spendable && utxo.amount >= total_amount)
+            .expect("to find UTXO to cover multi-payment");
+
+        let mut outputs = serde_json::value::Map::new();
+
+        for _ in 0..n_utxos {
+            let address = address_fn();
+            outputs.insert(address.to_string(), json!(utxo_amount.to_btc()));
+        }
+
+        let create_raw_tx_request = json!(
+            {
+                "jsonrpc": "1.0",
+                "method": "createrawtransaction",
+                "params":
+                [
+                    [ {"txid": utxo.txid, "vout": utxo.vout} ],
+                    outputs
+                ]
+            }
+        );
+
+        let create_raw_tx_response: CreateRawTransactionResponse = self
+            .client
+            .post(&self.host)
+            .json(&create_raw_tx_request)
+            .send()
+            .await?
+            .json()
+            .await?;
+
+        let sign_raw_tx_with_wallet_request = json!(
+            {
+                "jsonrpc": "1.0",
+                "method": "signrawtransactionwithwallet",
+                "params": [ create_raw_tx_response.result ]
+            }
+        );
+
+        let sign_raw_tx_with_wallet_response: SignRawTransactionWithWalletResponse = self
+            .client
+            .post(&self.host)
+            .json(&sign_raw_tx_with_wallet_request)
+            .send()
+            .await?
+            .json()
+            .await?;
+
+        let send_raw_tx_request = json!(
+            {
+                "jsonrpc": "1.0",
+                "method": "sendrawtransaction",
+                "params": [ sign_raw_tx_with_wallet_response.result.hex, 0 ]
+            }
+        );
+
+        let send_raw_tx_response: SendRawTransactionResponse = self
+            .client
+            .post(&self.host)
+            .json(&send_raw_tx_request)
+            .send()
+            .await?
+            .json()
+            .await?;
+
+        tracing::info!(
+            txid = %send_raw_tx_response.result,
+            %utxo_amount,
+            %n_utxos,
+            "Published multi-utxo transaction"
+        );
+
+        Ok(())
+    }
+
     pub async fn post(&self, endpoint: &str, body: Option<String>) -> Result<Response> {
         let mut builder = self.client.post(endpoint.to_string());
         if let Some(body) = body {
@@ -87,4 +183,43 @@ impl Bitcoind {
         }
         Ok(response)
     }
+}
+
+#[derive(Deserialize, Debug)]
+struct GetNewAddressResponse {
+    result: String,
+}
+
+#[derive(Deserialize, Debug)]
+struct ListUnspentResponse {
+    result: Vec<Utxo>,
+}
+
+#[derive(Deserialize, Debug)]
+struct Utxo {
+    txid: String,
+    vout: usize,
+    #[serde(with = "bitcoin::util::amount::serde::as_btc")]
+    amount: Amount,
+    spendable: bool,
+}
+
+#[derive(Deserialize, Debug)]
+struct CreateRawTransactionResponse {
+    result: String,
+}
+
+#[derive(Deserialize, Debug)]
+struct SignRawTransactionWithWalletResponse {
+    result: SignRawTransactionWithWalletResponseBody,
+}
+
+#[derive(Deserialize, Debug)]
+struct SignRawTransactionWithWalletResponseBody {
+    hex: String,
+}
+
+#[derive(Deserialize, Debug)]
+struct SendRawTransactionResponse {
+    result: String,
 }

--- a/crates/tests-e2e/src/setup.rs
+++ b/crates/tests-e2e/src/setup.rs
@@ -67,7 +67,8 @@ impl TestSetup {
             .unwrap();
 
         self.bitcoind.mine(1).await.unwrap();
-        self.coordinator.sync_node().await.unwrap();
+
+        self.sync_coordinator().await;
 
         // TODO: Get coordinator balance to verify this claim.
         tracing::info!("Successfully funded coordinator");
@@ -134,9 +135,15 @@ impl TestSetup {
         sync_dlc_channels();
         refresh_wallet_info();
 
-        setup.coordinator.sync_node().await.unwrap();
+        setup.sync_coordinator().await;
 
         setup
+    }
+
+    async fn sync_coordinator(&self) {
+        if let Err(e) = self.coordinator.sync_node().await {
+            tracing::error!("Got error from coordinator sync: {e:#}");
+        };
     }
 }
 

--- a/crates/tests-e2e/tests/basic.rs
+++ b/crates/tests-e2e/tests/basic.rs
@@ -4,7 +4,7 @@ use tests_e2e::setup::TestSetup;
 #[tokio::test(flavor = "multi_thread")]
 #[ignore = "need to be run with 'just e2e' command"]
 async fn app_can_be_funded_with_bitcoind() -> Result<()> {
-    TestSetup::new_after_funding(None).await;
+    TestSetup::new_after_funding().await;
 
     Ok(())
 }

--- a/crates/tests-e2e/tests/open_position.rs
+++ b/crates/tests-e2e/tests/open_position.rs
@@ -9,24 +9,20 @@ use tests_e2e::setup::TestSetup;
 use tests_e2e::wait_until;
 use tokio::task::spawn_blocking;
 
-fn dummy_order() -> NewOrder {
-    NewOrder {
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "need to be run with 'just e2e' command"]
+async fn can_open_position() {
+    let test = TestSetup::new_after_funding().await;
+    let app = &test.app;
+
+    let order = NewOrder {
         leverage: 2.0,
         contract_symbol: ContractSymbol::BtcUsd,
         direction: api::Direction::Long,
         quantity: 1.0,
         order_type: Box::new(OrderType::Market),
         stable: false,
-    }
-}
-
-#[tokio::test(flavor = "multi_thread")]
-#[ignore = "need to be run with 'just e2e' command"]
-async fn can_open_position() {
-    let test = TestSetup::new_after_funding(None).await;
-    let app = &test.app;
-
-    let order = dummy_order();
+    };
     spawn_blocking({
         let order = order.clone();
         move || api::submit_order(order).unwrap()

--- a/crates/tests-e2e/tests/open_position_small_utxos.rs
+++ b/crates/tests-e2e/tests/open_position_small_utxos.rs
@@ -1,0 +1,95 @@
+use bitcoin::Amount;
+use native::api;
+use native::api::calculate_margin;
+use native::api::ContractSymbol;
+use native::trade::order::api::NewOrder;
+use native::trade::order::api::OrderType;
+use native::trade::position::PositionState;
+use rust_decimal::prelude::ToPrimitive;
+use std::str::FromStr;
+use tests_e2e::app::refresh_wallet_info;
+use tests_e2e::setup::TestSetup;
+use tests_e2e::wait_until;
+use tokio::task::spawn_blocking;
+
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "need to be run with 'just e2e' command"]
+#[should_panic]
+async fn can_open_position_with_multiple_small_utxos() {
+    // Arrange
+
+    let setup = TestSetup::new().await;
+
+    setup.fund_coordinator(Amount::ONE_BTC).await;
+
+    let app = &setup.app;
+
+    // Fund app with multiple small UTXOs that can cover the required margin.
+
+    let order = NewOrder {
+        leverage: 2.0,
+        contract_symbol: ContractSymbol::BtcUsd,
+        direction: api::Direction::Long,
+        quantity: 100.0,
+        order_type: Box::new(OrderType::Market),
+        stable: false,
+    };
+
+    // We take the ask price because the app is going long.
+    let ask_price = app
+        .rx
+        .prices()
+        .unwrap()
+        .get(&ContractSymbol::BtcUsd)
+        .unwrap()
+        .ask
+        .unwrap()
+        .to_f32()
+        .unwrap();
+
+    let margin_app = calculate_margin(ask_price, order.quantity, order.leverage).0;
+
+    // We want to use small UTXOs.
+    let utxo_size = 1_000;
+
+    let n_utxos = margin_app / utxo_size;
+
+    // Double the number of UTXOs to cover costs beyond the margin i.e. fees.
+    let n_utxos = 2 * n_utxos;
+
+    let address_fn = || bitcoin::Address::from_str(&api::get_new_address().unwrap()).unwrap();
+
+    setup
+        .bitcoind
+        .send_multiple_utxos_to_address(address_fn, Amount::from_sat(utxo_size), n_utxos)
+        .await
+        .unwrap();
+
+    let fund_amount = n_utxos * utxo_size;
+
+    setup.bitcoind.mine(1).await.unwrap();
+
+    wait_until!({
+        refresh_wallet_info();
+        app.rx.wallet_info().unwrap().balances.on_chain >= fund_amount
+    });
+
+    // Act
+
+    spawn_blocking({
+        let order = order.clone();
+        move || api::submit_order(order).unwrap()
+    })
+    .await
+    .unwrap();
+
+    // Assert
+
+    wait_until!(matches!(
+        app.rx.position(),
+        Some(native::trade::position::Position {
+            position_state: PositionState::Open,
+            ..
+        })
+    ));
+}

--- a/crates/tests-e2e/tests/open_position_small_utxos.rs
+++ b/crates/tests-e2e/tests/open_position_small_utxos.rs
@@ -14,7 +14,6 @@ use tokio::task::spawn_blocking;
 
 #[tokio::test(flavor = "multi_thread")]
 #[ignore = "need to be run with 'just e2e' command"]
-#[should_panic]
 async fn can_open_position_with_multiple_small_utxos() {
     // Arrange
 

--- a/crates/tests-e2e/tests/reject_offer.rs
+++ b/crates/tests-e2e/tests/reject_offer.rs
@@ -14,7 +14,10 @@ use tokio::task::spawn_blocking;
 #[tokio::test(flavor = "multi_thread")]
 #[ignore = "need to be run with 'just e2e' command"]
 async fn reject_offer() {
-    let test = TestSetup::new_after_funding(Some(Amount::from_sat(250_000))).await;
+    let test = TestSetup::new().await;
+    test.fund_coordinator(Amount::ONE_BTC).await;
+    test.fund_app(Amount::from_sat(250_000)).await;
+
     let app = &test.app;
 
     let invalid_order = NewOrder {

--- a/mobile/native/src/api.rs
+++ b/mobile/native/src/api.rs
@@ -405,6 +405,10 @@ pub fn get_unused_address() -> SyncReturn<String> {
     SyncReturn(ln_dlc::get_unused_address())
 }
 
+pub fn get_new_address() -> Result<String> {
+    ln_dlc::get_new_address()
+}
+
 #[tokio::main(flavor = "current_thread")]
 pub async fn close_channel() -> Result<()> {
     ln_dlc::close_channel(false).await

--- a/mobile/native/src/ln_dlc/mod.rs
+++ b/mobile/native/src/ln_dlc/mod.rs
@@ -697,6 +697,12 @@ pub fn get_unused_address() -> String {
     state::get_node().inner.get_unused_address().to_string()
 }
 
+pub fn get_new_address() -> Result<String> {
+    let address = state::get_node().inner.get_new_address()?;
+
+    Ok(address.to_string())
+}
+
 pub async fn close_channel(is_force_close: bool) -> Result<()> {
     tracing::info!(force = is_force_close, "Offering to close a channel");
     let node = state::try_get_node().context("failed to get ln dlc node")?;


### PR DESCRIPTION
Fixes #1912.

There are more problems that can lead to #1912, but this is definitely one of them as was demonstrated with ccbd0c55cb5682b2c5e38de4f8e9046f5e55013f.

In a different PR I will address the problem of `rust-dlc` underestimating how much money each party needs to bring in to cover the fees for all the transactions that are involved in a DLC channel.