### PR TITLE
feat: finetune leader board

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Feat(mobile): Let user add a name to their profile for the leaderboard
+
 ## [1.8.7] - 2024-02-10
 
 - Fix(mobile): Make disclaimer screen usable on smaller devices.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - Feat(mobile): Let user add a name to their profile for the leaderboard
+- Feat(coordinator): Allow to specify time range for leadership board
 
 ## [1.8.7] - 2024-02-10
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,6 +77,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2969dcb958b36655471fc61f7e416fa76033bdd4bfed0678d8fee1e2d07a1f0"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "allo-isolate"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -109,10 +118,58 @@ dependencies = [
 ]
 
 [[package]]
-name = "anyhow"
-version = "1.0.71"
+name = "anstream"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c7d0618f0e0b7e8ff11427422b64564d5fb0be1940354bfe2e0529b18a9d9b8"
+checksum = "6e2e1ebcb11de5c03c67de28a7df593d32191b44939c482e97702baaaa6ab6a5"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8901269c6307e8d93993578286ac0edf7f195079ffff5ebdeea6a59ffb7e36bc"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c75ac65da39e5fe5ab759307499ddad880d724eed2f6ce5b5e8a26f4f387928c"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e28923312444cdd728e4738b3f9c9cac739500909bb3d3c94b43551b16517648"
+dependencies = [
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cd54b81ec8d6180e24654d0b371ad22fc3dd083b6ff8ba325b72e00c87660a7"
+dependencies = [
+ "anstyle",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "anyhow"
+version = "1.0.79"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "080e9890a082662b09c1ad45f567faeeb47f22b5fb23895fbe1e651e718e25ca"
 dependencies = [
  "backtrace",
 ]
@@ -679,24 +736,48 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.1.6"
+version = "3.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0b0588d44d4d63a87dbd75c136c166bbfd9a86a31cb89e09906521c7d3f5e3"
+checksum = "4ea181bf566f71cb9a5d17a59e1871af638180a18fb0035c92ae62b705207123"
 dependencies = [
+ "atty",
  "bitflags 1.3.2",
- "clap_derive",
- "clap_lex",
- "is-terminal",
+ "clap_derive 3.2.25",
+ "clap_lex 0.2.4",
+ "indexmap 1.9.2",
  "once_cell",
- "strsim",
+ "strsim 0.10.0",
  "termcolor",
+ "textwrap",
+]
+
+[[package]]
+name = "clap"
+version = "4.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80c21025abd42669a92efc996ef13cfb2c5c627858421ea58d5c3b331a6c134f"
+dependencies = [
+ "clap_builder",
+ "clap_derive 4.5.0",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "458bf1f341769dfcf849846f65dffdf9146daa56bcd2a47cb4e1de9915567c99"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex 0.7.0",
+ "strsim 0.11.0",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "4.1.0"
+version = "3.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "684a277d672e91966334af371f1a7b5833f9aa00b07c84e92fbce95e00208ce8"
+checksum = "ae6371b8bdc8b7d3959e9cf7b22d4435ef3e79e138688421ec654acf8c81b008"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -706,13 +787,31 @@ dependencies = [
 ]
 
 [[package]]
-name = "clap_lex"
-version = "0.3.2"
+name = "clap_derive"
+version = "4.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "350b9cf31731f9957399229e9b2adc51eeabdfbe9d71d9a0552275fd12710d09"
+checksum = "307bc0538d5f0f83b8248db3087aa92fe504e4691294d0c96c0eabc33f47ba47"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
 dependencies = [
  "os_str_bytes",
 ]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
 
 [[package]]
 name = "codespan-reporting"
@@ -723,6 +822,12 @@ dependencies = [
  "termcolor",
  "unicode-width",
 ]
+
+[[package]]
+name = "colorchoice"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "commons"
@@ -811,7 +916,7 @@ dependencies = [
  "axum 0.6.20",
  "bdk",
  "bitcoin",
- "clap",
+ "clap 4.5.0",
  "commons",
  "console-subscriber",
  "diesel",
@@ -1056,7 +1161,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim",
+ "strsim 0.10.0",
  "syn 1.0.109",
 ]
 
@@ -1070,7 +1175,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim",
+ "strsim 0.10.0",
  "syn 2.0.48",
 ]
 
@@ -1436,7 +1541,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bitcoin",
- "clap",
+ "clap 4.5.0",
  "commons",
  "reqwest",
  "serde",
@@ -2022,18 +2127,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "is-terminal"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b6b32576413a8e69b90e952e4a026476040d81017b80445deda5f2d3921857"
-dependencies = [
- "hermit-abi 0.3.1",
- "io-lifetimes",
- "rustix 0.36.17",
- "windows-sys 0.45.0",
-]
-
-[[package]]
 name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2170,12 +2263,6 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
-
-[[package]]
-name = "linux-raw-sys"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
@@ -2270,12 +2357,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.17"
+version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
-dependencies = [
- "cfg-if",
-]
+checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
 name = "loom"
@@ -2305,7 +2389,7 @@ dependencies = [
  "bitcoin",
  "bitmex-client",
  "bitmex-stream",
- "clap",
+ "clap 4.5.0",
  "commons",
  "diesel",
  "diesel_migrations",
@@ -2343,7 +2427,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
 dependencies = [
- "regex-automata",
+ "regex-automata 0.1.10",
 ]
 
 [[package]]
@@ -2354,9 +2438,9 @@ checksum = "b87248edafb776e59e6ee64a79086f65890d3510f2c656c000bf2a7e8a0aea40"
 
 [[package]]
 name = "memchr"
-version = "2.5.0"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
 
 [[package]]
 name = "memoffset"
@@ -2525,6 +2609,7 @@ dependencies = [
  "openssl",
  "orderbook-client",
  "parking_lot 0.12.1",
+ "petname",
  "reqwest",
  "rusqlite",
  "rust_decimal",
@@ -2798,9 +2883,9 @@ dependencies = [
 
 [[package]]
 name = "os_str_bytes"
-version = "6.4.1"
+version = "6.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b7820b9daea5457c9f21c69448905d723fbd21136ccf521748f23fd49e723ee"
+checksum = "e2355d85b9a3786f481747ced0e0ff2ba35213a1f9bd406ed906554d7af805a1"
 
 [[package]]
 name = "overload"
@@ -2898,6 +2983,17 @@ name = "percent-encoding-rfc3986"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3637c05577168127568a64e9dc5a6887da720efef07b3d9472d45f63ab191166"
+
+[[package]]
+name = "petname"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fce4164d60963550beb856b011fdf32b03b0e8bc0c3fce023c7b0ccecddf7950"
+dependencies = [
+ "clap 3.2.25",
+ "itertools",
+ "rand",
+]
 
 [[package]]
 name = "pin-project"
@@ -3190,11 +3286,14 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.7.1"
+version = "1.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48aaa5748ba571fb95cd2c85c09f629215d3a6ece942baa100950af03a34f733"
+checksum = "b62dbe01f0b06f9d8dc7d49e05a0785f153b00b2c227856282f671e0318c9b15"
 dependencies = [
- "regex-syntax 0.6.28",
+ "aho-corasick",
+ "memchr",
+ "regex-automata 0.4.5",
+ "regex-syntax 0.8.2",
 ]
 
 [[package]]
@@ -3204,6 +3303,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
 dependencies = [
  "regex-syntax 0.6.28",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5bb987efffd3c6d0d8f5f89510bb458559eab11e4f869acb20bf845e016259cd"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax 0.8.2",
 ]
 
 [[package]]
@@ -3217,6 +3327,12 @@ name = "regex-syntax"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
 name = "rend"
@@ -3421,20 +3537,6 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.36.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "305efbd14fde4139eb501df5f136994bb520b033fa9fbdce287507dc23b8c7ed"
-dependencies = [
- "bitflags 1.3.2",
- "errno",
- "io-lifetimes",
- "libc",
- "linux-raw-sys 0.1.4",
- "windows-sys 0.45.0",
-]
-
-[[package]]
-name = "rustix"
 version = "0.37.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b96e891d04aa506a6d1f318d2771bcb1c7dfda84e126660ace067c9b474bb2c0"
@@ -3443,7 +3545,7 @@ dependencies = [
  "errno",
  "io-lifetimes",
  "libc",
- "linux-raw-sys 0.3.8",
+ "linux-raw-sys",
  "windows-sys 0.48.0",
 ]
 
@@ -3896,6 +3998,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
+name = "strsim"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ee073c9e4cd00e28217186dbe12796d692868f432bf2e97ee73bed0c56dfa01"
+
+[[package]]
 name = "subtle"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3939,7 +4047,7 @@ dependencies = [
  "cfg-if",
  "fastrand",
  "redox_syscall 0.3.5",
- "rustix 0.37.20",
+ "rustix",
  "windows-sys 0.48.0",
 ]
 
@@ -3976,7 +4084,7 @@ dependencies = [
  "anyhow",
  "assertables",
  "bitcoin",
- "clap",
+ "clap 4.5.0",
  "commons",
  "coordinator",
  "flutter_rust_bridge",
@@ -3998,6 +4106,12 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
 ]
+
+[[package]]
+name = "textwrap"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
 
 [[package]]
 name = "thiserror"
@@ -4638,6 +4752,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
+name = "utf8parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+
+[[package]]
 name = "uuid"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4811,7 +4931,7 @@ dependencies = [
  "axum 0.7.4",
  "axum-login",
  "bitcoin",
- "clap",
+ "clap 4.5.0",
  "commons",
  "console-subscriber",
  "hyper 1.1.0",
@@ -4920,6 +5040,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.0",
+]
+
+[[package]]
 name = "windows-targets"
 version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4950,6 +5079,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-targets"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a18201040b24831fbb9e4eb208f8892e1f50a37feb53cc7ff887feb8f50e7cd"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.0",
+ "windows_aarch64_msvc 0.52.0",
+ "windows_i686_gnu 0.52.0",
+ "windows_i686_msvc 0.52.0",
+ "windows_x86_64_gnu 0.52.0",
+ "windows_x86_64_gnullvm 0.52.0",
+ "windows_x86_64_msvc 0.52.0",
+]
+
+[[package]]
 name = "windows_aarch64_gnullvm"
 version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4960,6 +5104,12 @@ name = "windows_aarch64_gnullvm"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7764e35d4db8a7921e09562a0304bf2f93e0a51bfccee0bd0bb0b666b015ea"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -4974,6 +5124,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
 
 [[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbaa0368d4f1d2aaefc55b6fcfee13f41544ddf36801e793edbbfd7d7df075ef"
+
+[[package]]
 name = "windows_i686_gnu"
 version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4984,6 +5140,12 @@ name = "windows_i686_gnu"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28637cb1fa3560a16915793afb20081aba2c92ee8af57b4d5f28e4b3e7df313"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -4998,6 +5160,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffe5e8e31046ce6230cc7215707b816e339ff4d4d67c65dffa206fd0f7aa7b9a"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5008,6 +5176,12 @@ name = "windows_x86_64_gnu"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d6fa32db2bc4a2f5abeacf2b69f7992cd09dca97498da74a151a3132c26befd"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -5022,6 +5196,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a657e1e9d3f514745a572a6846d3c7aa7dbe1658c056ed9c3344c4109a6949e"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5032,6 +5212,12 @@ name = "windows_x86_64_msvc"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
 
 [[package]]
 name = "winnow"

--- a/coordinator/migrations/2024-02-09-152833_add_nickname_to_user_table/down.sql
+++ b/coordinator/migrations/2024-02-09-152833_add_nickname_to_user_table/down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE
+    users DROP COLUMN nickname;

--- a/coordinator/migrations/2024-02-09-152833_add_nickname_to_user_table/up.sql
+++ b/coordinator/migrations/2024-02-09-152833_add_nickname_to_user_table/up.sql
@@ -1,2 +1,2 @@
 ALTER TABLE
-    users ADD COLUMN nickname TEXT NOT NULL DEFAULT '';
+    users ADD COLUMN nickname TEXT;

--- a/coordinator/migrations/2024-02-09-152833_add_nickname_to_user_table/up.sql
+++ b/coordinator/migrations/2024-02-09-152833_add_nickname_to_user_table/up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE
+    users ADD COLUMN nickname TEXT NOT NULL DEFAULT '';

--- a/coordinator/src/db/positions.rs
+++ b/coordinator/src/db/positions.rs
@@ -97,6 +97,7 @@ impl Position {
 
         Ok(positions)
     }
+
     pub fn get_all_closed_positions(
         conn: &mut PgConnection,
     ) -> QueryResult<Vec<crate::position::models::Position>> {

--- a/coordinator/src/db/user.rs
+++ b/coordinator/src/db/user.rs
@@ -19,7 +19,7 @@ pub struct User {
     pub timestamp: OffsetDateTime,
     pub fcm_token: String,
     pub last_login: OffsetDateTime,
-    pub nickname: String,
+    pub nickname: Option<String>,
 }
 
 impl From<RegisterParams> for User {
@@ -28,7 +28,7 @@ impl From<RegisterParams> for User {
             id: None,
             pubkey: value.pubkey.to_string(),
             contact: value.contact.unwrap_or("".to_owned()),
-            nickname: value.nickname.unwrap_or("".to_owned()),
+            nickname: value.nickname,
             timestamp: OffsetDateTime::now_utc(),
             fcm_token: "".to_owned(),
             last_login: OffsetDateTime::now_utc(),
@@ -56,7 +56,6 @@ pub fn upsert_user(
 ) -> QueryResult<User> {
     // If no name or contact has been provided we default to empty string
     let contact = contact.unwrap_or_default();
-    let nickname = nickname.unwrap_or_default();
 
     let timestamp = OffsetDateTime::now_utc();
 
@@ -112,7 +111,7 @@ pub fn login_user(conn: &mut PgConnection, trader_id: PublicKey, token: String) 
             id: None,
             pubkey: trader_id.to_string(),
             contact: "".to_owned(),
-            nickname: "".to_string(),
+            nickname: None,
             timestamp: OffsetDateTime::now_utc(),
             fcm_token: token.clone(),
             last_login,

--- a/coordinator/src/db/user.rs
+++ b/coordinator/src/db/user.rs
@@ -19,6 +19,7 @@ pub struct User {
     pub timestamp: OffsetDateTime,
     pub fcm_token: String,
     pub last_login: OffsetDateTime,
+    pub nickname: String,
 }
 
 impl From<RegisterParams> for User {
@@ -27,6 +28,7 @@ impl From<RegisterParams> for User {
             id: None,
             pubkey: value.pubkey.to_string(),
             contact: value.contact.unwrap_or("".to_owned()),
+            nickname: value.nickname.unwrap_or("".to_owned()),
             timestamp: OffsetDateTime::now_utc(),
             fcm_token: "".to_owned(),
             last_login: OffsetDateTime::now_utc(),
@@ -49,8 +51,13 @@ pub fn by_id(conn: &mut PgConnection, id: String) -> QueryResult<Option<User>> {
 pub fn upsert_user(
     conn: &mut PgConnection,
     trader_id: PublicKey,
-    contact: String,
+    contact: Option<String>,
+    nickname: Option<String>,
 ) -> QueryResult<User> {
+    // If no name or contact has been provided we default to empty string
+    let contact = contact.unwrap_or_default();
+    let nickname = nickname.unwrap_or_default();
+
     let timestamp = OffsetDateTime::now_utc();
 
     let user: User = diesel::insert_into(users::table)
@@ -58,15 +65,43 @@ pub fn upsert_user(
             id: None,
             pubkey: trader_id.to_string(),
             contact: contact.clone(),
+            nickname: nickname.clone(),
             timestamp,
             fcm_token: "".to_owned(),
             last_login: timestamp,
         })
         .on_conflict(schema::users::pubkey)
         .do_update()
-        .set((users::contact.eq(&contact), users::last_login.eq(timestamp)))
+        .set((
+            users::contact.eq(&contact),
+            users::nickname.eq(&nickname),
+            users::last_login.eq(timestamp),
+        ))
         .get_result(conn)?;
     Ok(user)
+}
+
+pub fn update_nickname(
+    conn: &mut PgConnection,
+    trader_id: PublicKey,
+    nickname: Option<String>,
+) -> QueryResult<()> {
+    let nickname = nickname.unwrap_or_default();
+
+    let updated_rows = diesel::update(users::table)
+        .filter(users::pubkey.eq(trader_id.to_string()))
+        .set(users::nickname.eq(nickname.clone()))
+        .execute(conn)?;
+
+    if updated_rows == 0 {
+        tracing::warn!(
+            trader_id = trader_id.to_string(),
+            nickname,
+            "No username updated"
+        )
+    }
+
+    Ok(())
 }
 
 pub fn login_user(conn: &mut PgConnection, trader_id: PublicKey, token: String) -> Result<()> {
@@ -77,6 +112,7 @@ pub fn login_user(conn: &mut PgConnection, trader_id: PublicKey, token: String) 
             id: None,
             pubkey: trader_id.to_string(),
             contact: "".to_owned(),
+            nickname: "".to_string(),
             timestamp: OffsetDateTime::now_utc(),
             fcm_token: token.clone(),
             last_login,

--- a/coordinator/src/leaderboard.rs
+++ b/coordinator/src/leaderboard.rs
@@ -63,7 +63,7 @@ pub(crate) fn generate_leader_board(
         .map(|entry| {
             let nickname = db::user::get_user(conn, entry.trader).unwrap_or_default();
             LeaderBoardEntry {
-                nickname: nickname.map(|user| user.nickname).unwrap_or_default(),
+                nickname: nickname.and_then(|user| user.nickname).unwrap_or_default(),
                 ..entry
             }
         })

--- a/coordinator/src/leaderboard.rs
+++ b/coordinator/src/leaderboard.rs
@@ -10,15 +10,17 @@ use rust_decimal::Decimal;
 use serde::Deserialize;
 use serde::Serialize;
 use std::collections::HashMap;
+use time::OffsetDateTime;
 
 #[derive(Serialize)]
 pub struct LeaderBoard {
     pub(crate) entries: Vec<LeaderBoardEntry>,
 }
 
-#[derive(Serialize, Clone, Copy)]
+#[derive(Serialize, Clone)]
 pub struct LeaderBoardEntry {
     pub trader: PublicKey,
+    pub nickname: String,
     pub pnl: Decimal,
     pub volume: Decimal,
     pub rank: usize,
@@ -29,6 +31,8 @@ pub struct LeaderBoardQueryParams {
     pub(crate) top: Option<usize>,
     pub(crate) reverse: Option<bool>,
     pub(crate) category: Option<LeaderBoardCategory>,
+    pub(crate) start: Option<String>,
+    pub(crate) end: Option<String>,
 }
 
 #[derive(Debug, Deserialize, Clone)]
@@ -48,10 +52,22 @@ pub(crate) fn generate_leader_board(
     top: usize,
     category: LeaderBoardCategory,
     reverse: bool,
+    start: OffsetDateTime,
+    end: OffsetDateTime,
 ) -> Result<Vec<LeaderBoardEntry>> {
-    let positions = load_positions(conn)?;
+    let positions = load_positions(conn, start, end)?;
 
     let leader_board = sort_leader_board(top, category, reverse, positions);
+    let leader_board = leader_board
+        .into_iter()
+        .map(|entry| {
+            let nickname = db::user::get_user(conn, entry.trader).unwrap_or_default();
+            LeaderBoardEntry {
+                nickname: nickname.map(|user| user.nickname).unwrap_or_default(),
+                ..entry
+            }
+        })
+        .collect();
 
     Ok(leader_board)
 }
@@ -64,18 +80,21 @@ fn sort_leader_board(
 ) -> Vec<LeaderBoardEntry> {
     let mut leader_board = positions
         .into_iter()
-        .map(|(trader, positions)| LeaderBoardEntry {
-            trader,
-            pnl: positions
-                .iter()
-                .map(|p| Decimal::from(p.trader_realized_pnl_sat.unwrap_or_default()))
-                .sum(),
-            volume: positions
-                .iter()
-                .map(|p| Decimal::from_f32(p.quantity).expect("to fit into decimal"))
-                .sum(),
-            // default all ranks are 0, this will be filled later
-            rank: 0,
+        .map(|(trader, positions)| {
+            LeaderBoardEntry {
+                trader,
+                nickname: "".to_string(),
+                pnl: positions
+                    .iter()
+                    .map(|p| Decimal::from(p.trader_realized_pnl_sat.unwrap_or_default()))
+                    .sum(),
+                volume: positions
+                    .iter()
+                    .map(|p| Decimal::from_f32(p.quantity).expect("to fit into decimal"))
+                    .sum(),
+                // default all ranks are 0, this will be filled later
+                rank: 0,
+            }
         })
         .collect::<Vec<LeaderBoardEntry>>();
 
@@ -109,8 +128,14 @@ fn sort_leader_board(
 
 fn load_positions(
     conn: &mut PooledConnection<ConnectionManager<PgConnection>>,
+    start: OffsetDateTime,
+    end: OffsetDateTime,
 ) -> Result<HashMap<PublicKey, Vec<Position>>> {
     let positions = db::positions::Position::get_all_closed_positions(conn)?;
+    let positions = positions
+        .into_iter()
+        .filter(|pos| pos.creation_timestamp > start && pos.creation_timestamp < end)
+        .collect::<Vec<_>>();
 
     let mut positions_by_trader = HashMap::new();
 

--- a/coordinator/src/orderbook/tests/registration_test.rs
+++ b/coordinator/src/orderbook/tests/registration_test.rs
@@ -20,9 +20,16 @@ async fn registered_user_is_stored_in_db() {
 
     let dummy_pubkey = dummy_public_key();
     let dummy_email = "dummy@user.com".to_string();
+    let nickname = "dummy_user".to_string();
     let fcm_token = "just_a_token".to_string();
 
-    let user = user::upsert_user(&mut conn, dummy_pubkey, dummy_email.clone()).unwrap();
+    let user = user::upsert_user(
+        &mut conn,
+        dummy_pubkey,
+        Some(dummy_email.clone()),
+        Some(nickname.clone()),
+    )
+    .unwrap();
     assert!(user.id.is_some(), "Id should be filled in by diesel");
     user::login_user(&mut conn, dummy_pubkey, fcm_token.clone()).unwrap();
 
@@ -31,6 +38,7 @@ async fn registered_user_is_stored_in_db() {
     // We started without the id, so we can't compare the whole user.
     assert_eq!(users.first().unwrap().pubkey, dummy_pubkey.to_string());
     assert_eq!(users.first().unwrap().contact, dummy_email);
+    assert_eq!(users.first().unwrap().nickname, nickname);
     assert_eq!(users.first().unwrap().fcm_token, fcm_token);
 }
 

--- a/coordinator/src/orderbook/tests/registration_test.rs
+++ b/coordinator/src/orderbook/tests/registration_test.rs
@@ -20,14 +20,14 @@ async fn registered_user_is_stored_in_db() {
 
     let dummy_pubkey = dummy_public_key();
     let dummy_email = "dummy@user.com".to_string();
-    let nickname = "dummy_user".to_string();
+    let nickname = Some("dummy_user".to_string());
     let fcm_token = "just_a_token".to_string();
 
     let user = user::upsert_user(
         &mut conn,
         dummy_pubkey,
         Some(dummy_email.clone()),
-        Some(nickname.clone()),
+        nickname.clone(),
     )
     .unwrap();
     assert!(user.id.is_some(), "Id should be filled in by diesel");

--- a/coordinator/src/orderbook/trading.rs
+++ b/coordinator/src/orderbook/trading.rs
@@ -127,7 +127,7 @@ pub async fn process_new_order(
     network: Network,
     oracle_pk: XOnlyPublicKey,
 ) -> Result<Order> {
-    tracing::info!(
+    tracing::trace!(
         trader_id = %new_order.trader_id,
         order_type = ?new_order.order_type,
         "Processing new order",

--- a/coordinator/src/routes.rs
+++ b/coordinator/src/routes.rs
@@ -487,7 +487,7 @@ impl TryFrom<User> for commons::User {
                 AppError::InternalServerError("Could not parse user pubkey".to_string())
             })?,
             contact: Some(value.contact).filter(|s| !s.is_empty()),
-            nickname: Some(value.nickname).filter(|s| !s.is_empty()),
+            nickname: value.nickname,
         })
     }
 }

--- a/coordinator/src/schema.rs
+++ b/coordinator/src/schema.rs
@@ -332,7 +332,7 @@ diesel::table! {
         timestamp -> Timestamptz,
         fcm_token -> Text,
         last_login -> Timestamptz,
-        nickname -> Text,
+        nickname -> Nullable<Text>,
     }
 }
 

--- a/coordinator/src/schema.rs
+++ b/coordinator/src/schema.rs
@@ -332,6 +332,7 @@ diesel::table! {
         timestamp -> Timestamptz,
         fcm_token -> Text,
         last_login -> Timestamptz,
+        nickname -> Text,
     }
 }
 

--- a/crates/commons/src/lib.rs
+++ b/crates/commons/src/lib.rs
@@ -38,10 +38,19 @@ pub const AUTH_SIGN_MESSAGE: &[u8; 19] = b"Hello it's me Mario";
 pub struct RegisterParams {
     pub pubkey: PublicKey,
     pub contact: Option<String>,
+    pub nickname: Option<String>,
+}
+
+/// Registration details for enrolling into the beta program
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UpdateUsernameParams {
+    pub pubkey: PublicKey,
+    pub nickname: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct User {
     pub pubkey: PublicKey,
     pub contact: Option<String>,
+    pub nickname: Option<String>,
 }

--- a/mobile/lib/common/settings/user_screen.dart
+++ b/mobile/lib/common/settings/user_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:get_10101/common/color.dart';
 import 'package:get_10101/common/settings/settings_screen.dart';
 import 'package:get_10101/common/snack_bar.dart';
 import 'package:go_router/go_router.dart';
@@ -15,17 +16,6 @@ class UserSettings extends StatefulWidget {
 }
 
 class _UserSettingsState extends State<UserSettings> {
-  var contactFieldController = TextEditingController();
-  bool contactFieldEnabled = false;
-
-  @override
-  void initState() {
-    super.initState();
-    rust.api
-        .getUserDetails()
-        .then((user) => contactFieldController.text = user.contact != null ? user.contact! : "");
-  }
-
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -71,58 +61,103 @@ class _UserSettingsState extends State<UserSettings> {
             const SizedBox(
               height: 20,
             ),
-            Expanded(
-              child: Column(
-                mainAxisAlignment: MainAxisAlignment.start,
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  const Text(
-                    "Contact details \n",
-                    style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
-                  ),
-                  RichText(
-                    text: const TextSpan(
-                      text:
-                          '10101 will use these details to reach out to you in case of problems in the app. \n\n',
-                      style: TextStyle(fontSize: 16, color: Colors.black),
-                      children: <TextSpan>[
-                        TextSpan(
-                          text: 'This can be a ',
-                        ),
-                        TextSpan(
-                            text: 'Nostr Pubkey', style: TextStyle(fontWeight: FontWeight.bold)),
-                        TextSpan(
-                          text: ', a ',
-                        ),
-                        TextSpan(
-                            text: 'Telegram handle ',
-                            style: TextStyle(fontWeight: FontWeight.bold)),
-                        TextSpan(
-                          text: 'or an ',
-                        ),
-                        TextSpan(
-                            text: 'email address.', style: TextStyle(fontWeight: FontWeight.bold)),
-                        TextSpan(
-                            text:
-                                "\n\nIf you want to delete your contact details. Simply remove the details below.")
-                      ],
+            FutureBuilder(
+                future: rust.api.getUserDetails(),
+                builder: (BuildContext context, AsyncSnapshot<rust.User> snapshot) {
+                  if (!snapshot.hasData) {
+                    return const CircularProgressIndicator();
+                  }
+
+                  final nickname = snapshot.data?.nickname;
+                  final contact = snapshot.data?.contact;
+
+                  return Expanded(
+                    child: Padding(
+                      padding: const EdgeInsets.all(8.0),
+                      child: Column(
+                        mainAxisAlignment: MainAxisAlignment.start,
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          const Text(
+                            "Contact details \n",
+                            style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+                          ),
+                          RichText(
+                            text: const TextSpan(
+                              text:
+                                  '10101 will use these details to reach out to you in case of problems in the app. \n\n',
+                              style: TextStyle(fontSize: 16, color: Colors.black),
+                              children: <TextSpan>[
+                                TextSpan(
+                                  text: 'This can be a ',
+                                ),
+                                TextSpan(
+                                    text: 'Nostr Pubkey',
+                                    style: TextStyle(fontWeight: FontWeight.bold)),
+                                TextSpan(
+                                  text: ', a ',
+                                ),
+                                TextSpan(
+                                    text: 'Telegram handle ',
+                                    style: TextStyle(fontWeight: FontWeight.bold)),
+                                TextSpan(
+                                  text: 'or an ',
+                                ),
+                                TextSpan(
+                                    text: 'email address.',
+                                    style: TextStyle(fontWeight: FontWeight.bold)),
+                                TextSpan(
+                                    text:
+                                        "\n\nIf you want to delete your contact details. Simply remove the details below.")
+                              ],
+                            ),
+                          ),
+                          CustomInputField(
+                            onConfirm: (value) async {
+                              final messenger = ScaffoldMessenger.of(context);
+                              try {
+                                await rust.api.registerBeta(contact: value);
+                                showSnackBar(messenger, "Successfully updated to `$value`");
+                              } catch (error) {
+                                showSnackBar(messenger, "Failed updating details due to $error");
+                              }
+                            },
+                            labelText: "Contact details",
+                            initialValue: contact,
+                          ),
+                          const SizedBox(
+                            height: 20,
+                          ),
+                          const Text(
+                            "Nickname\n",
+                            style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+                          ),
+                          RichText(
+                            text: const TextSpan(
+                              text:
+                                  'We extract a regular hall-of-fame leaderboard. If you want to be recognized, feel free to enter your prefered nickname or generate a random one.',
+                              style: TextStyle(fontSize: 16, color: Colors.black),
+                              children: [],
+                            ),
+                          ),
+                          NicknameWidget(
+                            initialValue: nickname,
+                            labelText: 'Nickname',
+                            onConfirm: (value) async {
+                              final messenger = ScaffoldMessenger.of(context);
+                              try {
+                                await rust.api.updateNickname(nickname: value);
+                                showSnackBar(messenger, "Successfully updated to `$value`");
+                              } catch (error) {
+                                showSnackBar(messenger, "Failed updating details due to $error");
+                              }
+                            },
+                          )
+                        ],
+                      ),
                     ),
-                  ),
-                  CustomInputField(
-                    onConfirm: (value) async {
-                      final messenger = ScaffoldMessenger.of(context);
-                      try {
-                        await rust.api.registerBeta(contact: value);
-                        showSnackBar(messenger, "Successfully updated to $value");
-                      } catch (error) {
-                        showSnackBar(messenger, "Failed updating details due to $error");
-                      }
-                    },
-                    labelText: "Contact details",
-                  ),
-                ],
-              ),
-            ),
+                  );
+                }),
           ],
         ),
       )),
@@ -130,15 +165,114 @@ class _UserSettingsState extends State<UserSettings> {
   }
 }
 
-class CustomInputField extends StatefulWidget {
+class NicknameWidget extends StatefulWidget {
   final String labelText;
+  final String? initialValue;
   final Function onConfirm;
 
+  const NicknameWidget({
+    super.key,
+    required this.onConfirm,
+    required this.labelText,
+    this.initialValue,
+  });
+
+  @override
+  State<NicknameWidget> createState() => _NicknameWidgetState();
+}
+
+class _NicknameWidgetState extends State<NicknameWidget> {
+  bool fieldEnabled = false;
+  late final String labelText;
+  late final Function onConfirm;
+  TextEditingController fieldController = TextEditingController();
+
+  @override
+  void initState() {
+    super.initState();
+    labelText = widget.labelText;
+    onConfirm = widget.onConfirm;
+    if (widget.initialValue != null) {
+      fieldController.text = widget.initialValue!;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Stack(
+      alignment: Alignment.centerRight,
+      children: [
+        TextFormField(
+          enabled: fieldEnabled,
+          controller: fieldController,
+          decoration: InputDecoration(
+            border: const UnderlineInputBorder(),
+            labelText: labelText,
+          ),
+        ),
+        Visibility(
+          replacement: IconButton(
+            icon: const Icon(Icons.edit),
+            onPressed: () {
+              setState(() {
+                fieldEnabled = true;
+              });
+            },
+          ),
+          visible: fieldEnabled,
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.end,
+            children: [
+              IconButton(
+                icon: const Icon(
+                  Icons.refresh,
+                  color: tenTenOnePurple,
+                ),
+                onPressed: () {
+                  final newRandomName = rust.api.getNewRandomName();
+                  setState(() {
+                    fieldController.text = newRandomName;
+                  });
+                },
+              ),
+              IconButton(
+                icon: const Icon(
+                  Icons.check,
+                  color: Colors.green,
+                ),
+                onPressed: () async {
+                  final newContact = fieldController.value.text;
+                  try {
+                    await onConfirm(newContact);
+                  } finally {
+                    setState(() {
+                      fieldEnabled = false;
+                    });
+                  }
+                },
+              ),
+            ],
+          ),
+        )
+      ],
+    );
+  }
+
+  void showSnackBar(ScaffoldMessengerState messenger, String message) {
+    messenger.showSnackBar(SnackBar(content: Text(message)));
+  }
+}
+
+class CustomInputField extends StatefulWidget {
+  final String labelText;
+  final String? initialValue;
+  final Function onConfirm;
 
   const CustomInputField({
     super.key,
     required this.onConfirm,
     required this.labelText,
+    this.initialValue,
   });
 
   @override
@@ -156,53 +290,52 @@ class _CustomInputFieldState extends State<CustomInputField> {
     super.initState();
     labelText = widget.labelText;
     onConfirm = widget.onConfirm;
+    if (widget.initialValue != null) {
+      fieldController.text = widget.initialValue!;
+    }
   }
 
   @override
   Widget build(BuildContext context) {
-    return Padding(
-      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 16),
-      child: Stack(
-        alignment: Alignment.centerRight,
-        children: [
-          TextFormField(
-            enabled: fieldEnabled,
-            controller: fieldController,
-            decoration: InputDecoration(
-              border: const UnderlineInputBorder(),
-              labelText: labelText,
-            ),
+    return Stack(
+      alignment: Alignment.centerRight,
+      children: [
+        TextFormField(
+          enabled: fieldEnabled,
+          controller: fieldController,
+          decoration: InputDecoration(
+            border: const UnderlineInputBorder(),
+            labelText: labelText,
           ),
-          Visibility(
-            replacement: IconButton(
-              icon: const Icon(Icons.edit),
-              onPressed: () {
+        ),
+        Visibility(
+          replacement: IconButton(
+            icon: const Icon(Icons.edit),
+            onPressed: () {
+              setState(() {
+                fieldEnabled = true;
+              });
+            },
+          ),
+          visible: fieldEnabled,
+          child: IconButton(
+            icon: const Icon(
+              Icons.check,
+              color: Colors.green,
+            ),
+            onPressed: () async {
+              final newContact = fieldController.value.text;
+              try {
+                await onConfirm(newContact);
+              } finally {
                 setState(() {
-                  fieldEnabled = true;
+                  fieldEnabled = false;
                 });
-              },
-            ),
-            visible: fieldEnabled,
-            child: IconButton(
-              icon: const Icon(
-                Icons.check,
-                color: Colors.green,
-              ),
-              onPressed: () async {
-                final newContact = fieldController.value.text;
-                try {
-                  await onConfirm(newContact);
-                } finally {
-                  setState(() {
-                    fieldEnabled = false;
-                  });
-                }
-              },
-            ),
-          )
-        ],
-      ),
+              }
+            },
+          ),
+        )
+      ],
     );
   }
-
 }

--- a/mobile/native/Cargo.toml
+++ b/mobile/native/Cargo.toml
@@ -31,6 +31,7 @@ ln-dlc-storage = { path = "../../crates/ln-dlc-storage" }
 openssl = { version = "0.10.60", features = ["vendored"] }
 orderbook-client = { path = "../../crates/orderbook-client" }
 parking_lot = { version = "0.12.1" }
+petname = "1.1.3"
 reqwest = { version = "0.11", default-features = false, features = ["json", "stream"] }
 rusqlite = { version = "0.29.0", features = ["backup", "bundled"] }
 rust_decimal = { version = "1", features = ["serde-with-float"] }

--- a/mobile/native/src/api.rs
+++ b/mobile/native/src/api.rs
@@ -768,9 +768,11 @@ pub async fn register_beta(contact: String) -> Result<()> {
     users::register_beta(contact).await
 }
 
+#[derive(Debug)]
 pub struct User {
     pub pubkey: String,
     pub contact: Option<String>,
+    pub nickname: Option<String>,
 }
 
 impl From<commons::User> for User {
@@ -778,6 +780,7 @@ impl From<commons::User> for User {
         User {
             pubkey: value.pubkey.to_string(),
             contact: value.contact,
+            nickname: value.nickname,
         }
     }
 }
@@ -847,4 +850,13 @@ pub fn delete_dlc_channel(dlc_channel_id: String) -> Result<()> {
 
 pub fn sync_for_addresses(gap: u32) -> Result<bool> {
     ln_dlc::sync_for_addresses(gap)
+}
+
+pub fn get_new_random_name() -> SyncReturn<String> {
+    SyncReturn(crate::names::get_new_name())
+}
+
+#[tokio::main(flavor = "current_thread")]
+pub async fn update_nickname(nickname: String) -> Result<()> {
+    users::update_username(nickname).await
 }

--- a/mobile/native/src/lib.rs
+++ b/mobile/native/src/lib.rs
@@ -28,5 +28,6 @@ mod cipher;
 mod destination;
 mod dlc_channel;
 mod dlc_handler;
+mod names;
 mod polls;
 mod storage;

--- a/mobile/native/src/names.rs
+++ b/mobile/native/src/names.rs
@@ -1,0 +1,26 @@
+pub fn get_new_name() -> String {
+    let names = petname::Petnames::default();
+    let input = names.generate_one(2, " ");
+    return uppercase_first_characters(input.as_str(), ' ');
+}
+
+fn uppercase_first_characters(input: &str, separator: char) -> String {
+    let mut parts = input.splitn(2, separator);
+    if let (Some(first), Some(second)) = (parts.next(), parts.next()) {
+        return format!(
+            "{} {}",
+            uppercase_first_character(first),
+            uppercase_first_character(second)
+        );
+    }
+
+    input.to_string()
+}
+
+fn uppercase_first_character(s: &str) -> String {
+    let mut c = s.chars();
+    match c.next() {
+        None => String::new(),
+        Some(f) => f.to_uppercase().collect::<String>() + c.as_str(),
+    }
+}


### PR DESCRIPTION
Leader board has now a nickname which can be configured in the app (or is random generated on registration). 
There is no way to opt-out of the leader board at the moment. 

Also, the leaderboard api allows for defining a start and end date. 

e.g. use with 

`curl 'localhost:8000/api/leaderboard?top=3&category=Pnl&start=2024-02-11&end=2024-02-13' -v | jq .`

resolves [#341](https://github.com/get10101/meta/issues/341)

