### PR TITLE
fix: Handle wallet sync error during startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Fix(wallet): Gracefully handle an error during the wallet sync. Fixes an issue where the app was not able to start because of an inconsistent state.
+
 ## [1.9.0] - 2024-02-26
 
 - Feat(webapp): Let user manually sync wallet history.

--- a/crates/tests-e2e/src/setup.rs
+++ b/crates/tests-e2e/src/setup.rs
@@ -40,13 +40,13 @@ impl TestSetup {
 
         assert_eq!(
             app.rx.wallet_info().unwrap().balances.on_chain,
-            0,
+            Some(0),
             "App should start with empty on-chain wallet"
         );
 
         assert_eq!(
             app.rx.wallet_info().unwrap().balances.off_chain,
-            0,
+            Some(0),
             "App should start with empty off-chain wallet"
         );
 
@@ -93,10 +93,24 @@ impl TestSetup {
 
         wait_until!({
             refresh_wallet_info();
-            self.app.rx.wallet_info().unwrap().balances.on_chain >= fund_amount.to_sat()
+            self.app
+                .rx
+                .wallet_info()
+                .unwrap()
+                .balances
+                .on_chain
+                .unwrap()
+                >= fund_amount.to_sat()
         });
 
-        let on_chain_balance = self.app.rx.wallet_info().unwrap().balances.on_chain;
+        let on_chain_balance = self
+            .app
+            .rx
+            .wallet_info()
+            .unwrap()
+            .balances
+            .on_chain
+            .unwrap();
 
         tracing::info!(%fund_amount, %on_chain_balance, "Successfully funded app");
     }

--- a/crates/tests-e2e/tests/e2e_close_position.rs
+++ b/crates/tests-e2e/tests/e2e_close_position.rs
@@ -22,7 +22,14 @@ async fn can_open_close_open_close_position() {
     // - Opening fee of 7_500 paid to coordinator collateral reserve from app on-chain balance.
     // - App off-chain balance is 0 (first trade uses full DLC channel collateral for now).
 
-    let app_off_chain_balance = test.app.rx.wallet_info().unwrap().balances.off_chain;
+    let app_off_chain_balance = test
+        .app
+        .rx
+        .wallet_info()
+        .unwrap()
+        .balances
+        .off_chain
+        .unwrap();
     tracing::info!(%app_off_chain_balance, "Opened first position");
 
     let closing_order = {
@@ -40,7 +47,14 @@ async fn can_open_close_open_close_position() {
 
     // - App off-chain balance is 1_242_500 sats (margin minus 7_500 fee).
 
-    let app_off_chain_balance = test.app.rx.wallet_info().unwrap().balances.off_chain;
+    let app_off_chain_balance = test
+        .app
+        .rx
+        .wallet_info()
+        .unwrap()
+        .balances
+        .off_chain
+        .unwrap();
     tracing::info!(%app_off_chain_balance, "Closed first position");
 
     tracing::info!("Opening second position");
@@ -65,7 +79,14 @@ async fn can_open_close_open_close_position() {
     // - Opening fee of 3_750 paid to coordinator collateral reserve from app off-chain balance.
     // - App off-chain balance is 613_750.
 
-    let app_off_chain_balance = test.app.rx.wallet_info().unwrap().balances.off_chain;
+    let app_off_chain_balance = test
+        .app
+        .rx
+        .wallet_info()
+        .unwrap()
+        .balances
+        .off_chain
+        .unwrap();
     tracing::info!(%app_off_chain_balance, "Opened second position");
 
     tracing::info!("Closing second position");
@@ -83,7 +104,14 @@ async fn can_open_close_open_close_position() {
 
     // - App off-chain balance is 1_235_000 sats (reserve + margin - 3_750 fee).
 
-    let app_off_chain_balance = test.app.rx.wallet_info().unwrap().balances.off_chain;
+    let app_off_chain_balance = test
+        .app
+        .rx
+        .wallet_info()
+        .unwrap()
+        .balances
+        .off_chain
+        .unwrap();
     tracing::info!(%app_off_chain_balance, "Closed second position");
 
     // TODO: Assert that the position is closed in the coordinator

--- a/crates/tests-e2e/tests/e2e_collaborative_close_channel.rs
+++ b/crates/tests-e2e/tests/e2e_collaborative_close_channel.rs
@@ -13,7 +13,14 @@ async fn can_open_and_collab_close_channel() {
     // Setup
     let test = setup::TestSetup::new_with_open_position().await;
 
-    let app_off_chain_balance = test.app.rx.wallet_info().unwrap().balances.off_chain;
+    let app_off_chain_balance = test
+        .app
+        .rx
+        .wallet_info()
+        .unwrap()
+        .balances
+        .off_chain
+        .unwrap();
     tracing::info!(%app_off_chain_balance, "Opened position");
 
     let closing_order = {
@@ -32,8 +39,22 @@ async fn can_open_and_collab_close_channel() {
 
     tokio::time::sleep(std::time::Duration::from_secs(10)).await;
 
-    let app_on_chain_balance = test.app.rx.wallet_info().unwrap().balances.on_chain;
-    let app_off_chain_balance = test.app.rx.wallet_info().unwrap().balances.off_chain;
+    let app_on_chain_balance = test
+        .app
+        .rx
+        .wallet_info()
+        .unwrap()
+        .balances
+        .on_chain
+        .unwrap();
+    let app_off_chain_balance = test
+        .app
+        .rx
+        .wallet_info()
+        .unwrap()
+        .balances
+        .off_chain
+        .unwrap();
     tracing::info!(%app_off_chain_balance, "Closed first position");
 
     // Act
@@ -51,14 +72,14 @@ async fn can_open_and_collab_close_channel() {
             on_chain = app_balance.on_chain,
             "Balance while waiting"
         );
-        app_balance.off_chain == 0
+        app_balance.off_chain.unwrap() == 0
     });
 
     // Assert
 
     let wallet_info = test.app.rx.wallet_info().unwrap();
     assert_eq!(
-        wallet_info.balances.on_chain,
+        wallet_info.balances.on_chain.unwrap(),
         app_on_chain_balance + app_off_chain_balance
     );
 

--- a/crates/tests-e2e/tests/e2e_collaborative_revert.rs
+++ b/crates/tests-e2e/tests/e2e_collaborative_revert.rs
@@ -26,7 +26,7 @@ async fn can_revert_channel() {
 
     let dlc_channel_id = get_dlc_channel_id().unwrap();
 
-    let app_balance_before = app.rx.wallet_info().unwrap().balances.on_chain;
+    let app_balance_before = app.rx.wallet_info().unwrap().balances.on_chain.unwrap();
 
     // Act
 
@@ -50,7 +50,7 @@ async fn can_revert_channel() {
         sync_dlc_channels();
         refresh_wallet_info();
 
-        let app_balance = app.rx.wallet_info().unwrap().balances.on_chain;
+        let app_balance = app.rx.wallet_info().unwrap().balances.on_chain.unwrap();
 
         tracing::debug!(
             before = %app_balance_before,

--- a/crates/tests-e2e/tests/e2e_open_position_small_utxos.rs
+++ b/crates/tests-e2e/tests/e2e_open_position_small_utxos.rs
@@ -70,7 +70,7 @@ async fn can_open_position_with_multiple_small_utxos() {
 
     wait_until!({
         refresh_wallet_info();
-        app.rx.wallet_info().unwrap().balances.on_chain >= fund_amount
+        app.rx.wallet_info().unwrap().balances.on_chain.unwrap() >= fund_amount
     });
 
     // Act

--- a/mobile/lib/backend.dart
+++ b/mobile/lib/backend.dart
@@ -78,6 +78,8 @@ Future<void> _startBackend({seedDir, fcmToken}) async {
   try {
     await rust.api.runInFlutter(seedDir: seedDir, fcmToken: fcmToken);
   } catch (e) {
+    // TODO(holzeis): We should add a more gracefull handling of an error during startup here. At
+    // the moment the user will have no idea what happened and is not able to share his logs.
     logger.e("Launching the app failed $e");
     await Future.delayed(const Duration(seconds: 5));
     exit(-1);

--- a/mobile/lib/features/wallet/balance_row.dart
+++ b/mobile/lib/features/wallet/balance_row.dart
@@ -18,28 +18,35 @@ class _BalanceRowState extends State<BalanceRow> with SingleTickerProviderStateM
   Widget build(BuildContext context) {
     WalletChangeNotifier walletChangeNotifier = context.watch<WalletChangeNotifier>();
 
+    final offchainBalance = walletChangeNotifier.offChain()?.formatted() ?? "n/a";
+    final onchainBalance = walletChangeNotifier.onChain()?.formatted() ?? "n/a";
+
     final amountText = switch (widget.walletType) {
       WalletType.lightning => Row(
             mainAxisAlignment: MainAxisAlignment.center,
             crossAxisAlignment: CrossAxisAlignment.center,
             children: [
-              Text(walletChangeNotifier.offChain().formatted(),
+              Text(offchainBalance,
                   style: const TextStyle(
                       fontSize: 30, color: Colors.white, fontWeight: FontWeight.bold)),
-              const Text(" sats",
-                  style:
-                      TextStyle(fontSize: 14, color: Colors.white, fontWeight: FontWeight.normal))
+              walletChangeNotifier.offChain() != null
+                  ? const Text(" sats",
+                      style: TextStyle(
+                          fontSize: 14, color: Colors.white, fontWeight: FontWeight.normal))
+                  : Container()
             ]),
       WalletType.onChain => Row(
             mainAxisAlignment: MainAxisAlignment.center,
             crossAxisAlignment: CrossAxisAlignment.center,
             children: [
-              Text(walletChangeNotifier.onChain().formatted(),
+              Text(onchainBalance,
                   style: const TextStyle(
                       fontSize: 30, color: Colors.white, fontWeight: FontWeight.bold)),
-              const Text(" sats",
-                  style:
-                      TextStyle(fontSize: 14, color: Colors.white, fontWeight: FontWeight.normal))
+              walletChangeNotifier.onChain() != null
+                  ? const Text(" sats",
+                      style: TextStyle(
+                          fontSize: 14, color: Colors.white, fontWeight: FontWeight.normal))
+                  : Container()
             ]),
     };
 

--- a/mobile/lib/features/wallet/domain/wallet_balances.dart
+++ b/mobile/lib/features/wallet/domain/wallet_balances.dart
@@ -1,8 +1,8 @@
 import 'package:get_10101/common/domain/model.dart';
 
 class WalletBalances {
-  Amount onChain;
-  Amount offChain;
+  Amount? onChain;
+  Amount? offChain;
 
   WalletBalances({required this.onChain, required this.offChain});
 }

--- a/mobile/lib/features/wallet/domain/wallet_info.dart
+++ b/mobile/lib/features/wallet/domain/wallet_info.dart
@@ -8,10 +8,14 @@ class WalletInfo {
   List<WalletHistoryItemData> history;
 
   WalletInfo({required this.balances, required this.history});
+
   WalletInfo.fromApi(rust.WalletInfo walletInfo)
       : balances = WalletBalances(
-            onChain: Amount(walletInfo.balances.onChain),
-            offChain: Amount(walletInfo.balances.offChain)),
+            onChain:
+                walletInfo.balances.onChain != null ? Amount(walletInfo.balances.onChain!) : null,
+            offChain: walletInfo.balances.offChain != null
+                ? Amount(walletInfo.balances.offChain!)
+                : null),
         history = walletInfo.history.map((item) {
           return WalletHistoryItemData.fromApi(item);
         }).toList();

--- a/mobile/lib/features/wallet/send/send_onchain_screen.dart
+++ b/mobile/lib/features/wallet/send/send_onchain_screen.dart
@@ -162,7 +162,7 @@ class _SendOnChainScreenState extends State<SendOnChainScreen> {
                               return "Amount cannot be negative";
                             }
 
-                            if (amount.sats + currentFee().sats > balance.sats) {
+                            if (amount.sats + currentFee().sats > (balance?.sats ?? 0)) {
                               return "Not enough funds.";
                             }
 

--- a/mobile/lib/features/wallet/wallet_change_notifier.dart
+++ b/mobile/lib/features/wallet/wallet_change_notifier.dart
@@ -40,11 +40,11 @@ class WalletChangeNotifier extends ChangeNotifier implements Subscriber {
     await service.refreshWalletInfo();
   }
 
-  Amount total() => Amount(onChain().sats + offChain().sats);
+  Amount total() => Amount(onChain()?.sats ?? 0 + (offChain()?.sats ?? 0));
 
-  Amount onChain() => walletInfo.balances.onChain;
+  Amount? onChain() => walletInfo.balances.onChain;
 
-  Amount offChain() => walletInfo.balances.offChain;
+  Amount? offChain() => walletInfo.balances.offChain;
 
   @override
   void notify(bridge.Event event) {

--- a/mobile/lib/features/wallet/wallet_screen.dart
+++ b/mobile/lib/features/wallet/wallet_screen.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
-import 'package:get_10101/common/dlc_channel_change_notifier.dart';
 import 'package:get_10101/common/poll_widget.dart';
 import 'package:get_10101/common/secondary_action_button.dart';
 import 'package:get_10101/features/wallet/balance.dart';
@@ -22,7 +21,6 @@ class WalletScreen extends StatelessWidget {
   Widget build(BuildContext context) {
     final pollChangeNotifier = context.watch<PollChangeNotifier>();
     final walletChangeNotifier = context.watch<WalletChangeNotifier>();
-    final hasChannel = context.read<DlcChannelChangeNotifier>().hasDlcChannel();
 
     return Scaffold(
       body: RefreshIndicator(
@@ -44,13 +42,7 @@ class WalletScreen extends StatelessWidget {
                   child: Row(children: [
                     Expanded(
                       child: SecondaryActionButton(
-                        onPressed: () {
-                          context.go((hasChannel || walletChangeNotifier.offChain().sats > 0)
-                              ? ReceiveScreen.route
-                              :
-                              // TODO: we should have a dedicated on-boarding screen for on-boarding with on-chain funds
-                              ReceiveScreen.route);
-                        },
+                        onPressed: () => context.go(ReceiveScreen.route),
                         icon: FontAwesomeIcons.arrowDown,
                         title: 'Receive',
                       ),

--- a/mobile/native/src/api.rs
+++ b/mobile/native/src/api.rs
@@ -86,8 +86,8 @@ pub struct WalletInfo {
 
 #[derive(Clone, Debug, Default)]
 pub struct Balances {
-    pub on_chain: u64,
-    pub off_chain: u64,
+    pub on_chain: Option<u64>,
+    pub off_chain: Option<u64>,
 }
 
 /// Assembles the wallet info and publishes wallet info update event.

--- a/mobile/native/src/ln_dlc/mod.rs
+++ b/mobile/native/src/ln_dlc/mod.rs
@@ -473,9 +473,7 @@ pub async fn restore_from_mnemonic(seed_words: &str, target_seed_file: &Path) ->
 }
 
 fn keep_wallet_balance_and_history_up_to_date(node: &Node) -> Result<()> {
-    let wallet_balances = node
-        .get_wallet_balances()
-        .context("Failed to get wallet balances")?;
+    let wallet_balances = node.get_wallet_balances();
 
     let WalletHistories {
         on_chain,

--- a/mobile/native/src/ln_dlc/mod.rs
+++ b/mobile/native/src/ln_dlc/mod.rs
@@ -369,10 +369,14 @@ pub fn run(seed_dir: String, runtime: &Runtime) -> Result<()> {
         // TODO: This might not be necessary once we rewrite the on-chain wallet with bdk:1.0.0.
         spawn_blocking({
             let node = node.clone();
-            move || keep_wallet_balance_and_history_up_to_date(&node)
+            move || {
+                if let Err(e) = keep_wallet_balance_and_history_up_to_date(&node) {
+                    tracing::error!("Failed to sync balance and wallet history: {e:#}");
+                }
+            }
         })
         .await
-        .expect("task to complete")?;
+        .expect("task to complete");
 
         runtime.spawn({
             let node = node.clone();

--- a/mobile/native/src/ln_dlc/node.rs
+++ b/mobile/native/src/ln_dlc/node.rs
@@ -71,8 +71,8 @@ impl Node {
 }
 
 pub struct Balances {
-    pub on_chain: u64,
-    pub off_chain: u64,
+    pub on_chain: Option<u64>,
+    pub off_chain: Option<u64>,
 }
 
 impl From<Balances> for crate::api::Balances {
@@ -96,18 +96,18 @@ impl Node {
 
     pub fn get_wallet_balances(&self) -> Balances {
         let on_chain = match self.inner.get_on_chain_balance() {
-            Ok(on_chain) => on_chain.confirmed + on_chain.trusted_pending,
+            Ok(on_chain) => Some(on_chain.confirmed + on_chain.trusted_pending),
             Err(e) => {
                 tracing::error!("Failed to get onchain balance. {e:#}");
-                0
+                None
             }
         };
 
         let off_chain = match self.inner.get_dlc_channels_usable_balance() {
-            Ok(off_chain) => off_chain.to_sat(),
+            Ok(off_chain) => Some(off_chain.to_sat()),
             Err(e) => {
                 tracing::error!("Failed to get dlc channels usable balance. {e:#}");
-                0
+                None
             }
         };
 

--- a/webapp/src/api.rs
+++ b/webapp/src/api.rs
@@ -99,8 +99,8 @@ pub async fn get_unused_address() -> impl IntoResponse {
 
 #[derive(Serialize)]
 pub struct Balance {
-    on_chain: u64,
-    off_chain: u64,
+    on_chain: Option<u64>,
+    off_chain: Option<u64>,
 }
 
 pub async fn get_balance(


### PR DESCRIPTION
Let the app start even if the wallet sync fails.

If the wallet sync fails the balance will be set to `None`, telling the UI that we were unable to determine the balance.

fixes: #2075