### PR TITLE
chore: Disable force close timed out dlc channels

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -804,7 +804,7 @@ dependencies = [
 
 [[package]]
 name = "coordinator"
-version = "1.8.6"
+version = "1.8.7"
 dependencies = [
  "anyhow",
  "atty",
@@ -1196,7 +1196,7 @@ dependencies = [
 [[package]]
 name = "dlc"
 version = "0.4.0"
-source = "git+https://github.com/p2pderivatives/rust-dlc?rev=ba68a7bc5db4bdafb24f27fd485507fbf4322f81#ba68a7bc5db4bdafb24f27fd485507fbf4322f81"
+source = "git+https://github.com/p2pderivatives/rust-dlc?rev=7ce29115150586034b17aa0204f880b2ebd7f53a#7ce29115150586034b17aa0204f880b2ebd7f53a"
 dependencies = [
  "bitcoin",
  "miniscript 8.0.2",
@@ -1208,7 +1208,7 @@ dependencies = [
 [[package]]
 name = "dlc-manager"
 version = "0.4.0"
-source = "git+https://github.com/p2pderivatives/rust-dlc?rev=ba68a7bc5db4bdafb24f27fd485507fbf4322f81#ba68a7bc5db4bdafb24f27fd485507fbf4322f81"
+source = "git+https://github.com/p2pderivatives/rust-dlc?rev=7ce29115150586034b17aa0204f880b2ebd7f53a#7ce29115150586034b17aa0204f880b2ebd7f53a"
 dependencies = [
  "async-trait",
  "bitcoin",
@@ -1224,7 +1224,7 @@ dependencies = [
 [[package]]
 name = "dlc-messages"
 version = "0.4.0"
-source = "git+https://github.com/p2pderivatives/rust-dlc?rev=ba68a7bc5db4bdafb24f27fd485507fbf4322f81#ba68a7bc5db4bdafb24f27fd485507fbf4322f81"
+source = "git+https://github.com/p2pderivatives/rust-dlc?rev=7ce29115150586034b17aa0204f880b2ebd7f53a#7ce29115150586034b17aa0204f880b2ebd7f53a"
 dependencies = [
  "bitcoin",
  "dlc",
@@ -1237,7 +1237,7 @@ dependencies = [
 [[package]]
 name = "dlc-trie"
 version = "0.4.0"
-source = "git+https://github.com/p2pderivatives/rust-dlc?rev=ba68a7bc5db4bdafb24f27fd485507fbf4322f81#ba68a7bc5db4bdafb24f27fd485507fbf4322f81"
+source = "git+https://github.com/p2pderivatives/rust-dlc?rev=7ce29115150586034b17aa0204f880b2ebd7f53a#7ce29115150586034b17aa0204f880b2ebd7f53a"
 dependencies = [
  "bitcoin",
  "dlc",
@@ -2811,7 +2811,7 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 [[package]]
 name = "p2pd-oracle-client"
 version = "0.1.0"
-source = "git+https://github.com/p2pderivatives/rust-dlc?rev=ba68a7bc5db4bdafb24f27fd485507fbf4322f81#ba68a7bc5db4bdafb24f27fd485507fbf4322f81"
+source = "git+https://github.com/p2pderivatives/rust-dlc?rev=7ce29115150586034b17aa0204f880b2ebd7f53a#7ce29115150586034b17aa0204f880b2ebd7f53a"
 dependencies = [
  "chrono",
  "dlc-manager",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,11 +24,11 @@ resolver = "2"
 # `p2pderivatives/rust-dlc#feature/ln-dlc-channels`: 4e104b4. This patch ensures backwards
 # compatibility for 10101 through the `rust-lightning:0.0.116` upgrade. We will be able to drop it
 # once all users have been upgraded and traded once.
-dlc-manager = { git = "https://github.com/p2pderivatives/rust-dlc", rev = "ba68a7bc5db4bdafb24f27fd485507fbf4322f81" }
-dlc-messages = { git = "https://github.com/p2pderivatives/rust-dlc", rev = "ba68a7bc5db4bdafb24f27fd485507fbf4322f81" }
-dlc = { git = "https://github.com/p2pderivatives/rust-dlc", rev = "ba68a7bc5db4bdafb24f27fd485507fbf4322f81" }
-p2pd-oracle-client = { git = "https://github.com/p2pderivatives/rust-dlc", rev = "ba68a7bc5db4bdafb24f27fd485507fbf4322f81" }
-dlc-trie = { git = "https://github.com/p2pderivatives/rust-dlc", rev = "ba68a7bc5db4bdafb24f27fd485507fbf4322f81" }
+dlc-manager = { git = "https://github.com/p2pderivatives/rust-dlc", rev = "7ce29115150586034b17aa0204f880b2ebd7f53a" }
+dlc-messages = { git = "https://github.com/p2pderivatives/rust-dlc", rev = "7ce29115150586034b17aa0204f880b2ebd7f53a" }
+dlc = { git = "https://github.com/p2pderivatives/rust-dlc", rev = "7ce29115150586034b17aa0204f880b2ebd7f53a" }
+p2pd-oracle-client = { git = "https://github.com/p2pderivatives/rust-dlc", rev = "7ce29115150586034b17aa0204f880b2ebd7f53a" }
+dlc-trie = { git = "https://github.com/p2pderivatives/rust-dlc", rev = "7ce29115150586034b17aa0204f880b2ebd7f53a" }
 
 # We should usually track the `p2pderivatives/split-tx-experiment[-10101]` branch. For now we depend on a special fork which removes a panic in rust-lightning
 lightning = { git = "https://github.com/bonomat/rust-lightning-p2p-derivatives", rev = "e49030e" }


### PR DESCRIPTION
While in beta we don't want to automatically force close a dlc channel if timed out.

https://github.com/p2pderivatives/rust-dlc/commit/7ce29115150586034b17aa0204f880b2ebd7f53a