### PR TITLE
chore(dlc_protocol): Track rollovers in dlc protocol table

### DIFF
--- a/coordinator/migrations/2024-02-29-142400_add_dlc_action/down.sql
+++ b/coordinator/migrations/2024-02-29-142400_add_dlc_action/down.sql
@@ -1,0 +1,4 @@
+
+ALTER TABLE dlc_protocols DROP COLUMN IF EXISTS "protocol_type";
+
+DROP TYPE IF EXISTS "Protocol_Type_Type";

--- a/coordinator/migrations/2024-02-29-142400_add_dlc_action/up.sql
+++ b/coordinator/migrations/2024-02-29-142400_add_dlc_action/up.sql
@@ -1,0 +1,4 @@
+
+CREATE TYPE "Protocol_Type_Type" AS ENUM ('open', 'renew', 'settle', 'close', 'force-close', 'rollover');
+
+ALTER TABLE dlc_protocols ADD COLUMN "protocol_type" "Protocol_Type_Type" NOT NULL DEFAULT 'open';

--- a/coordinator/src/db/custom_types.rs
+++ b/coordinator/src/db/custom_types.rs
@@ -1,6 +1,7 @@
 use crate::db::channels::ChannelState;
 use crate::db::dlc_messages::MessageType;
 use crate::db::dlc_protocols::DlcProtocolState;
+use crate::db::dlc_protocols::DlcProtocolType;
 use crate::db::polls::PollType;
 use crate::db::positions::ContractSymbol;
 use crate::db::positions::PositionState;
@@ -11,6 +12,7 @@ use crate::schema::sql_types::MessageTypeType;
 use crate::schema::sql_types::PollTypeType;
 use crate::schema::sql_types::PositionStateType;
 use crate::schema::sql_types::ProtocolStateType;
+use crate::schema::sql_types::ProtocolTypeType;
 use diesel::deserialize;
 use diesel::deserialize::FromSql;
 use diesel::pg::Pg;
@@ -199,7 +201,35 @@ impl FromSql<ProtocolStateType, Pg> for DlcProtocolState {
             b"Pending" => Ok(DlcProtocolState::Pending),
             b"Success" => Ok(DlcProtocolState::Success),
             b"Failed" => Ok(DlcProtocolState::Failed),
-            _ => Err("Unrecognized enum variant for ContractTransactionType".into()),
+            _ => Err("Unrecognized enum variant for ProtocolStateType".into()),
+        }
+    }
+}
+
+impl ToSql<ProtocolTypeType, Pg> for DlcProtocolType {
+    fn to_sql<'b>(&'b self, out: &mut Output<'b, '_, Pg>) -> serialize::Result {
+        match *self {
+            DlcProtocolType::Open => out.write_all(b"open")?,
+            DlcProtocolType::Settle => out.write_all(b"settle")?,
+            DlcProtocolType::Renew => out.write_all(b"renew")?,
+            DlcProtocolType::Rollover => out.write_all(b"rollover")?,
+            DlcProtocolType::Close => out.write_all(b"close")?,
+            DlcProtocolType::ForceClose => out.write_all(b"force-close")?,
+        }
+        Ok(IsNull::No)
+    }
+}
+
+impl FromSql<ProtocolTypeType, Pg> for DlcProtocolType {
+    fn from_sql(bytes: PgValue<'_>) -> deserialize::Result<Self> {
+        match bytes.as_bytes() {
+            b"open" => Ok(DlcProtocolType::Open),
+            b"settle" => Ok(DlcProtocolType::Settle),
+            b"renew" => Ok(DlcProtocolType::Renew),
+            b"rollover" => Ok(DlcProtocolType::Rollover),
+            b"close" => Ok(DlcProtocolType::Close),
+            b"force-close" => Ok(DlcProtocolType::ForceClose),
+            _ => Err("Unrecognized enum variant for ProtocolTypeType".into()),
         }
     }
 }

--- a/coordinator/src/db/dlc_protocols.rs
+++ b/coordinator/src/db/dlc_protocols.rs
@@ -138,8 +138,8 @@ pub(crate) fn set_dlc_protocol_state_to_failed(
 pub(crate) fn set_dlc_protocol_state_to_success(
     conn: &mut PgConnection,
     protocol_id: ProtocolId,
-    contract_id: ContractId,
-    channel_id: DlcChannelId,
+    contract_id: &ContractId,
+    channel_id: &DlcChannelId,
 ) -> QueryResult<()> {
     let affected_rows = diesel::update(dlc_protocols::table)
         .filter(dlc_protocols::protocol_id.eq(protocol_id.to_uuid()))

--- a/coordinator/src/db/dlc_protocols.rs
+++ b/coordinator/src/db/dlc_protocols.rs
@@ -104,8 +104,8 @@ pub(crate) fn create(
     conn: &mut PgConnection,
     protocol_id: ProtocolId,
     previous_protocol_id: Option<ProtocolId>,
-    contract_id: ContractId,
-    channel_id: DlcChannelId,
+    contract_id: &ContractId,
+    channel_id: &DlcChannelId,
     trader: &PublicKey,
 ) -> QueryResult<()> {
     let affected_rows = diesel::insert_into(dlc_protocols::table)

--- a/coordinator/src/db/positions.rs
+++ b/coordinator/src/db/positions.rs
@@ -300,8 +300,8 @@ impl Position {
         conn: &mut PgConnection,
         trader_pubkey: String,
         temporary_contract_id: ContractId,
-    ) -> Result<()> {
-        let affected_rows = diesel::update(positions::table)
+    ) -> QueryResult<usize> {
+        diesel::update(positions::table)
             .filter(positions::trader_pubkey.eq(trader_pubkey))
             .filter(
                 positions::position_state
@@ -313,11 +313,7 @@ impl Position {
                 positions::temporary_contract_id.eq(hex::encode(temporary_contract_id)),
                 positions::update_timestamp.eq(OffsetDateTime::now_utc()),
             ))
-            .execute(conn)?;
-
-        ensure!(affected_rows > 0, "Could not set position to open");
-
-        Ok(())
+            .execute(conn)
     }
 
     pub fn update_unrealized_pnl(conn: &mut PgConnection, id: i32, pnl: i64) -> Result<()> {

--- a/coordinator/src/db/trade_params.rs
+++ b/coordinator/src/db/trade_params.rs
@@ -9,7 +9,6 @@ use diesel::QueryDsl;
 use diesel::QueryResult;
 use diesel::Queryable;
 use diesel::RunQueryDsl;
-use rust_decimal::prelude::ToPrimitive;
 use std::str::FromStr;
 use uuid::Uuid;
 
@@ -29,21 +28,16 @@ pub(crate) struct TradeParams {
 pub(crate) fn insert(
     conn: &mut PgConnection,
     protocol_id: ProtocolId,
-    params: &commons::TradeParams,
+    params: &dlc_protocol::TradeParams,
 ) -> QueryResult<()> {
-    let average_price = params
-        .average_execution_price()
-        .to_f32()
-        .expect("to fit into f32");
-
     let affected_rows = diesel::insert_into(trade_params::table)
         .values(&(
             trade_params::protocol_id.eq(protocol_id.to_uuid()),
             trade_params::quantity.eq(params.quantity),
             trade_params::leverage.eq(params.leverage),
-            trade_params::trader_pubkey.eq(params.pubkey.to_string()),
+            trade_params::trader_pubkey.eq(params.trader.to_string()),
             trade_params::direction.eq(Direction::from(params.direction)),
-            trade_params::average_price.eq(average_price),
+            trade_params::average_price.eq(params.average_price),
         ))
         .execute(conn)?;
 

--- a/coordinator/src/dlc_protocol.rs
+++ b/coordinator/src/dlc_protocol.rs
@@ -1,6 +1,7 @@
 use crate::db;
 use crate::position::models::PositionState;
 use crate::trade::models::NewTrade;
+use anyhow::Context;
 use anyhow::Result;
 use bitcoin::secp256k1::PublicKey;
 use diesel::r2d2::ConnectionManager;
@@ -8,6 +9,7 @@ use diesel::r2d2::Pool;
 use diesel::result::Error::RollbackTransaction;
 use diesel::Connection;
 use diesel::PgConnection;
+use diesel::QueryResult;
 use dlc_manager::ContractId;
 use dlc_manager::ReferenceId;
 use ln_dlc_node::node::rust_dlc_manager::DlcChannelId;
@@ -222,150 +224,242 @@ impl DlcProtocolExecutor {
         Ok(())
     }
 
-    /// Completes the trade dlc protocol as successful and updates the 10101 meta data
-    /// accordingly in a single database transaction.
-    /// - Set dlc protocol to success
-    /// - If not closing: Updates the `[PostionState::Proposed`] position state to
-    ///   `[PostionState::Open]`
-    /// - If closing: Calculates the pnl and sets the `[PositionState::Closing`] position state to
-    ///   `[PositionState::Closed`]
-    /// - Creates and inserts the new trade
-    pub fn finish_trade_dlc_protocol(
+    /// Finishes a dlc protocol by the corresponding dlc protocol type handling.
+    pub fn finish_dlc_protocol(
         &self,
         protocol_id: ProtocolId,
-        closing: bool,
-        contract_id: &ContractId,
+        trader_id: &PublicKey,
+        contract_id: Option<ContractId>,
         channel_id: &DlcChannelId,
     ) -> Result<()> {
         let mut conn = self.pool.get()?;
-
         conn.transaction(|conn| {
-            let trade_params: TradeParams = db::trade_params::get(conn, protocol_id)?;
+            let dlc_protocol = db::dlc_protocols::get_dlc_protocol(conn, protocol_id)?;
 
-            db::dlc_protocols::set_dlc_protocol_state_to_success(
-                conn,
-                protocol_id,
-                contract_id,
-                channel_id,
-            )?;
-
-            // TODO(holzeis): We are still updating the position based on the position state. This
-            // will change once we only have a single position per user and representing
-            // the position only as view on multiple trades.
-            let position = match closing {
-                false => db::positions::Position::update_proposed_position(
-                    conn,
-                    trade_params.trader.to_string(),
-                    PositionState::Open,
-                ),
-                true => {
-                    let position = match db::positions::Position::get_position_by_trader(
+            match dlc_protocol.protocol_type {
+                DlcProtocolType::Open { trade_params }
+                | DlcProtocolType::Renew { trade_params } => {
+                    let contract_id = contract_id
+                        .context("missing contract id")
+                        .map_err(|_| RollbackTransaction)?;
+                    self.finish_open_trade_dlc_protocol(
                         conn,
-                        trade_params.trader,
-                        vec![
-                            // The price doesn't matter here.
-                            PositionState::Closing { closing_price: 0.0 },
-                        ],
-                    )? {
-                        Some(position) => position,
-                        None => {
-                            tracing::error!("No position in state Closing found.");
-                            return Err(RollbackTransaction);
-                        }
-                    };
-
-                    tracing::debug!(
-                        ?position,
-                        trader_id = %trade_params.trader,
-                        "Finalize closing position",
-                    );
-
-                    let pnl = {
-                        let (initial_margin_long, initial_margin_short) =
-                            match trade_params.direction {
-                                Direction::Long => {
-                                    (position.trader_margin, position.coordinator_margin)
-                                }
-                                Direction::Short => {
-                                    (position.coordinator_margin, position.trader_margin)
-                                }
-                            };
-
-                        match calculate_pnl(
-                            Decimal::from_f32(position.average_entry_price)
-                                .expect("to fit into decimal"),
-                            Decimal::from_f32(trade_params.average_price)
-                                .expect("to fit into decimal"),
-                            trade_params.quantity,
-                            trade_params.direction,
-                            initial_margin_long as u64,
-                            initial_margin_short as u64,
-                        ) {
-                            Ok(pnl) => pnl,
-                            Err(e) => {
-                                tracing::error!("Failed to calculate pnl. Error: {e:#}");
-                                return Err(RollbackTransaction);
-                            }
-                        }
-                    };
-
-                    db::positions::Position::set_position_to_closed_with_pnl(conn, position.id, pnl)
+                        trade_params,
+                        protocol_id,
+                        &contract_id,
+                        channel_id,
+                    )
                 }
-            }?;
+                DlcProtocolType::Settle { trade_params } => {
+                    let settled_contract = &dlc_protocol.contract_id;
 
-            let coordinator_margin = calculate_margin(
-                Decimal::try_from(trade_params.average_price).expect("to fit into decimal"),
-                trade_params.quantity,
-                crate::trade::coordinator_leverage_for_trade(&trade_params.trader)
-                    .map_err(|_| RollbackTransaction)?,
-            );
+                    self.finish_close_trade_dlc_protocol(
+                        conn,
+                        trade_params,
+                        protocol_id,
+                        // If the contract got settled, we do not get a new contract id, hence we
+                        // copy the contract id of the settled contract.
+                        settled_contract,
+                        channel_id,
+                    )
+                }
+                DlcProtocolType::Rollover { .. } => {
+                    let contract_id = contract_id
+                        .context("missing contract id")
+                        .map_err(|_| RollbackTransaction)?;
+                    self.finish_rollover_dlc_protocol(
+                        conn,
+                        trader_id,
+                        protocol_id,
+                        &contract_id,
+                        channel_id,
+                    )
+                }
+                DlcProtocolType::Close { .. } | DlcProtocolType::ForceClose { .. } => {
+                    debug_assert!(false, "Finishing unexpected dlc protocol types");
+                    Ok(())
+                }
+            }
+        })?;
 
-            // TODO(holzeis): Add optional pnl to trade.
-            // Instead of tracking pnl on the position we want to track pnl on the trade. e.g. Long
-            // -> Short or Short -> Long.
-            let new_trade = NewTrade {
-                position_id: position.id,
-                contract_symbol: position.contract_symbol,
-                trader_pubkey: trade_params.trader,
-                quantity: trade_params.quantity,
-                trader_leverage: trade_params.leverage,
-                coordinator_margin: coordinator_margin as i64,
-                trader_direction: trade_params.direction,
-                average_price: trade_params.average_price,
-                dlc_expiry_timestamp: None,
+        Ok(())
+    }
+
+    /// Completes the close trade dlc protocol as successful and updates the 10101 meta data
+    /// accordingly in a single database transaction.
+    /// - Set dlc protocol to success
+    /// - Calculates the pnl and sets the `[PositionState::Closing`] position state to
+    ///   `[PositionState::Closed`]
+    /// - Creates and inserts the new trade
+    fn finish_close_trade_dlc_protocol(
+        &self,
+        conn: &mut PgConnection,
+        trade_params: TradeParams,
+        protocol_id: ProtocolId,
+        settled_contract: &ContractId,
+        channel_id: &DlcChannelId,
+    ) -> QueryResult<()> {
+        db::dlc_protocols::set_dlc_protocol_state_to_success(
+            conn,
+            protocol_id,
+            settled_contract,
+            channel_id,
+        )?;
+
+        // TODO(holzeis): We are still updating the position based on the position state. This
+        // will change once we only have a single position per user and representing
+        // the position only as view on multiple trades.
+        let position = match db::positions::Position::get_position_by_trader(
+            conn,
+            trade_params.trader,
+            vec![
+                // The price doesn't matter here.
+                PositionState::Closing { closing_price: 0.0 },
+            ],
+        )? {
+            Some(position) => position,
+            None => {
+                tracing::error!("No position in state Closing found.");
+                return Err(RollbackTransaction);
+            }
+        };
+
+        tracing::debug!(
+            ?position,
+            trader_id = %trade_params.trader,
+            "Finalize closing position",
+        );
+
+        let pnl = {
+            let (initial_margin_long, initial_margin_short) = match trade_params.direction {
+                Direction::Long => (position.trader_margin, position.coordinator_margin),
+                Direction::Short => (position.coordinator_margin, position.trader_margin),
             };
 
-            db::trades::insert(conn, new_trade)?;
+            match calculate_pnl(
+                Decimal::from_f32(position.average_entry_price).expect("to fit into decimal"),
+                Decimal::from_f32(trade_params.average_price).expect("to fit into decimal"),
+                trade_params.quantity,
+                trade_params.direction,
+                initial_margin_long as u64,
+                initial_margin_short as u64,
+            ) {
+                Ok(pnl) => pnl,
+                Err(e) => {
+                    tracing::error!("Failed to calculate pnl. Error: {e:#}");
+                    return Err(RollbackTransaction);
+                }
+            }
+        };
 
-            db::trade_params::delete(conn, protocol_id)
-        })?;
+        db::positions::Position::set_position_to_closed_with_pnl(conn, position.id, pnl)?;
+
+        let coordinator_margin = calculate_margin(
+            Decimal::try_from(trade_params.average_price).expect("to fit into decimal"),
+            trade_params.quantity,
+            crate::trade::coordinator_leverage_for_trade(&trade_params.trader)
+                .map_err(|_| RollbackTransaction)?,
+        );
+
+        // TODO(holzeis): Add optional pnl to trade.
+        // Instead of tracking pnl on the position we want to track pnl on the trade. e.g. Long
+        // -> Short or Short -> Long.
+        let new_trade = NewTrade {
+            position_id: position.id,
+            contract_symbol: position.contract_symbol,
+            trader_pubkey: trade_params.trader,
+            quantity: trade_params.quantity,
+            trader_leverage: trade_params.leverage,
+            coordinator_margin: coordinator_margin as i64,
+            trader_direction: trade_params.direction,
+            average_price: trade_params.average_price,
+            dlc_expiry_timestamp: None,
+        };
+
+        db::trades::insert(conn, new_trade)?;
+
+        db::trade_params::delete(conn, protocol_id)?;
+
+        Ok(())
+    }
+
+    /// Completes the open trade dlc protocol as successful and updates the 10101 meta data
+    /// accordingly in a single database transaction.
+    /// - Set dlc protocol to success
+    /// - Updates the `[PostionState::Proposed`] position state to `[PostionState::Open]`
+    /// - Creates and inserts the new trade
+    fn finish_open_trade_dlc_protocol(
+        &self,
+        conn: &mut PgConnection,
+        trade_params: TradeParams,
+        protocol_id: ProtocolId,
+        contract_id: &ContractId,
+        channel_id: &DlcChannelId,
+    ) -> QueryResult<()> {
+        db::dlc_protocols::set_dlc_protocol_state_to_success(
+            conn,
+            protocol_id,
+            contract_id,
+            channel_id,
+        )?;
+
+        // TODO(holzeis): We are still updating the position based on the position state. This
+        // will change once we only have a single position per user and representing
+        // the position only as view on multiple trades.
+        let position = db::positions::Position::update_proposed_position(
+            conn,
+            trade_params.trader.to_string(),
+            PositionState::Open,
+        )?;
+
+        let coordinator_margin = calculate_margin(
+            Decimal::try_from(trade_params.average_price).expect("to fit into decimal"),
+            trade_params.quantity,
+            crate::trade::coordinator_leverage_for_trade(&trade_params.trader)
+                .map_err(|_| RollbackTransaction)?,
+        );
+
+        // TODO(holzeis): Add optional pnl to trade.
+        // Instead of tracking pnl on the position we want to track pnl on the trade. e.g. Long
+        // -> Short or Short -> Long.
+        let new_trade = NewTrade {
+            position_id: position.id,
+            contract_symbol: position.contract_symbol,
+            trader_pubkey: trade_params.trader,
+            quantity: trade_params.quantity,
+            trader_leverage: trade_params.leverage,
+            coordinator_margin: coordinator_margin as i64,
+            trader_direction: trade_params.direction,
+            average_price: trade_params.average_price,
+            dlc_expiry_timestamp: None,
+        };
+
+        db::trades::insert(conn, new_trade)?;
+
+        db::trade_params::delete(conn, protocol_id)?;
 
         Ok(())
     }
 
     /// Completes the rollover dlc protocol as successful and updates the 10101 meta data
     /// accordingly in a single database transaction.
-    pub fn finish_rollover_dlc_protocol(
+    fn finish_rollover_dlc_protocol(
         &self,
+        conn: &mut PgConnection,
+        trader: &PublicKey,
         protocol_id: ProtocolId,
         contract_id: &ContractId,
         channel_id: &DlcChannelId,
-        trader: &PublicKey,
-    ) -> Result<()> {
+    ) -> QueryResult<()> {
         tracing::debug!(%trader, %protocol_id, "Finalizing rollover");
-        let mut conn = self.pool.get()?;
+        db::dlc_protocols::set_dlc_protocol_state_to_success(
+            conn,
+            protocol_id,
+            contract_id,
+            channel_id,
+        )?;
 
-        conn.transaction(|conn| {
-            db::dlc_protocols::set_dlc_protocol_state_to_success(
-                conn,
-                protocol_id,
-                contract_id,
-                channel_id,
-            )?;
-
-            db::positions::Position::set_position_to_open(conn, trader.to_string(), *contract_id)
-        })?;
-
+        db::positions::Position::set_position_to_open(conn, trader.to_string(), *contract_id)?;
         Ok(())
     }
 }

--- a/coordinator/src/dlc_protocol.rs
+++ b/coordinator/src/dlc_protocol.rs
@@ -136,8 +136,8 @@ impl DlcProtocolExecutor {
         &self,
         protocol_id: ProtocolId,
         previous_protocol_id: Option<ProtocolId>,
-        contract_id: ContractId,
-        channel_id: DlcChannelId,
+        contract_id: &ContractId,
+        channel_id: &DlcChannelId,
         trade_params: &commons::TradeParams,
     ) -> Result<()> {
         let mut conn = self.pool.get()?;

--- a/coordinator/src/node.rs
+++ b/coordinator/src/node.rs
@@ -277,9 +277,9 @@ impl Node {
                             let contract_id =
                                 channel.get_contract_id().context("missing contract id")?;
 
-                            let contract_executor =
+                            let protocol_executor =
                                 dlc_protocol::DlcProtocolExecutor::new(self.pool.clone());
-                            contract_executor.finish_dlc_protocol(
+                            protocol_executor.finish_dlc_protocol(
                                 protocol_id,
                                 false,
                                 contract_id,
@@ -343,9 +343,9 @@ impl Node {
                             }
                         };
 
-                        let contract_executor =
+                        let protocol_executor =
                             dlc_protocol::DlcProtocolExecutor::new(self.pool.clone());
-                        contract_executor.finish_dlc_protocol(
+                        protocol_executor.finish_dlc_protocol(
                             protocol_id,
                             true,
                             contract_id,
@@ -402,9 +402,9 @@ impl Node {
                         let contract_id =
                             channel.get_contract_id().context("missing contract id")?;
 
-                        let contract_executor =
+                        let protocol_executor =
                             dlc_protocol::DlcProtocolExecutor::new(self.pool.clone());
-                        contract_executor.finish_dlc_protocol(
+                        protocol_executor.finish_dlc_protocol(
                             protocol_id,
                             false,
                             contract_id,

--- a/coordinator/src/node.rs
+++ b/coordinator/src/node.rs
@@ -6,7 +6,6 @@ use crate::node::storage::NodeStorage;
 use crate::position::models::PositionState;
 use crate::storage::CoordinatorTenTenOneStorage;
 use crate::trade::TradeExecutor;
-use anyhow::bail;
 use anyhow::Context;
 use anyhow::Result;
 use bitcoin::secp256k1::PublicKey;
@@ -271,26 +270,15 @@ impl Node {
                         );
 
                         let channel = self.inner.get_dlc_channel_by_id(channel_id)?;
-                        let contract_id =
-                            channel.get_contract_id().context("missing contract id")?;
 
                         let protocol_executor =
                             dlc_protocol::DlcProtocolExecutor::new(self.pool.clone());
-                        if self.is_in_rollover(node_id)? {
-                            protocol_executor.finish_rollover_dlc_protocol(
-                                protocol_id,
-                                &contract_id,
-                                &channel.get_id(),
-                                &to_secp_pk_30(channel.get_counter_party_id()),
-                            )?;
-                        } else {
-                            protocol_executor.finish_trade_dlc_protocol(
-                                protocol_id,
-                                false,
-                                &contract_id,
-                                &channel.get_id(),
-                            )?;
-                        }
+                        protocol_executor.finish_dlc_protocol(
+                            protocol_id,
+                            &node_id,
+                            channel.get_contract_id(),
+                            channel_id,
+                        )?;
                     }
                     ChannelMessage::SettleFinalize(SettleFinalize {
                         channel_id,
@@ -321,39 +309,13 @@ impl Node {
                             "DLC channel settle protocol was finalized"
                         );
 
-                        let mut connection = self.pool.get()?;
-                        let dlc_protocol =
-                            db::dlc_protocols::get_dlc_protocol(&mut connection, protocol_id)?;
-
-                        let trader_id = dlc_protocol.trader.to_string();
-                        tracing::debug!(trader_id, ?protocol_id, "Finalize closing position",);
-
-                        let contract_id = dlc_protocol.contract_id;
-
-                        match self.inner.get_closed_contract(contract_id) {
-                            Ok(Some(closed_contract)) => closed_contract,
-                            Ok(None) => {
-                                tracing::error!(
-                                    trader_id,
-                                    ?protocol_id,
-                                    "Can't close position as contract is not closed."
-                                );
-                                bail!("Can't close position as contract is not closed.");
-                            }
-                            Err(e) => {
-                                tracing::error!(
-                                    "Failed to get closed contract from DLC manager storage: {e:#}"
-                                );
-                                bail!(e);
-                            }
-                        };
-
                         let protocol_executor =
                             dlc_protocol::DlcProtocolExecutor::new(self.pool.clone());
-                        protocol_executor.finish_trade_dlc_protocol(
+                        protocol_executor.finish_dlc_protocol(
                             protocol_id,
-                            true,
-                            &contract_id,
+                            &node_id,
+                            // the settled signed channel does not have a contract
+                            None,
                             channel_id,
                         )?;
                     }
@@ -404,15 +366,13 @@ impl Node {
                         );
 
                         let channel = self.inner.get_dlc_channel_by_id(&channel_id)?;
-                        let contract_id =
-                            channel.get_contract_id().context("missing contract id")?;
 
                         let protocol_executor =
                             dlc_protocol::DlcProtocolExecutor::new(self.pool.clone());
-                        protocol_executor.finish_trade_dlc_protocol(
+                        protocol_executor.finish_dlc_protocol(
                             protocol_id,
-                            false,
-                            &contract_id,
+                            &node_id,
+                            channel.get_contract_id(),
                             &channel_id,
                         )?;
                     }

--- a/coordinator/src/schema.rs
+++ b/coordinator/src/schema.rs
@@ -52,6 +52,10 @@ pub mod sql_types {
     #[derive(diesel::sql_types::SqlType)]
     #[diesel(postgres_type(name = "Protocol_State_Type"))]
     pub struct ProtocolStateType;
+
+    #[derive(diesel::sql_types::SqlType)]
+    #[diesel(postgres_type(name = "Protocol_Type_Type"))]
+    pub struct ProtocolTypeType;
 }
 
 diesel::table! {
@@ -120,6 +124,7 @@ diesel::table! {
 diesel::table! {
     use diesel::sql_types::*;
     use super::sql_types::ProtocolStateType;
+    use super::sql_types::ProtocolTypeType;
 
     dlc_protocols (id) {
         id -> Int4,
@@ -130,6 +135,7 @@ diesel::table! {
         protocol_state -> ProtocolStateType,
         trader_pubkey -> Text,
         timestamp -> Timestamptz,
+        protocol_type -> ProtocolTypeType,
     }
 }
 

--- a/coordinator/src/trade/mod.rs
+++ b/coordinator/src/trade/mod.rs
@@ -345,8 +345,8 @@ impl TradeExecutor {
         protocol_executor.start_dlc_protocol(
             protocol_id,
             None,
-            temporary_contract_id,
-            temporary_channel_id,
+            &temporary_contract_id,
+            &temporary_channel_id,
             trade_params,
         )?;
 
@@ -515,8 +515,8 @@ impl TradeExecutor {
         protocol_executor.start_dlc_protocol(
             protocol_id,
             previous_id,
-            temporary_contract_id,
-            channel.get_id(),
+            &temporary_contract_id,
+            &channel.get_id(),
             trade_params,
         )?;
 
@@ -631,8 +631,8 @@ impl TradeExecutor {
         protocol_executor.start_dlc_protocol(
             protocol_id,
             previous_id,
-            contract_id,
-            channel.get_id(),
+            &contract_id,
+            &channel.get_id(),
             trade_params,
         )?;
 

--- a/coordinator/src/trade/mod.rs
+++ b/coordinator/src/trade/mod.rs
@@ -341,8 +341,8 @@ impl TradeExecutor {
             .await
             .context("Could not propose DLC channel")?;
 
-        let contract_executor = dlc_protocol::DlcProtocolExecutor::new(self.pool.clone());
-        contract_executor.start_dlc_protocol(
+        let protocol_executor = dlc_protocol::DlcProtocolExecutor::new(self.pool.clone());
+        protocol_executor.start_dlc_protocol(
             protocol_id,
             None,
             temporary_contract_id,
@@ -511,8 +511,8 @@ impl TradeExecutor {
             .await
             .context("Could not propose DLC channel update")?;
 
-        let contract_executor = dlc_protocol::DlcProtocolExecutor::new(self.pool.clone());
-        contract_executor.start_dlc_protocol(
+        let protocol_executor = dlc_protocol::DlcProtocolExecutor::new(self.pool.clone());
+        protocol_executor.start_dlc_protocol(
             protocol_id,
             previous_id,
             temporary_contract_id,
@@ -627,8 +627,8 @@ impl TradeExecutor {
             )
             .await?;
 
-        let contract_executor = dlc_protocol::DlcProtocolExecutor::new(self.pool.clone());
-        contract_executor.start_dlc_protocol(
+        let protocol_executor = dlc_protocol::DlcProtocolExecutor::new(self.pool.clone());
+        protocol_executor.start_dlc_protocol(
             protocol_id,
             previous_id,
             contract_id,

--- a/coordinator/src/trade/mod.rs
+++ b/coordinator/src/trade/mod.rs
@@ -2,6 +2,7 @@ use crate::compute_relative_contracts;
 use crate::db;
 use crate::decimal_from_f32;
 use crate::dlc_protocol;
+use crate::dlc_protocol::DlcProtocolType;
 use crate::dlc_protocol::ProtocolId;
 use crate::message::OrderbookMessage;
 use crate::node::storage::NodeStorage;
@@ -347,7 +348,9 @@ impl TradeExecutor {
             None,
             &temporary_contract_id,
             &temporary_channel_id,
-            trade_params,
+            DlcProtocolType::Open {
+                trade_params: (protocol_id, trade_params).into(),
+            },
         )?;
 
         // After the DLC channel has been proposed the position can be created. This fixes
@@ -517,7 +520,9 @@ impl TradeExecutor {
             previous_id,
             &temporary_contract_id,
             &channel.get_id(),
-            trade_params,
+            DlcProtocolType::Renew {
+                trade_params: (protocol_id, trade_params).into(),
+            },
         )?;
 
         // TODO(holzeis): The position should only get created after the dlc protocol has finished
@@ -633,7 +638,9 @@ impl TradeExecutor {
             previous_id,
             &contract_id,
             &channel.get_id(),
-            trade_params,
+            DlcProtocolType::Settle {
+                trade_params: (protocol_id, trade_params).into(),
+            },
         )?;
 
         db::positions::Position::set_open_position_to_closing(

--- a/crates/ln-dlc-node/src/node/dlc_channel.rs
+++ b/crates/ln-dlc-node/src/node/dlc_channel.rs
@@ -18,7 +18,6 @@ use dlc_manager::channel::signed_channel::SignedChannel;
 use dlc_manager::channel::signed_channel::SignedChannelState;
 use dlc_manager::channel::Channel;
 use dlc_manager::contract::contract_input::ContractInput;
-use dlc_manager::contract::ClosedContract;
 use dlc_manager::contract::Contract;
 use dlc_manager::contract::ContractDescriptor;
 use dlc_manager::ContractId;
@@ -758,27 +757,6 @@ impl<D: BdkStorage, S: TenTenOneStorage + 'static, N: LnDlcStorage + Sync + Send
         }
 
         Ok(())
-    }
-
-    pub fn get_closed_contract(
-        &self,
-        temporary_contract_id: ContractId,
-    ) -> Result<Option<ClosedContract>> {
-        let contract = self
-            .dlc_manager
-            .get_store()
-            .get_contracts()?
-            .into_iter()
-            .find_map(|contract| match contract {
-                Contract::Closed(closed_contract)
-                    if closed_contract.temporary_contract_id == temporary_contract_id =>
-                {
-                    Some(closed_contract)
-                }
-                _ => None,
-            });
-
-        Ok(contract)
     }
 
     // Rollback the channel to the last "stable" state. Note, this is potentially risky to do as the

--- a/crates/ln-dlc-node/src/node/dlc_channel.rs
+++ b/crates/ln-dlc-node/src/node/dlc_channel.rs
@@ -308,7 +308,9 @@ impl<D: BdkStorage, S: TenTenOneStorage + 'static, N: LnDlcStorage + Sync + Send
                 let offered_contract = offered_contracts
                     .iter()
                     .find(|contract| contract.counter_party == counterparty_pubkey)
-                    .context("Cold not find offered contract after proposing DLC channel update")?;
+                    .context(
+                        "Could not find offered contract after proposing DLC channel update",
+                    )?;
 
                 Ok(offered_contract.id)
             }

--- a/crates/ln-dlc-node/src/node/dlc_channel.rs
+++ b/crates/ln-dlc-node/src/node/dlc_channel.rs
@@ -274,7 +274,7 @@ impl<D: BdkStorage, S: TenTenOneStorage + 'static, N: LnDlcStorage + Sync + Send
         dlc_channel_id: &DlcChannelId,
         contract_input: ContractInput,
         protocol_id: ReferenceId,
-    ) -> Result<[u8; 32]> {
+    ) -> Result<ContractId> {
         tracing::info!(channel_id = %hex::encode(dlc_channel_id), "Proposing a DLC channel update");
         spawn_blocking({
             let dlc_manager = self.dlc_manager.clone();

--- a/crates/tests-e2e/src/coordinator.rs
+++ b/crates/tests-e2e/src/coordinator.rs
@@ -122,7 +122,7 @@ pub enum ChannelState {
     Cancelled,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Debug, PartialEq)]
 pub enum SignedChannelState {
     Established,
     SettledOffered,


### PR DESCRIPTION
Adds a `dlc_protocol_type` to the `dlc_protocols` table, allowing us to show what action triggered the dlc protocol. I opted to adding this enum, as it is helpful in deciding post processing actions, and the renew protocol is used for rollover and opening positions, so it would be ambiguous picking that information from the `dlc_messages`. 

```
orderbook=# select protocol_type, previous_protocol_id, protocol_id, contract_id, channel_id, protocol_state from dlc_protocols where trader_pubkey='02e66db0280277b35f88b1a1fcf58f8b2208568b6c7ea9eb071d894836865bef63';
 protocol_type |         previous_protocol_id         |             protocol_id              |                           contract_id                            |                            channel_id                            | protocol_state 
---------------+--------------------------------------+--------------------------------------+------------------------------------------------------------------+------------------------------------------------------------------+----------------
 open          |                                      | 6d6a8ded-997e-4ed1-a390-d626f271eee0 | a02000f42e1bee780c81f4e13f4623c0db6b047a9e59b70cf079eedc45b20801 | 990afbeff87f7ef9cd68b7982f35174a2283005d301130c621e4ed15feb2a5e5 | Success
 settle        | 6d6a8ded-997e-4ed1-a390-d626f271eee0 | 47c03bc0-eb46-4edc-96ff-e993d9f382be | a02000f42e1bee780c81f4e13f4623c0db6b047a9e59b70cf079eedc45b20801 | 990afbeff87f7ef9cd68b7982f35174a2283005d301130c621e4ed15feb2a5e5 | Success
 renew         | 47c03bc0-eb46-4edc-96ff-e993d9f382be | 2fd477dd-9a1b-4bd9-a86a-91eda2624415 | f2ff62b546ed3b43cb0031be56c512e3f5b6e4fd8cae89311ecfd4c6f21a6daa | 990afbeff87f7ef9cd68b7982f35174a2283005d301130c621e4ed15feb2a5e5 | Success
 rollover      | 2fd477dd-9a1b-4bd9-a86a-91eda2624415 | ad913883-bda0-4ffd-934e-df25610c08ae | 3336fd8a8b07d88dd1e5ab39f7b356f32db8d17f78d65f0f7214fd73caafad8f | 990afbeff87f7ef9cd68b7982f35174a2283005d301130c621e4ed15feb2a5e5 | Success
 settle        | ad913883-bda0-4ffd-934e-df25610c08ae | c22adca5-cc5b-4e1d-9ef9-33bf5e4aeee5 | 3336fd8a8b07d88dd1e5ab39f7b356f32db8d17f78d65f0f7214fd73caafad8f | 990afbeff87f7ef9cd68b7982f35174a2283005d301130c621e4ed15feb2a5e5 | Success
 ```