### PR TITLE
chore: Add trader and coordinator reserve to dlc channels api

### DIFF
--- a/crates/ln-dlc-node/src/ln/contract_details.rs
+++ b/crates/ln-dlc-node/src/ln/contract_details.rs
@@ -10,8 +10,8 @@ pub struct ContractDetails {
     #[serde(serialize_with = "contract_id_as_hex")]
     pub temporary_contract_id: ContractId,
     pub contract_state: ContractState,
-    pub offered_collateral_sats: Option<u64>,
-    pub accepted_collateral_sats: Option<u64>,
+    pub offered_funding_sats: Option<u64>,
+    pub accepted_funding_sats: Option<u64>,
     pub fee_rate_per_vb: Option<u64>,
     pub event_id: Option<String>,
 }
@@ -34,8 +34,8 @@ impl From<Contract> for ContractDetails {
     fn from(contract: Contract) -> Self {
         let (
             contract_state,
-            offered_collateral_sats,
-            accepted_collateral_sats,
+            offered_funding_sats,
+            accepted_funding_sats,
             fee_rate_per_vb,
             event_id,
         ) = match &contract {
@@ -174,8 +174,8 @@ impl From<Contract> for ContractDetails {
             contract_id: contract.get_id(),
             temporary_contract_id: contract.get_temporary_id(),
             contract_state,
-            offered_collateral_sats,
-            accepted_collateral_sats,
+            offered_funding_sats,
+            accepted_funding_sats,
             fee_rate_per_vb,
             event_id: event_id.flatten(),
         }


### PR DESCRIPTION
```
  {
    "dlc_channel_id": "467d121ab8f5ba7f0d64bce2f7e78f34cf61b8b16edad88685240082ef05d094",
    "counter_party": "03cb9f87a078e4a35c7cfd3aaf3a144b23cc52433ef6d5772ceb84b12fd1f935d5",
    "channel_state": "Signed",
    "signed_channel_state": "Established",
    "update_idx": 281474976710653,
    "fee_rate_per_vb": 3,
    "funding_txid": "d48266275348fe69bb070f7c8888116a3190157a30e2d2cb4fd03fbfbf8fec94",
    "funding_tx_vout": 2,
    "closing_txid": null,
    "contract_id": "48dc031ca469e145a92829a88ba625acb55029473c0c1ce5be79bf95244dbcd6",
    "temporary_contract_id": "9c5e653bf7211f2c122f26d4032e34c684c03c3d0ceece2ef1a9802a9bc25040",
    "contract_state": "Confirmed",
    "offered_funding_sats": 342325,
    "accepted_funding_sats": 344379,
    "event_id": "btcusd1710460800",
    "user_email": "",
    "user_registration_timestamp": "2024-03-13T19:23:29.67574Z",
    "coordinator_reserve_sats": 314354,
    "trader_reserve_sats": 304136
  },
```

To get the current margin locked up in a trade we only have to substract the reserve from the funding amount.