### PR TITLE
Fix: make NewOrderRequest serialization deterministic

### DIFF
--- a/coordinator/src/node/expired_positions.rs
+++ b/coordinator/src/node/expired_positions.rs
@@ -14,6 +14,7 @@ use commons::Order;
 use commons::OrderReason;
 use commons::OrderState;
 use commons::OrderType;
+use rust_decimal::prelude::FromPrimitive;
 use rust_decimal::prelude::ToPrimitive;
 use rust_decimal::Decimal;
 use std::ops::Add;
@@ -87,7 +88,7 @@ pub async fn close(node: Node, trading_sender: mpsc::Sender<NewOrderMessage>) ->
             quantity: Decimal::try_from(position.quantity).expect("to fit into decimal"),
             trader_id: position.trader,
             direction: position.trader_direction.opposite(),
-            leverage: position.trader_leverage,
+            leverage: Decimal::from_f32(position.trader_leverage).expect("to fit into decimal"),
             order_type: OrderType::Market,
             // This order can basically not expire, but if the user does not come back online within
             // a certain time period we can assume the channel to be abandoned and we should force

--- a/coordinator/src/orderbook/db/orders.rs
+++ b/coordinator/src/orderbook/db/orders.rs
@@ -179,7 +179,10 @@ impl From<OrderbookNewOrder> for NewOrder {
             expiry: value.expiry,
             order_reason: OrderReason::Manual,
             contract_symbol: value.contract_symbol.into(),
-            leverage: value.leverage,
+            leverage: value
+                .leverage
+                .to_f32()
+                .expect("To be able to convert decimal to f32"),
             stable: value.stable,
         }
     }

--- a/coordinator/src/orderbook/tests/sample_test.rs
+++ b/coordinator/src/orderbook/tests/sample_test.rs
@@ -98,7 +98,7 @@ fn dummy_order(expiry: OffsetDateTime, order_type: OrderType) -> NewOrder {
         order_type,
         expiry,
         contract_symbol: trade::ContractSymbol::BtcUsd,
-        leverage: 1.0,
+        leverage: dec!(1.0),
         stable: false,
     }
 }

--- a/crates/commons/Cargo.toml
+++ b/crates/commons/Cargo.toml
@@ -17,3 +17,6 @@ time = { version = "0.3", features = ["serde", "std"] }
 tokio-tungstenite-wasm = { version = "0.3.0" }
 trade = { path = "../trade" }
 uuid = { version = "1.3.0", features = ["v4", "serde"] }
+
+[dev-dependencies]
+secp256k1 = { version = "0.27.0", features = ["serde", "rand", "global-context"] }

--- a/crates/commons/src/order.rs
+++ b/crates/commons/src/order.rs
@@ -39,7 +39,8 @@ pub struct NewOrder {
     pub quantity: Decimal,
     pub trader_id: PublicKey,
     pub direction: Direction,
-    pub leverage: f32,
+    #[serde(with = "rust_decimal::serde::float")]
+    pub leverage: Decimal,
     pub order_type: OrderType,
     pub expiry: OffsetDateTime,
     pub stable: bool,
@@ -166,7 +167,7 @@ pub mod tests {
             quantity: rust_decimal_macros::dec!(2000),
             trader_id: public_key,
             direction: Direction::Long,
-            leverage: 2.0,
+            leverage: rust_decimal_macros::dec!(2.0),
             order_type: OrderType::Market,
             expiry: OffsetDateTime::now_utc(),
             stable: false,

--- a/crates/commons/src/order.rs
+++ b/crates/commons/src/order.rs
@@ -242,13 +242,4 @@ pub mod tests {
         let secp = Secp256k1::verification_only();
         parsed_request.verify(&secp).unwrap();
     }
-
-    #[test]
-    pub fn parse_new_order_request_from_string_and_verify() {
-        let new_order_string = "{\"value\":{\"id\":\"00000000-0000-0000-0000-000000000000\",\"contract_symbol\":\"BtcUsd\",\"price\":53000.0,\"quantity\":2000.0,\"trader_id\":\"02165446faa03b41d7f2e29741c5d5d5a27a3c1667f6a35d6ea03ba7c2d9619e35\",\"direction\":\"Long\",\"leverage\":2.0,\"order_type\":\"Market\",\"expiry\":[2024,53,12,18,24,406906000,0,0,0],\"stable\":false},\"signature\":\"304402203290d4415c230360f43847586bcf68d11b925e1c3011aab89a7c11d99fd3d5fa0220542830b5ec92a1b6e48240ea5205d66306668728402a5058cee014cecce38f40\"}";
-        let new_order: NewOrderRequest = serde_json::from_str(new_order_string).unwrap();
-
-        let secp = Secp256k1::verification_only();
-        new_order.verify(&secp).unwrap();
-    }
 }

--- a/mobile/native/src/trade/order/mod.rs
+++ b/mobile/native/src/trade/order/mod.rs
@@ -1,5 +1,6 @@
 use crate::calculations::calculate_margin;
 use crate::ln_dlc;
+use rust_decimal::prelude::FromPrimitive;
 use rust_decimal::Decimal;
 use serde::Serialize;
 use time::OffsetDateTime;
@@ -199,7 +200,7 @@ impl From<Order> for commons::NewOrder {
             quantity,
             trader_id,
             direction: order.direction,
-            leverage: order.leverage,
+            leverage: Decimal::from_f32(order.leverage).expect("to fit into f32"),
             order_type: order.order_type.into(),
             expiry: order.order_expiry_timestamp,
             stable: order.stable,


### PR DESCRIPTION
Note: this is a breaking change as old formats will be serialized differently. 

Creating NewOrders with an old version will simply fail until the user upgrades. 