### PR TITLE
fix: use correct path

### DIFF
--- a/.github/workflows/android-fastlane.yml
+++ b/.github/workflows/android-fastlane.yml
@@ -200,7 +200,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
           name: apks
-          path: build/app/outputs/flutter-apk/
+          path: mobile/build/app/outputs/flutter-apk/
 
       - name: Release to Google Play Store
         env:


### PR DESCRIPTION
this action is executed from the workspace dir, hence, we need to provide the full path