### PR TITLE
Do not run CI on push to branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,10 +3,6 @@ name: CI
 on:
   pull_request:
   merge_group:
-  push:
-    branches:
-      - "staging"
-      - "main"
 
 env:
   CARGO_INCREMENTAL: 0


### PR DESCRIPTION
- The `staging` branch is no longer used since we migrated from `bors` to GitHub merge queue.

- Building on push to `main` is redundant if we only ever merge to `main` via the merge queue[^1].

[^1]: https://github.com/orgs/community/discussions/14333#discussioncomment-3077104.