### PR TITLE
Shoehorn channel-opening flow into first-trade flow

### DIFF
--- a/coordinator/src/routes.rs
+++ b/coordinator/src/routes.rs
@@ -67,7 +67,7 @@ use commons::PollAnswers;
 use commons::RegisterParams;
 use commons::Restore;
 use commons::RouteHintHop;
-use commons::TradeParams;
+use commons::TradeAndChannelParams;
 use commons::UpdateUsernameParams;
 use diesel::r2d2::ConnectionManager;
 use diesel::r2d2::Pool;
@@ -364,18 +364,16 @@ pub async fn get_invoice(
 // TODO: We might want to have our own ContractInput type here so we can potentially map fields if
 // the library changes?
 #[instrument(skip_all, err(Debug))]
-
 pub async fn post_trade(
     State(state): State<Arc<AppState>>,
-    trade_params: Json<TradeParams>,
+    params: Json<TradeAndChannelParams>,
 ) -> Result<(), AppError> {
-    state.node.trade(&trade_params.0).await.map_err(|e| {
+    state.node.trade(&params.0).await.map_err(|e| {
         AppError::InternalServerError(format!("Could not handle trade request: {e:#}"))
     })
 }
 
 #[instrument(skip_all, err(Debug))]
-
 pub async fn rollover(
     State(state): State<Arc<AppState>>,
     Path(dlc_channel_id): Path<String>,

--- a/crates/commons/src/trade.rs
+++ b/crates/commons/src/trade.rs
@@ -1,3 +1,4 @@
+use bitcoin::Amount;
 use rust_decimal::Decimal;
 use secp256k1::PublicKey;
 use secp256k1::XOnlyPublicKey;
@@ -8,9 +9,19 @@ use trade::ContractSymbol;
 use trade::Direction;
 use uuid::Uuid;
 
-/// The trade parameters defining the trade execution
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct TradeAndChannelParams {
+    pub trade_params: TradeParams,
+    #[serde(with = "bitcoin::util::amount::serde::as_sat::opt")]
+    pub trader_reserve: Option<Amount>,
+    #[serde(with = "bitcoin::util::amount::serde::as_sat::opt")]
+    pub coordinator_reserve: Option<Amount>,
+}
+
+/// The trade parameters defining the trade execution.
 ///
 /// Emitted by the orderbook when a match is found.
+///
 /// Both trading parties will receive trade params and then request trade execution with said trade
 /// parameters from the coordinator.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]

--- a/crates/tests-e2e/src/app.rs
+++ b/crates/tests-e2e/src/app.rs
@@ -3,6 +3,7 @@ use crate::test_subscriber::ThreadSafeSenders;
 use crate::wait_until;
 use native::api;
 use native::api::DlcChannel;
+use native::trade::order::api::NewOrder;
 use tempfile::TempDir;
 use tokio::task::block_in_place;
 
@@ -105,6 +106,20 @@ pub fn get_dlc_channel_id() -> Option<String> {
 
 pub fn get_dlc_channels() -> Vec<DlcChannel> {
     block_in_place(move || api::list_dlc_channels().unwrap())
+}
+
+pub fn submit_order(order: NewOrder) {
+    block_in_place(move || api::submit_order(order).unwrap());
+}
+
+pub fn submit_channel_opening_order(
+    order: NewOrder,
+    coordinator_reserve: u64,
+    trader_reserve: u64,
+) {
+    block_in_place(move || {
+        api::submit_channel_opening_order(order, coordinator_reserve, trader_reserve).unwrap()
+    });
 }
 
 // Values mostly taken from `environment.dart`

--- a/crates/tests-e2e/src/setup.rs
+++ b/crates/tests-e2e/src/setup.rs
@@ -1,5 +1,6 @@
 use crate::app::refresh_wallet_info;
 use crate::app::run_app;
+use crate::app::submit_channel_opening_order;
 use crate::app::sync_dlc_channels;
 use crate::app::AppHandle;
 use crate::bitcoind::Bitcoind;
@@ -13,7 +14,6 @@ use native::api::ContractSymbol;
 use native::trade::order::api::NewOrder;
 use native::trade::order::api::OrderType;
 use native::trade::position::PositionState;
-use tokio::task::spawn_blocking;
 
 pub struct TestSetup {
     pub app: AppHandle,
@@ -119,12 +119,7 @@ impl TestSetup {
 
         tracing::info!("Opening a position");
         let order = dummy_order();
-        spawn_blocking({
-            let order = order.clone();
-            move || api::submit_order(order).unwrap()
-        })
-        .await
-        .unwrap();
+        submit_channel_opening_order(order.clone(), 0, 0);
 
         wait_until!(rx.order().is_some());
 

--- a/crates/tests-e2e/tests/e2e_close_position.rs
+++ b/crates/tests-e2e/tests/e2e_close_position.rs
@@ -5,10 +5,10 @@ use native::api::ContractSymbol;
 use native::trade::order::api::NewOrder;
 use native::trade::order::api::OrderType;
 use native::trade::position::PositionState;
+use tests_e2e::app::submit_order;
 use tests_e2e::setup;
 use tests_e2e::setup::dummy_order;
 use tests_e2e::wait_until;
-use tokio::task::spawn_blocking;
 
 // Comments are based on a fixed price of 40_000.
 // TODO: Add assertions when the maker price can be fixed.
@@ -33,10 +33,7 @@ async fn can_open_close_open_close_position() {
 
     tracing::info!("Closing first position");
 
-    spawn_blocking(move || api::submit_order(closing_order).unwrap())
-        .await
-        .unwrap();
-
+    submit_order(closing_order.clone());
     wait_until!(test.app.rx.position_close().is_some());
 
     tokio::time::sleep(std::time::Duration::from_secs(10)).await;
@@ -57,12 +54,7 @@ async fn can_open_close_open_close_position() {
         stable: false,
     };
 
-    spawn_blocking({
-        let order = order.clone();
-        move || api::submit_order(order).unwrap()
-    })
-    .await
-    .unwrap();
+    submit_order(order.clone());
 
     wait_until!(test.app.rx.position().is_some());
     wait_until!(test.app.rx.position().unwrap().position_state == PositionState::Open);
@@ -83,9 +75,7 @@ async fn can_open_close_open_close_position() {
         ..order
     };
 
-    spawn_blocking(move || api::submit_order(closing_order).unwrap())
-        .await
-        .unwrap();
+    submit_order(closing_order);
 
     wait_until!(test.app.rx.position_close().is_some());
 

--- a/crates/tests-e2e/tests/e2e_open_position.rs
+++ b/crates/tests-e2e/tests/e2e_open_position.rs
@@ -5,9 +5,9 @@ use native::health::ServiceStatus;
 use native::trade::order::api::NewOrder;
 use native::trade::order::api::OrderType;
 use native::trade::position::PositionState;
+use tests_e2e::app::submit_channel_opening_order;
 use tests_e2e::setup::TestSetup;
 use tests_e2e::wait_until;
-use tokio::task::spawn_blocking;
 
 #[tokio::test(flavor = "multi_thread")]
 #[ignore = "need to be run with 'just e2e' command"]
@@ -23,12 +23,7 @@ async fn can_open_position() {
         order_type: Box::new(OrderType::Market),
         stable: false,
     };
-    spawn_blocking({
-        let order = order.clone();
-        move || api::submit_order(order).unwrap()
-    })
-    .await
-    .unwrap();
+    submit_channel_opening_order(order.clone(), 10_000, 10_000);
 
     assert_eq!(app.rx.status(Service::Orderbook), ServiceStatus::Online);
     assert_eq!(app.rx.status(Service::Coordinator), ServiceStatus::Online);

--- a/crates/tests-e2e/tests/e2e_open_position_small_utxos.rs
+++ b/crates/tests-e2e/tests/e2e_open_position_small_utxos.rs
@@ -8,9 +8,9 @@ use native::trade::position::PositionState;
 use rust_decimal::prelude::ToPrimitive;
 use std::str::FromStr;
 use tests_e2e::app::refresh_wallet_info;
+use tests_e2e::app::submit_channel_opening_order;
 use tests_e2e::setup::TestSetup;
 use tests_e2e::wait_until;
-use tokio::task::spawn_blocking;
 
 #[tokio::test(flavor = "multi_thread")]
 #[ignore = "need to be run with 'just e2e' command"]
@@ -75,12 +75,7 @@ async fn can_open_position_with_multiple_small_utxos() {
 
     // Act
 
-    spawn_blocking({
-        let order = order.clone();
-        move || api::submit_order(order).unwrap()
-    })
-    .await
-    .unwrap();
+    submit_channel_opening_order(order.clone(), 0, 0);
 
     // Assert
 

--- a/crates/tests-e2e/tests/e2e_reject_offer.rs
+++ b/crates/tests-e2e/tests/e2e_reject_offer.rs
@@ -7,9 +7,9 @@ use native::trade::order::api::NewOrder;
 use native::trade::order::api::OrderType;
 use native::trade::order::OrderState;
 use native::trade::position::PositionState;
+use tests_e2e::app::submit_channel_opening_order;
 use tests_e2e::setup::TestSetup;
 use tests_e2e::wait_until;
-use tokio::task::spawn_blocking;
 
 #[tokio::test(flavor = "multi_thread")]
 #[ignore = "need to be run with 'just e2e' command"]
@@ -31,12 +31,7 @@ async fn reject_offer() {
 
     // submit order for which the app does not have enough liquidity. will fail with `Failed to
     // accept dlc channel offer. Invalid state: Not enough UTXOs for amount`
-    spawn_blocking({
-        let order = invalid_order.clone();
-        move || api::submit_order(order).unwrap()
-    })
-    .await
-    .unwrap();
+    submit_channel_opening_order(invalid_order.clone(), 0, 0);
 
     assert_eq!(app.rx.status(Service::Orderbook), ServiceStatus::Online);
     assert_eq!(app.rx.status(Service::Coordinator), ServiceStatus::Online);
@@ -70,12 +65,7 @@ async fn reject_offer() {
         stable: false,
     };
 
-    spawn_blocking({
-        let order = order.clone();
-        move || api::submit_order(order).unwrap()
-    })
-    .await
-    .unwrap();
+    submit_channel_opening_order(order.clone(), 0, 0);
 
     // Assert that the order was posted
     wait_until!(app.rx.order().is_some());

--- a/crates/tests-e2e/tests/e2e_restore_from_backup.rs
+++ b/crates/tests-e2e/tests/e2e_restore_from_backup.rs
@@ -1,6 +1,7 @@
 use native::api;
 use native::trade::position::PositionState;
 use tests_e2e::app::run_app;
+use tests_e2e::app::submit_order;
 use tests_e2e::logger::init_tracing;
 use tests_e2e::setup;
 use tests_e2e::setup::dummy_order;
@@ -43,9 +44,7 @@ async fn app_can_be_restored_from_a_backup() {
     };
 
     tracing::info!("Closing a position");
-    spawn_blocking(move || api::submit_order(closing_order).unwrap())
-        .await
-        .unwrap();
+    submit_order(closing_order);
 
     wait_until!(test.app.rx.position().unwrap().position_state == PositionState::Closing);
     wait_until!(test.app.rx.position_close().is_some());

--- a/mobile/lib/common/application/lsp_change_notifier.dart
+++ b/mobile/lib/common/application/lsp_change_notifier.dart
@@ -5,6 +5,7 @@ import 'package:get_10101/common/application/event_service.dart';
 import 'package:get_10101/common/domain/liquidity_option.dart';
 import 'package:get_10101/common/domain/model.dart';
 
+// TODO: Name seems wrong as we use this to get on-chain sats too.
 class LspChangeNotifier extends ChangeNotifier implements Subscriber {
   ChannelInfoService channelInfoService;
 

--- a/mobile/lib/features/trade/application/order_service.dart
+++ b/mobile/lib/features/trade/application/order_service.dart
@@ -19,6 +19,28 @@ class OrderService {
     return await rust.api.submitOrder(order: order);
   }
 
+  Future<String> submitChannelOpeningMarketOrder(
+      Leverage leverage,
+      Amount quantity,
+      ContractSymbol contractSymbol,
+      Direction direction,
+      bool stable,
+      Amount coordinatorReserve,
+      Amount traderReserve) async {
+    rust.NewOrder order = rust.NewOrder(
+        leverage: leverage.leverage,
+        quantity: quantity.asDouble(),
+        contractSymbol: contractSymbol.toApi(),
+        direction: direction.toApi(),
+        orderType: const rust.OrderType.market(),
+        stable: stable);
+
+    return await rust.api.submitChannelOpeningOrder(
+        order: order,
+        coordinatorReserve: coordinatorReserve.sats,
+        traderReserve: traderReserve.sats);
+  }
+
   Future<List<Order>> fetchOrders() async {
     List<rust.Order> apiOrders = await rust.api.getOrders();
     List<Order> orders = apiOrders.map((order) => Order.fromApi(order)).toList();

--- a/mobile/lib/features/trade/channel_configuration.dart
+++ b/mobile/lib/features/trade/channel_configuration.dart
@@ -1,0 +1,250 @@
+import 'package:flutter/material.dart';
+import 'package:get_10101/common/amount_text_field.dart';
+import 'package:get_10101/common/amount_text_input_form_field.dart';
+import 'package:get_10101/common/application/lsp_change_notifier.dart';
+import 'package:get_10101/common/domain/model.dart';
+import 'package:get_10101/common/value_data_row.dart';
+import 'package:get_10101/features/trade/domain/channel_opening_params.dart';
+import 'package:get_10101/features/trade/domain/leverage.dart';
+import 'package:get_10101/features/trade/domain/trade_values.dart';
+import 'package:get_10101/util/constants.dart';
+import 'package:go_router/go_router.dart';
+import 'package:provider/provider.dart';
+
+// TODO: Fetch from backend.
+Amount openingFee = Amount(0);
+
+// TODO: Include fee reserve.
+
+channelConfiguration({
+  required BuildContext context,
+  required TradeValues tradeValues,
+  required Function(ChannelOpeningParams channelOpeningParams) onConfirmation,
+}) {
+  showModalBottomSheet<void>(
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(
+          top: Radius.circular(20),
+        ),
+      ),
+      clipBehavior: Clip.antiAlias,
+      isScrollControlled: true,
+      useRootNavigator: true,
+      barrierColor: Colors.black.withOpacity(0),
+      context: context,
+      builder: (BuildContext context) {
+        return SafeArea(
+            child: Padding(
+                padding: EdgeInsets.only(bottom: MediaQuery.of(context).viewInsets.bottom),
+                // the GestureDetector ensures that we can close the keyboard by tapping into the modal
+                child: GestureDetector(
+                    onTap: () {
+                      FocusScopeNode currentFocus = FocusScope.of(context);
+
+                      if (!currentFocus.hasPrimaryFocus) {
+                        currentFocus.unfocus();
+                      }
+                    },
+                    child: SingleChildScrollView(
+                      child: SizedBox(
+                        height: 450,
+                        child: ChannelConfiguration(
+                          tradeValues: tradeValues,
+                          onConfirmation: onConfirmation,
+                        ),
+                      ),
+                    ))));
+      });
+}
+
+class ChannelConfiguration extends StatefulWidget {
+  final TradeValues tradeValues;
+
+  final Function(ChannelOpeningParams channelOpeningParams) onConfirmation;
+
+  const ChannelConfiguration({super.key, required this.tradeValues, required this.onConfirmation});
+
+  @override
+  State<ChannelConfiguration> createState() => _ChannelConfiguration();
+}
+
+class _ChannelConfiguration extends State<ChannelConfiguration> {
+  late final LspChangeNotifier lspChangeNotifier;
+
+  Amount minMargin = Amount.zero();
+  Amount counterpartyMargin = Amount.zero();
+  Amount ownTotalCollateral = Amount.zero();
+  Amount counterpartyCollateral = Amount.zero();
+
+  double counterpartyLeverage = 1;
+
+  Amount maxOnChainSpending = Amount.zero();
+  Amount maxCounterpartyCollateral = Amount.zero();
+
+  Amount orderMatchingFees = Amount.zero();
+
+  final _formKey = GlobalKey<FormState>();
+
+  @override
+  void initState() {
+    super.initState();
+
+    lspChangeNotifier = context.read<LspChangeNotifier>();
+    var tradeConstraints = lspChangeNotifier.channelInfoService.getTradeConstraints();
+
+    maxCounterpartyCollateral = Amount(tradeConstraints.maxCounterpartyMarginSats);
+
+    maxOnChainSpending = Amount(tradeConstraints.maxLocalMarginSats);
+    counterpartyLeverage = tradeConstraints.coordinatorLeverage;
+
+    counterpartyMargin = widget.tradeValues.calculateMargin(Leverage(counterpartyLeverage));
+
+    minMargin = Amount(tradeConstraints.minMargin);
+
+    ownTotalCollateral = tradeConstraints.minMargin > widget.tradeValues.margin!.sats
+        ? Amount(tradeConstraints.minMargin)
+        : widget.tradeValues.margin!;
+
+    orderMatchingFees = widget.tradeValues.fee ?? Amount.zero();
+
+    updateCounterpartyCollateral();
+
+    // We add this so that the confirmation slider can be enabled immediately
+    // _if_ the form is already valid. Otherwise we have to wait for the user to
+    // interact with the form.
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      setState(() {
+        _formKey.currentState?.validate();
+      });
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Form(
+        key: _formKey,
+        child: Container(
+            padding: const EdgeInsets.only(top: 20, left: 20, right: 20),
+            child: Column(children: [
+              const Text("DLC Channel Configuration",
+                  style: TextStyle(fontWeight: FontWeight.bold, fontSize: 17)),
+              const SizedBox(
+                height: 20,
+              ),
+              RichText(
+                  text: TextSpan(
+                text:
+                    "This is your first trade. 10101 will open a DLC channel with you, creating your position in the process.\n\nPlease specify your preferred channel size, impacting how much you will be able to win up to.",
+                style: DefaultTextStyle.of(context).style,
+              )),
+              const SizedBox(
+                height: 20,
+              ),
+              Center(
+                child: Container(
+                  padding: const EdgeInsets.symmetric(vertical: 10),
+                  child: Column(
+                    children: [
+                      Wrap(
+                        runSpacing: 10,
+                        children: [
+                          SizedBox(
+                            height: 80,
+                            child: Row(
+                              crossAxisAlignment: CrossAxisAlignment.start,
+                              children: [
+                                Flexible(
+                                    child: AmountInputField(
+                                  value: ownTotalCollateral,
+                                  label: 'Your collateral (sats)',
+                                  onChanged: (value) {
+                                    setState(() {
+                                      ownTotalCollateral = Amount.parseAmount(value);
+
+                                      updateCounterpartyCollateral();
+                                    });
+                                  },
+                                  validator: (value) {
+                                    if (ownTotalCollateral.sats < minMargin.sats) {
+                                      return "Min collateral: $minMargin";
+                                    }
+
+                                    // TODO(holzeis): Add validation considering the on-chain fees
+
+                                    if (ownTotalCollateral.add(orderMatchingFees).sats >
+                                        maxOnChainSpending.sats) {
+                                      return "Max on-chain: ${Amount(maxOnChainSpending.sats - orderMatchingFees.sats)}";
+                                    }
+
+                                    if (maxCounterpartyCollateral.sats <
+                                        counterpartyCollateral.sats) {
+                                      return "Over limit: $counterpartyCollateral";
+                                    }
+
+                                    return null;
+                                  },
+                                  infoText:
+                                      "Your total collateral in the dlc channel.\n\nChoose a bigger amount here if you plan to make bigger trades in the future and don't want to open a new channel.",
+                                )),
+                                const SizedBox(
+                                  width: 10,
+                                ),
+                                Flexible(
+                                    child: AmountTextField(
+                                  value: counterpartyCollateral,
+                                  label: 'Win up to (sats)',
+                                ))
+                              ],
+                            ),
+                          ),
+                          const SizedBox(height: 30),
+                          ValueDataRow(
+                              type: ValueType.amount,
+                              value: ownTotalCollateral,
+                              label: 'Your collateral'),
+                          ValueDataRow(
+                            type: ValueType.amount,
+                            value: openingFee,
+                            label: 'Channel-opening fee',
+                          ),
+                        ],
+                      ),
+                      const Divider(),
+                      ValueDataRow(
+                          type: ValueType.amount,
+                          value: ownTotalCollateral.add(openingFee),
+                          label: "Total"),
+                      const SizedBox(height: 30),
+                      Column(
+                        crossAxisAlignment: CrossAxisAlignment.stretch,
+                        mainAxisAlignment: MainAxisAlignment.end,
+                        children: [
+                          ElevatedButton(
+                            key: tradeScreenBottomSheetChannelConfigurationConfirmButton,
+                            onPressed:
+                                _formKey.currentState != null && _formKey.currentState!.validate()
+                                    ? () {
+                                        GoRouter.of(context).pop();
+                                        widget.onConfirmation(ChannelOpeningParams(
+                                            coordinatorCollateral: counterpartyCollateral,
+                                            traderCollateral: ownTotalCollateral));
+                                      }
+                                    : null,
+                            style: ElevatedButton.styleFrom(minimumSize: const Size.fromHeight(50)),
+                            child: const Text("Confirm"),
+                          ),
+                        ],
+                      )
+                    ],
+                  ),
+                ),
+              )
+            ])));
+  }
+
+  void updateCounterpartyCollateral() {
+    final collateral = (ownTotalCollateral.sats / counterpartyLeverage).floor();
+    counterpartyCollateral =
+        counterpartyMargin.sats > collateral ? counterpartyMargin : Amount(collateral);
+  }
+}

--- a/mobile/lib/features/trade/domain/channel_opening_params.dart
+++ b/mobile/lib/features/trade/domain/channel_opening_params.dart
@@ -1,0 +1,8 @@
+import 'package:get_10101/common/domain/model.dart';
+
+class ChannelOpeningParams {
+  Amount coordinatorCollateral;
+  Amount traderCollateral;
+
+  ChannelOpeningParams({required this.coordinatorCollateral, required this.traderCollateral});
+}

--- a/mobile/lib/features/trade/domain/trade_values.dart
+++ b/mobile/lib/features/trade/domain/trade_values.dart
@@ -126,6 +126,12 @@ class TradeValues {
     _recalculateLiquidationPrice();
   }
 
+  // Can be used to calculate the counterparty's margin, based on their
+  // leverage.
+  calculateMargin(Leverage leverage) {
+    return tradeValuesService.calculateMargin(price: price, quantity: quantity, leverage: leverage);
+  }
+
   _recalculateMargin() {
     Amount? margin =
         tradeValuesService.calculateMargin(price: price, quantity: quantity, leverage: leverage);

--- a/mobile/lib/features/trade/trade_screen.dart
+++ b/mobile/lib/features/trade/trade_screen.dart
@@ -150,6 +150,7 @@ class TradeScreen extends StatelessWidget {
                             tradeBottomSheetConfirmation(
                                 context: context,
                                 direction: direction,
+                                channelOpeningParams: null,
                                 onConfirmation: () {
                                   submitOrderChangeNotifier.closePosition(
                                       position, tradeValues.price, tradeValues.fee);
@@ -167,7 +168,7 @@ class TradeScreen extends StatelessWidget {
                                         return const TradeDialog();
                                       });
                                 },
-                                close: true);
+                                tradeAction: TradeAction.closePosition);
                           },
                         );
                       },

--- a/mobile/lib/logger/logger.dart
+++ b/mobile/lib/logger/logger.dart
@@ -22,3 +22,16 @@ void buildLogger(bool isLogLevelTrace) {
 
   AppLogger.instance = logger;
 }
+
+void buildTestLogger(bool isLogLevelTrace) {
+  final logger = Logger(
+      filter: ProductionFilter(),
+      level: isLogLevelTrace ? Level.trace : Level.debug,
+      printer: SimpleUTCPrinter(
+          // Colorful log messages
+          colors: false,
+          // Should each log print contain a timestamp
+          printTime: true));
+
+  AppLogger.instance = logger;
+}

--- a/mobile/lib/util/constants.dart
+++ b/mobile/lib/util/constants.dart
@@ -23,6 +23,7 @@ const _stable = "stable/";
 
 const _bottomSheet = "bottom_sheet/";
 const _confirmSheet = "confirm/";
+const _channelConfig = "channel_config/";
 
 // concrete selectors
 
@@ -30,6 +31,8 @@ const _buy = "buy";
 const _sell = "sell";
 const _positions = "positions";
 const _orders = "orders";
+const _configureChannel = "configure_channel";
+const _openChannel = "open_channel";
 
 const tradeScreenTabsOrders = Key(_trade + _tabs + _orders);
 const tradeScreenTabsPositions = Key(_trade + _tabs + _positions);
@@ -42,6 +45,12 @@ const tradeScreenBottomSheetTabsSell = Key(_trade + _bottomSheet + _tabs + _sell
 
 const tradeScreenBottomSheetButtonBuy = Key(_trade + _bottomSheet + _button + _buy);
 const tradeScreenBottomSheetButtonSell = Key(_trade + _bottomSheet + _button + _sell);
+
+const tradeScreenBottomSheetChannelConfigurationConfirmButton =
+    Key(_trade + _bottomSheet + _configureChannel + _configureChannel);
+
+const tradeScreenBottomSheetConfirmationConfigureChannelSlider =
+    Key(_trade + _bottomSheet + _confirmSheet + _channelConfig + _slider + _openChannel);
 
 const tradeScreenBottomSheetConfirmationSliderBuy =
     Key(_trade + _bottomSheet + _confirmSheet + _slider + _buy);

--- a/mobile/native/migrations/2024-02-07-031110_add_channel_opening_params_table/down.sql
+++ b/mobile/native/migrations/2024-02-07-031110_add_channel_opening_params_table/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE "channel_opening_params";

--- a/mobile/native/migrations/2024-02-07-031110_add_channel_opening_params_table/up.sql
+++ b/mobile/native/migrations/2024-02-07-031110_add_channel_opening_params_table/up.sql
@@ -1,0 +1,6 @@
+CREATE TABLE "channel_opening_params" (
+    order_id TEXT PRIMARY KEY NOT NULL,
+    coordinator_reserve BIGINT NOT NULL,
+    trader_reserve BIGINT NOT NULL,
+    created_at BIGINT NOT NULL
+);

--- a/mobile/native/src/channel_trade_constraints.rs
+++ b/mobile/native/src/channel_trade_constraints.rs
@@ -26,6 +26,7 @@ pub fn channel_trade_constraints() -> Result<TradeConstraints> {
 
     let dlc_channels = ln_dlc::get_signed_dlc_channels()?;
 
+    // FIXME: This doesn't work if the channel is in `Closing` and related states.
     let maybe_channel = dlc_channels.first();
 
     let trade_constraints = match maybe_channel {

--- a/mobile/native/src/db/mod.rs
+++ b/mobile/native/src/db/mod.rs
@@ -1,6 +1,7 @@
 use crate::config;
 use crate::db::models::base64_engine;
 use crate::db::models::Channel;
+use crate::db::models::ChannelOpeningParams;
 use crate::db::models::FailureReason;
 use crate::db::models::NewTrade;
 use crate::db::models::Order;
@@ -559,8 +560,6 @@ pub fn get_all_transactions_without_fees() -> Result<Vec<ln_dlc_node::transactio
     Ok(transactions)
 }
 
-// Trade
-
 pub fn get_all_trades() -> Result<Vec<crate::trade::Trade>> {
     let mut db = connection()?;
 
@@ -601,4 +600,22 @@ pub fn delete_answered_poll_cache() -> Result<()> {
     let mut db = connection()?;
     polls::delete_all(&mut db)?;
     Ok(())
+}
+
+pub fn insert_channel_opening_params(
+    conn: &mut SqliteConnection,
+    channel_opening_params: crate::ln_dlc::ChannelOpeningParams,
+) -> Result<()> {
+    ChannelOpeningParams::insert(conn, channel_opening_params.into())?;
+
+    Ok(())
+}
+
+pub fn get_channel_opening_params_by_order_id(
+    order_id: Uuid,
+) -> Result<Option<crate::ln_dlc::ChannelOpeningParams>> {
+    let mut db = connection()?;
+    let params = ChannelOpeningParams::get_by_order_id(&mut db, order_id)?;
+
+    Ok(params.map(crate::ln_dlc::ChannelOpeningParams::from))
 }

--- a/mobile/native/src/lib.rs
+++ b/mobile/native/src/lib.rs
@@ -14,7 +14,15 @@ pub mod schema;
 pub mod state;
 
 mod backup;
+mod channel_trade_constraints;
+mod cipher;
+mod destination;
+mod dlc_channel;
+mod dlc_handler;
+mod names;
 mod orderbook;
+mod polls;
+mod storage;
 
 #[allow(
     clippy::all,
@@ -23,11 +31,3 @@ mod orderbook;
     unused_qualifications
 )]
 mod bridge_generated;
-mod channel_trade_constraints;
-mod cipher;
-mod destination;
-mod dlc_channel;
-mod dlc_handler;
-mod names;
-mod polls;
-mod storage;

--- a/mobile/native/src/schema.rs
+++ b/mobile/native/src/schema.rs
@@ -1,6 +1,15 @@
 // @generated automatically by Diesel CLI.
 
 diesel::table! {
+    channel_opening_params (order_id) {
+        order_id -> Text,
+        coordinator_reserve -> BigInt,
+        trader_reserve -> BigInt,
+        created_at -> BigInt,
+    }
+}
+
+diesel::table! {
     answered_polls (id) {
         id -> Integer,
         poll_id -> Integer,
@@ -143,6 +152,7 @@ diesel::joinable!(last_outbound_dlc_messages -> dlc_messages (message_hash));
 
 diesel::allow_tables_to_appear_in_same_query!(
     answered_polls,
+    channel_opening_params,
     channels,
     dlc_messages,
     ignored_polls,

--- a/mobile/native/src/trade/order/mod.rs
+++ b/mobile/native/src/trade/order/mod.rs
@@ -151,6 +151,7 @@ pub struct Order {
     pub order_expiry_timestamp: OffsetDateTime,
     pub reason: OrderReason,
     pub stable: bool,
+    // FIXME: Why is this failure_reason duplicated? It's also in the `order_state`?
     pub failure_reason: Option<FailureReason>,
 }
 

--- a/webapp/README.md
+++ b/webapp/README.md
@@ -1,4 +1,4 @@
-# A simple webfrontend to be self-hosted
+# A simple web frontend to be self-hosted
 
 ## Run frontend only in dev mode
 
@@ -7,31 +7,43 @@ cd frontend
 flutter run -d chrome
 ```
 
-## Build the frontend to be served by rust
+## Build the frontend to be served by Rust
 
 ```bash
 flutter build web
 ```
 
-## Run the rust app
+## Run the Rust app
+
+### With TLS
+
+```bash
+cargo run -- --cert-dir certs --data-dir ../data --secure
+```
+
+The web interface will be reachable under `https://localhost:3001`.
+
+### Without TLS
 
 ```bash
 cargo run -- --cert-dir certs --data-dir ../data
 ```
 
-The webinterface will be reachable under `https://localhost:3001`
+The web interface will be reachable under `http://localhost:3001`
 
-Note: if you can't see anything, you probably forgot to run `flutter build web` before
+### Troubleshooting
 
-## How to use curl with webapp
+If you can't see anything, you probably forgot to run `flutter build web` before.
 
-We need to store cookies between two curl calls, for that you can use the cookie jar of curl:
+## How to interact with the backend with `curl`
+
+We need to store cookies between `curl` calls. For that you can use the `curl`'s cookie jar:
 
 ```bash
 curl -b .cookie-jar.txt -c .cookie-jar.txt -X POST http://localhost:3001/api/login -d '{ "password": "satoshi" }' -H "Content-Type: application/json" -v
 ```
 
-This will read and store the cookies in `.cookie-jar.txt`. So on the next call you can reference it the same way, e.g.
+This will read and store the cookies in `.cookie-jar.txt`. So on the next call you can reference it the same way:
 
 ```bash
 curl -b .cookie-jar.txt -c .cookie-jar.txt http://localhost:3001/api/balance


### PR DESCRIPTION
Fixes #1793.

https://github.com/get10101/10101/assets/9418575/a391988c-edbc-4ffd-86c3-fa4e714a4f29

TODOs:

- [x] Let user trade normally after channel-opening trade.
- [x] Fix failing UI test. Adapted it with the new flow.
- [x] Add another UI test for when the channel is already established.
- [x] Fix confirmation slider bug when confirming channel configuration.
- [x] Close all bottom sheets when first trade succeeds.
- [x] Add e2e test for `submit_channel_opening_order` API.
- [x] Use `TradeValues` to calculate coordinator margin.
- [x] Set channel-opening fee to 0. When we are ready to charge for opening channels we can read this information from the liquidity options through the backend.
- [x] Do not assume coordinator's proportional liquidity in UI and use leverage in `TradeConstraints` instead.
- [x] Cap coordinator's maximum liquidity per channel.
- [x] Fix `webapp` if affected.
- [x] Pop all bottom sheets once the channel-opening trade is confirmed.
- [ ] Include funding transaction fees, and fee reserve, in channel configuration screen.
