### PR TITLE
Replace TCP with WebSockets (when feature gate enabled)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -836,7 +836,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "time",
- "tokio-tungstenite",
+ "tokio-tungstenite-wasm",
  "trade",
  "uuid",
 ]
@@ -2561,7 +2561,7 @@ dependencies = [
  "thiserror",
  "time",
  "tokio",
- "tokio-tungstenite",
+ "tokio-tungstenite-wasm",
  "tokio-util",
  "tracing",
  "tracing-log 0.2.0",
@@ -2815,7 +2815,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "tokio",
- "tokio-tungstenite",
+ "tokio-tungstenite-wasm",
  "tracing",
  "tracing-subscriber",
  "url",
@@ -4246,6 +4246,24 @@ dependencies = [
  "tokio",
  "tokio-native-tls",
  "tungstenite",
+]
+
+[[package]]
+name = "tokio-tungstenite-wasm"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ec8c7cf09b20184f946f114e3d8c0deca34368912c90100812861c14bb63b66"
+dependencies = [
+ "futures-channel",
+ "futures-util",
+ "http 1.0.0",
+ "httparse",
+ "js-sys",
+ "thiserror",
+ "tokio",
+ "tokio-tungstenite 0.21.0",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -284,7 +284,7 @@ dependencies = [
  "sha1",
  "sync_wrapper",
  "tokio",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.20.1",
  "tower",
  "tower-layer",
  "tower-service",
@@ -563,7 +563,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.20.1",
  "tracing",
  "tracing-subscriber",
  "url",
@@ -1664,8 +1664,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "190092ea657667030ac6a35e305e62fc4dd69fd98ac98631e5d3a2b1575a12b5"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2037,9 +2039,9 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d20d6b07bfbc108882d88ed8e37d39636dcc260e15e30c45e6ba089610b917c"
+checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
 dependencies = [
  "unicode-bidi",
  "unicode-normalization",
@@ -2128,9 +2130,9 @@ checksum = "fad582f4b9e86b6caa621cabeb0963332d92eea04729ab12892c2533951e6440"
 
 [[package]]
 name = "js-sys"
-version = "0.3.61"
+version = "0.3.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "445dde2150c55e483f3d8416706b97ec8e8237c307e5b7b4b8dd15e6af2a0730"
+checksum = "406cda4b368d531c842222cf9d2600a9a4acce8d29423695379c6868a143a9ee"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -2198,16 +2200,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lightning-net-tokio"
-version = "0.0.117"
-source = "git+https://github.com/bonomat/rust-lightning-p2p-derivatives?rev=e49030e#e49030e785408f0fd4da077f63f8101cc0b2436e"
-dependencies = [
- "bitcoin",
- "lightning",
- "tokio",
-]
-
-[[package]]
 name = "lightning-persister"
 version = "0.0.117"
 source = "git+https://github.com/bonomat/rust-lightning-p2p-derivatives?rev=e49030e#e49030e785408f0fd4da077f63f8101cc0b2436e"
@@ -2258,22 +2250,24 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "axum 0.6.20",
  "bdk",
  "bdk_coin_select",
  "bip39",
  "bitcoin",
+ "cfg-if",
  "dlc",
  "dlc-manager",
  "dlc-messages",
  "dlc-trie",
  "esplora-client",
  "futures",
+ "getrandom",
  "hex",
  "hkdf",
  "lightning",
  "lightning-background-processor",
  "lightning-invoice",
- "lightning-net-tokio",
  "lightning-persister",
  "lightning-rapid-gossip-sync",
  "lightning-transaction-sync",
@@ -2292,6 +2286,7 @@ dependencies = [
  "sha2",
  "time",
  "tokio",
+ "tokio-tungstenite-wasm",
  "tracing",
  "tracing-log 0.1.3",
  "tracing-subscriber",
@@ -2914,9 +2909,9 @@ dependencies = [
 
 [[package]]
 name = "percent-encoding"
-version = "2.3.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
+checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "percent-encoding-rfc3986"
@@ -4245,20 +4240,35 @@ dependencies = [
  "native-tls",
  "tokio",
  "tokio-native-tls",
- "tungstenite",
+ "tungstenite 0.20.1",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c83b561d025642014097b66e6c1bb422783339e0909e4429cde4749d1990bc38"
+dependencies = [
+ "futures-util",
+ "log",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tungstenite 0.21.0",
 ]
 
 [[package]]
 name = "tokio-tungstenite-wasm"
-version = "0.2.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ec8c7cf09b20184f946f114e3d8c0deca34368912c90100812861c14bb63b66"
+checksum = "bc38dd78643be6a1fb37dff75e0d326e7f4ad5a8f6563adb7934df47a5156f7d"
 dependencies = [
  "futures-channel",
  "futures-util",
  "http 1.0.0",
  "httparse",
  "js-sys",
+ "native-tls",
  "thiserror",
  "tokio",
  "tokio-tungstenite 0.21.0",
@@ -4597,6 +4607,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "tungstenite"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ef1a641ea34f399a848dea702823bbecfb4c486f911735368f1f137cb8257e1"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "data-encoding",
+ "http 1.0.0",
+ "httparse",
+ "log",
+ "native-tls",
+ "rand",
+ "sha1",
+ "thiserror",
+ "url",
+ "utf-8",
+]
+
+[[package]]
 name = "typenum"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4687,9 +4717,9 @@ dependencies = [
 
 [[package]]
 name = "url"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "143b538f18257fac9cad154828a57c6bf5157e1aa604d4816b5995bf6de87ae5"
+checksum = "31e6302e3bb753d46e83516cae55ae196fc0c309407cf11ab35cc51a4c2a4633"
 dependencies = [
  "form_urlencoded",
  "idna",
@@ -4792,9 +4822,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.84"
+version = "0.2.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31f8dcbc21f30d9b8f2ea926ecb58f6b91192c17e9d33594b3df58b2007ca53b"
+checksum = "c1e124130aee3fb58c5bdd6b639a0509486b0338acaaae0c84a5124b0f588b7f"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -4802,16 +4832,16 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.84"
+version = "0.2.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95ce90fd5bcc06af55a641a86428ee4229e44e07033963a2290a8e241607ccb9"
+checksum = "c9e7e1900c352b609c8488ad12639a311045f40a35491fb69ba8c12f758af70b"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.48",
  "wasm-bindgen-shared",
 ]
 
@@ -4829,9 +4859,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.84"
+version = "0.2.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c21f77c0bedc37fd5dc21f897894a5ca01e7bb159884559461862ae90c0b4c5"
+checksum = "b30af9e2d358182b5c7449424f017eba305ed32a7010509ede96cdc4696c46ed"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4839,22 +4869,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.84"
+version = "0.2.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2aff81306fcac3c7515ad4e177f521b5c9a15f2b08f4e32d823066102f35a5f6"
+checksum = "642f325be6301eb8107a83d12a8ac6c1e1c54345a7ef1a9261962dfefda09e66"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.48",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.84"
+version = "0.2.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0046fef7e28c3804e5e38bfa31ea2a0f73905319b677e57ebe37e49358989b5d"
+checksum = "4f186bd2dcf04330886ce82d6f33dd75a7bfcf69ecf5763b89fcde53b6ac9838"
 
 [[package]]
 name = "wasm-streams"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,6 @@ dlc-trie = { git = "https://github.com/get10101/rust-dlc", rev = "0191dc4" }
 lightning = { git = "https://github.com/bonomat/rust-lightning-p2p-derivatives", rev = "e49030e" }
 lightning-background-processor = { git = "https://github.com/bonomat/rust-lightning-p2p-derivatives", rev = "e49030e" }
 lightning-transaction-sync = { git = "https://github.com/bonomat/rust-lightning-p2p-derivatives", rev = "e49030e" }
-lightning-net-tokio = { git = "https://github.com/bonomat/rust-lightning-p2p-derivatives", rev = "e49030e" }
 lightning-persister = { git = "https://github.com/bonomat/rust-lightning-p2p-derivatives", rev = "e49030e" }
 lightning-rapid-gossip-sync = { git = "https://github.com/bonomat/rust-lightning-p2p-derivatives", rev = "e49030e" }
 

--- a/coordinator/Cargo.toml
+++ b/coordinator/Cargo.toml
@@ -77,6 +77,7 @@ version = "0.25"
 
 [dependencies.ln-dlc-node]
 path = "../crates/ln-dlc-node"
+features = ["ln_net_axum_ws"]
 
 [dependencies.openssl]
 version = "0.10.60"

--- a/coordinator/src/admin.rs
+++ b/coordinator/src/admin.rs
@@ -508,6 +508,7 @@ pub async fn open_channel(
         let peer = NodeInfo {
             pubkey,
             address: target_address,
+            is_ws: false,
         };
         state.node.inner.connect(peer).await.map_err(|e| {
             AppError::InternalServerError(format!("Could not connect to target node {e:#}"))

--- a/coordinator/src/bin/coordinator.rs
+++ b/coordinator/src/bin/coordinator.rs
@@ -331,7 +331,7 @@ async fn main() -> Result<()> {
     tracing::debug!("Listening on http://{}", http_address);
 
     match axum::Server::bind(&http_address)
-        .serve(app.into_make_service())
+        .serve(app.into_make_service_with_connect_info::<SocketAddr>())
         .await
     {
         Ok(_) => {

--- a/coordinator/src/node/connection.rs
+++ b/coordinator/src/node/connection.rs
@@ -76,6 +76,7 @@ fn reconnect_to_disconnected_public_channel_peers(
                     let node_info = NodeInfo {
                         pubkey: peer,
                         address,
+                        is_ws: false,
                     };
 
                     match node.connect(node_info).await {

--- a/crates/commons/Cargo.toml
+++ b/crates/commons/Cargo.toml
@@ -18,6 +18,6 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sha2 = { version = "0.10", default-features = false }
 time = { version = "0.3", features = ["serde", "std"] }
-tokio-tungstenite = { version = "0.20" }
+tokio-tungstenite-wasm = { version = "0.3.0" }
 trade = { path = "../trade" }
 uuid = { version = "1.3.0", features = ["v4", "serde"] }

--- a/crates/commons/src/message.rs
+++ b/crates/commons/src/message.rs
@@ -11,7 +11,7 @@ use secp256k1::PublicKey;
 use serde::Deserialize;
 use serde::Serialize;
 use std::fmt::Display;
-use tokio_tungstenite::tungstenite;
+use tokio_tungstenite_wasm as tungstenite;
 use uuid::Uuid;
 
 pub type ChannelId = [u8; 32];

--- a/crates/ln-dlc-node/Cargo.toml
+++ b/crates/ln-dlc-node/Cargo.toml
@@ -13,6 +13,7 @@ bdk = { version = "0.28.0", default-features = false, features = ["key-value-db"
 bdk_coin_select = "0.2.0"
 bip39 = { version = "2", features = ["rand_core"] }
 bitcoin = "0.29.2"
+cfg-if = "1.0.0"
 dlc = { version = "0.4.0" }
 dlc-manager = { version = "0.4.0", features = ["use-serde"] }
 dlc-messages = { version = "0.4.0" }
@@ -24,7 +25,6 @@ hkdf = "0.12"
 lightning = { version = "0.0.117", features = ["max_level_trace", "std"] }
 lightning-background-processor = { version = "0.0.117", features = ["futures"] }
 lightning-invoice = { version = "0.25" }
-lightning-net-tokio = { version = "0.0.117" }
 lightning-persister = { version = "0.0.117" }
 lightning-rapid-gossip-sync = { version = "0.0.117" }
 lightning-transaction-sync = { version = "0.0.117", features = ["esplora-blocking"] }
@@ -42,11 +42,19 @@ serde = "1.0.147"
 serde_with = "3.1.0"
 sha2 = "0.10"
 time = "0.3"
-tokio = { version = "1", default-features = false, features = ["io-util", "macros", "rt", "rt-multi-thread", "sync", "net", "time", "tracing"] }
+tokio = { version = "1", default-features = false, features = ["io-util", "macros", "rt", "rt-multi-thread", "sync", "time", "tracing"] }
 tracing = "0.1.37"
 tracing-log = "0.1.3"
 ureq = "2.5.0"
 uuid = { version = "1.3.0", features = ["v4", "serde"] }
+
+axum = { version = "0.6", features = ["ws"], optional = true }
+tokio-tungstenite-wasm = { version = "0.3.0", features = ["native-tls"], optional = true }
+
+# To enable JS support when compiling under wasm
+[dependencies.getrandom]
+version = "*"
+features = ["js"] # Has no effect on other targets
 
 [dev-dependencies]
 time = { version = "0.3", features = ["serde"] }
@@ -54,4 +62,8 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 uuid = { version = "1.3.0", features = ["v4", "serde"] }
 
 [features]
+default = ["ln_net_tcp"]
 load_tests = []
+ln_net_axum_ws = ["dep:axum"]
+ln_net_ws = ["dep:tokio-tungstenite-wasm"]
+ln_net_tcp = ["tokio/net"]

--- a/crates/ln-dlc-node/src/lib.rs
+++ b/crates/ln-dlc-node/src/lib.rs
@@ -19,7 +19,6 @@ use lightning::routing::scoring::ProbabilisticScoringFeeParameters;
 use lightning::routing::utxo::UtxoLookup;
 use lightning_invoice::Bolt11Invoice;
 use lightning_invoice::Bolt11InvoiceDescription;
-use lightning_net_tokio::SocketDescriptor;
 use ln_dlc_wallet::LnDlcWallet;
 use std::fmt;
 use std::sync::Arc;
@@ -36,6 +35,7 @@ pub mod channel;
 pub mod config;
 pub mod dlc_message;
 pub mod ln;
+pub mod networking;
 pub mod node;
 pub mod scorer;
 pub mod seed;
@@ -43,6 +43,7 @@ pub mod storage;
 pub mod transaction;
 pub mod util;
 
+use crate::networking::DynamicSocketDescriptor;
 pub use config::CONFIRMATION_TARGET;
 pub use ldk_node_wallet::WalletSettings;
 pub use lightning;
@@ -69,7 +70,7 @@ type ChainMonitor<S, N> = chainmonitor::ChainMonitor<
 >;
 
 pub type PeerManager<S, N> = lightning::ln::peer_handler::PeerManager<
-    SocketDescriptor,
+    DynamicSocketDescriptor,
     Arc<SubChannelManager<S, N>>,
     Arc<dyn RoutingMessageHandler + Send + Sync>,
     Arc<TenTenOneOnionMessageHandler>,

--- a/crates/ln-dlc-node/src/networking.rs
+++ b/crates/ln-dlc-node/src/networking.rs
@@ -1,0 +1,87 @@
+use crate::node::NodeInfo;
+use futures::future;
+use lightning::ln::peer_handler::APeerManager;
+use lightning::ln::peer_handler::SocketDescriptor;
+use std::future::Future;
+use std::ops::Deref;
+use tracing::debug;
+
+#[cfg(feature = "ln_net_axum_ws")]
+pub mod axum;
+#[cfg(feature = "ln_net_tcp")]
+pub mod tcp;
+#[cfg(feature = "ln_net_ws")]
+mod tungstenite;
+
+#[allow(clippy::diverging_sub_expression, unused_variables, unreachable_code)] // From the panic!() below
+pub async fn connect_outbound<PM: Deref + 'static + Send + Sync + Clone>(
+    peer_manager: PM,
+    peer: NodeInfo,
+) -> Option<impl Future<Output = ()>>
+where
+    PM::Target: APeerManager<Descriptor = DynamicSocketDescriptor>,
+{
+    if peer.is_ws {
+        debug!("Connecting over WS");
+
+        #[cfg(not(feature = "ln_net_ws"))]
+        let ws: Option<future::Either<future::Ready<()>, _>> =
+            panic!("Cannot connect outbound over WS when ln_net_ws is not enabled");
+
+        #[cfg(feature = "ln_net_ws")]
+        let ws = tungstenite::connect_outbound(peer_manager, peer)
+            .await
+            .map(future::Either::Left);
+
+        ws
+    } else {
+        debug!("Connecting over TCP");
+
+        #[cfg(not(feature = "ln_net_tcp"))]
+        let tcp: Option<future::Either<_, future::Ready<()>>> =
+            panic!("Cannot connect outbound over TCP when ln_net_tcp is not enabled");
+
+        #[cfg(feature = "ln_net_tcp")]
+        let tcp = tcp::connect_outbound(peer_manager, peer.pubkey, peer.address)
+            .await
+            .map(future::Either::Right);
+
+        tcp
+    }
+}
+
+/// A dynamic socket descriptor that could either be over WASM (JS) websockets, TCP sockets
+/// (lightning_net_tokio), or Axum websockets.
+#[derive(Hash, Clone, Eq, PartialEq)]
+pub enum DynamicSocketDescriptor {
+    #[cfg(feature = "ln_net_tcp")]
+    Tcp(tcp::SocketDescriptor),
+    #[cfg(feature = "ln_net_axum_ws")]
+    Axum(axum::SocketDescriptor),
+    #[cfg(feature = "ln_net_ws")]
+    Tungstenite(tungstenite::SocketDescriptor),
+}
+
+impl SocketDescriptor for DynamicSocketDescriptor {
+    fn send_data(&mut self, data: &[u8], resume_read: bool) -> usize {
+        match self {
+            #[cfg(feature = "ln_net_tcp")]
+            DynamicSocketDescriptor::Tcp(sock) => sock.send_data(data, resume_read),
+            #[cfg(feature = "ln_net_axum_ws")]
+            DynamicSocketDescriptor::Axum(sock) => sock.send_data(data, resume_read),
+            #[cfg(feature = "ln_net_ws")]
+            DynamicSocketDescriptor::Tungstenite(sock) => sock.send_data(data, resume_read),
+        }
+    }
+
+    fn disconnect_socket(&mut self) {
+        match self {
+            #[cfg(feature = "ln_net_tcp")]
+            DynamicSocketDescriptor::Tcp(sock) => sock.disconnect_socket(),
+            #[cfg(feature = "ln_net_axum_ws")]
+            DynamicSocketDescriptor::Axum(sock) => sock.disconnect_socket(),
+            #[cfg(feature = "ln_net_ws")]
+            DynamicSocketDescriptor::Tungstenite(sock) => sock.disconnect_socket(),
+        }
+    }
+}

--- a/crates/ln-dlc-node/src/networking/axum.rs
+++ b/crates/ln-dlc-node/src/networking/axum.rs
@@ -1,0 +1,147 @@
+use crate::networking::DynamicSocketDescriptor;
+use anyhow::Context;
+use axum::extract::ws::Message;
+use axum::extract::ws::WebSocket;
+use futures::future::Either;
+use futures::StreamExt;
+use lightning::ln::peer_handler;
+use lightning::ln::peer_handler::APeerManager;
+use std::future;
+use std::hash::Hash;
+use std::hash::Hasher;
+use std::net::SocketAddr;
+use std::ops::ControlFlow;
+use std::ops::Deref;
+use std::sync::atomic::AtomicU64;
+use std::sync::atomic::Ordering;
+use tokio::sync::mpsc;
+use tokio::sync::mpsc::UnboundedReceiver;
+use tracing::error;
+
+static ID_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+pub async fn setup_inbound<PM: Deref + 'static + Send + Sync + Clone>(
+    peer_manager: PM,
+    mut ws: WebSocket,
+    remote: SocketAddr,
+) where
+    PM::Target: APeerManager<Descriptor = DynamicSocketDescriptor>,
+{
+    let (task_tx, mut task_rx) = mpsc::unbounded_channel();
+    let mut descriptor = DynamicSocketDescriptor::Axum(SocketDescriptor {
+        tx: task_tx,
+        id: ID_COUNTER.fetch_add(1, Ordering::AcqRel),
+    });
+
+    if peer_manager
+        .as_ref()
+        .new_inbound_connection(descriptor.clone(), Some(remote.into()))
+        .is_ok()
+    {
+        let mut emit_read_events = true;
+        loop {
+            match process_messages(
+                &peer_manager,
+                &mut task_rx,
+                &mut ws,
+                &mut descriptor,
+                &mut emit_read_events,
+            )
+            .await
+            {
+                Ok(ControlFlow::Break(())) => break,
+                Ok(ControlFlow::Continue(())) => (),
+                Err(err) => {
+                    error!("Disconnecting websocket with error: {err}");
+                    peer_manager.as_ref().socket_disconnected(&descriptor);
+                    peer_manager.as_ref().process_events();
+                    break;
+                }
+            }
+        }
+
+        let _ = ws.close().await;
+    }
+}
+
+async fn process_messages<PM>(
+    peer_manager: &PM,
+    task_rx: &mut UnboundedReceiver<BgTaskMessage>,
+    ws: &mut WebSocket,
+    descriptor: &mut DynamicSocketDescriptor,
+    emit_read_events: &mut bool,
+) -> Result<ControlFlow<()>, anyhow::Error>
+where
+    PM: Deref + 'static + Send + Sync + Clone,
+    PM::Target: APeerManager<Descriptor = DynamicSocketDescriptor>,
+{
+    let ws_next = if *emit_read_events {
+        Either::Left(ws.next())
+    } else {
+        Either::Right(future::pending())
+    };
+
+    tokio::select! {
+        task_msg = task_rx.recv() => match task_msg.context("rust-lightning SocketDescriptor dropped")? {
+            BgTaskMessage::SendData { data, resume_read } => {
+                if resume_read {
+                    *emit_read_events = true;
+                }
+
+                ws.send(Message::Binary(data)).await?;
+            },
+            BgTaskMessage::Close => {
+                return Ok(ControlFlow::Break(()))
+            },
+        },
+        ws_msg = ws_next => {
+            let data = ws_msg.context("WS returned no data")??.into_data();
+            if let Ok(true) = peer_manager.as_ref().read_event(descriptor, &data) {
+                *emit_read_events = false; // Pause read events
+            }
+
+            peer_manager.as_ref().process_events();
+        }
+    }
+
+    Ok(ControlFlow::Continue(()))
+}
+
+enum BgTaskMessage {
+    SendData { data: Vec<u8>, resume_read: bool },
+    Close,
+}
+
+#[derive(Clone)]
+pub struct SocketDescriptor {
+    tx: mpsc::UnboundedSender<BgTaskMessage>,
+    id: u64,
+}
+
+impl Eq for SocketDescriptor {}
+impl PartialEq for SocketDescriptor {
+    fn eq(&self, o: &Self) -> bool {
+        self.id == o.id
+    }
+}
+
+impl Hash for SocketDescriptor {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.id.hash(state);
+    }
+}
+
+impl peer_handler::SocketDescriptor for SocketDescriptor {
+    fn send_data(&mut self, data: &[u8], resume_read: bool) -> usize {
+        // See the TODO in tungstenite.rs
+        let _ = self.tx.send(BgTaskMessage::SendData {
+            data: data.to_vec(),
+            resume_read,
+        });
+        data.len()
+    }
+
+    fn disconnect_socket(&mut self) {
+        let _ = self.tx.send(BgTaskMessage::Close);
+    }
+}

--- a/crates/ln-dlc-node/src/networking/tcp.rs
+++ b/crates/ln-dlc-node/src/networking/tcp.rs
@@ -1,0 +1,646 @@
+// This code comes from https://github.com/bonomat/rust-lightning-p2p-derivatives/blob/main/lightning-net-tokio/src/lib.rs
+// (revision fd2464374b2e826a77582c511eb65bece4403be4)  and is under following license. Please
+// interpret 'visible in version control' to refer to the version control of the
+// rust-lightning-p2p-derivatives repository, NOT the 10101 repository. It has been modified for
+// use with 10101.
+//
+// Original license follows:
+// This file is Copyright its original authors, visible in version control
+// history.
+//
+// This file is licensed under the Apache License, Version 2.0 <LICENSE-APACHE
+// or http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your option.
+// You may not use this file except in accordance with one or both of these
+// licenses.
+
+//! A socket handling library for those running in Tokio environments who wish to use
+//! rust-lightning with native [`TcpStream`]s.
+//!
+//! Designed to be as simple as possible, the high-level usage is almost as simple as "hand over a
+//! [`TcpStream`] and a reference to a [`PeerManager`] and the rest is handled".
+//!
+//! The [`PeerManager`], due to the fire-and-forget nature of this logic, must be a reference,
+//! (e.g. an [`Arc`]) and must use the [`SocketDescriptor`] provided here as the [`PeerManager`]'s
+//! `SocketDescriptor` implementation.
+//!
+//! Three methods are exposed to register a new connection for handling in [`tokio::spawn`] calls;
+//! see their individual docs for details.
+//!
+//! [`PeerManager`]: lightning::ln::peer_handler::PeerManager
+
+// Prefix these with `rustdoc::` when we update our MSRV to be >= 1.52 to remove warnings.
+#![allow(clippy::unwrap_used)]
+#![deny(broken_intra_doc_links)]
+#![deny(private_intra_doc_links)]
+#![deny(missing_docs)]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+
+use crate::networking::DynamicSocketDescriptor;
+use bitcoin::secp256k1::PublicKey;
+use lightning::ln::msgs::SocketAddress;
+use lightning::ln::peer_handler;
+use lightning::ln::peer_handler::APeerManager;
+use lightning::ln::peer_handler::SocketDescriptor as LnSocketTrait;
+use std::future::Future;
+use std::hash::Hash;
+use std::net::SocketAddr;
+use std::net::TcpStream as StdTcpStream;
+use std::ops::Deref;
+use std::pin::Pin;
+use std::sync::atomic::AtomicU64;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::task::Poll;
+use std::task::{self};
+use std::time::Duration;
+use tokio::io;
+use tokio::io::AsyncReadExt;
+use tokio::io::AsyncWrite;
+use tokio::io::AsyncWriteExt;
+use tokio::net::TcpStream;
+use tokio::sync::mpsc;
+use tokio::time;
+
+static ID_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+// We only need to select over multiple futures in one place, and taking on the full `tokio/macros`
+// dependency tree in order to do so (which has broken our MSRV before) is excessive. Instead, we
+// define a trivial two- and three- select macro with the specific types we need and just use that.
+
+pub(crate) enum SelectorOutput {
+    A(Option<()>),
+    B(Option<()>),
+    C(tokio::io::Result<usize>),
+}
+
+pub(crate) struct TwoSelector<
+    A: Future<Output = Option<()>> + Unpin,
+    B: Future<Output = Option<()>> + Unpin,
+> {
+    pub a: A,
+    pub b: B,
+}
+
+impl<A: Future<Output = Option<()>> + Unpin, B: Future<Output = Option<()>> + Unpin> Future
+    for TwoSelector<A, B>
+{
+    type Output = SelectorOutput;
+    fn poll(mut self: Pin<&mut Self>, ctx: &mut task::Context<'_>) -> Poll<SelectorOutput> {
+        match Pin::new(&mut self.a).poll(ctx) {
+            Poll::Ready(res) => {
+                return Poll::Ready(SelectorOutput::A(res));
+            }
+            Poll::Pending => {}
+        }
+        match Pin::new(&mut self.b).poll(ctx) {
+            Poll::Ready(res) => {
+                return Poll::Ready(SelectorOutput::B(res));
+            }
+            Poll::Pending => {}
+        }
+        Poll::Pending
+    }
+}
+
+pub(crate) struct ThreeSelector<
+    A: Future<Output = Option<()>> + Unpin,
+    B: Future<Output = Option<()>> + Unpin,
+    C: Future<Output = tokio::io::Result<usize>> + Unpin,
+> {
+    pub a: A,
+    pub b: B,
+    pub c: C,
+}
+
+impl<
+        A: Future<Output = Option<()>> + Unpin,
+        B: Future<Output = Option<()>> + Unpin,
+        C: Future<Output = tokio::io::Result<usize>> + Unpin,
+    > Future for ThreeSelector<A, B, C>
+{
+    type Output = SelectorOutput;
+    fn poll(mut self: Pin<&mut Self>, ctx: &mut task::Context<'_>) -> Poll<SelectorOutput> {
+        match Pin::new(&mut self.a).poll(ctx) {
+            Poll::Ready(res) => {
+                return Poll::Ready(SelectorOutput::A(res));
+            }
+            Poll::Pending => {}
+        }
+        match Pin::new(&mut self.b).poll(ctx) {
+            Poll::Ready(res) => {
+                return Poll::Ready(SelectorOutput::B(res));
+            }
+            Poll::Pending => {}
+        }
+        match Pin::new(&mut self.c).poll(ctx) {
+            Poll::Ready(res) => {
+                return Poll::Ready(SelectorOutput::C(res));
+            }
+            Poll::Pending => {}
+        }
+        Poll::Pending
+    }
+}
+
+/// Connection contains all our internal state for a connection - we hold a reference to the
+/// Connection object (in an Arc<Mutex<>>) in each SocketDescriptor we create as well as in the
+/// read future (which is returned by schedule_read).
+struct Connection {
+    writer: Option<io::WriteHalf<TcpStream>>,
+    // Because our PeerManager is templated by user-provided types, and we can't (as far as I can
+    // tell) have a const RawWakerVTable built out of templated functions, we need some indirection
+    // between being woken up with write-ready and calling PeerManager::write_buffer_space_avail.
+    // This provides that indirection, with a Sender which gets handed to the PeerManager Arc on
+    // the schedule_read stack.
+    //
+    // An alternative (likely more effecient) approach would involve creating a RawWakerVTable at
+    // runtime with functions templated by the Arc<PeerManager> type, calling
+    // write_buffer_space_avail directly from tokio's write wake, however doing so would require
+    // more unsafe voodo than I really feel like writing.
+    write_avail: mpsc::Sender<()>,
+    // When we are told by rust-lightning to pause read (because we have writes backing up), we do
+    // so by setting read_paused. At that point, the read task will stop reading bytes from the
+    // socket. To wake it up (without otherwise changing its state, we can push a value into this
+    // Sender.
+    read_waker: mpsc::Sender<()>,
+    read_paused: bool,
+    rl_requested_disconnect: bool,
+    id: u64,
+}
+impl Connection {
+    async fn poll_event_process<PM: Deref + 'static + Send + Sync>(
+        peer_manager: PM,
+        mut event_receiver: mpsc::Receiver<()>,
+    ) where
+        PM::Target: APeerManager<Descriptor = DynamicSocketDescriptor>,
+    {
+        loop {
+            if event_receiver.recv().await.is_none() {
+                return;
+            }
+            peer_manager.as_ref().process_events();
+        }
+    }
+
+    async fn schedule_read<PM: Deref + 'static + Send + Sync + Clone>(
+        peer_manager: PM,
+        us: Arc<Mutex<Self>>,
+        mut reader: io::ReadHalf<TcpStream>,
+        mut read_wake_receiver: mpsc::Receiver<()>,
+        mut write_avail_receiver: mpsc::Receiver<()>,
+    ) where
+        PM::Target: APeerManager<Descriptor = DynamicSocketDescriptor>,
+    {
+        // Create a waker to wake up poll_event_process, above
+        let (event_waker, event_receiver) = mpsc::channel(1);
+        tokio::spawn(Self::poll_event_process(
+            peer_manager.clone(),
+            event_receiver,
+        ));
+
+        // 4KiB is nice and big without handling too many messages all at once, giving other peers
+        // a chance to do some work.
+        let mut buf = [0; 4096];
+
+        let mut our_descriptor = DynamicSocketDescriptor::Tcp(SocketDescriptor::new(us.clone()));
+        // An enum describing why we did/are disconnecting:
+        enum Disconnect {
+            // Rust-Lightning told us to disconnect, either by returning an Err or by calling
+            // SocketDescriptor::disconnect_socket.
+            // In this case, we do not call peer_manager.socket_disconnected() as Rust-Lightning
+            // already knows we're disconnected.
+            CloseConnection,
+            // The connection was disconnected for some other reason, ie because the socket was
+            // closed.
+            // In this case, we do need to call peer_manager.socket_disconnected() to inform
+            // Rust-Lightning that the socket is gone.
+            PeerDisconnected,
+        }
+        let disconnect_type = loop {
+            let read_paused = {
+                let us_lock = us.lock().unwrap();
+                if us_lock.rl_requested_disconnect {
+                    break Disconnect::CloseConnection;
+                }
+                us_lock.read_paused
+            };
+            // TODO: Drop the Box'ing of the futures once Rust has pin-on-stack support.
+            let select_result = if read_paused {
+                TwoSelector {
+                    a: Box::pin(write_avail_receiver.recv()),
+                    b: Box::pin(read_wake_receiver.recv()),
+                }
+                .await
+            } else {
+                ThreeSelector {
+                    a: Box::pin(write_avail_receiver.recv()),
+                    b: Box::pin(read_wake_receiver.recv()),
+                    c: Box::pin(reader.read(&mut buf)),
+                }
+                .await
+            };
+            match select_result {
+                SelectorOutput::A(v) => {
+                    assert!(v.is_some()); // We can't have dropped the sending end, its in the us Arc!
+                    if peer_manager
+                        .as_ref()
+                        .write_buffer_space_avail(&mut our_descriptor)
+                        .is_err()
+                    {
+                        break Disconnect::CloseConnection;
+                    }
+                }
+                SelectorOutput::B(_) => {}
+                SelectorOutput::C(read) => match read {
+                    Ok(0) => break Disconnect::PeerDisconnected,
+                    Ok(len) => {
+                        let read_res = peer_manager
+                            .as_ref()
+                            .read_event(&mut our_descriptor, &buf[0..len]);
+                        let mut us_lock = us.lock().unwrap();
+                        match read_res {
+                            Ok(pause_read) => {
+                                if pause_read {
+                                    us_lock.read_paused = true;
+                                }
+                            }
+                            Err(_) => break Disconnect::CloseConnection,
+                        }
+                    }
+                    Err(_) => break Disconnect::PeerDisconnected,
+                },
+            }
+            let _ = event_waker.try_send(());
+
+            // At this point we've processed a message or two, and reset the ping timer for this
+            // peer, at least in the "are we still receiving messages" context, if we don't give up
+            // our timeslice to another task we may just spin on this peer, starving other peers
+            // and eventually disconnecting them for ping timeouts. Instead, we explicitly yield
+            // here.
+            let _ = tokio::task::yield_now().await;
+        };
+        let writer_option = us.lock().unwrap().writer.take();
+        if let Some(mut writer) = writer_option {
+            // If the socket is already closed, shutdown() will fail, so just ignore it.
+            let _ = writer.shutdown().await;
+        }
+        if let Disconnect::PeerDisconnected = disconnect_type {
+            peer_manager.as_ref().socket_disconnected(&our_descriptor);
+            peer_manager.as_ref().process_events();
+        }
+    }
+
+    fn new(
+        stream: StdTcpStream,
+    ) -> (
+        io::ReadHalf<TcpStream>,
+        mpsc::Receiver<()>,
+        mpsc::Receiver<()>,
+        Arc<Mutex<Self>>,
+    ) {
+        // We only ever need a channel of depth 1 here: if we returned a non-full write to the
+        // PeerManager, we will eventually get notified that there is room in the socket to write
+        // new bytes, which will generate an event. That event will be popped off the queue before
+        // we call write_buffer_space_avail, ensuring that we have room to push a new () if, during
+        // the write_buffer_space_avail() call, send_data() returns a non-full write.
+        let (write_avail, write_receiver) = mpsc::channel(1);
+        // Similarly here - our only goal is to make sure the reader wakes up at some point after
+        // we shove a value into the channel which comes after we've reset the read_paused bool to
+        // false.
+        let (read_waker, read_receiver) = mpsc::channel(1);
+        stream.set_nonblocking(true).unwrap();
+        let (reader, writer) = io::split(TcpStream::from_std(stream).unwrap());
+
+        (
+            reader,
+            write_receiver,
+            read_receiver,
+            Arc::new(Mutex::new(Self {
+                writer: Some(writer),
+                write_avail,
+                read_waker,
+                read_paused: false,
+                rl_requested_disconnect: false,
+                id: ID_COUNTER.fetch_add(1, Ordering::AcqRel),
+            })),
+        )
+    }
+}
+
+fn get_addr_from_stream(stream: &StdTcpStream) -> Option<SocketAddress> {
+    match stream.peer_addr() {
+        Ok(SocketAddr::V4(sockaddr)) => Some(SocketAddress::TcpIpV4 {
+            addr: sockaddr.ip().octets(),
+            port: sockaddr.port(),
+        }),
+        Ok(SocketAddr::V6(sockaddr)) => Some(SocketAddress::TcpIpV6 {
+            addr: sockaddr.ip().octets(),
+            port: sockaddr.port(),
+        }),
+        Err(_) => None,
+    }
+}
+
+/// Process incoming messages and feed outgoing messages on the provided socket generated by
+/// accepting an incoming connection.
+///
+/// The returned future will complete when the peer is disconnected and associated handling
+/// futures are freed, though, because all processing futures are spawned with tokio::spawn, you do
+/// not need to poll the provided future in order to make progress.
+pub fn setup_inbound<PM: Deref + 'static + Send + Sync + Clone>(
+    peer_manager: PM,
+    stream: StdTcpStream,
+) -> impl Future<Output = ()>
+where
+    PM::Target: APeerManager<Descriptor = DynamicSocketDescriptor>,
+{
+    let remote_addr = get_addr_from_stream(&stream);
+    let (reader, write_receiver, read_receiver, us) = Connection::new(stream);
+    #[cfg(test)]
+    let last_us = Arc::clone(&us);
+
+    let descriptor = DynamicSocketDescriptor::Tcp(SocketDescriptor::new(us.clone()));
+    let handle_opt = if peer_manager
+        .as_ref()
+        .new_inbound_connection(descriptor, remote_addr)
+        .is_ok()
+    {
+        Some(tokio::spawn(Connection::schedule_read(
+            peer_manager,
+            us,
+            reader,
+            read_receiver,
+            write_receiver,
+        )))
+    } else {
+        // Note that we will skip socket_disconnected here, in accordance with the PeerManager
+        // requirements.
+        None
+    };
+
+    async move {
+        if let Some(handle) = handle_opt {
+            if let Err(e) = handle.await {
+                assert!(e.is_cancelled());
+            } else {
+                // This is certainly not guaranteed to always be true - the read loop may exit
+                // while there are still pending write wakers that need to be woken up after the
+                // socket shutdown(). Still, as a check during testing, to make sure tokio doesn't
+                // keep too many wakers around, this makes sense. The race should be rare (we do
+                // some work after shutdown()) and an error would be a major memory leak.
+                #[cfg(test)]
+                debug_assert!(Arc::try_unwrap(last_us).is_ok());
+            }
+        }
+    }
+}
+
+/// Process incoming messages and feed outgoing messages on the provided socket generated by
+/// making an outbound connection which is expected to be accepted by a peer with the given
+/// public key. The relevant processing is set to run free (via tokio::spawn).
+///
+/// The returned future will complete when the peer is disconnected and associated handling
+/// futures are freed, though, because all processing futures are spawned with tokio::spawn, you do
+/// not need to poll the provided future in order to make progress.
+pub fn setup_outbound<PM: Deref + 'static + Send + Sync + Clone>(
+    peer_manager: PM,
+    their_node_id: PublicKey,
+    stream: StdTcpStream,
+) -> impl Future<Output = ()>
+where
+    PM::Target: APeerManager<Descriptor = DynamicSocketDescriptor>,
+{
+    let remote_addr = get_addr_from_stream(&stream);
+    let (reader, mut write_receiver, read_receiver, us) = Connection::new(stream);
+    #[cfg(test)]
+    let last_us = Arc::clone(&us);
+    let descriptor = DynamicSocketDescriptor::Tcp(SocketDescriptor::new(us.clone()));
+    let handle_opt = if let Ok(initial_send) =
+        peer_manager
+            .as_ref()
+            .new_outbound_connection(their_node_id, descriptor, remote_addr)
+    {
+        Some(tokio::spawn(async move {
+            // We should essentially always have enough room in a TCP socket buffer to send the
+            // initial 10s of bytes. However, tokio running in single-threaded mode will always
+            // fail writes and wake us back up later to write. Thus, we handle a single
+            // std::task::Poll::Pending but still expect to write the full set of bytes at once
+            // and use a relatively tight timeout.
+            if let Ok(Ok(())) = tokio::time::timeout(Duration::from_millis(100), async {
+                loop {
+                    match SocketDescriptor::new(us.clone()).send_data(&initial_send, true) {
+                        v if v == initial_send.len() => break Ok(()),
+                        0 => {
+                            write_receiver.recv().await;
+                            // In theory we could check for if we've been instructed to disconnect
+                            // the peer here, but its OK to just skip it - we'll check for it in
+                            // schedule_read prior to any relevant calls into RL.
+                        }
+                        _ => {
+                            tracing::error!("Failed to write first full message to socket!");
+                            let descriptor = DynamicSocketDescriptor::Tcp(SocketDescriptor::new(
+                                Arc::clone(&us),
+                            ));
+                            peer_manager.as_ref().socket_disconnected(&descriptor);
+                            break Err(());
+                        }
+                    }
+                }
+            })
+            .await
+            {
+                Connection::schedule_read(peer_manager, us, reader, read_receiver, write_receiver)
+                    .await;
+            }
+        }))
+    } else {
+        // Note that we will skip socket_disconnected here, in accordance with the PeerManager
+        // requirements.
+        None
+    };
+
+    async move {
+        if let Some(handle) = handle_opt {
+            if let Err(e) = handle.await {
+                assert!(e.is_cancelled());
+            } else {
+                // This is certainly not guaranteed to always be true - the read loop may exit
+                // while there are still pending write wakers that need to be woken up after the
+                // socket shutdown(). Still, as a check during testing, to make sure tokio doesn't
+                // keep too many wakers around, this makes sense. The race should be rare (we do
+                // some work after shutdown()) and an error would be a major memory leak.
+                #[cfg(test)]
+                debug_assert!(Arc::try_unwrap(last_us).is_ok());
+            }
+        }
+    }
+}
+
+/// Process incoming messages and feed outgoing messages on a new connection made to the given
+/// socket address which is expected to be accepted by a peer with the given public key (by
+/// scheduling futures with tokio::spawn).
+///
+/// Shorthand for TcpStream::connect(addr) with a timeout followed by setup_outbound().
+///
+/// Returns a future (as the fn is async) which needs to be polled to complete the connection and
+/// connection setup. That future then returns a future which will complete when the peer is
+/// disconnected and associated handling futures are freed, though, because all processing in said
+/// futures are spawned with tokio::spawn, you do not need to poll the second future in order to
+/// make progress.
+pub async fn connect_outbound<PM: Deref + 'static + Send + Sync + Clone>(
+    peer_manager: PM,
+    their_node_id: PublicKey,
+    addr: SocketAddr,
+) -> Option<impl Future<Output = ()>>
+where
+    PM::Target: APeerManager<Descriptor = DynamicSocketDescriptor>,
+{
+    if let Ok(Ok(stream)) = time::timeout(Duration::from_secs(10), async {
+        TcpStream::connect(&addr)
+            .await
+            .map(|s| s.into_std().unwrap())
+    })
+    .await
+    {
+        Some(setup_outbound(peer_manager, their_node_id, stream))
+    } else {
+        None
+    }
+}
+
+const SOCK_WAKER_VTABLE: task::RawWakerVTable = task::RawWakerVTable::new(
+    clone_socket_waker,
+    wake_socket_waker,
+    wake_socket_waker_by_ref,
+    drop_socket_waker,
+);
+
+fn clone_socket_waker(orig_ptr: *const ()) -> task::RawWaker {
+    write_avail_to_waker(orig_ptr as *const mpsc::Sender<()>)
+}
+// When waking, an error should be fine. Most likely we got two send_datas in a row, both of which
+// failed to fully write, but we only need to call write_buffer_space_avail() once. Otherwise, the
+// sending thread may have already gone away due to a socket close, in which case there's nothing
+// to wake up anyway.
+fn wake_socket_waker(orig_ptr: *const ()) {
+    let sender = unsafe { &mut *(orig_ptr as *mut mpsc::Sender<()>) };
+    let _ = sender.try_send(());
+    drop_socket_waker(orig_ptr);
+}
+fn wake_socket_waker_by_ref(orig_ptr: *const ()) {
+    let sender_ptr = orig_ptr as *const mpsc::Sender<()>;
+    let sender = unsafe { (*sender_ptr).clone() };
+    let _ = sender.try_send(());
+}
+fn drop_socket_waker(orig_ptr: *const ()) {
+    let _orig_box = unsafe { Box::from_raw(orig_ptr as *mut mpsc::Sender<()>) };
+    // _orig_box is now dropped
+}
+fn write_avail_to_waker(sender: *const mpsc::Sender<()>) -> task::RawWaker {
+    let new_box = Box::leak(Box::new(unsafe { (*sender).clone() }));
+    let new_ptr = new_box as *const mpsc::Sender<()>;
+    task::RawWaker::new(new_ptr as *const (), &SOCK_WAKER_VTABLE)
+}
+
+/// The SocketDescriptor used to refer to sockets by a PeerHandler. This is pub only as it is a
+/// type in the template of PeerHandler.
+pub struct SocketDescriptor {
+    conn: Arc<Mutex<Connection>>,
+    id: u64,
+}
+impl SocketDescriptor {
+    fn new(conn: Arc<Mutex<Connection>>) -> Self {
+        let id = conn.lock().unwrap().id;
+        Self { conn, id }
+    }
+}
+impl peer_handler::SocketDescriptor for SocketDescriptor {
+    fn send_data(&mut self, data: &[u8], resume_read: bool) -> usize {
+        // To send data, we take a lock on our Connection to access the WriteHalf of the TcpStream,
+        // writing to it if there's room in the kernel buffer, or otherwise create a new Waker with
+        // a SocketDescriptor in it which can wake up the write_avail Sender, waking up the
+        // processing future which will call write_buffer_space_avail and we'll end up back here.
+        let mut us = self.conn.lock().unwrap();
+        if us.writer.is_none() {
+            // The writer gets take()n when it is time to shut down, so just fast-return 0 here.
+            return 0;
+        }
+
+        if resume_read && us.read_paused {
+            // The schedule_read future may go to lock up but end up getting woken up by there
+            // being more room in the write buffer, dropping the other end of this Sender
+            // before we get here, so we ignore any failures to wake it up.
+            us.read_paused = false;
+            let _ = us.read_waker.try_send(());
+        }
+        if data.is_empty() {
+            return 0;
+        }
+        let waker = unsafe { task::Waker::from_raw(write_avail_to_waker(&us.write_avail)) };
+        let mut ctx = task::Context::from_waker(&waker);
+        let mut written_len = 0;
+        loop {
+            match std::pin::Pin::new(us.writer.as_mut().unwrap())
+                .poll_write(&mut ctx, &data[written_len..])
+            {
+                task::Poll::Ready(Ok(res)) => {
+                    // The tokio docs *seem* to indicate this can't happen, and I certainly don't
+                    // know how to handle it if it does (cause it should be a Poll::Pending
+                    // instead):
+                    assert_ne!(res, 0);
+                    written_len += res;
+                    if written_len == data.len() {
+                        return written_len;
+                    }
+                }
+                task::Poll::Ready(Err(e)) => {
+                    // The tokio docs *seem* to indicate this can't happen, and I certainly don't
+                    // know how to handle it if it does (cause it should be a Poll::Pending
+                    // instead):
+                    assert_ne!(e.kind(), io::ErrorKind::WouldBlock);
+                    // Probably we've already been closed, just return what we have and let the
+                    // read thread handle closing logic.
+                    return written_len;
+                }
+                task::Poll::Pending => {
+                    // We're queued up for a write event now, but we need to make sure we also
+                    // pause read given we're now waiting on the remote end to ACK (and in
+                    // accordance with the send_data() docs).
+                    us.read_paused = true;
+                    // Further, to avoid any current pending read causing a `read_event` call, wake
+                    // up the read_waker and restart its loop.
+                    let _ = us.read_waker.try_send(());
+                    return written_len;
+                }
+            }
+        }
+    }
+
+    fn disconnect_socket(&mut self) {
+        let mut us = self.conn.lock().unwrap();
+        us.rl_requested_disconnect = true;
+        // Wake up the sending thread, assuming it is still alive
+        let _ = us.write_avail.try_send(());
+    }
+}
+impl Clone for SocketDescriptor {
+    fn clone(&self) -> Self {
+        Self {
+            conn: Arc::clone(&self.conn),
+            id: self.id,
+        }
+    }
+}
+impl Eq for SocketDescriptor {}
+impl PartialEq for SocketDescriptor {
+    fn eq(&self, o: &Self) -> bool {
+        self.id == o.id
+    }
+}
+impl Hash for SocketDescriptor {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.id.hash(state);
+    }
+}

--- a/crates/ln-dlc-node/src/networking/tungstenite.rs
+++ b/crates/ln-dlc-node/src/networking/tungstenite.rs
@@ -1,0 +1,179 @@
+use crate::networking::DynamicSocketDescriptor;
+use crate::node::NodeInfo;
+use anyhow::Context;
+use futures::future::Either;
+use futures::SinkExt;
+use futures::StreamExt;
+use lightning::ln::peer_handler;
+use lightning::ln::peer_handler::APeerManager;
+use std::future;
+use std::future::Future;
+use std::hash::Hash;
+use std::hash::Hasher;
+use std::ops::ControlFlow;
+use std::ops::Deref;
+use std::sync::atomic::AtomicU64;
+use std::sync::atomic::Ordering;
+use tokio::sync::mpsc;
+use tokio::sync::mpsc::UnboundedReceiver;
+use tokio_tungstenite_wasm::Message;
+use tokio_tungstenite_wasm::WebSocketStream;
+use tracing::error;
+
+static ID_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+pub async fn connect_outbound<PM>(
+    peer_manager: PM,
+    node_info: NodeInfo,
+) -> Option<impl Future<Output = ()>>
+where
+    PM: Deref + 'static + Send + Sync + Clone,
+    PM::Target: APeerManager<Descriptor = DynamicSocketDescriptor>,
+{
+    let url = &format!(
+        "ws://{}:{}",
+        node_info.address.ip(),
+        node_info.address.port()
+    );
+    let mut ws = tokio_tungstenite_wasm::connect(url)
+        .await
+        .map_err(|err| error!("error connecting to peer over websocket: {err:#?}"))
+        .ok()?;
+
+    let (task_tx, mut task_rx) = mpsc::unbounded_channel();
+    let mut descriptor = DynamicSocketDescriptor::Tungstenite(SocketDescriptor {
+        tx: task_tx,
+        id: ID_COUNTER.fetch_add(1, Ordering::AcqRel),
+    });
+
+    if let Ok(initial_send) = peer_manager.as_ref().new_outbound_connection(
+        node_info.pubkey,
+        descriptor.clone(),
+        Some(node_info.address.into()),
+    ) {
+        ws.send(Message::Binary(initial_send))
+            .await
+            .map_err(|err| error!("error sending initial data over websocket: {err:#?}"))
+            .ok()?;
+
+        Some(async move {
+            let mut emit_read_events = true;
+            loop {
+                match process_messages(
+                    &peer_manager,
+                    &mut task_rx,
+                    &mut ws,
+                    &mut descriptor,
+                    &mut emit_read_events,
+                )
+                .await
+                {
+                    Ok(ControlFlow::Break(())) => break,
+                    Ok(ControlFlow::Continue(())) => (),
+                    Err(err) => {
+                        error!("Disconnecting websocket with error: {err}");
+                        let _ = ws.close().await;
+                        peer_manager.as_ref().socket_disconnected(&descriptor);
+                        peer_manager.as_ref().process_events();
+                        break;
+                    }
+                }
+            }
+        })
+    } else {
+        None
+    }
+}
+
+async fn process_messages<PM>(
+    peer_manager: &PM,
+    task_rx: &mut UnboundedReceiver<BgTaskMessage>,
+    ws: &mut WebSocketStream,
+    descriptor: &mut DynamicSocketDescriptor,
+    emit_read_events: &mut bool,
+) -> Result<ControlFlow<()>, anyhow::Error>
+where
+    PM: Deref + 'static + Send + Sync + Clone,
+    PM::Target: APeerManager<Descriptor = DynamicSocketDescriptor>,
+{
+    let ws_next = if *emit_read_events {
+        Either::Left(ws.next())
+    } else {
+        Either::Right(future::pending())
+    };
+
+    tokio::select! {
+        task_msg = task_rx.recv() => match task_msg.context("rust-lightning SocketDescriptor dropped")? {
+            BgTaskMessage::SendData { data, resume_read } => {
+                if resume_read {
+                    *emit_read_events = true;
+                }
+
+                ws.send(Message::Binary(data)).await?;
+            },
+            BgTaskMessage::Close => {
+                let _ = ws.close().await;
+                return Ok(ControlFlow::Break(()))
+            },
+        },
+        ws_msg = ws_next => {
+            let data = ws_msg.context("WS returned no data")??.into_data();
+            if let Ok(true) = peer_manager.as_ref().read_event(descriptor, &data) {
+                *emit_read_events = false; // Pause reading
+            }
+
+            peer_manager.as_ref().process_events();
+        }
+    }
+
+    Ok(ControlFlow::Continue(()))
+}
+
+enum BgTaskMessage {
+    SendData { data: Vec<u8>, resume_read: bool },
+    Close,
+}
+
+#[derive(Clone)]
+pub struct SocketDescriptor {
+    tx: mpsc::UnboundedSender<BgTaskMessage>,
+    id: u64,
+}
+
+impl Eq for SocketDescriptor {}
+impl PartialEq for SocketDescriptor {
+    fn eq(&self, o: &Self) -> bool {
+        self.id == o.id
+    }
+}
+
+impl Hash for SocketDescriptor {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.id.hash(state);
+    }
+}
+
+impl peer_handler::SocketDescriptor for SocketDescriptor {
+    fn send_data(&mut self, data: &[u8], resume_read: bool) -> usize {
+        // TODO(ws):
+        // This isn't so great as we should be waiting for this to be sent before returning the
+        // amount of data sent (which implies that the send operation is done). This is so that the
+        // backpressure stuff works properly
+        //
+        // It's a little more complicated than it may seem. If we don't send all the data when
+        // calling send_data then there is a function we need to call of the peer manager
+        // which results in send_data being called again. At first glance you'd think you
+        // can just make the 2nd a no-op, but there could be more data that's waiting to be
+        // sent by then. Therefore, we need to keep track of how much we promised to send
+        // and how much extra must be sent.
+        let _ = self.tx.send(BgTaskMessage::SendData {
+            data: data.to_vec(),
+            resume_read,
+        });
+        data.len()
+    }
+
+    fn disconnect_socket(&mut self) {
+        let _ = self.tx.send(BgTaskMessage::Close);
+    }
+}

--- a/crates/ln-dlc-node/src/node/connection.rs
+++ b/crates/ln-dlc-node/src/node/connection.rs
@@ -1,3 +1,4 @@
+use crate::networking;
 use crate::node::event::NodeEvent;
 use crate::node::event::NodeEventHandler;
 use crate::node::Node;
@@ -74,12 +75,8 @@ impl<S: TenTenOneStorage + 'static, N: Storage + Sync + Send + 'static> Node<S, 
             loop {
                 tracing::debug!(%peer, "Setting up connection");
 
-                if let Some(fut) = lightning_net_tokio::connect_outbound(
-                    self.peer_manager.clone(),
-                    peer.pubkey,
-                    peer.address,
-                )
-                .await
+                if let Some(fut) =
+                    networking::connect_outbound(self.peer_manager.clone(), peer).await
                 {
                     return fut;
                 };

--- a/crates/orderbook-client/Cargo.toml
+++ b/crates/orderbook-client/Cargo.toml
@@ -14,7 +14,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sha2 = { version = "0.10", default-features = false }
 tokio = { version = "1", features = ["macros", "time", "tracing"] }
-tokio-tungstenite = { version = "0.20", features = ["native-tls"] }
+tokio-tungstenite-wasm = { version = "0.3.0", features = ["native-tls"] }
 tracing = "0.1"
 url = "2.3.0"
 

--- a/mobile/native/Cargo.toml
+++ b/mobile/native/Cargo.toml
@@ -42,7 +42,7 @@ state = "0.5.3"
 thiserror = "1"
 time = { version = "0.3.20", features = ["formatting"] }
 tokio = { version = "1.25.0", features = ["macros", "rt", "rt-multi-thread", "sync", "time"] }
-tokio-tungstenite = { version = "0.20", features = ["native-tls"] }
+tokio-tungstenite-wasm = { version = "0.3.0", features = ["native-tls"] }
 tokio-util = { version = "0.7", features = ["io", "codec"] }
 tracing = "0.1.37"
 tracing-log = "0.2.0"

--- a/mobile/native/Cargo.toml
+++ b/mobile/native/Cargo.toml
@@ -26,7 +26,7 @@ itertools = "0.10"
 lightning = { version = "0.0.117" }
 lightning-invoice = { version = "0.25" }
 lightning-persister = { version = "0.0.117" }
-ln-dlc-node = { path = "../../crates/ln-dlc-node" }
+ln-dlc-node = { path = "../../crates/ln-dlc-node", default-features = false }
 ln-dlc-storage = { path = "../../crates/ln-dlc-storage" }
 openssl = { version = "0.10.60", features = ["vendored"] }
 orderbook-client = { path = "../../crates/orderbook-client" }
@@ -54,3 +54,8 @@ uuid = { version = "1.3.0", features = ["v4", "fast-rng", "macro-diagnostics"] }
 dlc = { version = "0.4.0" }
 dlc-trie = "0.4.0"
 secp256k1-zkp = { version = "0.7.0", features = ["bitcoin_hashes", "rand", "rand-std"] }
+
+[features]
+default = ["native_tcp"]
+ws = ["ln-dlc-node/ln_net_ws"]
+native_tcp = ["ln-dlc-node/ln_net_tcp"]

--- a/mobile/native/src/config/mod.rs
+++ b/mobile/native/src/config/mod.rs
@@ -14,6 +14,7 @@ pub struct ConfigInternal {
     coordinator_pubkey: PublicKey,
     electrs_endpoint: String,
     http_endpoint: SocketAddr,
+    #[allow(dead_code)] // Irrelevant when using websockets
     p2p_endpoint: SocketAddr,
     network: bitcoin::Network,
     oracle_endpoint: String,
@@ -35,9 +36,18 @@ pub fn health_check_interval() -> Duration {
 
 pub fn get_coordinator_info() -> NodeInfo {
     let config = crate::state::get_config();
+
+    #[cfg(feature = "ws")]
+    #[allow(unused_variables)] // In case both features are enabled
+    let (address, is_ws) = (config.http_endpoint, true);
+
+    #[cfg(feature = "native_tcp")]
+    let (address, is_ws) = (config.p2p_endpoint, false);
+
     NodeInfo {
         pubkey: config.coordinator_pubkey,
-        address: config.p2p_endpoint,
+        address,
+        is_ws,
     }
 }
 

--- a/mobile/native/src/orderbook.rs
+++ b/mobile/native/src/orderbook.rs
@@ -34,7 +34,7 @@ use tokio::runtime::Runtime;
 use tokio::sync::broadcast;
 use tokio::sync::broadcast::error::RecvError;
 use tokio::sync::watch;
-use tokio_tungstenite::tungstenite;
+use tokio_tungstenite_wasm as tungstenite;
 use uuid::Uuid;
 
 /// FIXME(holzeis): There is an edge case where the app is still open while we move into the


### PR DESCRIPTION
This PR replaces all instances of TCP with WebSockets when the `ln_net_native_ws` or `ln_net_wasm_ws` features are enabled. This is step 1 for 10101 WASM :tada: 

The new, default, `ln_net_tcp` carries out the old behaviour. When it is not enabled, the node will not listen for incoming TCP connections. The coordinator supports both TCP and WS connections. WS connections simply connect to its HTTP endpoint at `/` with a Websocket upgrade header.

There is a _potential_ breaking protocol change in how we handle pings/pongs with the orderbook. I have swapped uses of `tungstenite` in transitive dependencies of `native` to the `tokio_tungstenite_wasm` crate, which is a facade over `tungstenite` and WASM websockets (depending on target). Since WASM websockets can't directly intercept `Ping`/`Pong` frames, instead we use `Text` messages with the content `"ping"` and `"pong"`. Additionally, we do the same in the BitMex protocol (which supports this natively as well).

The coordinator's axum websocket implementation is not perfect as it kind of 'lies' to rust-lightning about when the data gets sent exactly. See the SocketDescriptor `send_data` implementation comment for more info. FWIW, this is how Mutiny does it too so hopefully it's okay. This also applies to the `ln_net_native_ws` implementation, but this is only intended for testing anyway and should be removed later down the road.

Because of the large potential impact, I've requested a review from everyone.


To do:
- [x] ~~Support WSS (web socket secure)~~ Probably not needed as we don't use this currently (rust-lightning encrypts everything anyway)
- [x] Fix wasm implementation