### PR TITLE
fix: relaxed constraint on failed orders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Fix(mobile): Fixed a bug where the app didn't load. This was because of some inconsistency in the db where a failed order didn't have a failure reason.
+
 ## [1.8.9] - 2024-02-19
 
 - Fix(validation): Show correct max counterparty collateral in validation message.

--- a/mobile/lib/features/welcome/loading_screen.dart
+++ b/mobile/lib/features/welcome/loading_screen.dart
@@ -79,7 +79,7 @@ class _LoadingScreenState extends State<LoadingScreen> {
       }
     }).catchError((error) {
       logger.e("Failed to start backend. $error");
-      showSnackBar(ScaffoldMessenger.of(context), "Failed to start 10101!");
+      showSnackBar(ScaffoldMessenger.of(context), "Failed to start 10101! $error");
     });
   }
 


### PR DESCRIPTION
So far, a failed order needed a reason when converting between types. However, we failed to do so when setting orders to failed. I've relaxed this constraint now. If there is no reason in the db, we assume an `Unknown` reason in the frontend. At the same time, we ensure that we set a reason when setting all orders to failed

Resolves #2031 

We should roll out a release after this is merged as it blocks at least one user and myself. 