### PR TITLE
Simplify cache

### DIFF
--- a/.github/workflows/android-fastlane.yml
+++ b/.github/workflows/android-fastlane.yml
@@ -95,17 +95,10 @@ jobs:
       - uses: actions/cache@v4
         id: cache-deps
         with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            ./rust/target
           key: ${{ runner.os }}-cargo-build-release-android-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Install just
-        if: steps.cache-deps.outputs.cache-hit != 'true'
-        run: cargo install just
+        run: cargo install just --force
 
       - uses: actions/setup-java@v3
         with:
@@ -121,15 +114,13 @@ jobs:
           bundle info fastlane
 
       - name: Install FFI bindings
-        if: steps.cache-deps.outputs.cache-hit != 'true'
-        run: just deps-gen
+        run: just deps-gen --force
 
       - name: Add Rust targets
         run: rustup target add armv7-linux-androideabi aarch64-linux-android
 
       # #499, https://github.com/actions/virtual-environments/issues/5595
       - name: Configure ndk
-        if: steps.cache-deps.outputs.cache-hit != 'true'
         run: |
           ANDROID_HOME=$HOME/Library/Android/sdk
           SDKMANAGER=$ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager
@@ -139,8 +130,7 @@ jobs:
           ln -sfn $ANDROID_HOME/ndk/21.4.7075529 $ANDROID_HOME/ndk-bundle
 
       - name: Install cargo ndk
-        if: steps.cache-deps.outputs.cache-hit != 'true'
-        run: cargo install cargo-ndk
+        run: cargo install cargo-ndk --force
 
       - name: Generate FFI bindings
         run: just gen

--- a/.github/workflows/ios-fastlane.yml
+++ b/.github/workflows/ios-fastlane.yml
@@ -122,16 +122,9 @@ jobs:
 
       - uses: actions/cache@v4
         with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            ./rust/target
           key: ${{ runner.os }}-cargo-build-release-ios-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Install just
-        if: steps.cache-deps.outputs.cache-hit != 'true'
         run: cargo install just --force
 
       - name: Install fastlane
@@ -142,12 +135,10 @@ jobs:
           bundle info fastlane
 
       - name: Install FFI bindings
-        if: steps.cache-deps.outputs.cache-hit != 'true'
-        run: just deps-gen
+        run: just deps-gen --force
 
       - name: Install ios dependencies
-        if: steps.cache-deps.outputs.cache-hit != 'true'
-        run: cargo install cargo-lipo
+        run: cargo install cargo-lipo --force
 
       - name: Set rustup targets
         run: rustup target add aarch64-apple-ios x86_64-apple-ios

--- a/justfile
+++ b/justfile
@@ -39,8 +39,8 @@ precommit: gen lint
 # Install missing dependencies.
 deps: deps-gen deps-android deps-ios
 
-deps-gen:
-    cargo install flutter_rust_bridge_codegen@1.78.0
+deps-gen args="":
+    cargo install flutter_rust_bridge_codegen@1.78.0 {{args}}
 
 # Install dependencies for Android (build targets and cargo-ndk)
 deps-android:


### PR DESCRIPTION
Using default cache settings will stop us from caching cargo binaries. This might slow down our production build but hopefully gets rid of random errors where libraries were already installed.