### PR TITLE
chore(emergency kit): Add option to rollback channel to last stable state

### DIFF
--- a/coordinator/src/admin.rs
+++ b/coordinator/src/admin.rs
@@ -447,6 +447,50 @@ pub async fn delete_dlc_channel(
     Ok(())
 }
 
+/// This function attempts to roll back a DLC channel to the last stable state!
+/// The action is irreversible, only use if you know what you are doing!
+#[instrument(skip_all, err(Debug))]
+pub async fn roll_back_dlc_channel(
+    Path(channel_id_string): Path<String>,
+    State(state): State<Arc<AppState>>,
+    Query(params): Query<Confirmation>,
+) -> Result<(), AppError> {
+    if !params.i_know_what_i_am_doing.unwrap_or_default() {
+        let error_message =
+            "Looks like you don't know what you are doing! Go and ask your supervisor for help!";
+        tracing::warn!(error_message);
+        return Err(AppError::BadRequest(error_message.to_string()));
+    }
+
+    let channel_id = parse_dlc_channel_id(&channel_id_string)
+        .map_err(|_| AppError::BadRequest("Provided channel ID was invalid".to_string()))?;
+
+    tracing::info!(channel_id = %channel_id_string, "Attempting to roll back dlc channel to last stable state");
+
+    let channel = state
+        .node
+        .inner
+        .get_dlc_channel_by_id(&channel_id)
+        .map_err(|e| AppError::BadRequest(format!("Couldn't find channel. {e:#}")))?;
+    if let Channel::Signed(signed_channel) = channel {
+        state
+            .node
+            .inner
+            .roll_back_channel(&signed_channel)
+            .map_err(|e| {
+                AppError::InternalServerError(format!("Failed to roll back channel. {e:#}"))
+            })?
+    } else {
+        return Err(AppError::BadRequest(
+            "It's only possible to rollback a channel in state signed".to_string(),
+        ));
+    }
+
+    tracing::info!(channel_id = %channel_id_string, "Rolled back dlc channel");
+
+    Ok(())
+}
+
 #[instrument(skip_all, err(Debug))]
 pub async fn sign_message(
     Path(msg): Path<String>,

--- a/coordinator/src/admin.rs
+++ b/coordinator/src/admin.rs
@@ -413,7 +413,7 @@ pub struct DeleteDlcChannel {
 /// This function deletes a DLC channel from our database irreversible!
 /// If you want to close a channel instead, use `close_channel`
 #[instrument(skip_all, err(Debug))]
-pub async fn delete_dlc_channels(
+pub async fn delete_dlc_channel(
     Path(channel_id_string): Path<String>,
     State(state): State<Arc<AppState>>,
     Query(params): Query<DeleteDlcChannel>,

--- a/coordinator/src/admin.rs
+++ b/coordinator/src/admin.rs
@@ -405,7 +405,7 @@ pub async fn close_channel(
 }
 
 #[derive(Debug, Deserialize)]
-pub struct DeleteDlcChannel {
+pub struct Confirmation {
     #[serde(default, deserialize_with = "empty_string_as_none")]
     i_know_what_i_am_doing: Option<bool>,
 }
@@ -416,7 +416,7 @@ pub struct DeleteDlcChannel {
 pub async fn delete_dlc_channel(
     Path(channel_id_string): Path<String>,
     State(state): State<Arc<AppState>>,
-    Query(params): Query<DeleteDlcChannel>,
+    Query(params): Query<Confirmation>,
 ) -> Result<(), AppError> {
     if !params.i_know_what_i_am_doing.unwrap_or_default() {
         let error_message =

--- a/coordinator/src/routes.rs
+++ b/coordinator/src/routes.rs
@@ -9,6 +9,7 @@ use crate::admin::is_connected;
 use crate::admin::list_dlc_channels;
 use crate::admin::list_on_chain_transactions;
 use crate::admin::list_peers;
+use crate::admin::roll_back_dlc_channel;
 use crate::admin::sign_message;
 use crate::backup::SledBackup;
 use crate::campaign::post_push_campaign;
@@ -171,6 +172,10 @@ pub fn router(
         .route(
             "/api/admin/dlc_channels/:channel_id",
             delete(delete_dlc_channel),
+        )
+        .route(
+            "/api/admin/dlc_channels/rollback/:channel_id",
+            post(roll_back_dlc_channel),
         )
         .route("/api/admin/transactions", get(list_on_chain_transactions))
         .route("/api/admin/sign/:msg", get(sign_message))

--- a/coordinator/src/routes.rs
+++ b/coordinator/src/routes.rs
@@ -1,7 +1,7 @@
 use crate::admin::close_channel;
 use crate::admin::collaborative_revert;
 use crate::admin::connect_to_peer;
-use crate::admin::delete_dlc_channels;
+use crate::admin::delete_dlc_channel;
 use crate::admin::get_balance;
 use crate::admin::get_fee_rate_estimation;
 use crate::admin::get_utxos;
@@ -170,7 +170,7 @@ pub fn router(
         .route("/api/admin/dlc_channels", get(list_dlc_channels))
         .route(
             "/api/admin/dlc_channels/:channel_id",
-            delete(delete_dlc_channels),
+            delete(delete_dlc_channel),
         )
         .route("/api/admin/transactions", get(list_on_chain_transactions))
         .route("/api/admin/sign/:msg", get(sign_message))

--- a/mobile/lib/common/settings/emergency_kit_screen.dart
+++ b/mobile/lib/common/settings/emergency_kit_screen.dart
@@ -181,6 +181,25 @@ class _EmergencyKitScreenState extends State<EmergencyKitScreen> {
                           goRouter.pop();
                         }),
                     const SizedBox(height: 30),
+                    EmergencyKitButton(
+                        icon: const Icon(FontAwesomeIcons.backwardStep),
+                        title: "Rollback channel state",
+                        onPressed: () async {
+                          final messenger = ScaffoldMessenger.of(context);
+                          final orderChangeNotifier = context.read<OrderChangeNotifier>();
+                          final goRouter = GoRouter.of(context);
+
+                          try {
+                            await rust.api.rollBackChannelState();
+                            await orderChangeNotifier.initialize();
+                            showSnackBar(messenger, "Successfully rolled back channel state");
+                          } catch (e) {
+                            showSnackBar(messenger, "Failed to rollback channel state. Error: $e");
+                          }
+
+                          goRouter.pop();
+                        }),
+                    const SizedBox(height: 30),
                     Visibility(
                         visible: config.network == "regtest",
                         child: EmergencyKitButton(

--- a/mobile/native/src/api.rs
+++ b/mobile/native/src/api.rs
@@ -819,3 +819,10 @@ pub fn get_new_random_name() -> SyncReturn<String> {
 pub async fn update_nickname(nickname: String) -> Result<()> {
     users::update_username(nickname).await
 }
+
+pub fn roll_back_channel_state() -> Result<()> {
+    tracing::warn!(
+        "Executing emergency kit! Attempting to rollback channel state to last stable state"
+    );
+    ln_dlc::roll_back_channel_state()
+}

--- a/mobile/native/src/ln_dlc/mod.rs
+++ b/mobile/native/src/ln_dlc/mod.rs
@@ -1057,3 +1057,14 @@ fn confirmation_status_to_status_and_timestamp(
 
     (status, timestamp.unix_timestamp() as u64)
 }
+
+pub fn roll_back_channel_state() -> Result<()> {
+    let node = state::get_node();
+
+    let counterparty_pubkey = config::get_coordinator_info().pubkey;
+    let signed_channel = node
+        .inner
+        .get_signed_channel_by_trader_id(counterparty_pubkey)?;
+
+    node.inner.roll_back_channel(&signed_channel)
+}


### PR DESCRIPTION
This might become very handy in case the protocol got stuck in an intermediate state. Unfortunately this will not help if one side has already reached the final state, while the other hasn't.

e.g. helps to recover from that https://github.com/get10101/10101/issues/2137