### PR TITLE
fix(dlc_handler): Only accept collab close offer if not our own

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1196,7 +1196,7 @@ dependencies = [
 [[package]]
 name = "dlc"
 version = "0.4.0"
-source = "git+https://github.com/p2pderivatives/rust-dlc?rev=0786724f947af867d72bd221fa99db492360f936#0786724f947af867d72bd221fa99db492360f936"
+source = "git+https://github.com/p2pderivatives/rust-dlc?rev=ba68a7bc5db4bdafb24f27fd485507fbf4322f81#ba68a7bc5db4bdafb24f27fd485507fbf4322f81"
 dependencies = [
  "bitcoin",
  "miniscript 8.0.2",
@@ -1208,7 +1208,7 @@ dependencies = [
 [[package]]
 name = "dlc-manager"
 version = "0.4.0"
-source = "git+https://github.com/p2pderivatives/rust-dlc?rev=0786724f947af867d72bd221fa99db492360f936#0786724f947af867d72bd221fa99db492360f936"
+source = "git+https://github.com/p2pderivatives/rust-dlc?rev=ba68a7bc5db4bdafb24f27fd485507fbf4322f81#ba68a7bc5db4bdafb24f27fd485507fbf4322f81"
 dependencies = [
  "async-trait",
  "bitcoin",
@@ -1224,7 +1224,7 @@ dependencies = [
 [[package]]
 name = "dlc-messages"
 version = "0.4.0"
-source = "git+https://github.com/p2pderivatives/rust-dlc?rev=0786724f947af867d72bd221fa99db492360f936#0786724f947af867d72bd221fa99db492360f936"
+source = "git+https://github.com/p2pderivatives/rust-dlc?rev=ba68a7bc5db4bdafb24f27fd485507fbf4322f81#ba68a7bc5db4bdafb24f27fd485507fbf4322f81"
 dependencies = [
  "bitcoin",
  "dlc",
@@ -1237,7 +1237,7 @@ dependencies = [
 [[package]]
 name = "dlc-trie"
 version = "0.4.0"
-source = "git+https://github.com/p2pderivatives/rust-dlc?rev=0786724f947af867d72bd221fa99db492360f936#0786724f947af867d72bd221fa99db492360f936"
+source = "git+https://github.com/p2pderivatives/rust-dlc?rev=ba68a7bc5db4bdafb24f27fd485507fbf4322f81#ba68a7bc5db4bdafb24f27fd485507fbf4322f81"
 dependencies = [
  "bitcoin",
  "dlc",
@@ -2811,7 +2811,7 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 [[package]]
 name = "p2pd-oracle-client"
 version = "0.1.0"
-source = "git+https://github.com/p2pderivatives/rust-dlc?rev=0786724f947af867d72bd221fa99db492360f936#0786724f947af867d72bd221fa99db492360f936"
+source = "git+https://github.com/p2pderivatives/rust-dlc?rev=ba68a7bc5db4bdafb24f27fd485507fbf4322f81#ba68a7bc5db4bdafb24f27fd485507fbf4322f81"
 dependencies = [
  "chrono",
  "dlc-manager",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,11 +24,11 @@ resolver = "2"
 # `p2pderivatives/rust-dlc#feature/ln-dlc-channels`: 4e104b4. This patch ensures backwards
 # compatibility for 10101 through the `rust-lightning:0.0.116` upgrade. We will be able to drop it
 # once all users have been upgraded and traded once.
-dlc-manager = { git = "https://github.com/p2pderivatives/rust-dlc", rev = "0786724f947af867d72bd221fa99db492360f936" }
-dlc-messages = { git = "https://github.com/p2pderivatives/rust-dlc", rev = "0786724f947af867d72bd221fa99db492360f936" }
-dlc = { git = "https://github.com/p2pderivatives/rust-dlc", rev = "0786724f947af867d72bd221fa99db492360f936" }
-p2pd-oracle-client = { git = "https://github.com/p2pderivatives/rust-dlc", rev = "0786724f947af867d72bd221fa99db492360f936" }
-dlc-trie = { git = "https://github.com/p2pderivatives/rust-dlc", rev = "0786724f947af867d72bd221fa99db492360f936" }
+dlc-manager = { git = "https://github.com/p2pderivatives/rust-dlc", rev = "ba68a7bc5db4bdafb24f27fd485507fbf4322f81" }
+dlc-messages = { git = "https://github.com/p2pderivatives/rust-dlc", rev = "ba68a7bc5db4bdafb24f27fd485507fbf4322f81" }
+dlc = { git = "https://github.com/p2pderivatives/rust-dlc", rev = "ba68a7bc5db4bdafb24f27fd485507fbf4322f81" }
+p2pd-oracle-client = { git = "https://github.com/p2pderivatives/rust-dlc", rev = "ba68a7bc5db4bdafb24f27fd485507fbf4322f81" }
+dlc-trie = { git = "https://github.com/p2pderivatives/rust-dlc", rev = "ba68a7bc5db4bdafb24f27fd485507fbf4322f81" }
 
 # We should usually track the `p2pderivatives/split-tx-experiment[-10101]` branch. For now we depend on a special fork which removes a panic in rust-lightning
 lightning = { git = "https://github.com/bonomat/rust-lightning-p2p-derivatives", rev = "e49030e" }

--- a/coordinator/src/dlc_handler.rs
+++ b/coordinator/src/dlc_handler.rs
@@ -103,7 +103,10 @@ impl DlcHandler {
 
         if let Some(SignedChannel {
             channel_id,
-            state: SignedChannelState::CollaborativeCloseOffered { .. },
+            state:
+                SignedChannelState::CollaborativeCloseOffered {
+                    is_offer: false, ..
+                },
             ..
         }) = signed_dlc_channels.iter().find(|c| c.counter_party == peer)
         {

--- a/mobile/native/src/dlc_handler.rs
+++ b/mobile/native/src/dlc_handler.rs
@@ -184,7 +184,10 @@ impl DlcHandler {
                 }
                 SignedChannel {
                     channel_id,
-                    state: SignedChannelState::CollaborativeCloseOffered { .. },
+                    state:
+                        SignedChannelState::CollaborativeCloseOffered {
+                            is_offer: false, ..
+                        },
                     ..
                 } => {
                     tracing::info!("Accepting pending dlc channel close offer.");
@@ -206,6 +209,7 @@ impl DlcHandler {
                         SignedChannelState::Established { .. }
                             | SignedChannelState::Settled { .. }
                             | SignedChannelState::Closing { .. }
+                            | SignedChannelState::CollaborativeCloseOffered { .. }
                     ) {
                         event::publish(&EventInternal::BackgroundNotification(
                             BackgroundTask::RecoverDlc(TaskStatus::Pending),


### PR DESCRIPTION
The `Channel::CollaborativelyCloseOffered` state did not include who offered, so the `on_reconnect` logic incorrectly always tried to accept a collab close offer even if it has been proposed by themselves.

`rust-dlc` does not store that information, so I fix that in https://github.com/p2pderivatives/rust-dlc/commit/ba68a7bc5db4bdafb24f27fd485507fbf4322f81 by adding a `is_offer` flag to the `Channel::CollaborativelyCloseOffered` state. (analog to how it is done on the `Channel::RenewOffered` state)