### PR TITLE
chore: Remove test log

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1225,7 +1225,7 @@ dependencies = [
 [[package]]
 name = "dlc"
 version = "0.4.0"
-source = "git+https://github.com/p2pderivatives/rust-dlc?rev=8c13abf4283244d0e40b042468f0ffea3c0081b4#8c13abf4283244d0e40b042468f0ffea3c0081b4"
+source = "git+https://github.com/p2pderivatives/rust-dlc?rev=0786724f947af867d72bd221fa99db492360f936#0786724f947af867d72bd221fa99db492360f936"
 dependencies = [
  "bitcoin",
  "miniscript 8.0.2",
@@ -1237,7 +1237,7 @@ dependencies = [
 [[package]]
 name = "dlc-manager"
 version = "0.4.0"
-source = "git+https://github.com/p2pderivatives/rust-dlc?rev=8c13abf4283244d0e40b042468f0ffea3c0081b4#8c13abf4283244d0e40b042468f0ffea3c0081b4"
+source = "git+https://github.com/p2pderivatives/rust-dlc?rev=0786724f947af867d72bd221fa99db492360f936#0786724f947af867d72bd221fa99db492360f936"
 dependencies = [
  "async-trait",
  "bitcoin",
@@ -1253,7 +1253,7 @@ dependencies = [
 [[package]]
 name = "dlc-messages"
 version = "0.4.0"
-source = "git+https://github.com/p2pderivatives/rust-dlc?rev=8c13abf4283244d0e40b042468f0ffea3c0081b4#8c13abf4283244d0e40b042468f0ffea3c0081b4"
+source = "git+https://github.com/p2pderivatives/rust-dlc?rev=0786724f947af867d72bd221fa99db492360f936#0786724f947af867d72bd221fa99db492360f936"
 dependencies = [
  "bitcoin",
  "dlc",
@@ -1266,7 +1266,7 @@ dependencies = [
 [[package]]
 name = "dlc-trie"
 version = "0.4.0"
-source = "git+https://github.com/p2pderivatives/rust-dlc?rev=8c13abf4283244d0e40b042468f0ffea3c0081b4#8c13abf4283244d0e40b042468f0ffea3c0081b4"
+source = "git+https://github.com/p2pderivatives/rust-dlc?rev=0786724f947af867d72bd221fa99db492360f936#0786724f947af867d72bd221fa99db492360f936"
 dependencies = [
  "bitcoin",
  "dlc",
@@ -2827,7 +2827,7 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 [[package]]
 name = "p2pd-oracle-client"
 version = "0.1.0"
-source = "git+https://github.com/p2pderivatives/rust-dlc?rev=8c13abf4283244d0e40b042468f0ffea3c0081b4#8c13abf4283244d0e40b042468f0ffea3c0081b4"
+source = "git+https://github.com/p2pderivatives/rust-dlc?rev=0786724f947af867d72bd221fa99db492360f936#0786724f947af867d72bd221fa99db492360f936"
 dependencies = [
  "chrono",
  "dlc-manager",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,11 +24,11 @@ resolver = "2"
 # `p2pderivatives/rust-dlc#feature/ln-dlc-channels`: 4e104b4. This patch ensures backwards
 # compatibility for 10101 through the `rust-lightning:0.0.116` upgrade. We will be able to drop it
 # once all users have been upgraded and traded once.
-dlc-manager = { git = "https://github.com/p2pderivatives/rust-dlc", rev = "8c13abf4283244d0e40b042468f0ffea3c0081b4" }
-dlc-messages = { git = "https://github.com/p2pderivatives/rust-dlc", rev = "8c13abf4283244d0e40b042468f0ffea3c0081b4" }
-dlc = { git = "https://github.com/p2pderivatives/rust-dlc", rev = "8c13abf4283244d0e40b042468f0ffea3c0081b4" }
-p2pd-oracle-client = { git = "https://github.com/p2pderivatives/rust-dlc", rev = "8c13abf4283244d0e40b042468f0ffea3c0081b4" }
-dlc-trie = { git = "https://github.com/p2pderivatives/rust-dlc", rev = "8c13abf4283244d0e40b042468f0ffea3c0081b4" }
+dlc-manager = { git = "https://github.com/p2pderivatives/rust-dlc", rev = "0786724f947af867d72bd221fa99db492360f936" }
+dlc-messages = { git = "https://github.com/p2pderivatives/rust-dlc", rev = "0786724f947af867d72bd221fa99db492360f936" }
+dlc = { git = "https://github.com/p2pderivatives/rust-dlc", rev = "0786724f947af867d72bd221fa99db492360f936" }
+p2pd-oracle-client = { git = "https://github.com/p2pderivatives/rust-dlc", rev = "0786724f947af867d72bd221fa99db492360f936" }
+dlc-trie = { git = "https://github.com/p2pderivatives/rust-dlc", rev = "0786724f947af867d72bd221fa99db492360f936" }
 
 # We should usually track the `p2pderivatives/split-tx-experiment[-10101]` branch. For now we depend on a special fork which removes a panic in rust-lightning
 lightning = { git = "https://github.com/bonomat/rust-lightning-p2p-derivatives", rev = "e49030e" }


### PR DESCRIPTION
Points to the fixup in rust-dlc removing the test log

https://github.com/p2pderivatives/rust-dlc/commit/0786724f947af867d72bd221fa99db492360f936