### PR TITLE
Fix backwards-incompatible CLI change

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4863,7 +4863,7 @@ dependencies = [
 
 [[package]]
 name = "webapp"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "atty",

--- a/coordinator/src/cli.rs
+++ b/coordinator/src/cli.rs
@@ -43,7 +43,7 @@ pub struct Opts {
     pub database: String,
 
     /// The address to connect to the Electrs API.
-    #[clap(long, default_value = "http://localhost:3000")]
+    #[clap(long, default_value = "http://localhost:3000", aliases = ["esplora"])]
     pub electrs: String,
 
     /// If enabled, tokio runtime can be locally debugged with tokio_console

--- a/webapp/src/cli.rs
+++ b/webapp/src/cli.rs
@@ -28,7 +28,7 @@ pub struct Opts {
     pub network: Network,
 
     /// The address to connect to the Electrs API.
-    #[clap(long, default_value = "http://localhost:3000")]
+    #[clap(long, default_value = "http://localhost:3000", aliases = ["esplora"])]
     pub electrs: String,
 
     /// The endpoint of the p2p-derivatives oracle


### PR DESCRIPTION
Patch https://github.com/get10101/10101/commit/cd04992884b88d911c04b48c075e4c23883cfa0f changed the name of the `esplora` CLI argument to `electrs` for correctness. But the change was introduced in a backwards-incompatible manner.

This patch solves that issue by introducing an alias for the CLI argument with the original name.

All this applies to both the coordinator and the webapp.