### PR TITLE
feat(trade): Block users from trading with an old app version 

### DIFF
--- a/.github/workflows/draft_new_release.yml
+++ b/.github/workflows/draft_new_release.yml
@@ -63,12 +63,22 @@ jobs:
         run: |
           cargo set-version --package webapp ${{ github.event.inputs.version }}
 
-      - name: Commit changelog and manifest files
+      - name: Bump mobile/native Cargo.toml version
+        uses: stellar/binaries@v13
+        with:
+          name: cargo-edit
+          version: 0.11.6
+      - id: set-mobile-version
+        continue-on-error: true
+        run: |
+          cargo set-version --package mobile/native ${{ github.event.inputs.version }}
+
+      - name: Commit manifest files
         id: make-commit
         run: |
           /home/runner/.dprint/bin/dprint fmt
 
-          git add mobile/pubspec.yaml coordinator/Cargo.toml webapp/Cargo.toml
+          git add mobile/native/Cargo.toml mobile/pubspec.yaml coordinator/Cargo.toml webapp/Cargo.toml
           git commit --message "Prepare release ${{ github.event.inputs.version }}"
 
           echo "::set-output name=commit::$(git rev-parse HEAD)"

--- a/.github/workflows/draft_new_release.yml
+++ b/.github/workflows/draft_new_release.yml
@@ -78,7 +78,7 @@ jobs:
         run: |
           /home/runner/.dprint/bin/dprint fmt
 
-          git add mobile/native/Cargo.toml mobile/pubspec.yaml coordinator/Cargo.toml webapp/Cargo.toml
+          git add mobile/native/Cargo.toml mobile/pubspec.yaml coordinator/Cargo.toml webapp/Cargo.toml Cargo.lock
           git commit --message "Prepare release ${{ github.event.inputs.version }}"
 
           echo "::set-output name=commit::$(git rev-parse HEAD)"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2611,7 +2611,7 @@ dependencies = [
 
 [[package]]
 name = "native"
-version = "0.1.0"
+version = "1.9.0"
 dependencies = [
  "aes-gcm-siv",
  "anyhow",

--- a/coordinator/migrations/2024-03-06-1135500_add_version_to_user/down.sql
+++ b/coordinator/migrations/2024-03-06-1135500_add_version_to_user/down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE users DROP COLUMN IF EXISTS "version";

--- a/coordinator/migrations/2024-03-06-1135500_add_version_to_user/up.sql
+++ b/coordinator/migrations/2024-03-06-1135500_add_version_to_user/up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE users ADD COLUMN "version" TEXT;

--- a/coordinator/src/check_version.rs
+++ b/coordinator/src/check_version.rs
@@ -1,0 +1,21 @@
+use crate::db;
+use crate::db::user::User;
+use anyhow::ensure;
+use anyhow::Context;
+use anyhow::Result;
+use bitcoin::secp256k1::PublicKey;
+use diesel::PgConnection;
+
+pub fn check_version(conn: &mut PgConnection, trader_id: &PublicKey) -> Result<()> {
+    let user: User = db::user::get_user(conn, trader_id)?.context("Couldn't find user")?;
+
+    let app_version = user.version.context("No version found")?;
+
+    let coordinator_version = env!("CARGO_PKG_VERSION").to_string();
+    ensure!(
+        app_version == coordinator_version,
+        format!("Please upgrade to the latest version: {coordinator_version}")
+    );
+
+    Ok(())
+}

--- a/coordinator/src/db/user.rs
+++ b/coordinator/src/db/user.rs
@@ -20,6 +20,8 @@ pub struct User {
     pub fcm_token: String,
     pub last_login: OffsetDateTime,
     pub nickname: Option<String>,
+    // TODO(holzeis): Version is only optional for the first upgrade. Afterwards we should make it
+    // mandatory.
     pub version: Option<String>,
 }
 

--- a/coordinator/src/db/user.rs
+++ b/coordinator/src/db/user.rs
@@ -144,7 +144,7 @@ pub fn login_user(
     Ok(())
 }
 
-pub fn get_user(conn: &mut PgConnection, trader_id: PublicKey) -> Result<Option<User>> {
+pub fn get_user(conn: &mut PgConnection, trader_id: &PublicKey) -> Result<Option<User>> {
     let maybe_user = users::table
         .filter(users::pubkey.eq(trader_id.to_string()))
         .first(conn)

--- a/coordinator/src/leaderboard.rs
+++ b/coordinator/src/leaderboard.rs
@@ -61,7 +61,7 @@ pub(crate) fn generate_leader_board(
     let leader_board = leader_board
         .into_iter()
         .map(|entry| {
-            let nickname = db::user::get_user(conn, entry.trader).unwrap_or_default();
+            let nickname = db::user::get_user(conn, &entry.trader).unwrap_or_default();
             LeaderBoardEntry {
                 nickname: nickname.and_then(|user| user.nickname).unwrap_or_default(),
                 ..entry

--- a/coordinator/src/lib.rs
+++ b/coordinator/src/lib.rs
@@ -22,6 +22,7 @@ mod payout_curve;
 pub mod admin;
 pub mod backup;
 pub mod campaign;
+pub mod check_version;
 pub mod cli;
 pub mod db;
 pub mod dlc_handler;

--- a/coordinator/src/node/rollover.rs
+++ b/coordinator/src/node/rollover.rs
@@ -1,3 +1,4 @@
+use crate::check_version::check_version;
 use crate::db;
 use crate::db::positions;
 use crate::dlc_protocol;
@@ -168,6 +169,12 @@ impl Node {
             .expect("task to complete")?;
 
         tracing::debug!(%trader_id, "Checking if the users positions is eligible for rollover");
+
+        if check_version(&mut conn, &trader_id).is_err() {
+            tracing::info!(%trader_id, "User is not on the latest version. Skipping check if users position is eligible for rollover");
+            return Ok(());
+        }
+
         if let Some(position) = positions::Position::get_position_by_trader(
             &mut conn,
             trader_id,

--- a/coordinator/src/orderbook/tests/registration_test.rs
+++ b/coordinator/src/orderbook/tests/registration_test.rs
@@ -22,16 +22,18 @@ async fn registered_user_is_stored_in_db() {
     let dummy_email = "dummy@user.com".to_string();
     let nickname = Some("dummy_user".to_string());
     let fcm_token = "just_a_token".to_string();
+    let version = Some("1.9.0".to_string());
 
     let user = user::upsert_user(
         &mut conn,
         dummy_pubkey,
         Some(dummy_email.clone()),
         nickname.clone(),
+        version.clone(),
     )
     .unwrap();
     assert!(user.id.is_some(), "Id should be filled in by diesel");
-    user::login_user(&mut conn, dummy_pubkey, fcm_token.clone()).unwrap();
+    user::login_user(&mut conn, dummy_pubkey, fcm_token.clone(), version.clone()).unwrap();
 
     let users = user::all(&mut conn).unwrap();
     assert_eq!(users.len(), 1);
@@ -40,6 +42,7 @@ async fn registered_user_is_stored_in_db() {
     assert_eq!(users.first().unwrap().contact, dummy_email);
     assert_eq!(users.first().unwrap().nickname, nickname);
     assert_eq!(users.first().unwrap().fcm_token, fcm_token);
+    assert_eq!(users.first().unwrap().version, version);
 }
 
 fn dummy_public_key() -> PublicKey {

--- a/coordinator/src/orderbook/websocket.rs
+++ b/coordinator/src/orderbook/websocket.rs
@@ -119,6 +119,7 @@ pub async fn websocket_connection(stream: WebSocket, state: Arc<AppState>) {
                 }
                 Ok(OrderbookRequest::Authenticate {
                     fcm_token,
+                    version,
                     signature,
                 }) => {
                     let msg = create_sign_message(AUTH_SIGN_MESSAGE.to_vec());
@@ -160,7 +161,7 @@ pub async fn websocket_connection(stream: WebSocket, state: Arc<AppState>) {
                             }
 
                             let token = fcm_token.unwrap_or("unavailable".to_string());
-                            if let Err(e) = user::login_user(&mut conn, trader_id, token) {
+                            if let Err(e) = user::login_user(&mut conn, trader_id, token, version) {
                                 tracing::error!(%trader_id, "Failed to update logged in user. Error: {e:#}")
                             }
 

--- a/coordinator/src/routes.rs
+++ b/coordinator/src/routes.rs
@@ -389,7 +389,7 @@ pub async fn get_user(
     let trader_pubkey = PublicKey::from_str(trader_pubkey.as_str())
         .map_err(|_| AppError::BadRequest("Invalid trader id provided".to_string()))?;
 
-    let option = user::get_user(&mut conn, trader_pubkey)
+    let option = user::get_user(&mut conn, &trader_pubkey)
         .map_err(|e| AppError::InternalServerError(format!("Could not load users: {e:#}")))?;
 
     match option {

--- a/coordinator/src/routes.rs
+++ b/coordinator/src/routes.rs
@@ -337,6 +337,7 @@ pub async fn post_register(
         register_params.pubkey,
         register_params.contact.clone(),
         register_params.nickname.clone(),
+        register_params.version.clone(),
     )
     .map_err(|e| AppError::InternalServerError(format!("Could not upsert user: {e:#}")))?;
 

--- a/coordinator/src/schema.rs
+++ b/coordinator/src/schema.rs
@@ -374,6 +374,7 @@ diesel::table! {
         fcm_token -> Text,
         last_login -> Timestamptz,
         nickname -> Nullable<Text>,
+        version -> Nullable<Text>,
     }
 }
 

--- a/crates/commons/src/lib.rs
+++ b/crates/commons/src/lib.rs
@@ -38,6 +38,7 @@ pub struct RegisterParams {
     pub pubkey: PublicKey,
     pub contact: Option<String>,
     pub nickname: Option<String>,
+    pub version: Option<String>,
 }
 
 /// Registration details for enrolling into the beta program

--- a/crates/commons/src/message.rs
+++ b/crates/commons/src/message.rs
@@ -64,6 +64,7 @@ pub struct LspConfig {
 pub enum OrderbookRequest {
     Authenticate {
         fcm_token: Option<String>,
+        version: Option<String>,
         signature: Signature,
     },
     LimitOrderFilledMatches {

--- a/crates/orderbook-client/examples/authenticated.rs
+++ b/crates/orderbook-client/examples/authenticated.rs
@@ -26,7 +26,7 @@ async fn main() -> Result<Never> {
 
     loop {
         let (_, mut stream) =
-            orderbook_client::subscribe_with_authentication(url.clone(), &authenticate, None)
+            orderbook_client::subscribe_with_authentication(url.clone(), &authenticate, None, None)
                 .await?;
 
         loop {

--- a/crates/orderbook-client/src/lib.rs
+++ b/crates/orderbook-client/src/lib.rs
@@ -23,7 +23,7 @@ pub async fn subscribe(
     SplitSink<WebSocketStream, tungstenite::Message>,
     impl Stream<Item = Result<String, anyhow::Error>> + Unpin,
 )> {
-    subscribe_impl(None, url, None).await
+    subscribe_impl(None, url, None, None).await
 }
 
 /// Connects to the orderbook WebSocket API with authentication.
@@ -33,12 +33,13 @@ pub async fn subscribe_with_authentication(
     url: String,
     authenticate: impl Fn(Message) -> Signature,
     fcm_token: Option<String>,
+    version: Option<String>,
 ) -> Result<(
     SplitSink<WebSocketStream, tungstenite::Message>,
     impl Stream<Item = Result<String, anyhow::Error>> + Unpin,
 )> {
     let signature = create_auth_message_signature(authenticate);
-    subscribe_impl(Some(signature), url, fcm_token).await
+    subscribe_impl(Some(signature), url, fcm_token, version).await
 }
 
 pub fn create_auth_message_signature(authenticate: impl Fn(Message) -> Signature) -> Signature {
@@ -50,6 +51,7 @@ async fn subscribe_impl(
     signature: Option<Signature>,
     url: String,
     fcm_token: Option<String>,
+    version: Option<String>,
 ) -> Result<(
     SplitSink<WebSocketStream, tungstenite::Message>,
     impl Stream<Item = Result<String>> + Unpin,
@@ -67,6 +69,7 @@ async fn subscribe_impl(
             .send(tungstenite::Message::try_from(
                 OrderbookRequest::Authenticate {
                     fcm_token,
+                    version,
                     signature,
                 },
             )?)

--- a/mobile/lib/features/trade/domain/order.dart
+++ b/mobile/lib/features/trade/domain/order.dart
@@ -66,8 +66,6 @@ class FailureReason {
   static const FailureReason timeout = FailureReason._(
       failureType: FailureReasonType.timeout,
       details: "The order timed out before finding a match");
-  static const FailureReason rejected =
-      FailureReason._(failureType: FailureReasonType.rejected, details: "The order was rejected.");
   static const FailureReason unknown = FailureReason._(
       failureType: FailureReasonType.unknown, details: "An unknown error occurred.");
 
@@ -90,7 +88,8 @@ class FailureReason {
       case bridge.FailureReason_TimedOut():
         return timeout;
       case bridge.FailureReason_OrderRejected():
-        return rejected;
+        return FailureReason._(
+            failureType: FailureReasonType.rejected, details: failureReason.field0);
       case bridge.FailureReason_Unknown():
         return unknown;
     }

--- a/mobile/native/Cargo.toml
+++ b/mobile/native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "native"
-version = "0.1.0"
+version = "1.9.0"
 edition = "2021"
 
 [lib]

--- a/mobile/native/src/api.rs
+++ b/mobile/native/src/api.rs
@@ -431,10 +431,12 @@ pub fn run_in_flutter(seed_dir: String, fcm_token: String) -> Result<()> {
                     signature: ln_dlc::get_node_key().sign_ecdsa(msg),
                 });
 
+            let version = env!("CARGO_PKG_VERSION").to_string();
             let runtime = crate::state::get_or_create_tokio_runtime()?;
             runtime.block_on(async {
                 tx_websocket.send(OrderbookRequest::Authenticate {
                     fcm_token: Some(fcm_token),
+                    version: Some(version),
                     signature,
                 })
             })?;
@@ -724,7 +726,8 @@ pub fn init_new_mnemonic(target_seed_file_path: String) -> Result<()> {
 /// Enroll or update a user in the beta program
 #[tokio::main(flavor = "current_thread")]
 pub async fn register_beta(contact: String) -> Result<()> {
-    users::register_beta(contact).await
+    let version = env!("CARGO_PKG_VERSION").to_string();
+    users::register_beta(contact, version).await
 }
 
 #[derive(Debug)]

--- a/mobile/native/src/db/models.rs
+++ b/mobile/native/src/db/models.rs
@@ -660,7 +660,7 @@ pub enum FailureReason {
     SubchannelOfferOutdated,
     SubchannelOfferDateUndetermined,
     SubchannelOfferUnacceptable,
-    OrderRejected,
+    OrderRejected(String),
     Unknown,
 }
 
@@ -694,7 +694,9 @@ impl From<FailureReason> for crate::trade::order::FailureReason {
                     InvalidSubchannelOffer::Unacceptable,
                 )
             }
-            FailureReason::OrderRejected => crate::trade::order::FailureReason::OrderRejected,
+            FailureReason::OrderRejected(reason) => {
+                crate::trade::order::FailureReason::OrderRejected(reason)
+            }
             FailureReason::Unknown => crate::trade::order::FailureReason::Unknown,
         }
     }
@@ -722,7 +724,9 @@ impl From<crate::trade::order::FailureReason> for FailureReason {
                 }
                 InvalidSubchannelOffer::Unacceptable => FailureReason::SubchannelOfferUnacceptable,
             },
-            crate::trade::order::FailureReason::OrderRejected => FailureReason::OrderRejected,
+            crate::trade::order::FailureReason::OrderRejected(reason) => {
+                FailureReason::OrderRejected(reason)
+            }
             crate::trade::order::FailureReason::Unknown => FailureReason::Unknown,
         }
     }

--- a/mobile/native/src/orderbook.rs
+++ b/mobile/native/src/orderbook.rs
@@ -114,7 +114,8 @@ pub fn subscribe(
         loop {
             let url = url.clone();
             let fcm_token = fcm_token.clone();
-            match orderbook_client::subscribe_with_authentication(url, authenticate, fcm_token)
+            let version = env!("CARGO_PKG_VERSION").to_string();
+            match orderbook_client::subscribe_with_authentication(url, authenticate, fcm_token, Some(version))
                 .await
             {
                 Ok((mut sink, mut stream)) => {

--- a/mobile/native/src/trade/order/api.rs
+++ b/mobile/native/src/trade/order/api.rs
@@ -44,7 +44,7 @@ pub enum FailureReason {
     OrderNotAcceptable,
     TimedOut,
     InvalidDlcOffer,
-    OrderRejected,
+    OrderRejected(String),
     Unknown,
 }
 
@@ -144,7 +144,7 @@ impl From<order::FailureReason> for FailureReason {
             order::FailureReason::OrderNotAcceptable => FailureReason::OrderNotAcceptable,
             order::FailureReason::TimedOut => FailureReason::TimedOut,
             order::FailureReason::InvalidDlcOffer(_) => FailureReason::InvalidDlcOffer,
-            order::FailureReason::OrderRejected => FailureReason::OrderRejected,
+            order::FailureReason::OrderRejected(reason) => FailureReason::OrderRejected(reason),
             order::FailureReason::CollabRevert => FailureReason::CollabRevert,
             order::FailureReason::Unknown => FailureReason::Unknown,
         }

--- a/mobile/native/src/trade/order/handler.rs
+++ b/mobile/native/src/trade/order/handler.rs
@@ -116,7 +116,7 @@ pub async fn submit_order(
         update_order_state_in_db_and_ui(
             order.id,
             OrderState::Failed {
-                reason: FailureReason::OrderRejected,
+                reason: FailureReason::OrderRejected(err.to_string()),
             },
         )
         .map_err(SubmitOrderError::Storage)?;

--- a/mobile/native/src/trade/order/mod.rs
+++ b/mobile/native/src/trade/order/mod.rs
@@ -38,7 +38,7 @@ pub enum FailureReason {
     TimedOut,
     InvalidDlcOffer(InvalidSubchannelOffer),
     /// The order has been rejected by the orderbook
-    OrderRejected,
+    OrderRejected(String),
     Unknown,
 }
 

--- a/mobile/native/src/trade/order/orderbook_client.rs
+++ b/mobile/native/src/trade/order/orderbook_client.rs
@@ -34,8 +34,8 @@ impl OrderbookClient {
             let response = response.json().await?;
             Ok(response)
         } else {
-            tracing::error!("Could not create new order");
-            bail!("Could not create new order: {response:?}")
+            let error = response.text().await?;
+            bail!("Could not create new order: {error}")
         }
     }
 }

--- a/mobile/native/src/trade/users/mod.rs
+++ b/mobile/native/src/trade/users/mod.rs
@@ -9,17 +9,19 @@ use commons::UpdateUsernameParams;
 use commons::User;
 
 /// Enroll the user in the beta program
-pub async fn register_beta(contact: String) -> Result<()> {
+pub async fn register_beta(contact: String, version: String) -> Result<()> {
     let name = crate::names::get_new_name();
     let register = RegisterParams {
         pubkey: ln_dlc::get_node_pubkey(),
         contact: Some(contact),
         nickname: Some(name),
+        version: Some(version.clone()),
     };
 
     tracing::debug!(
         pubkey = register.pubkey.to_string(),
         contact = register.contact,
+        version,
         "Registering user"
     );
 

--- a/webapp/src/api.rs
+++ b/webapp/src/api.rs
@@ -417,7 +417,7 @@ impl From<&native::trade::order::Order> for Order {
                         }
                         InvalidSubchannelOffer::Unacceptable => "OfferUnacceptable",
                     },
-                    FailureReason::OrderRejected => "OrderRejected",
+                    FailureReason::OrderRejected(_) => "OrderRejected",
                     FailureReason::Unknown => "Unknown",
                 }
                 .to_string();


### PR DESCRIPTION
I opted to use the Cargo.toml version instead of the pubspec.yaml version as it is easier to access from rust and should probably anyways be bumped with every release.

A minor downside of this is now that we have to different sources for the version. However, both versions are bumped by the same ci pipeline during `draft_new_release` - so eventually the source is the same.

https://github.com/get10101/10101/assets/382048/e0b4c9d2-5e85-4373-8894-11df107a8a9d

fixes #2141
fixes #1748