### PR TITLE
chore(ci): Create pre-releases with generated release notes

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -21,12 +21,6 @@ jobs:
 
           print(f"::set-output name=version::{version}")
 
-      - name: Extract changelog section for release
-        id: changelog
-        uses: coditory/changelog-parser@v1
-        with:
-          version: ${{ steps.extract-version.outputs.version }}
-
       - uses: actions/download-artifact@v3
         with:
           name: ${{ needs.build.outputs.ANDROID_APK_NAME }}
@@ -35,8 +29,8 @@ jobs:
         uses: ncipollo/release-action@v1
         with:
           artifacts: ${{ needs.build.outputs.ANDROID_APK_NAME }}
-          body: ${{ steps.changelog.outputs.description }}
           token: ${{ secrets.GH_ACTION_TOKEN }}
           tag: ${{ steps.extract-version.outputs.version }}
           prerelease: true
           makeLatest: false
+          generateReleaseNotes: true

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -38,3 +38,5 @@ jobs:
           body: ${{ steps.changelog.outputs.description }}
           token: ${{ secrets.GH_ACTION_TOKEN }}
           tag: ${{ steps.extract-version.outputs.version }}
+          prerelease: true
+          makeLatest: false


### PR DESCRIPTION
As discussed in our last demo. We can skip creating manual change log entries if we are creating proper pull request titles.