### PR TITLE
feat: build android fat bundle and split bundles

### DIFF
--- a/.github/workflows/android-fastlane.yml
+++ b/.github/workflows/android-fastlane.yml
@@ -185,8 +185,10 @@ jobs:
           ORACLE_PUBKEY: ${{ inputs.oracle_pubkey }}
           RGS_SERVER_URL: ${{ inputs.rgs_server_url }}
 
-      - name: Build Android APK
-        id: build-android-apk
+      - name: Build Android APK for each platform
+        run: |
+          NETWORK=$NETWORK just build-android-app-apk --split-per-abi
+      - name: Build Android APK fat bundle
         run: |
           NETWORK=$NETWORK just build-android-app-apk
         env:

--- a/justfile
+++ b/justfile
@@ -579,7 +579,7 @@ build-android-app-bundle:
       --dart-define="RGS_SERVER_URL=${RGS_SERVER_URL}" \
        "${flavor_arg[@]}"
 
-build-android-app-apk:
+build-android-app-apk args="":
     #!/usr/bin/env bash
     BUILD_NAME=$(yq -r .version {{pubspec}})
     BUILD_NUMBER=$(git rev-list HEAD --count)
@@ -597,7 +597,7 @@ build-android-app-apk:
     os={{os()}}
     echo "building on '$os' for '$NETWORK'"
 
-    cd mobile && flutter build apk --split-per-abi \
+    cd mobile && flutter build apk {{args}} \
       --build-name=${BUILD_NAME} \
       --build-number=${BUILD_NUMBER} \
       --release \


### PR DESCRIPTION
Resolves #2025 

I've opted for also the split bundles, because the full one is so big.

This will generate different apk bundles: 

```
 81M Feb 13 14:28 app-arm64-v8a-full-release.apk
 40B Feb 13 14:29 app-arm64-v8a-full-release.apk.sha1
 57M Feb 13 14:28 app-armeabi-v7a-full-release.apk
 40B Feb 13 14:29 app-armeabi-v7a-full-release.apk.sha1
288M Feb 13 14:29 app-full-release.apk
 40B Feb 13 14:29 app-full-release.apk.sha1
 94M Feb 13 14:28 app-x86_64-full-release.apk
 40B Feb 13 14:29 app-x86_64-full-release.apk.sha1
```