### PR TITLE
chore: Cleanup docker compose

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,11 +165,11 @@ jobs:
       - uses: Swatinem/rust-cache@v2.2.0
       - name: Start containers
         run: |
-          docker-compose up -d
+          just docker
           sleep 10 # We need to give docker a bit of time to startup
       - name: Test containers are up
         run: |
-          curl -d '{"address":"bcrt1qylgu6ffkp3p0m8tw8kp4tt2dmdh755f4r5dq7s", "amount":"0.1"}' -H "Content-Type: application/json" -X POST http://localhost:3000/faucet
+          curl http://localhost:8080/bitcoin -d '{"jsonrpc": "1.0", "method": "sendtoaddress", "params": ["bcrt1qylgu6ffkp3p0m8tw8kp4tt2dmdh755f4r5dq7s", 0.1]}'
       - name: Run LN-DLC tests
         run: RUST_BACKTRACE=1 cargo test -p ln-dlc-node -- --ignored --nocapture --test-threads=1
       - name: bitcoin logs on e2e tests error
@@ -214,13 +214,13 @@ jobs:
         run: cargo build --examples
       - name: Start containers
         run: |
-          docker-compose up -d
+          just docker
           sleep 10 # We need to give docker a bit of time to startup
       - name: show disk space before tests
         run: df -h
       - name: Test containers are up
         run: |
-          curl -d '{"address":"bcrt1qylgu6ffkp3p0m8tw8kp4tt2dmdh755f4r5dq7s", "amount":"0.1"}' -H "Content-Type: application/json" -X POST http://localhost:3000/faucet
+          curl http://localhost:8080/bitcoin -d '{"jsonrpc": "1.0", "method": "sendtoaddress", "params": ["bcrt1qylgu6ffkp3p0m8tw8kp4tt2dmdh755f4r5dq7s", 0.1]}'
       - name: Run e2e tests
         run: just e2e --nocapture
       - name: Print maker logs on e2e tests error

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,9 +172,6 @@ jobs:
           curl -d '{"address":"bcrt1qylgu6ffkp3p0m8tw8kp4tt2dmdh755f4r5dq7s", "amount":"0.1"}' -H "Content-Type: application/json" -X POST http://localhost:3000/faucet
       - name: Run LN-DLC tests
         run: RUST_BACKTRACE=1 cargo test -p ln-dlc-node -- --ignored --nocapture --test-threads=1
-      - name: LND logs on e2e tests error
-        if: failure()
-        run: docker logs lnd
       - name: bitcoin logs on e2e tests error
         if: failure()
         run: docker logs bitcoin
@@ -232,9 +229,6 @@ jobs:
       - name: Print coordinator logs on e2e tests error
         if: failure()
         run: cat data/coordinator/regtest.log
-      - name: LND logs on e2e tests error
-        if: failure()
-        run: docker logs lnd
       - name: bitcoin logs on e2e tests error
         if: failure()
         run: docker logs bitcoin

--- a/crates/ln-dlc-node/src/tests/dlc_channel.rs
+++ b/crates/ln-dlc-node/src/tests/dlc_channel.rs
@@ -332,7 +332,10 @@ async fn setup_channel_with_position() -> (
     .await
     .unwrap();
 
-    mine(dlc_manager::manager::NB_CONFIRMATIONS as u16)
+    // FIXME(holzeis): `Chopsticks automatically mined an additional block when calling its API. now
+    // that we have removed chopsticks this acutally translates to mining 2 blocks instead of just
+    // 1. related to https://github.com/get10101/10101/issues/1990`
+    mine(dlc_manager::manager::NB_CONFIRMATIONS as u16 + 1)
         .await
         .unwrap();
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,7 +49,7 @@ services:
       - --cookie
       - admin1:123
       - --http-addr
-      - 0.0.0.0:30000
+      - 0.0.0.0:3000
       - --electrum-rpc-addr
       - 0.0.0.0:50000
       - --cors
@@ -62,7 +62,7 @@ services:
       - bitcoin
     ports:
       - "50000:50000"
-      - "30000:30000"
+      - "3000:3000"
     restart: unless-stopped
     networks:
       vtto:
@@ -73,7 +73,7 @@ services:
     image: ghcr.io/vulpemventures/esplora:latest
     container_name: esplora
     depends_on:
-      - chopsticks
+      - electrs
     environment:
       API_URL: http://localhost:3000
     ports:
@@ -82,30 +82,6 @@ services:
     networks:
       vtto:
         ipv4_address: 10.5.0.4
-
-  # Chopsticks
-  chopsticks:
-    image: ghcr.io/vulpemventures/nigiri-chopsticks:latest
-    container_name: chopsticks
-    command:
-      - --use-faucet
-      - --use-mining
-      - --use-logger
-      - --rpc-addr
-      - 10.5.0.2:18443
-      - --electrs-addr
-      - 10.5.0.3:30000
-      - --addr
-      - 0.0.0.0:3000
-    depends_on:
-      - bitcoin
-      - electrs
-    ports:
-      - "3000:3000"
-    restart: unless-stopped
-    networks:
-      vtto:
-        ipv4_address: 10.5.0.5
 
   faucet:
     image: nginx

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -107,26 +107,6 @@ services:
       vtto:
         ipv4_address: 10.5.0.5
 
-  lnd:
-    container_name: lnd
-    image: lightninglabs/lnd:v0.16.2-beta
-    depends_on:
-      - bitcoin
-    command:
-      - --configfile=/var/lib/lnd/lnd.conf
-    volumes:
-      - ./services/faucet/lnd.conf:/var/lib/lnd/lnd.conf
-      - lnd:/root/.lnd
-    restart: unless-stopped
-    stop_grace_period: 5m30s
-    ports:
-      - "9735:9735" # p2p
-      - "10009:10009" # grpc
-      - "18080:18080" # rest
-    networks:
-      vtto:
-        ipv4_address: 10.5.0.6
-
   faucet:
     image: nginx
     container_name: faucet
@@ -139,7 +119,6 @@ services:
       - ./services/faucet/btc-fee-estimates.json:/usr/share/nginx/html/fee/btc-fee-estimates.json
     depends_on:
       - bitcoin
-      - lnd
     restart: unless-stopped
     networks:
       vtto:
@@ -191,5 +170,4 @@ networks:
 volumes:
   bitcoin:
   postgres:
-  lnd:
   electrs:


### PR DESCRIPTION
Removes lnd and chopsticks from our dev setup.

The nigiri chopsticks container was only useful to create a wallet and generate the first 200 blocks. Other than that its just a technical burden.

This patch removes the chopstick service from our dev setup by manually creating a wallet and mining 300 blocks when running just docker.

‼️ docker-compose up -d on an wiped environment will not be sufficient anymore. You will have to use `just docker` to start the environment, which ensures that wallet is created and 101 blocks are mined.
‼️ Chopsticks weirdly always mined a block when broadcasting a transaction. This is changed now that we got rid of chopsticks.
