### PR TITLE
Use a fork of `rust-dlc` for now

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1292,7 +1292,7 @@ dependencies = [
 [[package]]
 name = "dlc"
 version = "0.4.0"
-source = "git+https://github.com/p2pderivatives/rust-dlc?rev=1534c18#1534c18731fd42d8e4219ad9c01beeb2d6f3a808"
+source = "git+https://github.com/get10101/rust-dlc?rev=1534c18#1534c18731fd42d8e4219ad9c01beeb2d6f3a808"
 dependencies = [
  "bitcoin",
  "miniscript 8.0.2",
@@ -1304,7 +1304,7 @@ dependencies = [
 [[package]]
 name = "dlc-manager"
 version = "0.4.0"
-source = "git+https://github.com/p2pderivatives/rust-dlc?rev=1534c18#1534c18731fd42d8e4219ad9c01beeb2d6f3a808"
+source = "git+https://github.com/get10101/rust-dlc?rev=1534c18#1534c18731fd42d8e4219ad9c01beeb2d6f3a808"
 dependencies = [
  "async-trait",
  "bitcoin",
@@ -1320,7 +1320,7 @@ dependencies = [
 [[package]]
 name = "dlc-messages"
 version = "0.4.0"
-source = "git+https://github.com/p2pderivatives/rust-dlc?rev=1534c18#1534c18731fd42d8e4219ad9c01beeb2d6f3a808"
+source = "git+https://github.com/get10101/rust-dlc?rev=1534c18#1534c18731fd42d8e4219ad9c01beeb2d6f3a808"
 dependencies = [
  "bitcoin",
  "dlc",
@@ -1333,7 +1333,7 @@ dependencies = [
 [[package]]
 name = "dlc-trie"
 version = "0.4.0"
-source = "git+https://github.com/p2pderivatives/rust-dlc?rev=1534c18#1534c18731fd42d8e4219ad9c01beeb2d6f3a808"
+source = "git+https://github.com/get10101/rust-dlc?rev=1534c18#1534c18731fd42d8e4219ad9c01beeb2d6f3a808"
 dependencies = [
  "bitcoin",
  "dlc",
@@ -2836,7 +2836,7 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 [[package]]
 name = "p2pd-oracle-client"
 version = "0.1.0"
-source = "git+https://github.com/p2pderivatives/rust-dlc?rev=1534c18#1534c18731fd42d8e4219ad9c01beeb2d6f3a808"
+source = "git+https://github.com/get10101/rust-dlc?rev=1534c18#1534c18731fd42d8e4219ad9c01beeb2d6f3a808"
 dependencies = [
  "chrono",
  "dlc-manager",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,19 +17,17 @@ default-members = [
 resolver = "2"
 
 [patch.crates-io]
-# We should usually track the `p2pderivatives/feature/ln-dlc-channels[-10101]` branch.
-#
-# We are currently depending on one patch that will _not_ be merged into
-# `p2pderivatives/rust-dlc#feature/ln-dlc-channels`: 4e104b4. This patch ensures backwards
-# compatibility for 10101 through the `rust-lightning:0.0.116` upgrade. We will be able to drop it
-# once all users have been upgraded and traded once.
-dlc-manager = { git = "https://github.com/p2pderivatives/rust-dlc", rev = "1534c18" }
-dlc-messages = { git = "https://github.com/p2pderivatives/rust-dlc", rev = "1534c18" }
-dlc = { git = "https://github.com/p2pderivatives/rust-dlc", rev = "1534c18" }
-p2pd-oracle-client = { git = "https://github.com/p2pderivatives/rust-dlc", rev = "1534c18" }
-dlc-trie = { git = "https://github.com/p2pderivatives/rust-dlc", rev = "1534c18" }
+# We are using our own fork of `rust-dlc` at least until we can drop all the LN-DLC features. Also,
+# `p2pderivatives/rust-dlc#master` is missing certain patches that can only be found in the LN-DLC
+# branch.
+dlc-manager = { git = "https://github.com/get10101/rust-dlc", rev = "1534c18" }
+dlc-messages = { git = "https://github.com/get10101/rust-dlc", rev = "1534c18" }
+dlc = { git = "https://github.com/get10101/rust-dlc", rev = "1534c18" }
+p2pd-oracle-client = { git = "https://github.com/get10101/rust-dlc", rev = "1534c18" }
+dlc-trie = { git = "https://github.com/get10101/rust-dlc", rev = "1534c18" }
 
-# We should usually track the `p2pderivatives/split-tx-experiment[-10101]` branch. For now we depend on a special fork which removes a panic in rust-lightning
+# We should usually track the `p2pderivatives/split-tx-experiment[-10101]` branch. For now we depend
+# on a special fork which removes a panic in `rust-lightning`.
 lightning = { git = "https://github.com/bonomat/rust-lightning-p2p-derivatives", rev = "e49030e" }
 lightning-background-processor = { git = "https://github.com/bonomat/rust-lightning-p2p-derivatives", rev = "e49030e" }
 lightning-transaction-sync = { git = "https://github.com/bonomat/rust-lightning-p2p-derivatives", rev = "e49030e" }


### PR DESCRIPTION
We will be using our own fork of `rust-dlc` until:
   - We can drop all the LN-DLC features. 
   - `p2pderivatives/rust-dlc#master` includes certain patches currently only found in the LN-DLC branch.

Perhaps we will always want to maintain our own fork, although ideally we don't diverge too much from the original.