### PR TITLE
Perform full sync of app on-chain wallet on startup if needed

### DIFF
--- a/crates/commons/src/lib.rs
+++ b/crates/commons/src/lib.rs
@@ -15,6 +15,7 @@ mod rollover;
 mod signature;
 mod trade;
 
+pub use crate::trade::*;
 pub use backup::*;
 pub use collab_revert::*;
 pub use liquidity_option::*;
@@ -27,7 +28,6 @@ pub use price::Price;
 pub use price::Prices;
 pub use rollover::*;
 pub use signature::*;
-pub use trade::*;
 
 pub const AUTH_SIGN_MESSAGE: &[u8; 19] = b"Hello it's me Mario";
 

--- a/mobile/lib/common/domain/background_task.dart
+++ b/mobile/lib/common/domain/background_task.dart
@@ -77,3 +77,17 @@ class CollabRevert {
     return bridge.BackgroundTask_CollabRevert(TaskStatus.apiDummy());
   }
 }
+
+class FullSync {
+  final TaskStatus taskStatus;
+
+  FullSync({required this.taskStatus});
+
+  static FullSync fromApi(bridge.BackgroundTask_FullSync fullSync) {
+    return FullSync(taskStatus: TaskStatus.fromApi(fullSync.field0));
+  }
+
+  static bridge.BackgroundTask apiDummy() {
+    return bridge.BackgroundTask_FullSync(TaskStatus.apiDummy());
+  }
+}

--- a/mobile/lib/common/full_sync_change_notifier.dart
+++ b/mobile/lib/common/full_sync_change_notifier.dart
@@ -1,0 +1,57 @@
+import 'package:flutter/material.dart';
+import 'package:get_10101/bridge_generated/bridge_definitions.dart' as bridge;
+import 'package:get_10101/common/application/event_service.dart';
+import 'package:get_10101/common/domain/background_task.dart';
+import 'package:get_10101/common/global_keys.dart';
+import 'package:get_10101/common/task_status_dialog.dart';
+import 'package:get_10101/logger/logger.dart';
+import 'package:provider/provider.dart';
+
+class FullSyncChangeNotifier extends ChangeNotifier implements Subscriber {
+  late TaskStatus taskStatus;
+
+  @override
+  void notify(bridge.Event event) async {
+    if (event is bridge.Event_BackgroundNotification) {
+      if (event.field0 is! bridge.BackgroundTask_FullSync) {
+        // ignoring other kinds of background tasks
+        return;
+      }
+      FullSync fullSync = FullSync.fromApi(event.field0 as bridge.BackgroundTask_FullSync);
+      logger.d("Received a full sync event. Status: ${fullSync.taskStatus}");
+
+      taskStatus = fullSync.taskStatus;
+
+      if (taskStatus == TaskStatus.pending) {
+        while (shellNavigatorKey.currentContext == null) {
+          await Future.delayed(const Duration(milliseconds: 100)); // Adjust delay as needed
+        }
+
+        // initialize dialog for the pending task
+        showDialog(
+          context: shellNavigatorKey.currentContext!,
+          builder: (context) {
+            TaskStatus status = context.watch<FullSyncChangeNotifier>().taskStatus;
+
+            Widget content;
+            switch (status) {
+              case TaskStatus.pending:
+                content = const Text("Waiting for on-chain sync to complete");
+              case TaskStatus.success:
+                content = const Text(
+                    "Full on-chain sync completed. If your balance is still incomplete, go to Wallet Settings to trigger further syncs.");
+              case TaskStatus.failed:
+                content = const Text(
+                    "Full on-chain sync failed. You can keep trying by shutting down the app and restarting.");
+            }
+
+            return TaskStatusDialog(title: "Full wallet sync", status: status, content: content);
+          },
+        );
+      } else {
+        // notify dialog about changed task status
+        notifyListeners();
+      }
+    }
+  }
+}

--- a/mobile/lib/common/init_service.dart
+++ b/mobile/lib/common/init_service.dart
@@ -3,6 +3,7 @@ import 'package:get_10101/common/application/lsp_change_notifier.dart';
 import 'package:get_10101/common/dlc_channel_change_notifier.dart';
 import 'package:get_10101/common/dlc_channel_service.dart';
 import 'package:get_10101/common/domain/lsp_config.dart';
+import 'package:get_10101/common/full_sync_change_notifier.dart';
 import 'package:get_10101/features/brag/github_service.dart';
 import 'package:get_10101/features/trade/candlestick_change_notifier.dart';
 import 'package:get_10101/features/trade/order_change_notifier.dart';
@@ -66,6 +67,7 @@ List<SingleChildWidget> createProviders() {
     ChangeNotifierProvider(create: (context) => CollabRevertChangeNotifier()),
     ChangeNotifierProvider(create: (context) => LspChangeNotifier(channelInfoService)),
     ChangeNotifierProvider(create: (context) => PollChangeNotifier(pollService)),
+    ChangeNotifierProvider(create: (context) => FullSyncChangeNotifier()),
     Provider(create: (context) => config),
     Provider(create: (context) => channelInfoService),
     Provider(create: (context) => pollService),
@@ -93,6 +95,7 @@ void subscribeToNotifiers(BuildContext context) {
   final recoverDlcChangeNotifier = context.read<RecoverDlcChangeNotifier>();
   final collabRevertChangeNotifier = context.read<CollabRevertChangeNotifier>();
   final lspConfigChangeNotifier = context.read<LspChangeNotifier>();
+  final fullSyncChangeNotifier = context.read<FullSyncChangeNotifier>();
 
   eventService.subscribe(
       orderChangeNotifier, bridge.Event.orderUpdateNotification(Order.apiDummy()));
@@ -135,6 +138,9 @@ void subscribeToNotifiers(BuildContext context) {
       collabRevertChangeNotifier, bridge.Event.backgroundNotification(CollabRevert.apiDummy()));
 
   eventService.subscribe(lspConfigChangeNotifier, bridge.Event.authenticated(LspConfig.apiDummy()));
+
+  eventService.subscribe(
+      fullSyncChangeNotifier, bridge.Event.backgroundNotification(FullSync.apiDummy()));
 
   eventService.subscribe(
       AnonSubscriber((event) => logger.i(event.field0)), const bridge.Event.log(""));

--- a/mobile/lib/common/settings/wallet_settings.dart
+++ b/mobile/lib/common/settings/wallet_settings.dart
@@ -66,69 +66,76 @@ class _WalletSettingsState extends State<WalletSettings> {
               height: 20,
             ),
             Expanded(
-              child: Column(
-                mainAxisAlignment: MainAxisAlignment.start,
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  const Text(
-                    "The amount of addresses to sync for (at least). Once you confirm, a full wallet sync will be performed. The higher the gap is, the longer the sync will take. Hence, we recommend syncing incrementally.",
-                    style: TextStyle(fontSize: 18),
-                  ),
-                  Padding(
-                    padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 16),
-                    child: Stack(
-                      alignment: Alignment.centerRight,
-                      children: [
-                        TextFormField(
-                          inputFormatters: <TextInputFormatter>[
-                            FilteringTextInputFormatter.digitsOnly
-                          ],
-                          keyboardType: TextInputType.number,
-                          controller: lookAheadController,
-                          decoration: const InputDecoration(
-                            border: UnderlineInputBorder(),
-                            labelText: 'Wallet Gap',
-                          ),
-                        ),
-                        Visibility(
-                            visible: !syncing,
-                            replacement: const CircularProgressIndicator(),
-                            child: IconButton(
-                              icon: const Icon(
-                                Icons.check,
-                                color: Colors.green,
-                              ),
-                              onPressed: () async {
-                                final messenger = ScaffoldMessenger.of(context);
-                                try {
-                                  var gap = lookAheadController.value.text;
-                                  var gapAsNumber = int.parse(gap);
-
-                                  setState(() {
-                                    syncing = true;
-                                  });
-
-                                  await rust.api.fullSync(stopGap: gapAsNumber);
-                                  showSnackBar(messenger, "Successfully synced for new gap.");
-
-                                  setState(() {
-                                    syncing = false;
-                                  });
-                                } catch (exception) {
-                                  logger.e("Failed to complete full sync $exception");
-                                  showSnackBar(
-                                      messenger, "Error when running full sync $exception");
-                                } finally {
-                                  setState(() {
-                                    syncing = false;
-                                  });
-                                }
-                              },
-                            ))
-                      ],
+              child: Padding(
+                padding: const EdgeInsets.all(8.0),
+                child: Column(
+                  mainAxisAlignment: MainAxisAlignment.start,
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    const Text(
+                      "Full sync \n",
+                      style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
                     ),
-                  )
-                ],
+                    const Text(
+                      "Select the stop gap and confirm to perform a full wallet sync.\n\nThe stop gap determines how many consecutive unused addresses the wallet will have to find to stop syncing. The bigger the gap, the longer the sync will take. Hence, we recommend syncing incrementally.\n\nFor example: use a stop gap of 5, wait for the sync to complete and check your balance; if your balance still seems incorrect, come back here and use a stop gap of 10, etc.",
+                      style: TextStyle(fontSize: 18),
+                    ),
+                    Padding(
+                      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 16),
+                      child: Stack(
+                        alignment: Alignment.centerRight,
+                        children: [
+                          TextFormField(
+                            inputFormatters: <TextInputFormatter>[
+                              FilteringTextInputFormatter.digitsOnly
+                            ],
+                            keyboardType: TextInputType.number,
+                            controller: lookAheadController,
+                            decoration: const InputDecoration(
+                              border: UnderlineInputBorder(),
+                              labelText: 'Stop Gap',
+                            ),
+                          ),
+                          Visibility(
+                              visible: !syncing,
+                              replacement: const CircularProgressIndicator(),
+                              child: IconButton(
+                                icon: const Icon(
+                                  Icons.check,
+                                  color: Colors.green,
+                                ),
+                                onPressed: () async {
+                                  final messenger = ScaffoldMessenger.of(context);
+                                  try {
+                                    var gap = lookAheadController.value.text;
+                                    var gapAsNumber = int.parse(gap);
+
+                                    setState(() {
+                                      syncing = true;
+                                    });
+
+                                    await rust.api.fullSync(stopGap: gapAsNumber);
+                                    showSnackBar(messenger, "Successfully synced for new gap.");
+
+                                    setState(() {
+                                      syncing = false;
+                                    });
+                                  } catch (exception) {
+                                    logger.e("Failed to complete full sync $exception");
+                                    showSnackBar(
+                                        messenger, "Error when running full sync $exception");
+                                  } finally {
+                                    setState(() {
+                                      syncing = false;
+                                    });
+                                  }
+                                },
+                              ))
+                        ],
+                      ),
+                    )
+                  ],
+                ),
               ),
             ),
           ],

--- a/mobile/native/src/event/api.rs
+++ b/mobile/native/src/event/api.rs
@@ -42,6 +42,8 @@ pub enum BackgroundTask {
     RecoverDlc(TaskStatus),
     /// The coordinator wants to collaboratively close a ln channel with a stuck position.
     CollabRevert(TaskStatus),
+    /// The app is performing a full sync of the on-chain wallet.
+    FullSync(TaskStatus),
 }
 
 impl From<EventInternal> for Event {
@@ -141,6 +143,7 @@ impl From<event::BackgroundTask> for BackgroundTask {
             event::BackgroundTask::CollabRevert(status) => {
                 BackgroundTask::CollabRevert(status.into())
             }
+            event::BackgroundTask::FullSync(status) => BackgroundTask::FullSync(status.into()),
         }
     }
 }

--- a/mobile/native/src/event/mod.rs
+++ b/mobile/native/src/event/mod.rs
@@ -47,6 +47,7 @@ pub enum BackgroundTask {
     Rollover(TaskStatus),
     CollabRevert(TaskStatus),
     RecoverDlc(TaskStatus),
+    FullSync(TaskStatus),
 }
 
 #[derive(Clone, Debug)]

--- a/mobile/native/src/ln_dlc/mod.rs
+++ b/mobile/native/src/ln_dlc/mod.rs
@@ -100,6 +100,9 @@ const UPDATE_WALLET_HISTORY_INTERVAL: Duration = Duration::from_secs(5);
 const CHECK_OPEN_ORDERS_INTERVAL: Duration = Duration::from_secs(60);
 const ON_CHAIN_SYNC_INTERVAL: Duration = Duration::from_secs(300);
 
+/// The name of the BDK wallet database file.
+const WALLET_DB_FILE_NAME: &str = "bdk-wallet";
+
 /// The prefix to the [`bdk_file_store`] database file where BDK persists
 /// [`bdk::wallet::ChangeSet`]s.
 ///
@@ -310,7 +313,7 @@ pub fn run(seed_dir: String, runtime: &Runtime) -> Result<()> {
         let node_event_handler = Arc::new(NodeEventHandler::new());
 
         let wallet_storage = {
-            let wallet_dir = Path::new(&config::get_data_dir()).join("wallet");
+            let wallet_dir = Path::new(&config::get_data_dir()).join(WALLET_DB_FILE_NAME);
             bdk_file_store::Store::open_or_create_new(WALLET_DB_PREFIX.as_bytes(), wallet_dir)?
         };
 


### PR DESCRIPTION
Fixes https://github.com/get10101/10101/issues/2130.

With the recent upgrade to `bdk:1.0.0`, we dropped existing wallet DBs in favour of a new format. This meant that a user would have to manually populate the new wallet DB to be able to see their wallet history and funds.

This is not a very good user experience, as at least some users would be surprised by this. This is why we have decided to execute a full wallet sync on startup if we find an old wallet DB. Once complete, we delete the old wallet DB since the data is irrelevant and we do not want to run a full sync on startup every time.

![Recording 2024-03-05 at 08 09 01](https://github.com/get10101/10101/assets/9418575/369386e8-6ac6-4454-ac62-0e0357dfd637)

---

The message is now updated based on the state of the background task :tada:  (Thanks, @holzeis).