### PR TITLE
feat(wallet): Unreserve locked outpoints if channel gets rejected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix(validation): Show correct max counterparty collateral in validation message.
 - Fix(mobile): Calculate counterparty balance correctly when checking the validity of trade parameters.
-- Fix(trade): Spawn dedicated tokio task when executing trade
+- Fix(trade): Spawn dedicated tokio task when executing trade.
+- Chore(wallet): Unreserve locked utxos if offer get rejected.
 
 ## [1.8.8] - 2024-02-14
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1292,7 +1292,7 @@ dependencies = [
 [[package]]
 name = "dlc"
 version = "0.4.0"
-source = "git+https://github.com/get10101/rust-dlc?rev=1534c18#1534c18731fd42d8e4219ad9c01beeb2d6f3a808"
+source = "git+https://github.com/get10101/rust-dlc?rev=0ce71cb21f2c0e636af96385c3ed660a1c3e9a6b#0ce71cb21f2c0e636af96385c3ed660a1c3e9a6b"
 dependencies = [
  "bitcoin",
  "miniscript 8.0.2",
@@ -1304,7 +1304,7 @@ dependencies = [
 [[package]]
 name = "dlc-manager"
 version = "0.4.0"
-source = "git+https://github.com/get10101/rust-dlc?rev=1534c18#1534c18731fd42d8e4219ad9c01beeb2d6f3a808"
+source = "git+https://github.com/get10101/rust-dlc?rev=0ce71cb21f2c0e636af96385c3ed660a1c3e9a6b#0ce71cb21f2c0e636af96385c3ed660a1c3e9a6b"
 dependencies = [
  "async-trait",
  "bitcoin",
@@ -1320,7 +1320,7 @@ dependencies = [
 [[package]]
 name = "dlc-messages"
 version = "0.4.0"
-source = "git+https://github.com/get10101/rust-dlc?rev=1534c18#1534c18731fd42d8e4219ad9c01beeb2d6f3a808"
+source = "git+https://github.com/get10101/rust-dlc?rev=0ce71cb21f2c0e636af96385c3ed660a1c3e9a6b#0ce71cb21f2c0e636af96385c3ed660a1c3e9a6b"
 dependencies = [
  "bitcoin",
  "dlc",
@@ -1333,7 +1333,7 @@ dependencies = [
 [[package]]
 name = "dlc-trie"
 version = "0.4.0"
-source = "git+https://github.com/get10101/rust-dlc?rev=1534c18#1534c18731fd42d8e4219ad9c01beeb2d6f3a808"
+source = "git+https://github.com/get10101/rust-dlc?rev=0ce71cb21f2c0e636af96385c3ed660a1c3e9a6b#0ce71cb21f2c0e636af96385c3ed660a1c3e9a6b"
 dependencies = [
  "bitcoin",
  "dlc",
@@ -2836,7 +2836,7 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 [[package]]
 name = "p2pd-oracle-client"
 version = "0.1.0"
-source = "git+https://github.com/get10101/rust-dlc?rev=1534c18#1534c18731fd42d8e4219ad9c01beeb2d6f3a808"
+source = "git+https://github.com/get10101/rust-dlc?rev=0ce71cb21f2c0e636af96385c3ed660a1c3e9a6b#0ce71cb21f2c0e636af96385c3ed660a1c3e9a6b"
 dependencies = [
  "chrono",
  "dlc-manager",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,11 +20,11 @@ resolver = "2"
 # We are using our own fork of `rust-dlc` at least until we can drop all the LN-DLC features. Also,
 # `p2pderivatives/rust-dlc#master` is missing certain patches that can only be found in the LN-DLC
 # branch.
-dlc-manager = { git = "https://github.com/get10101/rust-dlc", rev = "1534c18" }
-dlc-messages = { git = "https://github.com/get10101/rust-dlc", rev = "1534c18" }
-dlc = { git = "https://github.com/get10101/rust-dlc", rev = "1534c18" }
-p2pd-oracle-client = { git = "https://github.com/get10101/rust-dlc", rev = "1534c18" }
-dlc-trie = { git = "https://github.com/get10101/rust-dlc", rev = "1534c18" }
+dlc-manager = { git = "https://github.com/get10101/rust-dlc", rev = "0ce71cb21f2c0e636af96385c3ed660a1c3e9a6b" }
+dlc-messages = { git = "https://github.com/get10101/rust-dlc", rev = "0ce71cb21f2c0e636af96385c3ed660a1c3e9a6b" }
+dlc = { git = "https://github.com/get10101/rust-dlc", rev = "0ce71cb21f2c0e636af96385c3ed660a1c3e9a6b" }
+p2pd-oracle-client = { git = "https://github.com/get10101/rust-dlc", rev = "0ce71cb21f2c0e636af96385c3ed660a1c3e9a6b" }
+dlc-trie = { git = "https://github.com/get10101/rust-dlc", rev = "0ce71cb21f2c0e636af96385c3ed660a1c3e9a6b" }
 
 # We should usually track the `p2pderivatives/split-tx-experiment[-10101]` branch. For now we depend
 # on a special fork which removes a panic in `rust-lightning`.

--- a/crates/ln-dlc-node/src/ldk_node_wallet.rs
+++ b/crates/ln-dlc-node/src/ldk_node_wallet.rs
@@ -199,6 +199,13 @@ where
         Ok(utxos)
     }
 
+    pub fn unreserve_utxos(&self, outpoints: &[OutPoint]) -> Result<()> {
+        self.locked_outpoints
+            .lock()
+            .retain(|lo| !outpoints.contains(lo));
+        Ok(())
+    }
+
     pub fn get_utxos_for_dlc_funding_transaction(
         &self,
         amount: u64,

--- a/crates/ln-dlc-node/src/ln_dlc_wallet.rs
+++ b/crates/ln-dlc-node/src/ln_dlc_wallet.rs
@@ -21,6 +21,7 @@ use bitcoin::Block;
 use bitcoin::BlockHash;
 use bitcoin::KeyPair;
 use bitcoin::Network;
+use bitcoin::OutPoint;
 use bitcoin::Script;
 use bitcoin::Transaction;
 use bitcoin::Txid;
@@ -296,6 +297,16 @@ impl<S: TenTenOneStorage, N: Storage> dlc_manager::Wallet for LnDlcWallet<S, N> 
     }
 
     fn import_address(&self, _address: &Address) -> Result<(), Error> {
+        Ok(())
+    }
+
+    fn unreserve_utxos(&self, outpoints: &[OutPoint]) -> Result<(), Error> {
+        self.ln_wallet.unreserve_utxos(outpoints).map_err(|error| {
+            Error::InvalidState(format!(
+                "Could not unreserve utxos {outpoints:?}: {error:?}"
+            ))
+        })?;
+
         Ok(())
     }
 }


### PR DESCRIPTION
Unreserves locked outpoints if a channel gets rejected. This would otherwise only happen if the coordinator gets restarted.

Adds the following commits to rust-dlc

- Set contract to rejected if channel gets cancelled. https://github.com/get10101/rust-dlc/pull/4/commits/12ee7b717a70e2b9da8d15cc919aa3c95543e10e
- Adds the unreserve utxos api to the wallet trait: https://github.com/get10101/rust-dlc/pull/4/commits/38c91beefa2e11938fae74e19593a1e707230be1