### PR TITLE
Remove `periodic_chain_monitor`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1366,7 +1366,7 @@ dependencies = [
 [[package]]
 name = "dlc"
 version = "0.4.0"
-source = "git+https://github.com/get10101/rust-dlc?rev=1ab4bf5#1ab4bf594b2095ca96ea18e9ebf1838bb4e27504"
+source = "git+https://github.com/get10101/rust-dlc?rev=c3f8850#c3f88502fa41644b0bd576b34a2ddc9bc5fef745"
 dependencies = [
  "bitcoin 0.29.2",
  "miniscript 8.0.2",
@@ -1378,7 +1378,7 @@ dependencies = [
 [[package]]
 name = "dlc-manager"
 version = "0.4.0"
-source = "git+https://github.com/get10101/rust-dlc?rev=1ab4bf5#1ab4bf594b2095ca96ea18e9ebf1838bb4e27504"
+source = "git+https://github.com/get10101/rust-dlc?rev=c3f8850#c3f88502fa41644b0bd576b34a2ddc9bc5fef745"
 dependencies = [
  "async-trait",
  "bitcoin 0.29.2",
@@ -1394,7 +1394,7 @@ dependencies = [
 [[package]]
 name = "dlc-messages"
 version = "0.4.0"
-source = "git+https://github.com/get10101/rust-dlc?rev=1ab4bf5#1ab4bf594b2095ca96ea18e9ebf1838bb4e27504"
+source = "git+https://github.com/get10101/rust-dlc?rev=c3f8850#c3f88502fa41644b0bd576b34a2ddc9bc5fef745"
 dependencies = [
  "bitcoin 0.29.2",
  "dlc",
@@ -1407,7 +1407,7 @@ dependencies = [
 [[package]]
 name = "dlc-trie"
 version = "0.4.0"
-source = "git+https://github.com/get10101/rust-dlc?rev=1ab4bf5#1ab4bf594b2095ca96ea18e9ebf1838bb4e27504"
+source = "git+https://github.com/get10101/rust-dlc?rev=c3f8850#c3f88502fa41644b0bd576b34a2ddc9bc5fef745"
 dependencies = [
  "bitcoin 0.29.2",
  "dlc",
@@ -2928,7 +2928,7 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 [[package]]
 name = "p2pd-oracle-client"
 version = "0.1.0"
-source = "git+https://github.com/get10101/rust-dlc?rev=1ab4bf5#1ab4bf594b2095ca96ea18e9ebf1838bb4e27504"
+source = "git+https://github.com/get10101/rust-dlc?rev=c3f8850#c3f88502fa41644b0bd576b34a2ddc9bc5fef745"
 dependencies = [
  "chrono",
  "dlc-manager",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,11 +20,11 @@ resolver = "2"
 # We are using our own fork of `rust-dlc` at least until we can drop all the LN-DLC features. Also,
 # `p2pderivatives/rust-dlc#master` is missing certain patches that can only be found in the LN-DLC
 # branch.
-dlc-manager = { git = "https://github.com/get10101/rust-dlc", rev = "1ab4bf5" }
-dlc-messages = { git = "https://github.com/get10101/rust-dlc", rev = "1ab4bf5" }
-dlc = { git = "https://github.com/get10101/rust-dlc", rev = "1ab4bf5" }
-p2pd-oracle-client = { git = "https://github.com/get10101/rust-dlc", rev = "1ab4bf5" }
-dlc-trie = { git = "https://github.com/get10101/rust-dlc", rev = "1ab4bf5" }
+dlc-manager = { git = "https://github.com/get10101/rust-dlc", rev = "c3f8850" }
+dlc-messages = { git = "https://github.com/get10101/rust-dlc", rev = "c3f8850" }
+dlc = { git = "https://github.com/get10101/rust-dlc", rev = "c3f8850" }
+p2pd-oracle-client = { git = "https://github.com/get10101/rust-dlc", rev = "c3f8850" }
+dlc-trie = { git = "https://github.com/get10101/rust-dlc", rev = "c3f8850" }
 
 # We should usually track the `p2pderivatives/split-tx-experiment[-10101]` branch. For now we depend
 # on a special fork which removes a panic in `rust-lightning`.

--- a/coordinator/src/routes.rs
+++ b/coordinator/src/routes.rs
@@ -345,10 +345,6 @@ pub async fn post_sync(
     }
 
     spawn_blocking(move || {
-        if let Err(e) = state.node.inner.dlc_manager.periodic_chain_monitor() {
-            tracing::error!("Failed to run DLC manager periodic chain monitor task: {e:#}");
-        }
-
         if let Err(e) = state.node.inner.dlc_manager.periodic_check() {
             tracing::error!("Failed to run DLC manager periodic check: {e:#}");
         };

--- a/crates/ln-dlc-node/src/tests/dlc_channel.rs
+++ b/crates/ln-dlc-node/src/tests/dlc_channel.rs
@@ -528,9 +528,6 @@ async fn open_channel_and_position(
     .unwrap();
 
     wait_until(Duration::from_secs(30), || async {
-        if let Err(e) = app.dlc_manager.periodic_chain_monitor() {
-            tracing::error!("Failed to run DLC manager periodic chain monitor task: {e:#}");
-        };
         if let Err(e) = app.dlc_manager.periodic_check() {
             tracing::error!("Failed to run DLC manager periodic check: {e:#}");
         };
@@ -547,7 +544,6 @@ async fn open_channel_and_position(
     .unwrap();
 
     wait_until(Duration::from_secs(30), || async {
-        coordinator.dlc_manager.periodic_chain_monitor().unwrap();
         coordinator.dlc_manager.periodic_check().unwrap();
 
         let contract = coordinator

--- a/mobile/native/src/ln_dlc/mod.rs
+++ b/mobile/native/src/ln_dlc/mod.rs
@@ -155,10 +155,6 @@ pub async fn sync_dlc_channels() -> Result<()> {
 
     runtime
         .spawn_blocking(move || {
-            if let Err(e) = node.inner.dlc_manager.periodic_chain_monitor() {
-                tracing::error!("Failed to run DLC manager periodic chain monitor task: {e:#}");
-            };
-
             if let Err(e) = node.inner.dlc_manager.periodic_check() {
                 tracing::error!("Failed to run DLC manager periodic check: {e:#}");
             };


### PR DESCRIPTION
Fixes https://github.com/get10101/10101/issues/2205.

With the update to `rust-dlc`, we no longer need to run `periodic_chain_monitor` periodically, nor does `rust-dlc` have to process blocks independently of the our on-chain wallet.

Matching pull request in our `rust-dlc` fork: https://github.com/get10101/rust-dlc/pull/14.


---

If the tests pass, I think this is okay :D