### PR TITLE
Show log file location on desktop

### DIFF
--- a/mobile/lib/common/more_info.dart
+++ b/mobile/lib/common/more_info.dart
@@ -1,0 +1,56 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:get_10101/common/color.dart';
+import 'package:get_10101/common/snack_bar.dart';
+
+Widget moreInfo(BuildContext context,
+    {required String title, required String info, bool showCopyButton = false}) {
+  return Container(
+    padding: const EdgeInsets.all(15),
+    child: Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+      children: [
+        Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              title,
+              style:
+                  const TextStyle(fontSize: 17, fontWeight: FontWeight.w400, color: Colors.black),
+            ),
+            const SizedBox(
+              height: 7,
+            ),
+            showCopyButton
+                ? SizedBox(
+                    width: MediaQuery.of(context).size.width - 100,
+                    child: Text(
+                      info,
+                      style: TextStyle(
+                          fontSize: 18, fontWeight: FontWeight.w300, color: Colors.grey.shade700),
+                    ))
+                : const SizedBox()
+          ],
+        ),
+        showCopyButton
+            ? GestureDetector(
+                onTap: () async {
+                  showSnackBar(ScaffoldMessenger.of(context), "Copied $info");
+                  await Clipboard.setData(ClipboardData(text: info));
+                },
+                child: Icon(
+                  Icons.copy,
+                  size: 17,
+                  color: tenTenOnePurple.shade800,
+                ),
+              )
+            : Text(
+                info,
+                style: TextStyle(
+                    fontSize: 18, fontWeight: FontWeight.w300, color: Colors.grey.shade700),
+              )
+      ],
+    ),
+  );
+}

--- a/mobile/lib/common/settings/app_info_screen.dart
+++ b/mobile/lib/common/settings/app_info_screen.dart
@@ -1,15 +1,12 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
-import 'package:get_10101/common/color.dart';
+import 'package:get_10101/common/more_info.dart';
 import 'package:get_10101/common/settings/open_telegram.dart';
 import 'package:get_10101/common/settings/settings_screen.dart';
 import 'package:get_10101/common/snack_bar.dart';
 import 'package:get_10101/logger/logger.dart';
-
 import 'package:go_router/go_router.dart';
-
 import 'package:package_info_plus/package_info_plus.dart';
 import 'package:get_10101/ffi.dart' as rust;
 import 'package:url_launcher/url_launcher.dart';
@@ -229,56 +226,4 @@ class _AppInfoScreenState extends State<AppInfoScreen> {
           )),
     );
   }
-}
-
-Widget moreInfo(BuildContext context,
-    {required String title, required String info, bool showCopyButton = false}) {
-  return Container(
-    padding: const EdgeInsets.all(15),
-    child: Row(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      mainAxisAlignment: MainAxisAlignment.spaceBetween,
-      children: [
-        Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Text(
-              title,
-              style:
-                  const TextStyle(fontSize: 17, fontWeight: FontWeight.w400, color: Colors.black),
-            ),
-            const SizedBox(
-              height: 7,
-            ),
-            showCopyButton
-                ? SizedBox(
-                    width: MediaQuery.of(context).size.width - 100,
-                    child: Text(
-                      info,
-                      style: TextStyle(
-                          fontSize: 18, fontWeight: FontWeight.w300, color: Colors.grey.shade700),
-                    ))
-                : const SizedBox()
-          ],
-        ),
-        showCopyButton
-            ? GestureDetector(
-                onTap: () async {
-                  showSnackBar(ScaffoldMessenger.of(context), "Copied $info");
-                  await Clipboard.setData(ClipboardData(text: info));
-                },
-                child: Icon(
-                  Icons.copy,
-                  size: 17,
-                  color: tenTenOnePurple.shade800,
-                ),
-              )
-            : Text(
-                info,
-                style: TextStyle(
-                    fontSize: 18, fontWeight: FontWeight.w300, color: Colors.grey.shade700),
-              )
-      ],
-    ),
-  );
 }

--- a/mobile/lib/common/settings/share_logs_screen.dart
+++ b/mobile/lib/common/settings/share_logs_screen.dart
@@ -1,9 +1,11 @@
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:flutter/foundation.dart' show defaultTargetPlatform, TargetPlatform;
 import 'package:flutter/material.dart';
 import 'package:get_10101/common/application/switch.dart';
 import 'package:get_10101/common/color.dart';
+import 'package:get_10101/common/more_info.dart';
 import 'package:get_10101/common/settings/settings_screen.dart';
 import 'package:get_10101/logger/hybrid_logger.dart';
 import 'package:get_10101/logger/logger.dart';
@@ -84,44 +86,64 @@ class _ShareLogsScreenState extends State<ShareLogsScreen> {
                     const SizedBox(
                       height: 20,
                     ),
-                    GestureDetector(
-                      onTap: () async {
-                        logger.toString();
+                    Row(
+                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                      children: [
+                        FutureBuilder(
+                            future: HybridOutput.logFilePath(),
+                            builder: (BuildContext context, AsyncSnapshot<File> snapshot) {
+                              switch (defaultTargetPlatform) {
+                                case TargetPlatform.android:
+                                case TargetPlatform.iOS:
+                                  return GestureDetector(
+                                    onTap: () async {
+                                      logger.toString();
 
-                        var file = await HybridOutput.logFilePath();
-                        var logsAsString = await file.readAsString();
-                        final List<int> bytes = utf8.encode(logsAsString);
-                        final Directory tempDir = await getTemporaryDirectory();
-                        String now = DateFormat('yyyy-MM-dd_HHmmss').format(DateTime.now());
-                        final String filePath = '${tempDir.path}/$now.log';
-                        await File(filePath).writeAsBytes(bytes);
-                        final XFile logFile = XFile(filePath);
-                        Share.shareXFiles([logFile], text: 'Logs from $now');
-                      },
-                      child: Container(
-                        padding: const EdgeInsets.symmetric(vertical: 10, horizontal: 20),
-                        decoration: BoxDecoration(
-                            color: Colors.white, borderRadius: BorderRadius.circular(15)),
-                        child: Row(
-                          children: [
-                            Icon(
-                              Icons.ios_share_outlined,
-                              color: tenTenOnePurple.shade800,
-                              size: 22,
-                            ),
-                            const SizedBox(
-                              width: 20,
-                            ),
-                            Text(
-                              "Share Logs",
-                              style: TextStyle(
-                                  color: tenTenOnePurple.shade800,
-                                  fontSize: 16,
-                                  fontWeight: FontWeight.w500),
-                            )
-                          ],
-                        ),
-                      ),
+                                      var logsAsString = await snapshot.data!.readAsString();
+                                      final List<int> bytes = utf8.encode(logsAsString);
+                                      final Directory tempDir = await getTemporaryDirectory();
+                                      String now =
+                                          DateFormat('yyyy-MM-dd_HHmmss').format(DateTime.now());
+                                      final String filePath = '${tempDir.path}/$now.log';
+                                      await File(filePath).writeAsBytes(bytes);
+                                      final XFile logFile = XFile(filePath);
+                                      Share.shareXFiles([logFile], text: 'Logs from $now');
+                                    },
+                                    child: Container(
+                                      padding:
+                                          const EdgeInsets.symmetric(vertical: 10, horizontal: 20),
+                                      decoration: BoxDecoration(
+                                          color: Colors.white,
+                                          borderRadius: BorderRadius.circular(15)),
+                                      child: Row(
+                                        children: [
+                                          Icon(
+                                            Icons.ios_share_outlined,
+                                            color: tenTenOnePurple.shade800,
+                                            size: 22,
+                                          ),
+                                          const SizedBox(
+                                            width: 20,
+                                          ),
+                                          Text(
+                                            "Share Logs",
+                                            style: TextStyle(
+                                                color: tenTenOnePurple.shade800,
+                                                fontSize: 16,
+                                                fontWeight: FontWeight.w500),
+                                          )
+                                        ],
+                                      ),
+                                    ),
+                                  );
+                                default:
+                                  return moreInfo(context,
+                                      title: "Log file location",
+                                      info: snapshot.data!.path,
+                                      showCopyButton: true);
+                              }
+                            }),
+                      ],
                     ),
                     const SizedBox(height: 20),
                     Container(


### PR DESCRIPTION
Fix https://github.com/get10101/10101/issues/2076.

![share-logs-desktop](https://github.com/get10101/10101/assets/9418575/fa96be9a-c52c-4d4d-9f57-302f0b8c61ee)

The share button wasn't working on desktop anyway. On Linux it is just not supported. On Mac we heard that it did not work.

Desktop users (not officially supported) can now copy the log file location, find the log file using a file explorer, and share it with us.