### PR TITLE
fix: Do not accept channel collaborative close offer on reconnect.

### DIFF
--- a/coordinator/src/dlc_handler.rs
+++ b/coordinator/src/dlc_handler.rs
@@ -6,8 +6,6 @@ use bitcoin::secp256k1::PublicKey;
 use diesel::r2d2::ConnectionManager;
 use diesel::r2d2::Pool;
 use diesel::PgConnection;
-use dlc_manager::channel::signed_channel::SignedChannel;
-use dlc_manager::channel::signed_channel::SignedChannelState;
 use dlc_messages::Message;
 use futures::future::RemoteHandle;
 use futures::FutureExt;
@@ -99,25 +97,6 @@ impl DlcHandler {
     }
 
     pub fn on_connect(&self, peer: PublicKey) -> Result<()> {
-        let signed_dlc_channels = self.node.list_signed_dlc_channels()?;
-
-        if let Some(SignedChannel {
-            channel_id,
-            state: SignedChannelState::CollaborativeCloseOffered { .. },
-            ..
-        }) = signed_dlc_channels.iter().find(|c| c.counter_party == peer)
-        {
-            tracing::info!("Accepting pending dlc channel close offer.");
-            // Pending dlc channel close offer with the intend to close the dlc channel
-            // on-chain
-
-            // TODO(bonomat): we should verify that the proposed amount is acceptable
-            self.node
-                .accept_dlc_channel_collaborative_close(channel_id)?;
-
-            return Ok(());
-        }
-
         let mut conn = self.pool.get()?;
         let last_serialized_message = db::last_outbound_dlc_message::get(&mut conn, &peer)?;
 

--- a/mobile/native/src/dlc_handler.rs
+++ b/mobile/native/src/dlc_handler.rs
@@ -182,22 +182,6 @@ impl DlcHandler {
 
                     return Ok(());
                 }
-                SignedChannel {
-                    channel_id,
-                    state: SignedChannelState::CollaborativeCloseOffered { .. },
-                    ..
-                } => {
-                    tracing::info!("Accepting pending dlc channel close offer.");
-                    // Pending dlc channel close offer with the intend to close the dlc channel
-                    // on-chain
-
-                    // TODO(bonomat): we should verify that the proposed amount is acceptable
-                    self.node
-                        .inner
-                        .accept_dlc_channel_collaborative_close(channel_id)?;
-
-                    return Ok(());
-                }
                 signed_channel => {
                     // If the signed channel state is anything else but `Established`, `Settled` or
                     // `Closing` at reconnect. It means the protocol got interrupted.


### PR DESCRIPTION
The dlc channel will be updated to `CollaborativeCloseOffered` if the collab closed has been offered (by the offering party).

Hence it is wrong to interpret the state `SignedChannelState::CollaborativeCloseOffered` as pending offer.

fixes #1973 