### PR TITLE
chore: print latest height after sync

### DIFF
--- a/crates/ln-dlc-node/src/ldk_node_wallet.rs
+++ b/crates/ln-dlc-node/src/ldk_node_wallet.rs
@@ -119,8 +119,11 @@ where
 
         wallet_lock.sync(&self.blockchain, SyncOptions::default())?;
 
+        let height = self.blockchain.get_height()?;
+
         tracing::info!(
             duration = now.elapsed().as_millis(),
+            latest_height = height,
             "Finished on-chain sync",
         );
 


### PR DESCRIPTION
This is useful to see what height we have synced up to.

On the path of debugging https://github.com/get10101/10101/issues/1894 I wandered down the path of questioning our wallet design and if we miss a block or don't sync up to the latest height. This additional log field might help. 