### PR TITLE
feat: sign orders and whitelist makers

### DIFF
--- a/coordinator/example-settings/prod-coordinator-settings.toml
+++ b/coordinator/example-settings/prod-coordinator-settings.toml
@@ -7,6 +7,7 @@ rollover_window_open_scheduler = "0 5 15 * * 5,6"
 rollover_window_close_scheduler = "0 5 13 * * 5,6"
 close_expired_position_scheduler = "0 0 12 * * *"
 min_liquidity_threshold_sats = 10000000
+whitelisted_makers = []
 
 [ln_dlc]
 off_chain_sync_interval = 5

--- a/coordinator/example-settings/prod-coordinator-settings.toml
+++ b/coordinator/example-settings/prod-coordinator-settings.toml
@@ -7,6 +7,7 @@ rollover_window_open_scheduler = "0 5 15 * * 5,6"
 rollover_window_close_scheduler = "0 5 13 * * 5,6"
 close_expired_position_scheduler = "0 0 12 * * *"
 min_liquidity_threshold_sats = 10000000
+whitelist_enabled = false
 whitelisted_makers = []
 
 [ln_dlc]

--- a/coordinator/example-settings/test-coordinator-settings.toml
+++ b/coordinator/example-settings/test-coordinator-settings.toml
@@ -7,6 +7,7 @@ rollover_window_open_scheduler = "0 5 16 * * *"
 rollover_window_close_scheduler = "0 5 22 * * *"
 close_expired_position_scheduler = "0 0 12 * * *"
 min_liquidity_threshold_sats = 10000000
+whitelist_enabled = false
 # Default testnet maker
 whitelisted_makers = ["035eccdd1f05c65b433cf38e3b2597e33715e0392cb14d183e812f1319eb7b6794"]
 

--- a/coordinator/example-settings/test-coordinator-settings.toml
+++ b/coordinator/example-settings/test-coordinator-settings.toml
@@ -7,6 +7,8 @@ rollover_window_open_scheduler = "0 5 16 * * *"
 rollover_window_close_scheduler = "0 5 22 * * *"
 close_expired_position_scheduler = "0 0 12 * * *"
 min_liquidity_threshold_sats = 10000000
+# Default testnet maker
+whitelisted_makers = ["03f75f318471d32d39be3c86c622e2c51bd5731bf95f98aaa3ed5d6e1c0025927f"]
 
 [ln_dlc]
 off_chain_sync_interval = 5

--- a/coordinator/example-settings/test-coordinator-settings.toml
+++ b/coordinator/example-settings/test-coordinator-settings.toml
@@ -8,7 +8,7 @@ rollover_window_close_scheduler = "0 5 22 * * *"
 close_expired_position_scheduler = "0 0 12 * * *"
 min_liquidity_threshold_sats = 10000000
 # Default testnet maker
-whitelisted_makers = ["03f75f318471d32d39be3c86c622e2c51bd5731bf95f98aaa3ed5d6e1c0025927f"]
+whitelisted_makers = ["035eccdd1f05c65b433cf38e3b2597e33715e0392cb14d183e812f1319eb7b6794"]
 
 [ln_dlc]
 off_chain_sync_interval = 5

--- a/coordinator/src/orderbook/routes.rs
+++ b/coordinator/src/orderbook/routes.rs
@@ -77,6 +77,7 @@ pub async fn post_order(
 
     let settings = state.settings.read().await;
     if new_order.order_type == OrderType::Limit
+        && settings.whitelist_enabled
         && !settings.whitelisted_makers.contains(&new_order.trader_id)
     {
         tracing::warn!(

--- a/coordinator/src/settings.rs
+++ b/coordinator/src/settings.rs
@@ -63,6 +63,9 @@ pub struct Settings {
     // Location of the settings file in the file system.
     path: PathBuf,
 
+    /// If enabled, only makers in [`whitelisted_makers`] are allowed to post limit orders
+    pub whitelist_enabled: bool,
+
     /// A list of makers who are allowed to post limit orders. This is to prevent spam.
     pub whitelisted_makers: Vec<PublicKey>,
 }
@@ -138,6 +141,7 @@ impl Settings {
             close_expired_position_scheduler: file.close_expired_position_scheduler,
             min_liquidity_threshold_sats: file.min_liquidity_threshold_sats,
             path,
+            whitelist_enabled: file.whitelist_enabled,
             whitelisted_makers: file.whitelisted_makers,
         }
     }
@@ -163,6 +167,7 @@ pub struct SettingsFile {
 
     min_liquidity_threshold_sats: u64,
 
+    whitelist_enabled: bool,
     whitelisted_makers: Vec<PublicKey>,
 }
 
@@ -181,6 +186,7 @@ impl From<Settings> for SettingsFile {
             rollover_window_close_scheduler: value.rollover_window_close_scheduler,
             close_expired_position_scheduler: value.close_expired_position_scheduler,
             min_liquidity_threshold_sats: value.min_liquidity_threshold_sats,
+            whitelist_enabled: false,
             whitelisted_makers: value.whitelisted_makers,
         }
     }
@@ -219,6 +225,7 @@ mod tests {
             rollover_window_close_scheduler: "bar".to_string(),
             close_expired_position_scheduler: "baz".to_string(),
             min_liquidity_threshold_sats: 2,
+            whitelist_enabled: false,
             whitelisted_makers: vec![PublicKey::from_str(
                 "0218845781f631c48f1c9709e23092067d06837f30aa0cd0544ac887fe91ddd166",
             )

--- a/crates/commons/src/order.rs
+++ b/crates/commons/src/order.rs
@@ -1,4 +1,8 @@
+use anyhow::Result;
+use bitcoin::hashes::sha256;
 use rust_decimal::Decimal;
+use secp256k1::ecdsa::Signature;
+use secp256k1::Message;
 use secp256k1::PublicKey;
 use serde::Deserialize;
 use serde::Serialize;
@@ -6,6 +10,21 @@ use time::OffsetDateTime;
 use trade::ContractSymbol;
 use trade::Direction;
 use uuid::Uuid;
+
+#[derive(Serialize, Deserialize, Clone)]
+pub struct NewOrderRequest {
+    pub value: NewOrder,
+    /// A signature of the sha256 of [`value`]
+    pub signature: Signature,
+}
+
+impl NewOrderRequest {
+    pub fn verify(&self) -> Result<()> {
+        let message = self.value.message();
+        self.signature.verify(&message, &self.value.trader_id)?;
+        Ok(())
+    }
+}
 
 #[derive(Serialize, Deserialize, Clone)]
 pub struct NewOrder {
@@ -23,11 +42,51 @@ pub struct NewOrder {
     pub stable: bool,
 }
 
+impl NewOrder {
+    pub fn message(&self) -> Message {
+        let mut vec: Vec<u8> = vec![];
+        let mut id = self.id.as_bytes().to_vec();
+        let seconds = self.expiry.second();
+        let symbol = self.contract_symbol.label();
+        let symbol = symbol.as_bytes();
+        let order_type = self.order_type.label();
+        let order_type = order_type.as_bytes();
+        let direction = self.direction.to_string();
+        let direction = direction.as_bytes();
+        let quantity = self.quantity.to_string();
+        let quantity = quantity.as_bytes();
+        let price = self.price.to_string();
+        let price = price.as_bytes();
+        let string = self.leverage.to_string();
+        let leverage = string.as_bytes();
+        vec.append(&mut id);
+        vec.push(seconds);
+        vec.append(&mut symbol.to_vec());
+        vec.append(&mut order_type.to_vec());
+        vec.append(&mut direction.to_vec());
+        vec.append(&mut quantity.to_vec());
+        vec.append(&mut price.to_vec());
+        vec.append(&mut leverage.to_vec());
+
+        Message::from_hashed_data::<sha256::Hash>(vec.as_slice())
+    }
+}
+
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq)]
 pub enum OrderType {
     #[allow(dead_code)]
     Market,
     Limit,
+}
+
+impl OrderType {
+    pub fn label(self) -> String {
+        match self {
+            OrderType::Market => "Market",
+            OrderType::Limit => "Limit",
+        }
+        .to_string()
+    }
 }
 
 #[derive(Deserialize)]
@@ -75,4 +134,49 @@ pub struct Order {
     pub order_state: OrderState,
     pub order_reason: OrderReason,
     pub stable: bool,
+}
+
+#[cfg(test)]
+pub mod tests {
+    use crate::NewOrder;
+    use crate::NewOrderRequest;
+    use crate::OrderType;
+    use secp256k1::rand;
+    use secp256k1::SecretKey;
+    use secp256k1::SECP256K1;
+    use time::OffsetDateTime;
+    use trade::ContractSymbol;
+    use trade::Direction;
+
+    #[test]
+    pub fn round_trip_signature_new_order() {
+        let secret_key = SecretKey::new(&mut rand::thread_rng());
+        let public_key = secret_key.public_key(SECP256K1);
+
+        let order = NewOrder {
+            id: Default::default(),
+            contract_symbol: ContractSymbol::BtcUsd,
+            price: rust_decimal_macros::dec!(53_000),
+            quantity: rust_decimal_macros::dec!(2000),
+            trader_id: public_key,
+            direction: Direction::Long,
+            leverage: 2.0,
+            order_type: OrderType::Market,
+            expiry: OffsetDateTime::now_utc(),
+            stable: false,
+        };
+
+        let message = order.message();
+
+        let signature = secret_key.sign_ecdsa(message);
+        signature.verify(&message, &public_key).unwrap();
+    }
+
+    #[test]
+    pub fn parse_new_order_request_from_string_and_verify() {
+        let new_order_string = "{\"value\":{\"id\":\"00000000-0000-0000-0000-000000000000\",\"contract_symbol\":\"BtcUsd\",\"price\":53000.0,\"quantity\":2000.0,\"trader_id\":\"02165446faa03b41d7f2e29741c5d5d5a27a3c1667f6a35d6ea03ba7c2d9619e35\",\"direction\":\"Long\",\"leverage\":2.0,\"order_type\":\"Market\",\"expiry\":[2024,53,12,18,24,406906000,0,0,0],\"stable\":false},\"signature\":\"304402203290d4415c230360f43847586bcf68d11b925e1c3011aab89a7c11d99fd3d5fa0220542830b5ec92a1b6e48240ea5205d66306668728402a5058cee014cecce38f40\"}";
+        let new_order: NewOrderRequest = serde_json::from_str(new_order_string).unwrap();
+
+        new_order.verify().unwrap();
+    }
 }

--- a/mobile/native/src/trade/order/orderbook_client.rs
+++ b/mobile/native/src/trade/order/orderbook_client.rs
@@ -1,7 +1,9 @@
 use crate::commons::reqwest_client;
+use crate::ln_dlc::get_node_key;
 use anyhow::bail;
 use anyhow::Result;
 use commons::NewOrder;
+use commons::NewOrderRequest;
 use commons::OrderResponse;
 use reqwest::Url;
 
@@ -15,10 +17,18 @@ impl OrderbookClient {
     }
 
     pub(crate) async fn post_new_order(&self, order: NewOrder) -> Result<OrderResponse> {
+        let secret_key = get_node_key();
+        let message = order.message();
+        let signature = secret_key.sign_ecdsa(message);
+        let new_order_request = NewOrderRequest {
+            value: order,
+            signature,
+        };
+
         let url = self.url.join("/api/orderbook/orders")?;
         let client = reqwest_client();
 
-        let response = client.post(url).json(&order).send().await?;
+        let response = client.post(url).json(&new_order_request).send().await?;
 
         if response.status().as_u16() == 200 {
             let response = response.json().await?;


### PR DESCRIPTION
only whitelisted makers are allowed to post limit orders

Note: this is a breaking change: 
- apps which do not upgrade, cannot post orders --> I think this is a feature and not a bug :)
- our old maker won't work anymore --> we need to deploy our new maker in production
