### PR TITLE
feat: Add admin api to send targeted push notifications

### DIFF
--- a/coordinator/src/bin/coordinator.rs
+++ b/coordinator/src/bin/coordinator.rs
@@ -286,6 +286,7 @@ async fn main() -> Result<()> {
         tx_price_feed,
         tx_user_feed,
         auth_users_notifier.clone(),
+        notification_service.get_sender(),
         user_backup,
     );
 

--- a/coordinator/src/campaign.rs
+++ b/coordinator/src/campaign.rs
@@ -1,0 +1,80 @@
+use crate::db;
+use crate::notifications::FcmToken;
+use crate::notifications::Notification;
+use crate::notifications::NotificationKind;
+use crate::routes::AppState;
+use crate::AppError;
+use axum::extract::State;
+use axum::Json;
+use bitcoin::secp256k1::PublicKey;
+use serde::Deserialize;
+use serde::Serialize;
+use std::sync::Arc;
+use tracing::instrument;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PushCampaignParams {
+    pub node_ids: Vec<PublicKey>,
+    pub title: String,
+    pub message: String,
+    pub dry_run: Option<bool>,
+}
+
+#[instrument(skip_all, err(Debug))]
+pub async fn post_push_campaign(
+    State(state): State<Arc<AppState>>,
+    params: Json<PushCampaignParams>,
+) -> Result<String, AppError> {
+    let params = params.0;
+    tracing::info!(?params, "Sending campaign with push notifications");
+
+    let mut conn = state
+        .pool
+        .get()
+        .map_err(|e| AppError::InternalServerError(format!("Could not get connection: {e:#}")))?;
+
+    let users = db::user::get_users(&mut conn, params.node_ids)
+        .map_err(|e| AppError::InternalServerError(format!("Failed to get users: {e:#}")))?;
+
+    let fcm_tokens = users
+        .iter()
+        .map(|user| user.fcm_token.clone())
+        .filter(|token| !token.is_empty() && token != "unavailable")
+        .map(FcmToken::new)
+        .filter_map(Result::ok)
+        .collect::<Vec<_>>();
+
+    let notification_kind = NotificationKind::Campaign {
+        title: params.title.clone(),
+        message: params.message.clone(),
+    };
+
+    tracing::info!(
+        params.title,
+        params.message,
+        receivers = fcm_tokens.len(),
+        "Sending push notification campaign",
+    );
+
+    if params.dry_run.unwrap_or(true) {
+        tracing::debug!("Not sending push notification campaign because of dry run flag.");
+    } else {
+        state
+            .notification_sender
+            .send(Notification::new_batch(
+                fcm_tokens.clone(),
+                notification_kind,
+            ))
+            .await
+            .map_err(|e| {
+                AppError::InternalServerError(format!("Failed to send push notifications: {e:#}"))
+            })?;
+    }
+
+    Ok(format!(
+        "Sending push notification campaign (title: {}, message: {} to {} users",
+        params.title,
+        params.message,
+        fcm_tokens.len(),
+    ))
+}

--- a/coordinator/src/db/user.rs
+++ b/coordinator/src/db/user.rs
@@ -140,3 +140,11 @@ pub fn get_user(conn: &mut PgConnection, trader_id: PublicKey) -> Result<Option<
 
     Ok(maybe_user)
 }
+
+pub fn get_users(conn: &mut PgConnection, trader_ids: Vec<PublicKey>) -> Result<Vec<User>> {
+    let users = users::table
+        .filter(users::pubkey.eq_any(trader_ids.iter().map(|id| id.to_string())))
+        .load(conn)?;
+
+    Ok(users)
+}

--- a/coordinator/src/lib.rs
+++ b/coordinator/src/lib.rs
@@ -21,6 +21,7 @@ mod payout_curve;
 
 pub mod admin;
 pub mod backup;
+pub mod campaign;
 pub mod cli;
 pub mod db;
 pub mod dlc_handler;

--- a/coordinator/src/message.rs
+++ b/coordinator/src/message.rs
@@ -142,10 +142,7 @@ async fn process_orderbook_message(
                 let fcm_token = FcmToken::new(user.fcm_token)?;
 
                 notification_sender
-                    .send(Notification {
-                        user_fcm_token: fcm_token,
-                        notification_kind,
-                    })
+                    .send(Notification::new(fcm_token, notification_kind))
                     .await
                     .with_context(|| {
                         format!("Failed to send push notification to trader {trader_id}")

--- a/coordinator/src/routes.rs
+++ b/coordinator/src/routes.rs
@@ -11,6 +11,7 @@ use crate::admin::list_on_chain_transactions;
 use crate::admin::list_peers;
 use crate::admin::sign_message;
 use crate::backup::SledBackup;
+use crate::campaign::post_push_campaign;
 use crate::collaborative_revert::confirm_collaborative_revert;
 use crate::db;
 use crate::db::user;
@@ -22,6 +23,7 @@ use crate::leaderboard::LeaderBoardQueryParams;
 use crate::message::NewUserMessage;
 use crate::message::OrderbookMessage;
 use crate::node::Node;
+use crate::notifications::Notification;
 use crate::orderbook::routes::get_order;
 use crate::orderbook::routes::get_orders;
 use crate::orderbook::routes::post_order;
@@ -97,6 +99,7 @@ pub struct AppState {
     pub announcement_addresses: Vec<SocketAddress>,
     pub node_alias: String,
     pub auth_users_notifier: mpsc::Sender<OrderbookMessage>,
+    pub notification_sender: mpsc::Sender<Notification>,
     pub user_backup: SledBackup,
     pub secp: Secp256k1<VerifyOnly>,
 }
@@ -113,6 +116,7 @@ pub fn router(
     tx_price_feed: broadcast::Sender<Message>,
     tx_user_feed: broadcast::Sender<NewUserMessage>,
     auth_users_notifier: mpsc::Sender<OrderbookMessage>,
+    notification_sender: mpsc::Sender<Notification>,
     user_backup: SledBackup,
 ) -> Router {
     let secp = Secp256k1::verification_only();
@@ -128,6 +132,7 @@ pub fn router(
         announcement_addresses,
         node_alias: node_alias.to_string(),
         auth_users_notifier,
+        notification_sender,
         user_backup,
         secp,
     });
@@ -181,6 +186,7 @@ pub fn router(
             get(get_settings).put(update_settings),
         )
         .route("/api/admin/sync", post(post_sync))
+        .route("/api/admin/campaign/push", post(post_push_campaign))
         .route("/metrics", get(get_metrics))
         .route("/health", get(get_health))
         .route("/api/leaderboard", get(get_leaderboard))


### PR DESCRIPTION
Adds an admin api allowing to send targeted push notifications to a list of users using their node ids. Note, if the user opted to not receive notifications, he will not get that campaign message.

With the `dry_run` flag you can test to how many users the message will be sent to and validate if the message is as expected before actually sending it.

```
$ curl localhost:8000/api/admin/campaign/push -d '{"node_ids":["027775c06af68dd0fbd1591a3da81afd13f7680c015ec48a76ae290bf48225a486"], "title": "test", "message": "this is a test", "dry_run": false }' -H "Content-Type: application/json"
Sending push notification campaign (title: test, message: this is a test to 1 users%
```

fixes https://github.com/get10101/meta/issues/364