### PR TITLE
fix(validation): Calculate counterparty balance from channel state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Fix(mobile): Calculate counterparty balance correctly when checking the validity of trade parameters.
+
 ## [1.8.8] - 2024-02-14
 
 - Feat(mobile): Let user add a name to their profile for the leaderboard

--- a/crates/ln-dlc-node/src/node/dlc_channel.rs
+++ b/crates/ln-dlc-node/src/node/dlc_channel.rs
@@ -446,7 +446,8 @@ impl<S: TenTenOneStorage + 'static, N: LnDlcStorage + Sync + Send + 'static> Nod
 
     /// Return the usable balance for the DLC channel.
     ///
-    /// Usable balance excludes all balance which is being wagered in DLCs.
+    /// Usable balance excludes all balance which is being wagered in DLCs. It also excludes some
+    /// reserved funds to be used when the channel is closed on-chain.
     pub fn get_dlc_channel_usable_balance(&self, channel_id: &DlcChannelId) -> Result<Amount> {
         let dlc_channel = self.get_dlc_channel_by_id(channel_id)?;
 
@@ -499,13 +500,22 @@ impl<S: TenTenOneStorage + 'static, N: LnDlcStorage + Sync + Send + 'static> Nod
             // For all other cases we can rely on the `Contract`, since
             // `SignedChannelState::get_contract_id` will return a `ContractId` for
             // them.
-            _ => self.get_contract_usable_balance(&dlc_channel)?,
+            _ => self.get_contract_own_usable_balance(&dlc_channel)?,
         };
 
         Ok(usable_balance)
     }
 
-    fn get_contract_usable_balance(&self, dlc_channel: &Channel) -> Result<Amount> {
+
+    fn get_contract_own_usable_balance(&self, dlc_channel: &Channel) -> Result<Amount> {
+        self.get_contract_usable_balance(dlc_channel, true)
+    }
+
+    fn get_contract_usable_balance(
+        &self,
+        dlc_channel: &Channel,
+        is_balance_being_calculated_for_self: bool,
+    ) -> Result<Amount> {
         let contract_id = match dlc_channel.get_contract_id() {
             Some(contract_id) => contract_id,
             None => return Ok(Amount::ZERO),
@@ -529,10 +539,19 @@ impl<S: TenTenOneStorage + 'static, N: LnDlcStorage + Sync + Send + 'static> Nod
             _ => return Ok(Amount::ZERO),
         };
 
-        let is_offer_party = signed_contract
+        let am_i_offer_party = signed_contract
             .accepted_contract
             .offered_contract
             .is_offer_party;
+
+        let is_balance_being_calculated_for_offer_party = if is_balance_being_calculated_for_self {
+            am_i_offer_party
+        }
+        // If we want the counterparty balance, their role in the protocol (offer or accept) is the
+        // opposite of ours.
+        else {
+            !am_i_offer_party
+        };
 
         let offered_contract = signed_contract.accepted_contract.offered_contract;
 
@@ -550,7 +569,7 @@ impl<S: TenTenOneStorage + 'static, N: LnDlcStorage + Sync + Send + 'static> Nod
                 // The minimum payout for each party determines how many coins are _not_ currently
                 // being wagered. Since they are not being wagered, they have the potential to be
                 // wagered (by renewing the channel, for example) and so they are usable.
-                let reserve = if is_offer_party {
+                let reserve = if is_balance_being_calculated_for_offer_party {
                     payouts
                         .iter()
                         .min_by(|a, b| a.offer.cmp(&b.offer))

--- a/mobile/native/src/channel_trade_constraints.rs
+++ b/mobile/native/src/channel_trade_constraints.rs
@@ -45,14 +45,19 @@ pub fn channel_trade_constraints() -> Result<TradeConstraints> {
                 min_margin,
             }
         }
-        Some(channel) => TradeConstraints {
-            max_local_margin_sats: ln_dlc::get_usable_dlc_channel_balance()?.to_sat(),
-            max_counterparty_margin_sats: channel.counter_params.collateral,
-            coordinator_leverage,
-            min_quantity,
-            is_channel_balance: true,
-            min_margin,
-        },
+        Some(_) => {
+            let local_balance = ln_dlc::get_usable_dlc_channel_balance()?.to_sat();
+            let counterparty_balance =
+                ln_dlc::get_usable_dlc_channel_balance_counterparty()?.to_sat();
+            TradeConstraints {
+                max_local_margin_sats: local_balance,
+                max_counterparty_margin_sats: counterparty_balance,
+                coordinator_leverage,
+                min_quantity,
+                is_channel_balance: true,
+                min_margin,
+            }
+        }
     };
     Ok(trade_constraints)
 }

--- a/mobile/native/src/ln_dlc/mod.rs
+++ b/mobile/native/src/ln_dlc/mod.rs
@@ -733,9 +733,15 @@ pub fn get_onchain_balance() -> Result<Balance> {
     let node = state::try_get_node().context("failed to get ln dlc node")?;
     node.inner.get_on_chain_balance()
 }
+
 pub fn get_usable_dlc_channel_balance() -> Result<Amount> {
     let node = state::try_get_node().context("failed to get ln dlc node")?;
     node.inner.get_dlc_channels_usable_balance()
+}
+
+pub fn get_usable_dlc_channel_balance_counterparty() -> Result<Amount> {
+    let node = state::try_get_node().context("failed to get ln dlc node")?;
+    node.inner.get_dlc_channels_usable_balance_counterparty()
 }
 
 pub fn collaborative_revert_channel(


### PR DESCRIPTION
The balance of the counterparty is the difference from the users balance and the total collateral.

Before we were calculating the max amount based on the initial collateral of the counterparty which can obviously change.

fixes #2002 