### PR TITLE
chore: Set expired async orders to expired

### DIFF
--- a/coordinator/src/node/expired_positions.rs
+++ b/coordinator/src/node/expired_positions.rs
@@ -50,7 +50,7 @@ pub async fn close(node: Node, trading_sender: mpsc::Sender<NewOrderMessage>) ->
 
             if order.expiry < OffsetDateTime::now_utc() {
                 tracing::warn!(trader_id, order_id, "Matched order expired! Giving up on that position, looks like the corresponding dlc channel has to get force closed.");
-                orderbook::db::orders::set_order_state(&mut conn, order.id, OrderState::Failed)?;
+                orderbook::db::orders::set_order_state(&mut conn, order.id, OrderState::Expired)?;
 
                 orderbook::db::matches::set_match_state_by_order_id(
                     &mut conn,


### PR DESCRIPTION
Still not perfect that we set the position to `Closing`, but when we rework the position handling, we will get rid of the position state anyways - so I am not touching this for now.