### PR TITLE
chore(channel offer): Reject a dlc channel offer if the processing fails

### DIFF
--- a/mobile/native/src/ln_dlc/node.rs
+++ b/mobile/native/src/ln_dlc/node.rs
@@ -15,8 +15,11 @@ use anyhow::anyhow;
 use anyhow::Context;
 use anyhow::Result;
 use bitcoin::secp256k1::PublicKey;
+use dlc_manager::ReferenceId;
 use dlc_messages::channel::OfferChannel;
 use dlc_messages::channel::Reject;
+use dlc_messages::channel::RenewOffer;
+use dlc_messages::channel::SettleOffer;
 use dlc_messages::ChannelMessage;
 use dlc_messages::Message;
 use lightning::chain::transaction::OutPoint;
@@ -207,16 +210,32 @@ impl Node {
                     }) {
                     Ok(resp) => resp,
                     Err(e) => {
-                        if let Message::Channel(ChannelMessage::Offer(offer_channel)) = &msg {
-                            if let Err(e) =
-                                self.force_reject_dlc_channel_offer(node_id, offer_channel)
-                            {
-                                let channel_id = hex::encode(offer_channel.temporary_channel_id);
-                                tracing::error!(
-                                    channel_id,
-                                    "Failed to reject dlc channel offer. Error: {e:#}"
-                                );
+                        match &channel_msg {
+                            ChannelMessage::Offer(OfferChannel {
+                                temporary_channel_id: channel_id,
+                                reference_id,
+                                ..
+                            })
+                            | ChannelMessage::SettleOffer(SettleOffer {
+                                channel_id,
+                                reference_id,
+                                ..
+                            })
+                            | ChannelMessage::RenewOffer(RenewOffer {
+                                channel_id,
+                                reference_id,
+                                ..
+                            }) => {
+                                if let Err(e) =
+                                    self.force_reject_offer(node_id, *channel_id, *reference_id)
+                                {
+                                    tracing::error!(
+                                        channel_id = hex::encode(channel_id),
+                                        "Failed to reject offer. Error: {e:#}"
+                                    );
+                                }
                             }
+                            _ => {}
                         }
 
                         return Err(e);
@@ -360,21 +379,21 @@ impl Node {
         Ok(())
     }
 
-    /// Rejects a dlc channel offer that failed to get processed during the
-    /// [`dlc_manager.on_dlc_message`].
+    /// Rejects a offer that failed to get processed during the [`dlc_manager.on_dlc_message`].
     ///
     /// This function will simply update the 10101 meta data and send the reject message without
     /// going through rust-dlc.
     ///
-    /// Note we can't use the rust-dlc api to reject the dlc channel offer as the processing failed
-    /// and the `Channel::Offered` or `Contract::Offered` have not been stored to the dlc store. The
-    /// reject dlc channel offer would fail in rust-dlc, because this the `Channel::Offered` can't
-    /// be found by the provided `dlc_channel_id`.
-    #[instrument(fields(channel_id = hex::encode(offer_channel.temporary_channel_id), %counterparty),skip_all, err(Debug))]
-    pub fn force_reject_dlc_channel_offer(
+    /// Note we can't use the rust-dlc api to reject the offer as the processing failed
+    /// and the `Channel::Offered`, `Channel::RenewOffered`, `Channel::SettledOffered`  have not
+    /// been stored to the dlc store. The corresponding reject offer would fail in rust-dlc,
+    /// because this the expected channel can't be found by the provided `channel_id`.
+    #[instrument(fields(channel_id = hex::encode(channel_id), %counterparty),skip_all, err(Debug))]
+    pub fn force_reject_offer(
         &self,
         counterparty: PublicKey,
-        offer_channel: &OfferChannel,
+        channel_id: DlcChannelId,
+        reference_id: Option<ReferenceId>,
     ) -> Result<()> {
         let now = std::time::SystemTime::now();
         let now = now
@@ -383,15 +402,15 @@ impl Node {
             .as_secs();
 
         let reject = Reject {
-            channel_id: offer_channel.temporary_channel_id,
+            channel_id,
             timestamp: now,
-            reference_id: offer_channel.reference_id,
+            reference_id,
         };
 
         order::handler::order_failed(
             None,
             FailureReason::InvalidDlcOffer(InvalidSubchannelOffer::Unacceptable),
-            anyhow!("Failed to accept dlc channel offer"),
+            anyhow!("Failed to accept offer"),
         )
         .context("Could not set order to failed")?;
 


### PR DESCRIPTION
Unlike rejecting a dlc channel offer if accepting fails, the `Channel::Offered` and `Contract::Offered` have not been stored to the dlc store.

Hence, there is no `rust-dlc` state to be cleaned up. However, `rust-dlc` expects the `Channel::Offered` to be found by it's `dlc_channel_id`, which if it can't will fail the function.

This patch implements the reject only on the application layer, but we might want to consider moving that code to `rust-dlc`

Prevents users from running into bugs like this https://github.com/get10101/10101/issues/2131 to end up in a stuck state.