### PR TITLE
chore(test): Add environment file for esplora

### DIFF
--- a/.esplora.env
+++ b/.esplora.env
@@ -1,0 +1,1 @@
+API_URL=http://localhost:3000

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,6 +163,7 @@ jobs:
       - name: Setup rust toolchain
         run: rustup show
       - uses: Swatinem/rust-cache@v2.2.0
+      - uses: ndeloof/install-compose-action@v0.0.1
       - name: Start containers
         run: |
           just docker
@@ -245,6 +246,7 @@ jobs:
             target/debug/coordinator
           key: test-cache-${{ github.run_id }}-${{ github.run_number }}
       - uses: extractions/setup-just@v1
+      - uses: ndeloof/install-compose-action@v0.0.1
       - name: Start containers
         run: |
           just docker

--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,6 @@ mobile/ios/build
 mobile/ios/fastlane/report.xml
 mobile/ios/fastlane/README.md
 .DS_Store
+
+# esplora override environment variables
+.override.esplora.env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -79,8 +79,11 @@ services:
     container_name: esplora
     depends_on:
       - electrs
-    environment:
-      API_URL: http://localhost:3000
+    env_file:
+      - path: ./.esplora.env
+        required: true
+      - path: ./.override.esplora.env
+        required: false
     ports:
       - "5050:5000"
     restart: unless-stopped


### PR DESCRIPTION
This will allow us to overwrite the esplora environment variables to point to the correct electrs if run on a remote machine.

⚠️ Note, the file_env argument used in docker-compose requires at least v2.24

If you haven't already make sure to upgrade your docker-compose version as otherwise you won't be able to run `docker-compose up`

I also had to allow cors on our test setup as electrs and esplora are running on different ports. We could have used our nginx reverse proxy to circumvent that issue, but I figured its easier to simply allow cors on our test setup.

fixes https://github.com/get10101/cloud-conf/issues/257