### PR TITLE
fix: use platform dependent cache

### DIFF
--- a/.github/workflows/android-fastlane.yml
+++ b/.github/workflows/android-fastlane.yml
@@ -89,7 +89,7 @@ jobs:
           flutter-version: ${{ env.FLUTTER_VERSION }}
           channel: "stable"
           cache: true
-          cache-key: flutter-${{ env.FLUTTER_VERSION }}
+          cache-key: flutter-${{ env.FLUTTER_VERSION }}-macos-latest
           cache-path: ${{ runner.tool_cache }}/flutter
 
       - uses: actions/cache@v4

--- a/.github/workflows/ios-fastlane.yml
+++ b/.github/workflows/ios-fastlane.yml
@@ -109,7 +109,7 @@ jobs:
           flutter-version: ${{ env.FLUTTER_VERSION }}
           channel: "stable"
           cache: true
-          cache-key: flutter-${{ env.FLUTTER_VERSION }}
+          cache-key: flutter-${{ env.FLUTTER_VERSION }}-macos-14
           cache-path: ${{ runner.tool_cache }}/flutter
 
       - name: Check cocoapods version


### PR DESCRIPTION
I believe our CI issue is coming from the fact that we use two different macos versions but cache flutter for the same key