### PR TITLE
Run DLC channels checks during wallet refresh

### DIFF
--- a/crates/tests-e2e/src/app.rs
+++ b/crates/tests-e2e/src/app.rs
@@ -77,16 +77,6 @@ pub fn refresh_wallet_info() {
     block_in_place(move || api::refresh_wallet_info().unwrap());
 }
 
-/// Run periodic checks on the DLC channels, including syncing them with the blockchain.
-///
-/// To call this make sure that you are either outside of a runtime or in a multi-threaded runtime
-/// (i.e. use `flavor = "multi_thread"` in a `tokio::test`).
-pub fn sync_dlc_channels() {
-    // We must `block_in_place` because calling `sync_dlc_channels` starts a new runtime and that
-    // cannot happen within another runtime.
-    block_in_place(move || api::sync_dlc_channels().unwrap());
-}
-
 /// Force close DLC channel.
 ///
 /// To call this make sure that you are either outside of a runtime or in a multi-threaded runtime

--- a/crates/tests-e2e/src/setup.rs
+++ b/crates/tests-e2e/src/setup.rs
@@ -1,7 +1,6 @@
 use crate::app::refresh_wallet_info;
 use crate::app::run_app;
 use crate::app::submit_channel_opening_order;
-use crate::app::sync_dlc_channels;
 use crate::app::AppHandle;
 use crate::bitcoind::Bitcoind;
 use crate::coordinator::Coordinator;
@@ -141,11 +140,8 @@ impl TestSetup {
 
         tokio::time::sleep(std::time::Duration::from_secs(10)).await;
 
-        // Includes an on-chain sync.
+        // Includes on-chain sync and DLC channels sync.
         refresh_wallet_info();
-
-        // Relies on the on-chain sync to be able to detect the publication of the fund transaction.
-        sync_dlc_channels();
 
         setup.sync_coordinator().await;
 

--- a/crates/tests-e2e/tests/e2e_collaborative_revert.rs
+++ b/crates/tests-e2e/tests/e2e_collaborative_revert.rs
@@ -5,7 +5,6 @@ use native::api::WalletHistoryItemType;
 use rust_decimal_macros::dec;
 use tests_e2e::app::get_dlc_channel_id;
 use tests_e2e::app::refresh_wallet_info;
-use tests_e2e::app::sync_dlc_channels;
 use tests_e2e::coordinator::CollaborativeRevertCoordinatorRequest;
 use tests_e2e::setup;
 use tests_e2e::wait_until;
@@ -47,7 +46,6 @@ async fn can_revert_channel() {
     wait_until!({
         bitcoin.mine(1).await.unwrap();
 
-        sync_dlc_channels();
         refresh_wallet_info();
 
         let app_balance = app.rx.wallet_info().unwrap().balances.on_chain;

--- a/mobile/native/src/api.rs
+++ b/mobile/native/src/api.rs
@@ -93,13 +93,6 @@ pub async fn refresh_wallet_info() -> Result<()> {
 }
 
 #[tokio::main(flavor = "current_thread")]
-pub async fn sync_dlc_channels() -> Result<()> {
-    ln_dlc::sync_dlc_channels().await?;
-
-    Ok(())
-}
-
-#[tokio::main(flavor = "current_thread")]
 pub async fn full_sync(stop_gap: usize) -> Result<()> {
     ln_dlc::full_sync(stop_gap).await?;
 

--- a/mobile/native/src/ln_dlc/mod.rs
+++ b/mobile/native/src/ln_dlc/mod.rs
@@ -132,6 +132,10 @@ pub async fn refresh_wallet_info() -> Result<()> {
         tracing::error!("On-chain sync failed: {e:#}");
     }
 
+    if let Err(e) = sync_dlc_channels().await {
+        tracing::error!("Failed to sync DLC channels: {e:#}");
+    }
+
     // Spawn into the blocking thread pool of the dedicated backend runtime to avoid blocking the UI
     // thread.
     let runtime = state::get_or_create_tokio_runtime()?;


### PR DESCRIPTION
Fixes https://github.com/get10101/10101/issues/2082 [^1].

In the past we were concerned about running all these tasks together, but after the `bdk` upgrade and the pivot away from Lightning there should be no problems. Also, any error that might occur during `sync_dlc_channels` is simply logged and does not interfere with updating the wallet history and balance.

A nice consequence of this change is that if a user triggers a wallet refresh and a fund transaction or a collaborative close transaction is found to be confirmed, the corresponding channel should update automatically, ensuring that the app's state is up-to-date and ready to keep trading.

[^1]: In my testing, I didn't find a problem that prevented the app from transitioning to the correct state. Instead, I noticed that it would take a longer time than necessary, which is why this PR is relevant.