### PR TITLE
Feat: Add closing tx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Fix(wallet): Gracefully handle an error during the wallet sync. Fixes an issue where the app was not able to start because of an inconsistent state.
+- Fix(wallet): Gracefully handle an error during the wallet sync. Fixes an issue where the app was not able to start because of an inconsistent state.´
+- Feat: Show closing txid on closing and closed channels.
 
 ## [1.9.0] - 2024-02-26
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1292,7 +1292,7 @@ dependencies = [
 [[package]]
 name = "dlc"
 version = "0.4.0"
-source = "git+https://github.com/get10101/rust-dlc?rev=aa487662a8af75174bf0e60f24e07e171820d0c3#aa487662a8af75174bf0e60f24e07e171820d0c3"
+source = "git+https://github.com/get10101/rust-dlc?rev=bc31c6167e304d7886c328da91e8c17dad1afce5#bc31c6167e304d7886c328da91e8c17dad1afce5"
 dependencies = [
  "bitcoin",
  "miniscript 8.0.2",
@@ -1304,7 +1304,7 @@ dependencies = [
 [[package]]
 name = "dlc-manager"
 version = "0.4.0"
-source = "git+https://github.com/get10101/rust-dlc?rev=aa487662a8af75174bf0e60f24e07e171820d0c3#aa487662a8af75174bf0e60f24e07e171820d0c3"
+source = "git+https://github.com/get10101/rust-dlc?rev=bc31c6167e304d7886c328da91e8c17dad1afce5#bc31c6167e304d7886c328da91e8c17dad1afce5"
 dependencies = [
  "async-trait",
  "bitcoin",
@@ -1320,7 +1320,7 @@ dependencies = [
 [[package]]
 name = "dlc-messages"
 version = "0.4.0"
-source = "git+https://github.com/get10101/rust-dlc?rev=aa487662a8af75174bf0e60f24e07e171820d0c3#aa487662a8af75174bf0e60f24e07e171820d0c3"
+source = "git+https://github.com/get10101/rust-dlc?rev=bc31c6167e304d7886c328da91e8c17dad1afce5#bc31c6167e304d7886c328da91e8c17dad1afce5"
 dependencies = [
  "bitcoin",
  "dlc",
@@ -1333,7 +1333,7 @@ dependencies = [
 [[package]]
 name = "dlc-trie"
 version = "0.4.0"
-source = "git+https://github.com/get10101/rust-dlc?rev=aa487662a8af75174bf0e60f24e07e171820d0c3#aa487662a8af75174bf0e60f24e07e171820d0c3"
+source = "git+https://github.com/get10101/rust-dlc?rev=bc31c6167e304d7886c328da91e8c17dad1afce5#bc31c6167e304d7886c328da91e8c17dad1afce5"
 dependencies = [
  "bitcoin",
  "dlc",
@@ -2039,9 +2039,9 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
-version = "0.5.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
+checksum = "7d20d6b07bfbc108882d88ed8e37d39636dcc260e15e30c45e6ba089610b917c"
 dependencies = [
  "unicode-bidi",
  "unicode-normalization",
@@ -2130,9 +2130,9 @@ checksum = "fad582f4b9e86b6caa621cabeb0963332d92eea04729ab12892c2533951e6440"
 
 [[package]]
 name = "js-sys"
-version = "0.3.68"
+version = "0.3.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "406cda4b368d531c842222cf9d2600a9a4acce8d29423695379c6868a143a9ee"
+checksum = "445dde2150c55e483f3d8416706b97ec8e8237c307e5b7b4b8dd15e6af2a0730"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -2831,7 +2831,7 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 [[package]]
 name = "p2pd-oracle-client"
 version = "0.1.0"
-source = "git+https://github.com/get10101/rust-dlc?rev=aa487662a8af75174bf0e60f24e07e171820d0c3#aa487662a8af75174bf0e60f24e07e171820d0c3"
+source = "git+https://github.com/get10101/rust-dlc?rev=bc31c6167e304d7886c328da91e8c17dad1afce5#bc31c6167e304d7886c328da91e8c17dad1afce5"
 dependencies = [
  "chrono",
  "dlc-manager",
@@ -2909,9 +2909,9 @@ dependencies = [
 
 [[package]]
 name = "percent-encoding"
-version = "2.3.1"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
 
 [[package]]
 name = "percent-encoding-rfc3986"
@@ -4717,9 +4717,9 @@ dependencies = [
 
 [[package]]
 name = "url"
-version = "2.5.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31e6302e3bb753d46e83516cae55ae196fc0c309407cf11ab35cc51a4c2a4633"
+checksum = "143b538f18257fac9cad154828a57c6bf5157e1aa604d4816b5995bf6de87ae5"
 dependencies = [
  "form_urlencoded",
  "idna",
@@ -4822,9 +4822,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.91"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1e124130aee3fb58c5bdd6b639a0509486b0338acaaae0c84a5124b0f588b7f"
+checksum = "31f8dcbc21f30d9b8f2ea926ecb58f6b91192c17e9d33594b3df58b2007ca53b"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -4832,16 +4832,16 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.91"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9e7e1900c352b609c8488ad12639a311045f40a35491fb69ba8c12f758af70b"
+checksum = "95ce90fd5bcc06af55a641a86428ee4229e44e07033963a2290a8e241607ccb9"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 1.0.109",
  "wasm-bindgen-shared",
 ]
 
@@ -4859,9 +4859,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.91"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b30af9e2d358182b5c7449424f017eba305ed32a7010509ede96cdc4696c46ed"
+checksum = "4c21f77c0bedc37fd5dc21f897894a5ca01e7bb159884559461862ae90c0b4c5"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4869,22 +4869,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.91"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "642f325be6301eb8107a83d12a8ac6c1e1c54345a7ef1a9261962dfefda09e66"
+checksum = "2aff81306fcac3c7515ad4e177f521b5c9a15f2b08f4e32d823066102f35a5f6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 1.0.109",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.91"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f186bd2dcf04330886ce82d6f33dd75a7bfcf69ecf5763b89fcde53b6ac9838"
+checksum = "0046fef7e28c3804e5e38bfa31ea2a0f73905319b677e57ebe37e49358989b5d"
 
 [[package]]
 name = "wasm-streams"
@@ -5230,3 +5230,8 @@ name = "zeroize"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a0956f1ba7c7909bfb66c2e9e4124ab6f6482560f6628b5aaeba39207c9aad9"
+
+[[patch.unused]]
+name = "lightning-net-tokio"
+version = "0.0.117"
+source = "git+https://github.com/bonomat/rust-lightning-p2p-derivatives?rev=e49030e#e49030e785408f0fd4da077f63f8101cc0b2436e"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,17 +20,18 @@ resolver = "2"
 # We are using our own fork of `rust-dlc` at least until we can drop all the LN-DLC features. Also,
 # `p2pderivatives/rust-dlc#master` is missing certain patches that can only be found in the LN-DLC
 # branch.
-dlc-manager = { git = "https://github.com/get10101/rust-dlc", rev = "aa487662a8af75174bf0e60f24e07e171820d0c3" }
-dlc-messages = { git = "https://github.com/get10101/rust-dlc", rev = "aa487662a8af75174bf0e60f24e07e171820d0c3" }
-dlc = { git = "https://github.com/get10101/rust-dlc", rev = "aa487662a8af75174bf0e60f24e07e171820d0c3" }
-p2pd-oracle-client = { git = "https://github.com/get10101/rust-dlc", rev = "aa487662a8af75174bf0e60f24e07e171820d0c3" }
-dlc-trie = { git = "https://github.com/get10101/rust-dlc", rev = "aa487662a8af75174bf0e60f24e07e171820d0c3" }
+dlc-manager = { git = "https://github.com/get10101/rust-dlc", rev = "bc31c6167e304d7886c328da91e8c17dad1afce5" }
+dlc-messages = { git = "https://github.com/get10101/rust-dlc", rev = "bc31c6167e304d7886c328da91e8c17dad1afce5" }
+dlc = { git = "https://github.com/get10101/rust-dlc", rev = "bc31c6167e304d7886c328da91e8c17dad1afce5" }
+p2pd-oracle-client = { git = "https://github.com/get10101/rust-dlc", rev = "bc31c6167e304d7886c328da91e8c17dad1afce5" }
+dlc-trie = { git = "https://github.com/get10101/rust-dlc", rev = "bc31c6167e304d7886c328da91e8c17dad1afce5" }
 
 # We should usually track the `p2pderivatives/split-tx-experiment[-10101]` branch. For now we depend
 # on a special fork which removes a panic in `rust-lightning`.
 lightning = { git = "https://github.com/bonomat/rust-lightning-p2p-derivatives", rev = "e49030e" }
 lightning-background-processor = { git = "https://github.com/bonomat/rust-lightning-p2p-derivatives", rev = "e49030e" }
 lightning-transaction-sync = { git = "https://github.com/bonomat/rust-lightning-p2p-derivatives", rev = "e49030e" }
+lightning-net-tokio = { git = "https://github.com/bonomat/rust-lightning-p2p-derivatives", rev = "e49030e" }
 lightning-persister = { git = "https://github.com/bonomat/rust-lightning-p2p-derivatives", rev = "e49030e" }
 lightning-rapid-gossip-sync = { git = "https://github.com/bonomat/rust-lightning-p2p-derivatives", rev = "e49030e" }
 

--- a/coordinator/src/collaborative_revert.rs
+++ b/coordinator/src/collaborative_revert.rs
@@ -240,6 +240,7 @@ pub fn confirm_collaborative_revert(
             temporary_channel_id: signed_channel.temporary_channel_id,
             channel_id: signed_channel.channel_id,
             reference_id: None,
+            closing_txid: revert_transaction.txid(),
         }),
         // The contract doesn't matter anymore.
         None,

--- a/mobile/lib/common/dlc_channel_change_notifier.dart
+++ b/mobile/lib/common/dlc_channel_change_notifier.dart
@@ -64,13 +64,21 @@ class DlcChannelChangeNotifier extends ChangeNotifier {
         .toList();
   }
 
-  List<DlcChannel> getAllOtherDlcChannels() {
+  List<ClosedDlcChannel> getAllClosedDlcChannels() {
     return channels
         .where((channel) => [
               ChannelState.closed,
               ChannelState.counterClosed,
-              ChannelState.closedPunished,
               ChannelState.collaborativelyClosed,
+            ].contains(channel.state))
+        .map((channel) => channel as ClosedDlcChannel)
+        .toList();
+  }
+
+  List<DlcChannel> getAllOtherDlcChannels() {
+    return channels
+        .where((channel) => [
+              ChannelState.closedPunished,
               ChannelState.failedAccept,
               ChannelState.failedSign,
             ].contains(channel.state))

--- a/mobile/lib/common/domain/dlc_channel.dart
+++ b/mobile/lib/common/domain/dlc_channel.dart
@@ -19,6 +19,7 @@ class DlcChannel {
               state: ChannelState.signed,
               contractId: signed.contractId,
               fundingTxid: signed.fundingTxid,
+              closingTxid: signed.closingTxid,
               signedState: SignedChannelState.fromApi(signed.state));
         }
       case (bridge.ChannelState_Offered offered):
@@ -39,26 +40,34 @@ class DlcChannel {
       case (bridge.ChannelState_Closing closing):
         {
           return ClosingDlcChannel(
+            id: dlcChannel.dlcChannelId,
+            state: ChannelState.closing,
+            contractId: closing.contractId,
+            bufferTxid: closing.bufferTxid,
+          );
+        }
+      case (bridge.ChannelState_Closed c):
+        {
+          return ClosedDlcChannel(
+              id: dlcChannel.dlcChannelId, state: ChannelState.closed, closingTxid: c.closingTxid);
+        }
+      case (bridge.ChannelState_CounterClosed c):
+        {
+          return ClosedDlcChannel(
               id: dlcChannel.dlcChannelId,
-              state: ChannelState.closing,
-              contractId: closing.contractId,
-              bufferTxid: closing.bufferTxid);
-        }
-      case (bridge.ChannelState_Closed _):
-        {
-          return DlcChannel(id: dlcChannel.dlcChannelId, state: ChannelState.closed);
-        }
-      case (bridge.ChannelState_CounterClosed _):
-        {
-          return DlcChannel(id: dlcChannel.dlcChannelId, state: ChannelState.counterClosed);
+              state: ChannelState.counterClosed,
+              closingTxid: c.closingTxid);
         }
       case (bridge.ChannelState_ClosedPunished _):
         {
           return DlcChannel(id: dlcChannel.dlcChannelId, state: ChannelState.closedPunished);
         }
-      case (bridge.ChannelState_CollaborativelyClosed _):
+      case (bridge.ChannelState_CollaborativelyClosed c):
         {
-          return DlcChannel(id: dlcChannel.dlcChannelId, state: ChannelState.collaborativelyClosed);
+          return ClosedDlcChannel(
+              id: dlcChannel.dlcChannelId,
+              state: ChannelState.collaborativelyClosed,
+              closingTxid: c.closingTxid);
         }
       case (bridge.ChannelState_FailedAccept _):
         {
@@ -104,6 +113,7 @@ class AcceptedDlcChannel extends DlcChannel {
 class SignedDlcChannel extends DlcChannel {
   String? contractId;
   String fundingTxid;
+  String? closingTxid;
   SignedChannelState signedState;
 
   SignedDlcChannel(
@@ -111,6 +121,7 @@ class SignedDlcChannel extends DlcChannel {
       required super.state,
       required this.contractId,
       required this.fundingTxid,
+      required this.closingTxid,
       required this.signedState});
 
   @override
@@ -133,6 +144,12 @@ class ClosingDlcChannel extends DlcChannel {
   String? getContractId() {
     return contractId;
   }
+}
+
+class ClosedDlcChannel extends DlcChannel {
+  String closingTxid;
+
+  ClosedDlcChannel({required super.id, required super.state, required this.closingTxid});
 }
 
 class CancelledDlcChannel extends DlcChannel {

--- a/mobile/lib/common/settings/channel_screen.dart
+++ b/mobile/lib/common/settings/channel_screen.dart
@@ -46,6 +46,7 @@ class _ChannelScreenState extends State<ChannelScreen> {
       ...dlcChannelChangeNotifier.getAllAcceptedDlcChannels(),
       ...dlcChannelChangeNotifier.getAllCancelledDlcChannels(),
       ...dlcChannelChangeNotifier.getAllClosingDlcChannels(),
+      ...dlcChannelChangeNotifier.getAllClosedDlcChannels(),
       ...dlcChannelChangeNotifier.getAllOtherDlcChannels()
     ];
 
@@ -147,6 +148,12 @@ class _ChannelScreenState extends State<ChannelScreen> {
                                             style: TextStyle(fontSize: 17)),
                                         title: TransactionIdText(channel.fundingTxid),
                                       ),
+                                      channel.closingTxid != null
+                                          ? ListTile(
+                                              leading: const Text('Closing TxId',
+                                                  style: TextStyle(fontSize: 17)),
+                                              title: TransactionIdText(channel.closingTxid!))
+                                          : Container(),
                                     ],
                                   );
                                 }).toList()),
@@ -215,7 +222,12 @@ class ChannelsTile extends StatelessWidget {
                     ? ListTile(
                         leading: const Text('Buffer TxId', style: TextStyle(fontSize: 17)),
                         title: TransactionIdText(channel.bufferTxid))
-                    : Container()
+                    : Container(),
+                channel is ClosedDlcChannel
+                    ? ListTile(
+                        leading: const Text('Closing TxId', style: TextStyle(fontSize: 17)),
+                        title: TransactionIdText(channel.closingTxid))
+                    : Container(),
               ],
             );
           }).toList()),

--- a/mobile/lib/common/settings/channel_screen.dart
+++ b/mobile/lib/common/settings/channel_screen.dart
@@ -135,7 +135,7 @@ class _ChannelScreenState extends State<ChannelScreen> {
                                     ),
                                     children: <Widget>[
                                       ListTile(
-                                        leading: const Text('Dlc Channel Id',
+                                        leading: const Text('DLC Channel Id',
                                             style: TextStyle(fontSize: 17)),
                                         title: IdText(id: channel.id, length: 8),
                                       ),
@@ -144,13 +144,13 @@ class _ChannelScreenState extends State<ChannelScreen> {
                                               style: TextStyle(fontSize: 17)),
                                           title: IdText(id: channel.contractId ?? "n/a")),
                                       ListTile(
-                                        leading: const Text('Funding TxId',
+                                        leading: const Text('Funding TXID',
                                             style: TextStyle(fontSize: 17)),
                                         title: TransactionIdText(channel.fundingTxid),
                                       ),
                                       channel.closingTxid != null
                                           ? ListTile(
-                                              leading: const Text('Closing TxId',
+                                              leading: const Text('Closing TXID',
                                                   style: TextStyle(fontSize: 17)),
                                               title: TransactionIdText(channel.closingTxid!))
                                           : Container(),
@@ -210,7 +210,7 @@ class ChannelsTile extends StatelessWidget {
               title: Text(channel.state.toString()),
               children: <Widget>[
                 ListTile(
-                    leading: const Text('Dlc Channel Id', style: TextStyle(fontSize: 17)),
+                    leading: const Text('DLC Channel Id', style: TextStyle(fontSize: 17)),
                     title: IdText(id: channel.id)),
                 Visibility(
                   visible: channel.getContractId() != null,
@@ -220,12 +220,12 @@ class ChannelsTile extends StatelessWidget {
                 ),
                 channel is ClosingDlcChannel
                     ? ListTile(
-                        leading: const Text('Buffer TxId', style: TextStyle(fontSize: 17)),
+                        leading: const Text('Buffer TXID', style: TextStyle(fontSize: 17)),
                         title: TransactionIdText(channel.bufferTxid))
                     : Container(),
                 channel is ClosedDlcChannel
                     ? ListTile(
-                        leading: const Text('Closing TxId', style: TextStyle(fontSize: 17)),
+                        leading: const Text('Closing TXID', style: TextStyle(fontSize: 17)),
                         title: TransactionIdText(channel.closingTxid))
                     : Container(),
               ],

--- a/webapp/src/api.rs
+++ b/webapp/src/api.rs
@@ -645,16 +645,17 @@ impl From<&dlc_manager::channel::Channel> for DlcChannel {
             dlc_manager::channel::Channel::Closed(c) => DlcChannel {
                 dlc_channel_id: Some(c.channel_id.to_hex()),
                 channel_state: Some(ChannelState::Closed),
+                close_txid: Some(c.closing_txid.to_hex()),
                 ..DlcChannel::default()
             },
             dlc_manager::channel::Channel::CounterClosed(c) => DlcChannel {
                 dlc_channel_id: Some(c.channel_id.to_hex()),
                 channel_state: Some(ChannelState::CounterClosed),
+                close_txid: Some(c.closing_txid.to_hex()),
                 ..DlcChannel::default()
             },
             dlc_manager::channel::Channel::ClosedPunished(c) => DlcChannel {
                 dlc_channel_id: Some(c.channel_id.to_hex()),
-
                 channel_state: Some(ChannelState::ClosedPunished),
                 punnish_txid: Some(c.punish_txid.to_hex()),
                 ..DlcChannel::default()
@@ -662,6 +663,7 @@ impl From<&dlc_manager::channel::Channel> for DlcChannel {
             dlc_manager::channel::Channel::CollaborativelyClosed(c) => DlcChannel {
                 dlc_channel_id: Some(c.channel_id.to_hex()),
                 channel_state: Some(ChannelState::CollaborativelyClosed),
+                close_txid: Some(c.closing_txid.to_hex()),
                 ..DlcChannel::default()
             },
             dlc_manager::channel::Channel::FailedAccept(_) => DlcChannel {


### PR DESCRIPTION
Adds the closing txid to the dlc channels api and the channels screen in the settings (see screenshot below).

depends on https://github.com/get10101/rust-dlc/pull/13

Note this is a breaking change. Old closed channels can't be read anymore. But given that old closed channel state don't provide any valuable information, I think this is acceptable.

![image](https://github.com/get10101/10101/assets/382048/b8bb9219-678d-4fd7-8742-866abb65e862)
