### PR TITLE
refactor: Replace axum server with a low level rust-tls implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - Feat(mobile): Add in-app survey feature. The coordinator can trigger surveys which will be shown in the app.
+- Refactor(webapp): Replace axum-server with low lever rust-tls implementation
 
 ## [1.8.5] - 2024-02-05
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -118,12 +118,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "arc-swap"
-version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bddcadddf5e9015d310179a59bb28c4d4b9920ad0f11e8e14dbadf654890c9a6"
-
-[[package]]
 name = "arrayvec"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -329,29 +323,6 @@ dependencies = [
  "tower-sessions",
  "tracing",
  "urlencoding",
-]
-
-[[package]]
-name = "axum-server"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1ad46c3ec4e12f4a4b6835e173ba21c25e484c9d02b49770bf006ce5367c036"
-dependencies = [
- "arc-swap",
- "bytes",
- "futures-util",
- "http 1.0.0",
- "http-body 1.0.0",
- "http-body-util",
- "hyper 1.1.0",
- "hyper-util",
- "pin-project-lite",
- "rustls",
- "rustls-pemfile",
- "tokio",
- "tokio-rustls",
- "tower",
- "tower-service",
 ]
 
 [[package]]
@@ -1898,6 +1869,7 @@ dependencies = [
  "itoa",
  "pin-project-lite",
  "tokio",
+ "want",
 ]
 
 [[package]]
@@ -3489,19 +3461,12 @@ dependencies = [
 
 [[package]]
 name = "rustls-pemfile"
-version = "2.0.0"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35e4980fa29e4c4b212ffb3db068a564cbf560e51d3944b7c88bd8bf5bec64f4"
+checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
 dependencies = [
  "base64 0.21.0",
- "rustls-pki-types",
 ]
-
-[[package]]
-name = "rustls-pki-types"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e9d979b3ce68192e42760c7810125eb6cf2ea10efae545a156063e61f314e2a"
 
 [[package]]
 name = "rustls-webpki"
@@ -4845,22 +4810,25 @@ dependencies = [
  "atty",
  "axum 0.7.4",
  "axum-login",
- "axum-server",
  "bitcoin",
  "clap",
  "commons",
  "console-subscriber",
+ "hyper 1.1.0",
+ "hyper-util",
  "mime_guess",
  "native",
  "parking_lot 0.12.1",
  "rust-embed",
  "rust_decimal",
  "rust_decimal_macros",
+ "rustls-pemfile",
  "serde",
  "serde_json",
  "sha2",
  "time",
  "tokio",
+ "tokio-rustls",
  "tower",
  "tower-http",
  "tracing",

--- a/webapp/Cargo.toml
+++ b/webapp/Cargo.toml
@@ -9,22 +9,25 @@ anyhow = "1"
 atty = "0.2.14"
 axum = { version = "0.7", features = ["tracing"] }
 axum-login = "0.12.0"
-axum-server = { version = "0.6", features = ["tls-rustls"] }
 bitcoin = "0.29.2"
 clap = { version = "4", features = ["derive"] }
 commons = { path = "../crates/commons" }
 console-subscriber = "0.1.6"
+hyper = { version = "1.0.0", features = ["full"] }
+hyper-util = { version = "0.1" }
 mime_guess = "2.0.4"
 native = { path = "../mobile/native" }
 parking_lot = { version = "0.12.1" }
 rust-embed = "8.2.0"
 rust_decimal = { version = "1", features = ["serde-with-float"] }
 rust_decimal_macros = "1"
+rustls-pemfile = "1.0.4"
 serde = "1.0.147"
 serde_json = "1"
 sha2 = "0.10"
 time = "0.3"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+tokio-rustls = "0.24.1"
 tower = { version = "0.4", features = ["util"] }
 tower-http = { version = "0.5", features = ["fs", "trace", "cors"] }
 tracing = "0.1.37"


### PR DESCRIPTION
Example mostly copied from here https://github.com/tokio-rs/axum/blob/main/examples/low-level-rustls/src/main.rs

Not sure if going low level makes this more stable, but lets see and hope for the best :)

maybe fixes #1938 