### PR TITLE
feat: Reject dlc channel, settle and renew offer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - Feat(webapp): Show order history
+- Fix: Add reject dlc channel, settle and renew offer
 
 ## [1.8.4] - 2024-01-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Feat(webapp): Show order history
 - Fix: Add reject dlc channel, settle and renew offer
+- Chore: Change pending offer policy to reject on reconnect
 
 ## [1.8.4] - 2024-01-31
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1219,7 +1219,7 @@ dependencies = [
 [[package]]
 name = "dlc"
 version = "0.4.0"
-source = "git+https://github.com/p2pderivatives/rust-dlc?rev=69d63e1#69d63e113712cf9850c25643ed49816a283cb8a3"
+source = "git+https://github.com/p2pderivatives/rust-dlc?rev=785980c8ecc20a95e5b3c0b5fe262e1abff44cb5#785980c8ecc20a95e5b3c0b5fe262e1abff44cb5"
 dependencies = [
  "bitcoin",
  "miniscript 8.0.2",
@@ -1231,7 +1231,7 @@ dependencies = [
 [[package]]
 name = "dlc-manager"
 version = "0.4.0"
-source = "git+https://github.com/p2pderivatives/rust-dlc?rev=69d63e1#69d63e113712cf9850c25643ed49816a283cb8a3"
+source = "git+https://github.com/p2pderivatives/rust-dlc?rev=785980c8ecc20a95e5b3c0b5fe262e1abff44cb5#785980c8ecc20a95e5b3c0b5fe262e1abff44cb5"
 dependencies = [
  "async-trait",
  "bitcoin",
@@ -1247,7 +1247,7 @@ dependencies = [
 [[package]]
 name = "dlc-messages"
 version = "0.4.0"
-source = "git+https://github.com/p2pderivatives/rust-dlc?rev=69d63e1#69d63e113712cf9850c25643ed49816a283cb8a3"
+source = "git+https://github.com/p2pderivatives/rust-dlc?rev=785980c8ecc20a95e5b3c0b5fe262e1abff44cb5#785980c8ecc20a95e5b3c0b5fe262e1abff44cb5"
 dependencies = [
  "bitcoin",
  "dlc",
@@ -1260,7 +1260,7 @@ dependencies = [
 [[package]]
 name = "dlc-trie"
 version = "0.4.0"
-source = "git+https://github.com/p2pderivatives/rust-dlc?rev=69d63e1#69d63e113712cf9850c25643ed49816a283cb8a3"
+source = "git+https://github.com/p2pderivatives/rust-dlc?rev=785980c8ecc20a95e5b3c0b5fe262e1abff44cb5#785980c8ecc20a95e5b3c0b5fe262e1abff44cb5"
 dependencies = [
  "bitcoin",
  "dlc",
@@ -2819,7 +2819,7 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 [[package]]
 name = "p2pd-oracle-client"
 version = "0.1.0"
-source = "git+https://github.com/p2pderivatives/rust-dlc?rev=69d63e1#69d63e113712cf9850c25643ed49816a283cb8a3"
+source = "git+https://github.com/p2pderivatives/rust-dlc?rev=785980c8ecc20a95e5b3c0b5fe262e1abff44cb5#785980c8ecc20a95e5b3c0b5fe262e1abff44cb5"
 dependencies = [
  "chrono",
  "dlc-manager",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2241,7 +2241,7 @@ dependencies = [
  "time",
  "tokio",
  "tracing",
- "tracing-log",
+ "tracing-log 0.1.3",
  "tracing-subscriber",
  "ureq",
  "uuid",
@@ -2548,6 +2548,7 @@ dependencies = [
  "tokio-tungstenite",
  "tokio-util",
  "tracing",
+ "tracing-log 0.2.0",
  "tracing-subscriber",
  "trade",
  "uuid",
@@ -4459,6 +4460,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-serde"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4486,7 +4498,7 @@ dependencies = [
  "time",
  "tracing",
  "tracing-core",
- "tracing-log",
+ "tracing-log 0.1.3",
  "tracing-serde",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1219,7 +1219,7 @@ dependencies = [
 [[package]]
 name = "dlc"
 version = "0.4.0"
-source = "git+https://github.com/p2pderivatives/rust-dlc?rev=785980c8ecc20a95e5b3c0b5fe262e1abff44cb5#785980c8ecc20a95e5b3c0b5fe262e1abff44cb5"
+source = "git+https://github.com/p2pderivatives/rust-dlc?rev=8c13abf4283244d0e40b042468f0ffea3c0081b4#8c13abf4283244d0e40b042468f0ffea3c0081b4"
 dependencies = [
  "bitcoin",
  "miniscript 8.0.2",
@@ -1231,7 +1231,7 @@ dependencies = [
 [[package]]
 name = "dlc-manager"
 version = "0.4.0"
-source = "git+https://github.com/p2pderivatives/rust-dlc?rev=785980c8ecc20a95e5b3c0b5fe262e1abff44cb5#785980c8ecc20a95e5b3c0b5fe262e1abff44cb5"
+source = "git+https://github.com/p2pderivatives/rust-dlc?rev=8c13abf4283244d0e40b042468f0ffea3c0081b4#8c13abf4283244d0e40b042468f0ffea3c0081b4"
 dependencies = [
  "async-trait",
  "bitcoin",
@@ -1247,7 +1247,7 @@ dependencies = [
 [[package]]
 name = "dlc-messages"
 version = "0.4.0"
-source = "git+https://github.com/p2pderivatives/rust-dlc?rev=785980c8ecc20a95e5b3c0b5fe262e1abff44cb5#785980c8ecc20a95e5b3c0b5fe262e1abff44cb5"
+source = "git+https://github.com/p2pderivatives/rust-dlc?rev=8c13abf4283244d0e40b042468f0ffea3c0081b4#8c13abf4283244d0e40b042468f0ffea3c0081b4"
 dependencies = [
  "bitcoin",
  "dlc",
@@ -1260,7 +1260,7 @@ dependencies = [
 [[package]]
 name = "dlc-trie"
 version = "0.4.0"
-source = "git+https://github.com/p2pderivatives/rust-dlc?rev=785980c8ecc20a95e5b3c0b5fe262e1abff44cb5#785980c8ecc20a95e5b3c0b5fe262e1abff44cb5"
+source = "git+https://github.com/p2pderivatives/rust-dlc?rev=8c13abf4283244d0e40b042468f0ffea3c0081b4#8c13abf4283244d0e40b042468f0ffea3c0081b4"
 dependencies = [
  "bitcoin",
  "dlc",
@@ -2820,7 +2820,7 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 [[package]]
 name = "p2pd-oracle-client"
 version = "0.1.0"
-source = "git+https://github.com/p2pderivatives/rust-dlc?rev=785980c8ecc20a95e5b3c0b5fe262e1abff44cb5#785980c8ecc20a95e5b3c0b5fe262e1abff44cb5"
+source = "git+https://github.com/p2pderivatives/rust-dlc?rev=8c13abf4283244d0e40b042468f0ffea3c0081b4#8c13abf4283244d0e40b042468f0ffea3c0081b4"
 dependencies = [
  "chrono",
  "dlc-manager",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,11 +24,11 @@ resolver = "2"
 # `p2pderivatives/rust-dlc#feature/ln-dlc-channels`: 4e104b4. This patch ensures backwards
 # compatibility for 10101 through the `rust-lightning:0.0.116` upgrade. We will be able to drop it
 # once all users have been upgraded and traded once.
-dlc-manager = { git = "https://github.com/p2pderivatives/rust-dlc", rev = "69d63e1" }
-dlc-messages = { git = "https://github.com/p2pderivatives/rust-dlc", rev = "69d63e1" }
-dlc = { git = "https://github.com/p2pderivatives/rust-dlc", rev = "69d63e1" }
-p2pd-oracle-client = { git = "https://github.com/p2pderivatives/rust-dlc", rev = "69d63e1" }
-dlc-trie = { git = "https://github.com/p2pderivatives/rust-dlc", rev = "69d63e1" }
+dlc-manager = { git = "https://github.com/p2pderivatives/rust-dlc", rev = "785980c8ecc20a95e5b3c0b5fe262e1abff44cb5" }
+dlc-messages = { git = "https://github.com/p2pderivatives/rust-dlc", rev = "785980c8ecc20a95e5b3c0b5fe262e1abff44cb5" }
+dlc = { git = "https://github.com/p2pderivatives/rust-dlc", rev = "785980c8ecc20a95e5b3c0b5fe262e1abff44cb5" }
+p2pd-oracle-client = { git = "https://github.com/p2pderivatives/rust-dlc", rev = "785980c8ecc20a95e5b3c0b5fe262e1abff44cb5" }
+dlc-trie = { git = "https://github.com/p2pderivatives/rust-dlc", rev = "785980c8ecc20a95e5b3c0b5fe262e1abff44cb5" }
 
 # We should usually track the `p2pderivatives/split-tx-experiment[-10101]` branch. For now we depend on a special fork which removes a panic in rust-lightning
 lightning = { git = "https://github.com/bonomat/rust-lightning-p2p-derivatives", rev = "e49030e" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,11 +24,11 @@ resolver = "2"
 # `p2pderivatives/rust-dlc#feature/ln-dlc-channels`: 4e104b4. This patch ensures backwards
 # compatibility for 10101 through the `rust-lightning:0.0.116` upgrade. We will be able to drop it
 # once all users have been upgraded and traded once.
-dlc-manager = { git = "https://github.com/p2pderivatives/rust-dlc", rev = "785980c8ecc20a95e5b3c0b5fe262e1abff44cb5" }
-dlc-messages = { git = "https://github.com/p2pderivatives/rust-dlc", rev = "785980c8ecc20a95e5b3c0b5fe262e1abff44cb5" }
-dlc = { git = "https://github.com/p2pderivatives/rust-dlc", rev = "785980c8ecc20a95e5b3c0b5fe262e1abff44cb5" }
-p2pd-oracle-client = { git = "https://github.com/p2pderivatives/rust-dlc", rev = "785980c8ecc20a95e5b3c0b5fe262e1abff44cb5" }
-dlc-trie = { git = "https://github.com/p2pderivatives/rust-dlc", rev = "785980c8ecc20a95e5b3c0b5fe262e1abff44cb5" }
+dlc-manager = { git = "https://github.com/p2pderivatives/rust-dlc", rev = "8c13abf4283244d0e40b042468f0ffea3c0081b4" }
+dlc-messages = { git = "https://github.com/p2pderivatives/rust-dlc", rev = "8c13abf4283244d0e40b042468f0ffea3c0081b4" }
+dlc = { git = "https://github.com/p2pderivatives/rust-dlc", rev = "8c13abf4283244d0e40b042468f0ffea3c0081b4" }
+p2pd-oracle-client = { git = "https://github.com/p2pderivatives/rust-dlc", rev = "8c13abf4283244d0e40b042468f0ffea3c0081b4" }
+dlc-trie = { git = "https://github.com/p2pderivatives/rust-dlc", rev = "8c13abf4283244d0e40b042468f0ffea3c0081b4" }
 
 # We should usually track the `p2pderivatives/split-tx-experiment[-10101]` branch. For now we depend on a special fork which removes a panic in rust-lightning
 lightning = { git = "https://github.com/bonomat/rust-lightning-p2p-derivatives", rev = "e49030e" }

--- a/coordinator/src/bin/coordinator.rs
+++ b/coordinator/src/bin/coordinator.rs
@@ -143,8 +143,10 @@ async fn main() -> Result<()> {
     )?);
 
     let dlc_handler = DlcHandler::new(pool.clone(), node.clone());
-    let _handle =
-        dlc_handler::spawn_handling_dlc_messages(dlc_handler, node_event_handler.subscribe());
+    let _handle = dlc_handler::spawn_handling_outbound_dlc_messages(
+        dlc_handler,
+        node_event_handler.subscribe(),
+    );
 
     let event_handler = CoordinatorEventHandler::new(node.clone(), Some(node_event_sender));
     let running = node.start(event_handler, false)?;

--- a/coordinator/src/dlc_handler.rs
+++ b/coordinator/src/dlc_handler.rs
@@ -42,12 +42,10 @@ impl DlcHandler {
     }
 }
 
-/// [`spawn_handling_dlc_messages`] handles sending outbound dlc messages as well as keeping track
-/// of what dlc messages have already been processed and what was the last outbound dlc message
-/// so it can be resend on reconnect.
-///
-/// It does not handle the incoming dlc messages!
-pub fn spawn_handling_dlc_messages(
+/// [`spawn_handling_outbound_dlc_messages`] handles sending outbound dlc messages as well as
+/// keeping track of what dlc messages have already been processed and what was the last outbound
+/// dlc message so it can be resend on reconnect.
+pub fn spawn_handling_outbound_dlc_messages(
     dlc_handler: DlcHandler,
     mut receiver: broadcast::Receiver<NodeEvent>,
 ) -> RemoteHandle<()> {

--- a/coordinator/src/node.rs
+++ b/coordinator/src/node.rs
@@ -663,7 +663,7 @@ impl Node {
         let trader_peer_id = trade_params.pubkey;
         match self
             .inner
-            .get_dlc_channel_by_counterparty(&trader_peer_id)?
+            .get_signed_dlc_channel_by_counterparty(&trader_peer_id)?
         {
             None => {
                 ensure!(

--- a/coordinator/src/node.rs
+++ b/coordinator/src/node.rs
@@ -27,6 +27,7 @@ use diesel::Connection;
 use diesel::PgConnection;
 use dlc_manager::channel::signed_channel::SignedChannel;
 use dlc_manager::channel::signed_channel::SignedChannelState;
+use dlc_manager::channel::Channel;
 use dlc_manager::contract::contract_input::ContractInput;
 use dlc_manager::contract::contract_input::ContractInputInfo;
 use dlc_manager::contract::contract_input::OracleInput;
@@ -911,6 +912,68 @@ impl Node {
                             node_id.to_string(),
                             PositionState::Open,
                         )?;
+                    }
+                    ChannelMessage::Reject(reject) => {
+                        // TODO(holzeis): if an dlc channel gets rejected we have to deal with the
+                        // counterparty as well.
+
+                        let channel_id_hex_string = reject.channel_id.to_hex();
+
+                        let channel = self.inner.get_dlc_channel_by_id(&reject.channel_id)?;
+                        let mut connection = self.pool.get()?;
+
+                        match channel {
+                            Channel::Cancelled(_) => {
+                                tracing::info!(
+                                    channel_id = channel_id_hex_string,
+                                    node_id = node_id.to_string(),
+                                    "DLC Channel offer has been rejected. Setting position to failed."
+                                );
+
+                                db::positions::Position::update_proposed_position(
+                                    &mut connection,
+                                    node_id.to_string(),
+                                    PositionState::Failed,
+                                )?;
+                            }
+                            Channel::Signed(SignedChannel {
+                                state: SignedChannelState::Established { .. },
+                                ..
+                            }) => {
+                                // TODO(holzeis): Reverting the position state back from `Closing`
+                                // to `Open` only works as long as we do not support resizing. This
+                                // logic needs to be adapted when we implement resize.
+
+                                tracing::info!(
+                                    channel_id = channel_id_hex_string,
+                                    node_id = node_id.to_string(),
+                                    "DLC Channel settle offer has been rejected. Setting position to back to open."
+                                );
+
+                                db::positions::Position::update_closing_position(
+                                    &mut connection,
+                                    node_id.to_string(),
+                                    PositionState::Open,
+                                )?;
+                            }
+                            Channel::Signed(SignedChannel {
+                                state: SignedChannelState::Settled { .. },
+                                ..
+                            }) => {
+                                tracing::info!(
+                                    channel_id = channel_id_hex_string,
+                                    node_id = node_id.to_string(),
+                                    "DLC Channel renew offer has been rejected. Setting position to failed."
+                                );
+
+                                db::positions::Position::update_proposed_position(
+                                    &mut connection,
+                                    node_id.to_string(),
+                                    PositionState::Failed,
+                                )?;
+                            }
+                            _ => {}
+                        }
                     }
                     _ => {}
                 };

--- a/crates/ln-dlc-node/src/dlc_message.rs
+++ b/crates/ln-dlc-node/src/dlc_message.rs
@@ -50,6 +50,36 @@ impl SerializedDlcMessage {
     }
 }
 
+impl TryFrom<&SerializedDlcMessage> for Message {
+    type Error = anyhow::Error;
+
+    fn try_from(serialized_msg: &SerializedDlcMessage) -> Result<Self, Self::Error> {
+        let message: ChannelMessage = serde_json::from_str(&serialized_msg.message)?;
+        Ok(Message::Channel(message))
+    }
+}
+
+impl TryFrom<&Message> for SerializedDlcMessage {
+    type Error = anyhow::Error;
+
+    fn try_from(msg: &Message) -> Result<Self, Self::Error> {
+        let (message, message_type) = match msg {
+            Message::Channel(message) => {
+                let message_type = DlcMessageType::from(message);
+                let message = serde_json::to_string(&message)?;
+
+                (message, message_type)
+            }
+            _ => unreachable!(),
+        };
+
+        Ok(Self {
+            message,
+            message_type,
+        })
+    }
+}
+
 #[derive(Hash, Clone, Debug)]
 pub enum DlcMessageType {
     Offer,
@@ -68,124 +98,23 @@ pub enum DlcMessageType {
     Reject,
 }
 
-impl TryFrom<&SerializedDlcMessage> for Message {
-    type Error = anyhow::Error;
-
-    fn try_from(serialized_msg: &SerializedDlcMessage) -> Result<Self, Self::Error> {
-        let message = match serialized_msg.clone().message_type {
-            DlcMessageType::Offer => Message::Channel(ChannelMessage::Offer(serde_json::from_str(
-                &serialized_msg.message,
-            )?)),
-            DlcMessageType::Accept => Message::Channel(ChannelMessage::Accept(
-                serde_json::from_str(&serialized_msg.message)?,
-            )),
-            DlcMessageType::Sign => Message::Channel(ChannelMessage::Sign(serde_json::from_str(
-                &serialized_msg.message,
-            )?)),
-            DlcMessageType::SettleOffer => Message::Channel(ChannelMessage::SettleOffer(
-                serde_json::from_str(&serialized_msg.message)?,
-            )),
-            DlcMessageType::SettleAccept => Message::Channel(ChannelMessage::SettleAccept(
-                serde_json::from_str(&serialized_msg.message)?,
-            )),
-            DlcMessageType::SettleConfirm => Message::Channel(ChannelMessage::SettleConfirm(
-                serde_json::from_str(&serialized_msg.message)?,
-            )),
-            DlcMessageType::SettleFinalize => Message::Channel(ChannelMessage::SettleFinalize(
-                serde_json::from_str(&serialized_msg.message)?,
-            )),
-            DlcMessageType::RenewOffer => Message::Channel(ChannelMessage::RenewOffer(
-                serde_json::from_str(&serialized_msg.message)?,
-            )),
-            DlcMessageType::RenewAccept => Message::Channel(ChannelMessage::RenewAccept(
-                serde_json::from_str(&serialized_msg.message)?,
-            )),
-            DlcMessageType::RenewConfirm => Message::Channel(ChannelMessage::RenewConfirm(
-                serde_json::from_str(&serialized_msg.message)?,
-            )),
-            DlcMessageType::RenewFinalize => Message::Channel(ChannelMessage::RenewFinalize(
-                serde_json::from_str(&serialized_msg.message)?,
-            )),
-            DlcMessageType::RenewRevoke => Message::Channel(ChannelMessage::RenewRevoke(
-                serde_json::from_str(&serialized_msg.message)?,
-            )),
-            DlcMessageType::CollaborativeCloseOffer => {
-                Message::Channel(ChannelMessage::CollaborativeCloseOffer(
-                    serde_json::from_str(&serialized_msg.message)?,
-                ))
-            }
-            DlcMessageType::Reject => Message::Channel(ChannelMessage::Reject(
-                serde_json::from_str(&serialized_msg.message)?,
-            )),
-        };
-
-        Ok(message)
-    }
-}
-
-impl TryFrom<&Message> for SerializedDlcMessage {
-    type Error = anyhow::Error;
-
-    fn try_from(msg: &Message) -> Result<Self, Self::Error> {
-        let (message, message_type) = match &msg {
-            Message::Channel(message) => match message {
-                ChannelMessage::Offer(offer) => {
-                    (serde_json::to_string(&offer)?, DlcMessageType::Offer)
-                }
-                ChannelMessage::Accept(accept) => {
-                    (serde_json::to_string(&accept)?, DlcMessageType::Accept)
-                }
-                ChannelMessage::Sign(sign) => (serde_json::to_string(&sign)?, DlcMessageType::Sign),
-                ChannelMessage::SettleOffer(settle_offer) => (
-                    serde_json::to_string(&settle_offer)?,
-                    DlcMessageType::SettleOffer,
-                ),
-                ChannelMessage::SettleAccept(settle_accept) => (
-                    serde_json::to_string(&settle_accept)?,
-                    DlcMessageType::SettleAccept,
-                ),
-                ChannelMessage::SettleConfirm(settle_confirm) => (
-                    serde_json::to_string(&settle_confirm)?,
-                    DlcMessageType::SettleConfirm,
-                ),
-                ChannelMessage::SettleFinalize(settle_finalize) => (
-                    serde_json::to_string(&settle_finalize)?,
-                    DlcMessageType::SettleFinalize,
-                ),
-                ChannelMessage::RenewOffer(renew_offer) => (
-                    serde_json::to_string(&renew_offer)?,
-                    DlcMessageType::RenewOffer,
-                ),
-                ChannelMessage::RenewAccept(renew_accept) => (
-                    serde_json::to_string(&renew_accept)?,
-                    DlcMessageType::RenewAccept,
-                ),
-                ChannelMessage::RenewConfirm(renew_confirm) => (
-                    serde_json::to_string(&renew_confirm)?,
-                    DlcMessageType::RenewConfirm,
-                ),
-                ChannelMessage::RenewFinalize(renew_finalize) => (
-                    serde_json::to_string(&renew_finalize)?,
-                    DlcMessageType::RenewFinalize,
-                ),
-                ChannelMessage::RenewRevoke(renew_revoke) => (
-                    serde_json::to_string(&renew_revoke)?,
-                    DlcMessageType::RenewRevoke,
-                ),
-                ChannelMessage::CollaborativeCloseOffer(collaborative_close_offer) => (
-                    serde_json::to_string(&collaborative_close_offer)?,
-                    DlcMessageType::CollaborativeCloseOffer,
-                ),
-                ChannelMessage::Reject(reject) => {
-                    (serde_json::to_string(&reject)?, DlcMessageType::Reject)
-                }
-            },
-            _ => unreachable!(),
-        };
-
-        Ok(Self {
-            message,
-            message_type,
-        })
+impl From<&ChannelMessage> for DlcMessageType {
+    fn from(value: &ChannelMessage) -> Self {
+        match value {
+            ChannelMessage::Offer(_) => DlcMessageType::Offer,
+            ChannelMessage::Accept(_) => DlcMessageType::Accept,
+            ChannelMessage::Sign(_) => DlcMessageType::Sign,
+            ChannelMessage::SettleOffer(_) => DlcMessageType::SettleOffer,
+            ChannelMessage::SettleAccept(_) => DlcMessageType::SettleAccept,
+            ChannelMessage::SettleConfirm(_) => DlcMessageType::SettleConfirm,
+            ChannelMessage::SettleFinalize(_) => DlcMessageType::SettleFinalize,
+            ChannelMessage::RenewOffer(_) => DlcMessageType::RenewOffer,
+            ChannelMessage::RenewAccept(_) => DlcMessageType::RenewAccept,
+            ChannelMessage::RenewConfirm(_) => DlcMessageType::RenewConfirm,
+            ChannelMessage::RenewFinalize(_) => DlcMessageType::RenewFinalize,
+            ChannelMessage::RenewRevoke(_) => DlcMessageType::RenewRevoke,
+            ChannelMessage::CollaborativeCloseOffer(_) => DlcMessageType::CollaborativeCloseOffer,
+            ChannelMessage::Reject(_) => DlcMessageType::Reject,
+        }
     }
 }

--- a/crates/ln-dlc-node/src/ln/dlc_channel_details.rs
+++ b/crates/ln-dlc-node/src/ln/dlc_channel_details.rs
@@ -46,6 +46,7 @@ pub enum ChannelState {
     CollaborativelyClosed,
     FailedAccept,
     FailedSign,
+    Cancelled,
 }
 
 impl From<Channel> for DlcChannelDetails {
@@ -85,6 +86,7 @@ impl From<Channel> for ChannelState {
             Channel::CollaborativelyClosed(_) => ChannelState::CollaborativelyClosed,
             Channel::FailedAccept(_) => ChannelState::FailedAccept,
             Channel::FailedSign(_) => ChannelState::FailedSign,
+            Channel::Cancelled(_) => ChannelState::Cancelled,
         }
     }
 }

--- a/crates/ln-dlc-node/src/node/dlc_channel.rs
+++ b/crates/ln-dlc-node/src/node/dlc_channel.rs
@@ -373,7 +373,7 @@ impl<S: TenTenOneStorage + 'static, N: LnDlcStorage + Sync + Send + 'static> Nod
             })
     }
 
-    pub fn get_dlc_channel_by_counterparty(
+    pub fn get_signed_dlc_channel_by_counterparty(
         &self,
         counterparty_pk: &PublicKey,
     ) -> Result<Option<SignedChannel>> {

--- a/crates/ln-dlc-node/src/node/dlc_channel.rs
+++ b/crates/ln-dlc-node/src/node/dlc_channel.rs
@@ -333,9 +333,9 @@ impl<S: TenTenOneStorage + 'static, N: LnDlcStorage + Sync + Send + 'static> Nod
     /// Will return an error if the contract is not yet signed or confirmed on-chain.
     pub fn get_expiry_for_confirmed_dlc_channel(
         &self,
-        dlc_channel_id: DlcChannelId,
+        dlc_channel_id: &DlcChannelId,
     ) -> Result<OffsetDateTime> {
-        match self.get_contract_by_dlc_channel_id(&dlc_channel_id)? {
+        match self.get_contract_by_dlc_channel_id(dlc_channel_id)? {
             Contract::Signed(contract) | Contract::Confirmed(contract) => {
                 let offered_contract = contract.accepted_contract.offered_contract;
                 let contract_info = offered_contract

--- a/crates/ln-dlc-node/src/node/dlc_channel.rs
+++ b/crates/ln-dlc-node/src/node/dlc_channel.rs
@@ -102,6 +102,7 @@ impl<S: TenTenOneStorage + 'static, N: LnDlcStorage + Sync + Send + 'static> Nod
             peer: channel.get_counter_party_id(),
             msg: Message::Channel(ChannelMessage::Reject(Reject {
                 channel_id: channel.get_id(),
+                timestamp: OffsetDateTime::now_utc().unix_timestamp() as u64,
             })),
         })?;
 

--- a/crates/ln-dlc-node/src/node/dlc_channel.rs
+++ b/crates/ln-dlc-node/src/node/dlc_channel.rs
@@ -21,7 +21,6 @@ use dlc_manager::contract::ContractDescriptor;
 use dlc_manager::DlcChannelId;
 use dlc_manager::Oracle;
 use dlc_manager::Storage;
-use dlc_messages::channel::Reject;
 use dlc_messages::ChannelMessage;
 use dlc_messages::Message;
 use time::OffsetDateTime;
@@ -85,28 +84,6 @@ impl<S: TenTenOneStorage + 'static, N: LnDlcStorage + Sync + Send + 'static> Nod
             }
         })
         .await?
-    }
-
-    pub fn reject_dlc_channel_offer(&self, channel_id: &DlcChannelId) -> Result<()> {
-        let channel_id_hex = hex::encode(channel_id);
-
-        let channel = self
-            .dlc_manager
-            .get_store()
-            .get_channel(channel_id)?
-            .with_context(|| format!("Couldn't find channel by id. {}", channel_id.to_hex()))?;
-
-        tracing::info!(channel_id = %channel_id_hex, "Rejecting DLC channel offer");
-
-        self.event_handler.publish(NodeEvent::SendDlcMessage {
-            peer: channel.get_counter_party_id(),
-            msg: Message::Channel(ChannelMessage::Reject(Reject {
-                channel_id: channel.get_id(),
-                timestamp: OffsetDateTime::now_utc().unix_timestamp() as u64,
-            })),
-        })?;
-
-        Ok(())
     }
 
     pub fn accept_dlc_channel_offer(&self, channel_id: &DlcChannelId) -> Result<()> {

--- a/crates/ln-dlc-storage/src/lib.rs
+++ b/crates/ln-dlc-storage/src/lib.rs
@@ -155,7 +155,8 @@ convertible_enum!(
         ClosedPunished,
         CollaborativelyClosed,
         FailedAccept,
-        FailedSign,;
+        FailedSign,
+        Cancelled,;
     },
     Channel
 );
@@ -767,6 +768,7 @@ fn serialize_channel(channel: &Channel) -> Result<Vec<u8>, ::std::io::Error> {
             c.serialize()
         }
         Channel::ClosedPunished(c) => c.serialize(),
+        Channel::Cancelled(o) => o.serialize(),
     };
     let mut serialized = serialized?;
     let mut res = Vec::with_capacity(serialized.len() + 1);
@@ -816,6 +818,9 @@ fn deserialize_channel(buff: &Vec<u8>) -> Result<Channel, Error> {
         ChannelPrefix::ClosedPunished => Channel::ClosedPunished(
             ClosedPunishedChannel::deserialize(&mut cursor).map_err(to_storage_error)?,
         ),
+        ChannelPrefix::Cancelled => {
+            Channel::Cancelled(OfferedChannel::deserialize(&mut cursor).map_err(to_storage_error)?)
+        }
     };
     Ok(channel)
 }

--- a/crates/payout_curve/Cargo.toml
+++ b/crates/payout_curve/Cargo.toml
@@ -13,7 +13,7 @@ trade = { path = "../trade" }
 
 [dev-dependencies]
 csv = "1.3.0"
-dlc-manager = "0.4.0"
+dlc-manager = { version = "0.4.0", features = ["use-serde"] }
 proptest = "1"
 rust_decimal_macros = "1"
 tracing = "0.1.37"

--- a/crates/tests-e2e/src/coordinator.rs
+++ b/crates/tests-e2e/src/coordinator.rs
@@ -118,6 +118,7 @@ pub enum ChannelState {
     CollaborativelyClosed,
     FailedAccept,
     FailedSign,
+    Cancelled,
 }
 
 #[derive(Deserialize, Debug)]

--- a/crates/tests-e2e/src/setup.rs
+++ b/crates/tests-e2e/src/setup.rs
@@ -23,7 +23,7 @@ pub struct TestSetup {
 
 impl TestSetup {
     /// Start test with a running app and a funded wallet.
-    pub async fn new_after_funding() -> Self {
+    pub async fn new_after_funding(fund_amount: Option<Amount>) -> Self {
         init_tracing();
 
         let client = init_reqwest();
@@ -62,13 +62,13 @@ impl TestSetup {
             "App should start with empty off-chain wallet"
         );
 
-        let fund_amount = Amount::ONE_BTC;
+        let fund_amount = fund_amount.unwrap_or(Amount::ONE_BTC);
 
         let address = api::get_unused_address();
         let address = &address.0.parse().unwrap();
 
         bitcoind
-            .send_to_address(address, Amount::ONE_BTC)
+            .send_to_address(address, fund_amount)
             .await
             .unwrap();
 
@@ -92,7 +92,7 @@ impl TestSetup {
 
     /// Start test with a running app with a funded wallet and an open position.
     pub async fn new_with_open_position() -> Self {
-        let setup = Self::new_after_funding().await;
+        let setup = Self::new_after_funding(None).await;
         let rx = &setup.app.rx;
 
         tracing::info!("Opening a position");

--- a/crates/tests-e2e/tests/basic.rs
+++ b/crates/tests-e2e/tests/basic.rs
@@ -4,7 +4,7 @@ use tests_e2e::setup::TestSetup;
 #[tokio::test(flavor = "multi_thread")]
 #[ignore = "need to be run with 'just e2e' command"]
 async fn app_can_be_funded_with_bitcoind() -> Result<()> {
-    TestSetup::new_after_funding().await;
+    TestSetup::new_after_funding(None).await;
 
     Ok(())
 }

--- a/crates/tests-e2e/tests/open_position.rs
+++ b/crates/tests-e2e/tests/open_position.rs
@@ -23,7 +23,7 @@ fn dummy_order() -> NewOrder {
 #[tokio::test(flavor = "multi_thread")]
 #[ignore = "need to be run with 'just e2e' command"]
 async fn can_open_position() {
-    let test = TestSetup::new_after_funding().await;
+    let test = TestSetup::new_after_funding(None).await;
     let app = &test.app;
 
     let order = dummy_order();

--- a/crates/tests-e2e/tests/reject_offer.rs
+++ b/crates/tests-e2e/tests/reject_offer.rs
@@ -1,0 +1,101 @@
+use bitcoin::Amount;
+use native::api;
+use native::api::ContractSymbol;
+use native::health::Service;
+use native::health::ServiceStatus;
+use native::trade::order::api::NewOrder;
+use native::trade::order::api::OrderType;
+use native::trade::order::OrderState;
+use native::trade::position::PositionState;
+use tests_e2e::setup::TestSetup;
+use tests_e2e::wait_until;
+use tokio::task::spawn_blocking;
+
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "need to be run with 'just e2e' command"]
+async fn reject_offer() {
+    let test = TestSetup::new_after_funding(Some(Amount::from_sat(250_000))).await;
+    let app = &test.app;
+
+    let invalid_order = NewOrder {
+        leverage: 1.0,
+        contract_symbol: ContractSymbol::BtcUsd,
+        direction: api::Direction::Long,
+        quantity: 2000.0,
+        order_type: Box::new(OrderType::Market),
+        stable: false,
+    };
+
+    // submit order for which the app does not have enough liquidity. will fail with `Failed to
+    // accept dlc channel offer. Invalid state: Not enough UTXOs for amount`
+    spawn_blocking({
+        let order = invalid_order.clone();
+        move || api::submit_order(order).unwrap()
+    })
+    .await
+    .unwrap();
+
+    assert_eq!(app.rx.status(Service::Orderbook), ServiceStatus::Online);
+    assert_eq!(app.rx.status(Service::Coordinator), ServiceStatus::Online);
+
+    // Assert that the order was posted
+    wait_until!(app.rx.order().is_some());
+    assert_eq!(app.rx.order().unwrap().quantity, invalid_order.quantity);
+    assert_eq!(app.rx.order().unwrap().direction, invalid_order.direction);
+    assert_eq!(
+        app.rx.order().unwrap().contract_symbol,
+        invalid_order.contract_symbol
+    );
+    assert_eq!(app.rx.order().unwrap().leverage, invalid_order.leverage);
+
+    // Assert that the order failed
+    wait_until!(matches!(
+        app.rx.order().unwrap().state,
+        OrderState::Failed { .. }
+    ));
+
+    // Assert that no position has been opened
+    wait_until!(app.rx.position().is_none());
+
+    // Retry with a smaller order
+    let order = NewOrder {
+        leverage: 2.0,
+        contract_symbol: ContractSymbol::BtcUsd,
+        direction: api::Direction::Long,
+        quantity: 100.0,
+        order_type: Box::new(OrderType::Market),
+        stable: false,
+    };
+
+    spawn_blocking({
+        let order = order.clone();
+        move || api::submit_order(order).unwrap()
+    })
+    .await
+    .unwrap();
+
+    // Assert that the order was posted
+    wait_until!(app.rx.order().is_some());
+    assert_eq!(app.rx.order().unwrap().quantity, order.quantity);
+    assert_eq!(app.rx.order().unwrap().direction, order.direction);
+    assert_eq!(
+        app.rx.order().unwrap().contract_symbol,
+        order.contract_symbol
+    );
+    assert_eq!(app.rx.order().unwrap().leverage, order.leverage);
+
+    // Assert that the position is opened in the app
+    wait_until!(app.rx.position().is_some());
+    assert_eq!(app.rx.position().unwrap().quantity, order.quantity);
+    assert_eq!(app.rx.position().unwrap().direction, order.direction);
+    assert_eq!(
+        app.rx.position().unwrap().contract_symbol,
+        order.contract_symbol
+    );
+    assert_eq!(app.rx.position().unwrap().leverage, order.leverage);
+    wait_until!(app.rx.position().unwrap().position_state == PositionState::Open);
+
+    // TODO(holzeis): Add reject tests for SettleOffer and RenewOffer.
+    // Unfortunately its not easy to provoke a reject for a settle offer or renew offer from a grey
+    // box integration test.
+}

--- a/mobile/native/Cargo.toml
+++ b/mobile/native/Cargo.toml
@@ -44,6 +44,7 @@ tokio = { version = "1.25.0", features = ["macros", "rt", "rt-multi-thread", "sy
 tokio-tungstenite = { version = "0.20", features = ["native-tls"] }
 tokio-util = { version = "0.7", features = ["io", "codec"] }
 tracing = "0.1.37"
+tracing-log = "0.2.0"
 tracing-subscriber = { version = "0.3", default-features = false, features = ["fmt", "env-filter", "time", "json"] }
 trade = { path = "../../crates/trade" }
 uuid = { version = "1.3.0", features = ["v4", "fast-rng", "macro-diagnostics"] }

--- a/mobile/native/src/dlc_handler.rs
+++ b/mobile/native/src/dlc_handler.rs
@@ -120,7 +120,7 @@ impl DlcHandler {
                     temporary_channel_id,
                     ..
                 }) => {
-                    tracing::info!("Accepting pending dlc channel offer.");
+                    tracing::info!("Rejecting pending dlc channel offer.");
                     // Pending dlc channel offer not yet confirmed on-chain
 
                     event::publish(&EventInternal::BackgroundNotification(
@@ -128,8 +128,8 @@ impl DlcHandler {
                     ));
 
                     self.node
-                        .process_dlc_channel_offer(temporary_channel_id)
-                        .context("Failed to process pending dlc channel offer")?;
+                        .reject_dlc_channel_offer(temporary_channel_id)
+                        .context("Failed to reject pending dlc channel offer")?;
 
                     event::publish(&EventInternal::BackgroundNotification(
                         BackgroundTask::RecoverDlc(TaskStatus::Success),
@@ -142,7 +142,7 @@ impl DlcHandler {
                     state: SignedChannelState::SettledReceived { .. },
                     ..
                 }) => {
-                    tracing::info!("Accepting pending dlc channel settle offer.");
+                    tracing::info!("Rejecting pending dlc channel settle offer.");
                     // Pending dlc channel settle offer with a dlc channel already confirmed
                     // on-chain
 
@@ -151,8 +151,8 @@ impl DlcHandler {
                     ));
 
                     self.node
-                        .process_settle_offer(channel_id)
-                        .context("Failed to process pending settle offer")?;
+                        .reject_settle_offer(channel_id)
+                        .context("Failed to reject pending settle offer")?;
 
                     event::publish(&EventInternal::BackgroundNotification(
                         BackgroundTask::RecoverDlc(TaskStatus::Success),
@@ -165,7 +165,7 @@ impl DlcHandler {
                     state: SignedChannelState::RenewOffered { .. },
                     ..
                 }) => {
-                    tracing::info!("Accepting pending dlc channel renew offer.");
+                    tracing::info!("Rejecting pending dlc channel renew offer.");
                     // Pending dlc channel renew (resize) offer with a dlc channel already confirmed
                     // on-chain
 
@@ -173,13 +173,9 @@ impl DlcHandler {
                         BackgroundTask::RecoverDlc(TaskStatus::Pending),
                     ));
 
-                    let expiry_timestamp = self
-                        .node
-                        .inner
-                        .get_expiry_for_confirmed_dlc_channel(channel_id)?;
                     self.node
-                        .process_renew_offer(channel_id, expiry_timestamp)
-                        .context("Failed to process pending renew offer")?;
+                        .reject_renew_offer(channel_id)
+                        .context("Failed to reject pending renew offer")?;
 
                     event::publish(&EventInternal::BackgroundNotification(
                         BackgroundTask::RecoverDlc(TaskStatus::Success),

--- a/mobile/native/src/dlc_handler.rs
+++ b/mobile/native/src/dlc_handler.rs
@@ -40,9 +40,7 @@ impl DlcHandler {
 /// Handles sending outbound dlc messages as well as keeping track of what
 /// dlc messages have already been processed and what was the last outbound dlc message
 /// so it can be resend on reconnect.
-///
-/// Does not handle the incoming dlc messages!
-pub async fn handle_dlc_messages(
+pub async fn handle_outbound_dlc_messages(
     dlc_handler: DlcHandler,
     mut receiver: broadcast::Receiver<NodeEvent>,
 ) {

--- a/mobile/native/src/ln_dlc/mod.rs
+++ b/mobile/native/src/ln_dlc/mod.rs
@@ -347,7 +347,8 @@ pub fn run(seed_dir: String, runtime: &Runtime) -> Result<()> {
 
         let dlc_handler = DlcHandler::new(node.clone());
         runtime.spawn(async move {
-            dlc_handler::handle_dlc_messages(dlc_handler, node_event_handler.subscribe()).await
+            dlc_handler::handle_outbound_dlc_messages(dlc_handler, node_event_handler.subscribe())
+                .await
         });
 
         // Refresh the wallet balance and history eagerly so that it can complete before the

--- a/mobile/native/src/ln_dlc/node.rs
+++ b/mobile/native/src/ln_dlc/node.rs
@@ -252,7 +252,7 @@ impl Node {
 
                         let expiry_timestamp = self
                             .inner
-                            .get_expiry_for_confirmed_dlc_channel(r.channel_id)?;
+                            .get_expiry_for_confirmed_dlc_channel(&r.channel_id)?;
 
                         match db::get_order_in_filling()? {
                             Some(_) => {
@@ -283,7 +283,7 @@ impl Node {
                     ChannelMessage::Sign(signed) => {
                         let expiry_timestamp = self
                             .inner
-                            .get_expiry_for_confirmed_dlc_channel(signed.channel_id)?;
+                            .get_expiry_for_confirmed_dlc_channel(&signed.channel_id)?;
 
                         let filled_order = order::handler::order_filled()
                             .context("Cannot mark order as filled for confirmed DLC")?;

--- a/mobile/native/src/logger.rs
+++ b/mobile/native/src/logger.rs
@@ -4,6 +4,7 @@ use flutter_rust_bridge::StreamSink;
 use std::collections::BTreeMap;
 use std::sync::Arc;
 use std::sync::Once;
+use tracing_log::LogTracer;
 use tracing_subscriber::filter::Directive;
 use tracing_subscriber::filter::LevelFilter;
 use tracing_subscriber::fmt::time;
@@ -167,6 +168,8 @@ pub fn init_tracing(level: LevelFilter, json_format: bool) -> Result<()> {
         .with(fmt_layer)
         .try_init()
         .context("Failed to init tracing")?;
+
+    LogTracer::init()?;
 
     tracing::info!("Initialized logger");
 

--- a/mobile/native/src/trade/order/mod.rs
+++ b/mobile/native/src/trade/order/mod.rs
@@ -21,7 +21,7 @@ pub enum OrderType {
 }
 
 /// Internal type so we still have Copy on order
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, PartialEq)]
 pub enum FailureReason {
     /// An error occurred when setting the Order to filling in our DB
     FailedToSetToFilling,
@@ -42,7 +42,7 @@ pub enum FailureReason {
     Unknown,
 }
 
-#[derive(Debug, Clone, Copy, Serialize)]
+#[derive(Debug, Clone, Copy, Serialize, PartialEq)]
 pub enum InvalidSubchannelOffer {
     /// Received offer was outdated
     Outdated,
@@ -50,7 +50,7 @@ pub enum InvalidSubchannelOffer {
     Unacceptable,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum OrderState {
     /// Not submitted to orderbook yet
     ///


### PR DESCRIPTION
Adds a handling for dlc channel offer, settle offer and renew offer. If the corresponding accept handling fails the protocol now attempts to reject the offer. 

If the app identifies that there is a pending offer (dlc channel, settle offer or renew offer) it will automatically try to reject it. I think this is the safest we can do given that 1. for dlc channels the utxo might not be reserved anymore and 2. (more importantly) the price might have changed again, so we probably don't want to continue a dlc protocol that started some days ago.

`rust-dlc` has been enhanced for a reject dlc channel offer flow allowing to reject dlc channel offers.

This change also adds a handling for updating the app layer (app, coordinator) state of the order and position.

### Added rust-dlc changes

- **Set timeout on `RenewOffered` state**: https://github.com/p2pderivatives/rust-dlc/commit/8c13abf4283244d0e40b042468f0ffea3c0081b4
- **Add error message to InvalidArgument**: https://github.com/p2pderivatives/rust-dlc/commit/661e170c5b3a09eb914c3fc2d1506b519483dd64
- **Use docker images that also run on arm64**: https://github.com/p2pderivatives/rust-dlc/commit/69e13a952228ea03e606673fe0e8c3d63c9219f5
- **Reject dlc channel offer**: https://github.com/p2pderivatives/rust-dlc/commit/05b78f05f22754f01bb6348685733d7e904ceded
- **Make Channel Message serializable**: https://github.com/p2pderivatives/rust-dlc/commit/785980c8ecc20a95e5b3c0b5fe262e1abff44cb5
- **Add timestamp to reject and settle offer messages**: https://github.com/p2pderivatives/rust-dlc/commit/0c59a0688332792f73fa8890a14a19eea225c5b0
- **Add missing reject dlc message**: https://github.com/p2pderivatives/rust-dlc/commit/924da47521c39dd9024dd49f3ad823181179031d


fixes #1918
fixes #1919 