### PR TITLE
chore(app): Change background color back to grey

### DIFF
--- a/mobile/lib/common/scaffold_with_nav_bar.dart
+++ b/mobile/lib/common/scaffold_with_nav_bar.dart
@@ -25,7 +25,7 @@ class ScaffoldWithNavBar extends StatelessWidget {
         appBar: const PreferredSize(
             preferredSize: Size.fromHeight(40), child: SafeArea(child: AppBarWrapper())),
         bottomNavigationBar: BottomNavigationBar(
-          backgroundColor: Colors.white,
+          backgroundColor: const Color(0xFFFAFAFA),
           selectedItemColor: tenTenOnePurple,
           unselectedItemColor: Colors.black,
           items: <BottomNavigationBarItem>[

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -74,7 +74,7 @@ class _TenTenOneAppState extends State<TenTenOneApp> with WidgetsBindingObserver
       scaffoldMessengerKey: scaffoldMessengerKey,
       theme: ThemeData(
         primarySwatch: swatch,
-        scaffoldBackgroundColor: Colors.white,
+        scaffoldBackgroundColor: const Color(0xFFFAFAFA),
         cardTheme: const CardTheme(
             shape: RoundedRectangleBorder(borderRadius: BorderRadius.all(Radius.circular(12.0))),
             surfaceTintColor: Colors.white,


### PR DESCRIPTION
This was the background color before the flutter upgrade. Also fixing the issue with the background color of the candlestick chart.

|                                       |						|
|:-------------------------------------:|:-------------------------------------:|
| ![Simulator Screenshot - iPhone 15 Pro - 2024-03-04 at 10 29 29](https://github.com/get10101/10101/assets/382048/272257b2-f738-4aa8-a356-f9d32a1531b4) | ![Simulator Screenshot - iPhone 15 Pro - 2024-03-04 at 10 29 20](https://github.com/get10101/10101/assets/382048/dfd70187-6458-4bd5-9856-667081fc6bdb) |


