### PR TITLE
chore: Reject all pending dlc channel offers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Feat(webapp): Show order history
 - Fix: Add reject dlc channel, settle and renew offer
 - Chore: Change pending offer policy to reject on reconnect
+- Fix: Prevent proposing another dlc channel offer if there is already a pending one
 
 ## [1.8.4] - 2024-01-31
 


### PR DESCRIPTION
We need that as due to the bug https://github.com/get10101/10101/issues/1912 users have tried multiple times to submit their order. And since we don't check if the user already has an offered channel, we simply offer another one, which then again fails.

That will leave us with multiple positions in state `Proposed` and offered dlc channels. By simply rejected all offered on reconnect we clean up those positions and dlc channels.