### PR TITLE
feat: allow to increase the number of addresses to sync for

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - Fix(mobile): Make disclaimer screen usable on smaller devices.
+- Feat(mobile): Allow to manually increase for how many derived addresses to sync for. This might be needed if you recovered a wallet and do not see any on-chain funds.
 
 ## [1.8.6] - 2024-02-08
 

--- a/crates/ln-dlc-node/src/ldk_node_wallet.rs
+++ b/crates/ln-dlc-node/src/ldk_node_wallet.rs
@@ -182,6 +182,10 @@ where
         Ok(self.bdk_lock().get_address(AddressIndex::New)?.address)
     }
 
+    pub(crate) fn update_lookahead(&self, gap: u32) -> Result<bool> {
+        Ok(self.bdk_lock().ensure_addresses_cached(gap)?)
+    }
+
     pub fn is_mine(&self, script: &Script) -> Result<bool> {
         Ok(self.bdk_lock().is_mine(script)?)
     }

--- a/crates/ln-dlc-node/src/ln_dlc_wallet.rs
+++ b/crates/ln-dlc-node/src/ln_dlc_wallet.rs
@@ -122,6 +122,10 @@ impl<S: TenTenOneStorage, N: Storage> LnDlcWallet<S, N> {
         self.address_cache.read().clone()
     }
 
+    pub fn update_lookahead(&self, gap: u32) -> Result<bool> {
+        self.ldk_wallet().update_lookahead(gap)
+    }
+
     pub fn new_address(&self) -> Result<Address> {
         self.ldk_wallet().get_new_address()
     }

--- a/crates/ln-dlc-node/src/node/wallet.rs
+++ b/crates/ln-dlc-node/src/node/wallet.rs
@@ -59,6 +59,12 @@ impl<S: TenTenOneStorage, N: Storage> Node<S, N> {
         self.wallet.unused_address()
     }
 
+    pub fn sync_for_addresses(&self, gap: u32) -> Result<bool> {
+        let new_addresses_generated = self.wallet.update_lookahead(gap)?;
+        self.wallet.sync_and_update_address_cache()?;
+        Ok(new_addresses_generated)
+    }
+
     pub fn get_new_address(&self) -> Result<Address> {
         self.wallet
             .new_address()

--- a/mobile/lib/common/routes.dart
+++ b/mobile/lib/common/routes.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:get_10101/common/global_keys.dart';
 import 'package:get_10101/common/settings/channel_screen.dart';
 import 'package:get_10101/common/settings/emergency_kit_screen.dart';
+import 'package:get_10101/common/settings/wallet_settings.dart';
 import 'package:get_10101/common/status_screen.dart';
 import 'package:get_10101/features/wallet/domain/destination.dart';
 import 'package:get_10101/features/wallet/send/send_onchain_screen.dart';
@@ -99,6 +100,14 @@ GoRouter createRoutes() {
                 parentNavigatorKey: rootNavigatorKey,
                 builder: (BuildContext context, GoRouterState state) {
                   return const SeedScreen();
+                },
+              ),
+              GoRoute(
+                path: WalletSettings.subRouteName,
+                // Use root navigator so the screen overlays the application shell
+                parentNavigatorKey: rootNavigatorKey,
+                builder: (BuildContext context, GoRouterState state) {
+                  return const WalletSettings();
                 },
               ),
               GoRoute(

--- a/mobile/lib/common/settings/settings_screen.dart
+++ b/mobile/lib/common/settings/settings_screen.dart
@@ -12,6 +12,7 @@ import 'package:get_10101/common/settings/emergency_kit_screen.dart';
 import 'package:get_10101/common/settings/force_close_screen.dart';
 import 'package:get_10101/common/settings/open_telegram.dart';
 import 'package:get_10101/common/settings/share_logs_screen.dart';
+import 'package:get_10101/common/settings/wallet_settings.dart';
 import 'package:get_10101/common/snack_bar.dart';
 import 'package:get_10101/common/status_screen.dart';
 import 'package:get_10101/common/settings/seed_screen.dart';
@@ -165,7 +166,17 @@ class _SettingsScreenState extends State<SettingsScreen> {
                               SettingsClickable(
                                   icon: Icons.backup_outlined,
                                   title: "Backup",
-                                  callBackFunc: () => GoRouter.of(context).push(SeedScreen.route))
+                                  callBackFunc: () => GoRouter.of(context).push(SeedScreen.route)),
+                              const Divider(
+                                height: 0.5,
+                                thickness: 0.8,
+                                indent: 55,
+                              ),
+                              SettingsClickable(
+                                  icon: Icons.wallet_outlined,
+                                  title: "Wallet Settings",
+                                  callBackFunc: () =>
+                                      GoRouter.of(context).push(WalletSettings.route))
                             ],
                           ),
                         )

--- a/mobile/lib/common/settings/wallet_settings.dart
+++ b/mobile/lib/common/settings/wallet_settings.dart
@@ -1,0 +1,139 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:get_10101/common/settings/settings_screen.dart';
+import 'package:get_10101/common/snack_bar.dart';
+import 'package:get_10101/logger/logger.dart';
+import 'package:go_router/go_router.dart';
+import 'package:get_10101/ffi.dart' as rust;
+
+class WalletSettings extends StatefulWidget {
+  static const route = "${SettingsScreen.route}/$subRouteName";
+  static const subRouteName = "walletSettings";
+
+  const WalletSettings({super.key});
+
+  @override
+  State<WalletSettings> createState() => _WalletSettingsState();
+}
+
+class _WalletSettingsState extends State<WalletSettings> {
+  var lookAheadController = TextEditingController();
+  var syncing = false;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: SafeArea(
+          child: Padding(
+        padding: const EdgeInsets.only(top: 20, left: 10, right: 10),
+        child: Column(
+          children: [
+            Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                Expanded(
+                  child: Stack(
+                    children: [
+                      GestureDetector(
+                        child: Container(
+                            alignment: AlignmentDirectional.topStart,
+                            decoration: BoxDecoration(
+                                color: Colors.transparent, borderRadius: BorderRadius.circular(10)),
+                            width: 70,
+                            child: const Icon(
+                              Icons.arrow_back_ios_new_rounded,
+                              size: 22,
+                            )),
+                        onTap: () {
+                          GoRouter.of(context).pop();
+                        },
+                      ),
+                      const Row(
+                        mainAxisAlignment: MainAxisAlignment.center,
+                        children: [
+                          Text(
+                            "Wallet Settings",
+                            style: TextStyle(fontWeight: FontWeight.w500, fontSize: 20),
+                          ),
+                        ],
+                      ),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(
+              height: 20,
+            ),
+            Expanded(
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.start,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  const Text(
+                    "The amount of addresses to sync for (at least). Once you confirm, a full wallet sync will be performed. The higher the gap is, the longer the sync will take. Hence, we recommend syncing incrementally.",
+                    style: TextStyle(fontSize: 18),
+                  ),
+                  Padding(
+                    padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 16),
+                    child: Stack(
+                      alignment: Alignment.centerRight,
+                      children: [
+                        TextFormField(
+                          inputFormatters: <TextInputFormatter>[
+                            FilteringTextInputFormatter.digitsOnly
+                          ],
+                          keyboardType: TextInputType.number,
+                          controller: lookAheadController,
+                          decoration: const InputDecoration(
+                            border: UnderlineInputBorder(),
+                            labelText: 'Wallet Gap',
+                          ),
+                        ),
+                        Visibility(
+                            visible: !syncing,
+                            replacement: const CircularProgressIndicator(),
+                            child: IconButton(
+                              icon: const Icon(
+                                Icons.check,
+                                color: Colors.green,
+                              ),
+                              onPressed: () async {
+                                final messenger = ScaffoldMessenger.of(context);
+                                try {
+                                  var gap = lookAheadController.value.text;
+                                  var gapAsNumber = int.parse(gap);
+
+                                  setState(() {
+                                    syncing = true;
+                                  });
+
+                                  await rust.api.syncForAddresses(gap: gapAsNumber);
+                                  showSnackBar(messenger, "Successfully synced for new gap.");
+
+                                  setState(() {
+                                    syncing = false;
+                                  });
+                                } catch (exception) {
+                                  logger.e("Failed to sync for addresses $exception");
+                                  showSnackBar(
+                                      messenger, "Error when syncing for new addresses $exception");
+                                } finally {
+                                  setState(() {
+                                    syncing = false;
+                                  });
+                                }
+                              },
+                            ))
+                      ],
+                    ),
+                  )
+                ],
+              ),
+            ),
+          ],
+        ),
+      )),
+    );
+  }
+}

--- a/mobile/native/src/api.rs
+++ b/mobile/native/src/api.rs
@@ -825,3 +825,7 @@ pub fn delete_dlc_channel(dlc_channel_id: String) -> Result<()> {
     let dlc_channel_id = DlcChannelId::from_hex(dlc_channel_id)?;
     ln_dlc::delete_dlc_channel(&dlc_channel_id)
 }
+
+pub fn sync_for_addresses(gap: u32) -> Result<bool> {
+    ln_dlc::sync_for_addresses(gap)
+}

--- a/mobile/native/src/ln_dlc/mod.rs
+++ b/mobile/native/src/ln_dlc/mod.rs
@@ -1539,3 +1539,7 @@ fn ln_dlc_node_settings() -> LnDlcNodeSettings {
         gossip_source_config,
     }
 }
+
+pub(crate) fn sync_for_addresses(gap: u32) -> Result<bool> {
+    state::get_node().inner.sync_for_addresses(gap)
+}


### PR DESCRIPTION
I've decided against putting it into the recovery screen as the recommendation should be to increase this number incrementally. The reason is, the higher they gap, the slower the sync. 
If this setting would have been only available on the recover screen, a user might need to reset the app again to sync again, hence, it is kinda required to be used from a fully setup app. 
I've created a new category in the settings screen, which can come handy in the future, e.g. edit the esplora endpoint.

This fixes a problem where we don't see money in the wallet after recovering the wallet.

https://github.com/get10101/10101/assets/224613/10dc53a7-45cc-4537-a707-5ca83077986c


