### PR TITLE
fix(channel): use higher fee rate when opening a channel

### DIFF
--- a/coordinator/src/trade/mod.rs
+++ b/coordinator/src/trade/mod.rs
@@ -280,7 +280,7 @@ impl TradeExecutor {
         let sats_per_vbyte = self
             .node
             .fee_rate_estimator
-            .get(ConfirmationTarget::Background)
+            .get(ConfirmationTarget::Normal)
             .as_sat_per_vb()
             .round();
         // This fee rate is used to construct the fund and CET transactions.
@@ -433,7 +433,7 @@ impl TradeExecutor {
         let sats_per_vbyte = self
             .node
             .fee_rate_estimator
-            .get(ConfirmationTarget::Background)
+            .get(ConfirmationTarget::Normal)
             .as_sat_per_vb()
             .round();
         // This fee rate is used to construct the CET transactions.


### PR DESCRIPTION
In the past we set it to  because our feerate estimation was too far off. Now,  would be too low, hence, we switch to  which translates to  from mempool, i.e. it should get confirmed within 1h