### PR TITLE
fix: remove line that runs clippy on maker/

### DIFF
--- a/justfile
+++ b/justfile
@@ -254,7 +254,6 @@ lint: lint-flutter clippy
 clippy:
     cd mobile/native && just cargo-clippy
     cd coordinator && just cargo-clippy
-    cd maker && just cargo-clippy
     for crate in crates/*; do (cd "${crate}" && echo "Running clippy on ${crate}" && just cargo-clippy); done
 
 [private]


### PR DESCRIPTION
This is not longer in this repo anymore