### PR TITLE
chore(webapp): Bump axum-login dependency to 0.13.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -262,7 +262,7 @@ checksum = "3b829e4e32b91e643de6eafe82b1d90675f5874230191a4ffbc1b336dec4d6bf"
 dependencies = [
  "async-trait",
  "axum-core 0.3.4",
- "base64 0.21.0",
+ "base64 0.21.7",
  "bitflags 1.3.2",
  "bytes",
  "futures-util",
@@ -364,9 +364,9 @@ dependencies = [
 
 [[package]]
 name = "axum-login"
-version = "0.12.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fff85d5ba21f2063b3e8e47ba7192f7d2b73760e3d413db8e7c9b9bea3095b2"
+checksum = "df12ed681d759ff9c466e7dda53e34bf7f28d20edd3f66a5d9e1173e8eaf0257"
 dependencies = [
  "async-trait",
  "axum 0.7.4",
@@ -405,9 +405,9 @@ checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64"
-version = "0.21.0"
+version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
 name = "bdk"
@@ -2521,7 +2521,7 @@ version = "0.1.0"
 dependencies = [
  "aes-gcm-siv",
  "anyhow",
- "base64 0.21.0",
+ "base64 0.21.7",
  "bdk",
  "bip21",
  "bitcoin",
@@ -3284,7 +3284,7 @@ version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21eed90ec8570952d53b772ecf8f206aa1ec9a3d76b2521c56c42973f2d91ee9"
 dependencies = [
- "base64 0.21.0",
+ "base64 0.21.7",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -3502,7 +3502,7 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
 dependencies = [
- "base64 0.21.0",
+ "base64 0.21.7",
 ]
 
 [[package]]
@@ -3759,7 +3759,7 @@ version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1402f54f9a3b9e2efe71c1cea24e648acce55887983553eeb858cf3115acfd49"
 dependencies = [
- "base64 0.21.0",
+ "base64 0.21.7",
  "chrono",
  "hex",
  "indexmap 1.9.2",
@@ -4341,7 +4341,7 @@ checksum = "3082666a3a6433f7f511c7192923fa1fe07c69332d3c6a2e6bb040b569199d5a"
 dependencies = [
  "async-trait",
  "axum 0.6.20",
- "base64 0.21.0",
+ "base64 0.21.7",
  "bytes",
  "futures-core",
  "futures-util",
@@ -4437,42 +4437,48 @@ checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
 
 [[package]]
 name = "tower-sessions"
-version = "0.9.1"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "201aa0cccd55f565d89086d231328877fb897ba01163a224b6b917e2361a6db6"
-dependencies = [
- "tower-sessions-core",
- "tower-sessions-memory-store",
-]
-
-[[package]]
-name = "tower-sessions-core"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12564616434c7c811a229a223552b984f272e772d5dec4f71e61ca5bea7d3a3f"
+checksum = "b5dfd131ee564762468250d3dbb8a04f3bc933bcc9bd4f0958ce8acbfb578b73"
 dependencies = [
  "async-trait",
- "axum-core 0.4.3",
- "futures",
  "http 1.0.0",
- "parking_lot 0.12.1",
- "serde",
- "serde_json",
- "thiserror",
  "time",
  "tokio",
  "tower-cookies",
  "tower-layer",
  "tower-service",
+ "tower-sessions-core",
+ "tower-sessions-memory-store",
  "tracing",
- "uuid",
+]
+
+[[package]]
+name = "tower-sessions-core"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bed2607e4db384eed7a932a53c10f64202e73e9a970b6a7410bcbc018fd7c689"
+dependencies = [
+ "async-trait",
+ "axum-core 0.4.3",
+ "base64 0.21.7",
+ "futures",
+ "http 1.0.0",
+ "parking_lot 0.12.1",
+ "rand",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "time",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]
 name = "tower-sessions-memory-store"
-version = "0.9.1"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6800cb4ae79785b1bb413e48813306950902ef902f8ea93fce0a25032e2c254"
+checksum = "c5768acf21f287baf2774468f544e472e30d75ade0d29617046655c463cd4306"
 dependencies = [
  "async-trait",
  "time",
@@ -4702,7 +4708,7 @@ version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b11c96ac7ee530603dcdf68ed1557050f374ce55a5a07193ebf8cbc9f8927e9"
 dependencies = [
- "base64 0.21.0",
+ "base64 0.21.7",
  "flate2",
  "log",
  "once_cell",

--- a/webapp/Cargo.toml
+++ b/webapp/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 anyhow = "1"
 atty = "0.2.14"
 axum = { version = "0.7", features = ["tracing"] }
-axum-login = "0.12.0"
+axum-login = "0.13.1"
 bitcoin = "0.29.2"
 clap = { version = "4", features = ["derive"] }
 commons = { path = "../crates/commons" }


### PR DESCRIPTION
No being super optimistic, but maybe the latest axum-login release fixes the issue with the randomly unresponsive webapp (https://github.com/get10101/10101/issues/1938)

It looks like axum-login had issues with deadlocks in the past, but with tower-sessions those deadlock should have been fixed. Bumping from `0.12` to `0.13.1` also bumps the `tower-session` dependency. So this might help 🤞.