### PR TITLE
Do not error when user is typing send amount

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2378,6 +2378,7 @@ dependencies = [
  "serde",
  "serde_with 3.2.0",
  "sha2",
+ "thiserror",
  "time",
  "tokio",
  "tokio-tungstenite-wasm",

--- a/crates/ln-dlc-node/Cargo.toml
+++ b/crates/ln-dlc-node/Cargo.toml
@@ -42,6 +42,7 @@ secp256k1-zkp = { version = "0.7.0", features = ["global-context"] }
 serde = "1.0.147"
 serde_with = "3.1.0"
 sha2 = "0.10"
+thiserror = "1"
 time = "0.3"
 tokio = { version = "1", default-features = false, features = ["io-util", "macros", "rt", "rt-multi-thread", "sync", "time", "tracing"] }
 tracing = "0.1.37"

--- a/crates/ln-dlc-node/src/lib.rs
+++ b/crates/ln-dlc-node/src/lib.rs
@@ -46,6 +46,7 @@ pub use ln::DlcChannelDetails;
 pub use ln::EventHandlerTrait;
 pub use ln::EventSender;
 pub use on_chain_wallet::ConfirmationStatus;
+pub use on_chain_wallet::EstimateFeeError;
 pub use on_chain_wallet::TransactionDetails;
 
 #[cfg(test)]

--- a/crates/ln-dlc-node/src/node/mod.rs
+++ b/crates/ln-dlc-node/src/node/mod.rs
@@ -29,7 +29,6 @@ use bitcoin::address::NetworkUnchecked;
 use bitcoin::secp256k1::PublicKey;
 use bitcoin::secp256k1::XOnlyPublicKey;
 use bitcoin::Address;
-use bitcoin::Amount;
 use bitcoin::Network;
 use bitcoin::Txid;
 use dlc_messages::message_handler::MessageHandler as DlcMessageHandler;
@@ -536,19 +535,6 @@ impl<D: BdkStorage, S: TenTenOneStorage + 'static, N: Storage + Sync + Send + 's
             &self.chain_monitor,
             &self.esplora_client,
         )
-    }
-
-    /// Estimate the fee for sending the given `amount_sats` to the given `address` on-chain with
-    /// the given `fee`.
-    pub fn estimate_fee(
-        &self,
-        address: Address<NetworkUnchecked>,
-        amount_sats: u64,
-        fee: ConfirmationTarget,
-    ) -> Result<Amount> {
-        let address = address.require_network(self.network)?;
-
-        self.wallet.estimate_fee(&address, amount_sats, fee)
     }
 
     /// Send the given `amount_sats` sats to the given unchecked, on-chain `address`.

--- a/crates/ln-dlc-node/src/node/wallet.rs
+++ b/crates/ln-dlc-node/src/node/wallet.rs
@@ -8,7 +8,6 @@ use crate::storage::TenTenOneStorage;
 use anyhow::Context;
 use anyhow::Result;
 use bdk_esplora::EsploraAsyncExt;
-use bitcoin::address::NetworkUnchecked;
 use bitcoin::secp256k1::SecretKey;
 use bitcoin::Address;
 use bitcoin::Amount;
@@ -67,12 +66,10 @@ impl<D: BdkStorage, S: TenTenOneStorage, N: Storage + Send + Sync + 'static> Nod
     /// the given `fee`.
     pub fn estimate_fee(
         &self,
-        address: Address<NetworkUnchecked>,
+        address: Address,
         amount_sats: u64,
         fee: ConfirmationTarget,
     ) -> Result<Amount> {
-        let address = address.require_network(self.network)?;
-
         self.wallet.estimate_fee(&address, amount_sats, fee)
     }
 

--- a/crates/ln-dlc-node/src/node/wallet.rs
+++ b/crates/ln-dlc-node/src/node/wallet.rs
@@ -1,6 +1,7 @@
 use crate::bitcoin_conversion::to_secp_sk_30;
 use crate::node::Node;
 use crate::node::Storage;
+use crate::on_chain_wallet;
 use crate::on_chain_wallet::BdkStorage;
 use crate::on_chain_wallet::OnChainWallet;
 use crate::on_chain_wallet::TransactionDetails;
@@ -69,7 +70,7 @@ impl<D: BdkStorage, S: TenTenOneStorage, N: Storage + Send + Sync + 'static> Nod
         address: Address,
         amount_sats: u64,
         fee: ConfirmationTarget,
-    ) -> Result<Amount> {
+    ) -> Result<Amount, on_chain_wallet::EstimateFeeError> {
         self.wallet.estimate_fee(&address, amount_sats, fee)
     }
 

--- a/mobile/native/src/api.rs
+++ b/mobile/native/src/api.rs
@@ -674,7 +674,11 @@ pub fn calculate_all_fees_for_on_chain(address: String, amount: u64) -> Result<V
             let fee_rate = fee_rate(confirmation_target);
 
             let fee_config = Fee::Priority(confirmation_target);
-            let absolute_fee = ln_dlc::estimate_payment_fee(amount, &address, fee_config).await?;
+            let absolute_fee =
+                match ln_dlc::estimate_payment_fee(amount, &address, fee_config).await? {
+                    Some(fee) => fee,
+                    None => Amount::ZERO,
+                };
 
             fees.push(FeeEstimation {
                 sats_per_vbyte: fee_rate.ceil() as u64,

--- a/mobile/native/src/ln_dlc/mod.rs
+++ b/mobile/native/src/ln_dlc/mod.rs
@@ -980,7 +980,9 @@ pub fn estimated_funding_tx_fee() -> Result<Amount> {
 }
 
 pub async fn estimate_payment_fee(amount: u64, address: &str, fee: Fee) -> Result<Amount> {
-    let address = address.parse()?;
+    let address: Address<NetworkUnchecked> = address.parse().context("Failed to parse address")?;
+    // This is safe to do because we are only using this address to estimate a fee.
+    let address = address.assume_checked();
 
     let fee = match fee {
         Fee::Priority(target) => state::get_node()

--- a/mobile/native/src/ln_dlc/mod.rs
+++ b/mobile/native/src/ln_dlc/mod.rs
@@ -979,20 +979,29 @@ pub fn estimated_funding_tx_fee() -> Result<Amount> {
     Ok(fee)
 }
 
-pub async fn estimate_payment_fee(amount: u64, address: &str, fee: Fee) -> Result<Amount> {
+pub async fn estimate_payment_fee(amount: u64, address: &str, fee: Fee) -> Result<Option<Amount>> {
     let address: Address<NetworkUnchecked> = address.parse().context("Failed to parse address")?;
     // This is safe to do because we are only using this address to estimate a fee.
     let address = address.assume_checked();
 
     let fee = match fee {
-        Fee::Priority(target) => state::get_node()
-            .inner
-            .estimate_fee(address, amount, target.into())?
-            .to_sat(),
-        Fee::FeeRate { sats } => sats,
+        Fee::Priority(target) => {
+            match state::get_node()
+                .inner
+                .estimate_fee(address, amount, target.into())
+            {
+                Ok(fee) => Some(fee),
+                // It's not sensible to calculate the fee for an amount below dust.
+                Err(ln_dlc_node::EstimateFeeError::SendAmountBelowDust) => None,
+                Err(e) => {
+                    bail!("Failed to estimate payment fee: {e:#}")
+                }
+            }
+        }
+        Fee::FeeRate { sats } => Some(Amount::from_sat(sats)),
     };
 
-    Ok(Amount::from_sat(fee))
+    Ok(fee)
 }
 
 pub async fn trade(


### PR DESCRIPTION
Fixes https://github.com/get10101/10101/issues/2190.

When the user is about to send on-chain and is typing the send amount, we dynamically calculate a fee estimate so that we can update the screen as they update the value.

This is nice, but the user will inevitably start by typing in small amounts for which calculating a fee does not make economical sense.

We enhance the library code to handle this case explicitly by using a error enum variant `EstimateFeeError::SendAmountBelowDust`. We can then leverage this in the app backend to simply ignore this kind of error.

![Recording 2024-03-08 at 13 04 36](https://github.com/get10101/10101/assets/9418575/c1493d5c-7496-4a8a-8b7e-163e9d71b550)