### PR TITLE
feat(coordinator): sort dlc channels by state

### DIFF
--- a/crates/ln-dlc-node/src/ln/dlc_channel_details.rs
+++ b/crates/ln-dlc-node/src/ln/dlc_channel_details.rs
@@ -19,7 +19,7 @@ pub struct DlcChannelDetails {
     pub funding_tx_vout: Option<usize>,
 }
 
-#[derive(Serialize, Debug)]
+#[derive(Serialize, Debug, Ord, PartialOrd, Eq, PartialEq)]
 pub enum SignedChannelState {
     Established,
     SettledOffered,
@@ -35,7 +35,7 @@ pub enum SignedChannelState {
     CollaborativeCloseOffered,
 }
 
-#[derive(Serialize, Debug)]
+#[derive(Serialize, Debug, Eq, Ord, PartialOrd, PartialEq)]
 pub enum ChannelState {
     Offered,
     Accepted,


### PR DESCRIPTION
This will sort the channels retrieved via `/api/admin/dlc_channels` by their `state` first and then by their signed_channel_state` if the `state` is equal.

