### PR TITLE
fix: Insert channel params before posting new order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix(mobile): Calculate counterparty balance correctly when checking the validity of trade parameters.
 - Fix(trade): Spawn dedicated tokio task when executing trade.
 - Chore(wallet): Unreserve locked utxos if offer get rejected.
+- Fix(order): Insert channel-opening parameters before posting order to the coordinator. This prevents the app from running into a race condition between the completion of the HTTP request and the app being notified about the order being matched.
 
 ## [1.8.8] - 2024-02-14
 

--- a/mobile/lib/features/trade/submit_order_change_notifier.dart
+++ b/mobile/lib/features/trade/submit_order_change_notifier.dart
@@ -94,23 +94,21 @@ class SubmitOrderChangeNotifier extends ChangeNotifier implements Subscriber {
     if (event is bridge.Event_OrderUpdateNotification) {
       Order order = Order.fromApi(event.field0);
 
-      if (_pendingOrder?.id == order.id) {
-        switch (order.state) {
-          case OrderState.open:
-          case OrderState.filling:
-            return;
-          case OrderState.filled:
-            _pendingOrder!.state = PendingOrderState.orderFilled;
-            break;
-          case OrderState.failed:
-          case OrderState.rejected:
-            _pendingOrder!.state = PendingOrderState.orderFailed;
-            break;
-        }
-        _pendingOrder!.failureReason = order.failureReason;
-
-        notifyListeners();
+      switch (order.state) {
+        case OrderState.open:
+        case OrderState.filling:
+          return;
+        case OrderState.filled:
+          _pendingOrder!.state = PendingOrderState.orderFilled;
+          break;
+        case OrderState.failed:
+        case OrderState.rejected:
+          _pendingOrder!.state = PendingOrderState.orderFailed;
+          break;
       }
+      _pendingOrder!.failureReason = order.failureReason;
+
+      notifyListeners();
     } else {
       logger.w("Received unexpected event: ${event.toString()}");
     }

--- a/mobile/native/src/db/models.rs
+++ b/mobile/native/src/db/models.rs
@@ -1477,14 +1477,16 @@ impl ChannelOpeningParams {
     pub fn insert(
         conn: &mut SqliteConnection,
         channel_opening_params: ChannelOpeningParams,
-    ) -> Result<()> {
+    ) -> QueryResult<()> {
         let affected_rows = diesel::insert_into(channel_opening_params::table)
             .values(channel_opening_params)
             .execute(conn)?;
 
-        ensure!(affected_rows > 0, "Could not insert channel-opening params");
+        if affected_rows == 0 {
+            return diesel::result::QueryResult::Err(diesel::result::Error::NotFound);
+        }
 
-        Ok(())
+        diesel::result::QueryResult::Ok(())
     }
 
     pub fn get_by_order_id(

--- a/mobile/native/src/trade/order/handler.rs
+++ b/mobile/native/src/trade/order/handler.rs
@@ -18,7 +18,6 @@ use anyhow::anyhow;
 use anyhow::bail;
 use anyhow::Context;
 use anyhow::Result;
-use diesel::Connection;
 use reqwest::Url;
 use time::Duration;
 use time::OffsetDateTime;
@@ -84,40 +83,32 @@ pub async fn submit_order(
         });
     }
 
+    db::insert_order(order.clone()).map_err(SubmitOrderError::Storage)?;
+
+    if let Some(channel_opening_params) = channel_opening_params {
+        let runtime = get_or_create_tokio_runtime().expect("to be able to get runtime");
+        runtime
+            .spawn_blocking({
+                move || {
+                    let mut conn = db::connection()?;
+                    tracing::debug!(
+                        ?channel_opening_params,
+                        "Recording channel-opening parameters"
+                    );
+
+                    db::insert_channel_opening_params(&mut conn, channel_opening_params)
+                }
+            })
+            .await
+            .expect("task to complete")
+            .map_err(SubmitOrderError::Storage)?;
+    }
+
     let url = format!("http://{}", config::get_http_endpoint());
     let url = Url::parse(&url).expect("correct URL");
     let orderbook_client = OrderbookClient::new(url);
 
-    db::insert_order(order.clone()).map_err(SubmitOrderError::Storage)?;
-
-    let runtime = get_or_create_tokio_runtime().expect("to be ablet to get runtime");
-    if let Err(err) = runtime
-        .spawn_blocking({
-            let order = order.clone();
-            move || {
-                let mut db = db::connection()?;
-                // We need to ensure that the channel-opening parameters are inserted after the
-                // order has been posted, but before order has been match and we need them to open
-                // the DLC channel. Without this database transaction we can easily end up with a
-                // match before we insert them!
-                db.transaction(|conn| {
-                    if let Some(channel_opening_params) = channel_opening_params {
-                        tracing::debug!(
-                            ?channel_opening_params,
-                            "Recording channel-opening parameters"
-                        );
-
-                        db::insert_channel_opening_params(conn, channel_opening_params)
-                            .map_err(SubmitOrderError::Storage)?;
-                    }
-
-                    runtime.block_on(orderbook_client.post_new_order(order.into()))
-                })
-            }
-        })
-        .await
-        .expect("task to complete")
-    {
+    if let Err(err) = orderbook_client.post_new_order(order.clone().into()).await {
         let order_id = order.id.clone().to_string();
 
         tracing::error!(order_id, "Failed to post new order: {err:#}");


### PR DESCRIPTION
I am not exactly sure why this is fixing the issue, but my assumption is the following.

If we receive the order match (async via websockets) before the `post_new_order` http request has finished. We'd still hold an open connection and the write lock on the order.

I presume this leads to the order match processing to fail because of `Could not load order from db: cannot acquire database connection: timed out waiting for connection`. But I am not sure why that would result into the processing of the order match running into a timeout when trying to get a connection.

When the `post_new_order` finally finishes the lock is freed up. I guess afterwards the pool would return connections again but we are already stuck because we do not send the trade request anymore (since processing the match already failed)

Additionally I had to remove the order_id check on `the submit_order_change_notifier`, since it could happen that we don't have the id yet if the order match is already processed before the http post new order request finished. IMHO that should be fine because we only ever have one active order anyways and we don't have to separate them.

fixes #2055 