### PR TITLE
chore: introduce fvm (flutter version manager)

### DIFF
--- a/.github/actions/setup-fvm/action.yml
+++ b/.github/actions/setup-fvm/action.yml
@@ -1,0 +1,45 @@
+name: Setup Flutter FVM Environment
+description: "Setup FVM, Flutter for building Flutter apps."
+
+inputs:
+  fvm_config:
+    description: "Path to fvm config file."
+    required: false
+  working_dir:
+    description: "The directory to run these steps in"
+    required: false
+
+runs:
+  using: composite
+  steps:
+    - uses: kuhnroyal/flutter-fvm-config-action@v2
+      id: fvm-config-action
+      with:
+        path: ${{ inputs.fvm_config }}
+
+    - uses: subosito/flutter-action@v2
+      with:
+        cache: true
+        flutter-version: ${{ steps.fvm-config-action.outputs.FLUTTER_VERSION }}
+        channel: ${{ steps.fvm-config-action.outputs.FLUTTER_CHANNEL }}
+
+    - name: install fvm (linux)
+      if: runner.os == 'Linux'
+      shell: bash
+      working-directory: ${{inputs.working_dir}}
+      run: |
+        eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
+        brew tap leoafarias/fvm
+        brew install fvm
+        echo "/home/linuxbrew/.linuxbrew/bin" >> $GITHUB_PATH
+        fvm install
+
+    - name: install fvm (macos)
+      if: runner.os == 'macOS'
+      shell: bash
+      working-directory: ${{inputs.working_dir}}
+      run: |
+        brew tap leoafarias/fvm
+        brew install fvm
+        echo "/opt/homebrew/bin" >> $GITHUB_PATH
+        fvm install

--- a/.github/workflows/android-fastlane.yml
+++ b/.github/workflows/android-fastlane.yml
@@ -58,9 +58,6 @@ on:
         description: "The public key of the oracle. Must match with the public key returned at http://${oracle_endpoint}/oracle/publickey"
         type: string
 
-env:
-  FLUTTER_VERSION: "3.19.1"
-
 jobs:
   build:
     runs-on: macos-latest
@@ -76,13 +73,10 @@ jobs:
       - name: List used Xcode version
         run: /usr/bin/xcodebuild -version
 
-      - uses: subosito/flutter-action@v2
+      - uses: ./.github/actions/setup-fvm
         with:
-          flutter-version: ${{ env.FLUTTER_VERSION }}
-          channel: "stable"
-          cache: true
-          cache-key: flutter-${{ env.FLUTTER_VERSION }}-macos-latest
-          cache-path: ${{ runner.tool_cache }}/flutter
+          fvm_config: ./mobile/.fvmrc
+          working_dir: ./mobile
 
       - uses: actions/cache@v4
         id: cache-deps

--- a/.github/workflows/build-release-binaries.yml
+++ b/.github/workflows/build-release-binaries.yml
@@ -11,7 +11,6 @@ on:
 
 
 env:
-  FLUTTER_VERSION: "3.19.1"
   RUST_VERSION: "1.70.0"
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,6 @@ on:
 env:
   CARGO_INCREMENTAL: 0
   CARGO_TERM_COLOR: always
-  FLUTTER_VERSION: "3.19.1"
 
 jobs:
   formatting-dprint:
@@ -27,13 +26,10 @@ jobs:
       - name: Setup rust toolchain
         run: rustup show
       - uses: Swatinem/rust-cache@v2.2.0
-      - uses: subosito/flutter-action@v2
+      - uses: ./.github/actions/setup-fvm
         with:
-          flutter-version: ${{ env.FLUTTER_VERSION }}
-          channel: "stable"
-          cache: true
-          cache-key: flutter-${{ env.FLUTTER_VERSION }}
-          cache-path: ${{ runner.tool_cache }}/flutter
+          fvm_config: ./mobile/.fvmrc
+          working_dir: ./mobile
       - name: Install FFI bindings
         run: just deps-gen
       - name: Generate FFI bindings
@@ -94,13 +90,15 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: extractions/setup-just@v1
-      - uses: subosito/flutter-action@v2
+      - uses: ./.github/actions/setup-fvm
         with:
-          flutter-version: ${{ env.FLUTTER_VERSION }}
-          channel: "stable"
-          cache: true
-          cache-key: flutter-${{ env.FLUTTER_VERSION }}
-          cache-path: ${{ runner.tool_cache }}/flutter
+          fvm_config: ./mobile/.fvmrc
+          working_dir: ./mobile
+
+      - uses: ./.github/actions/setup-fvm
+        with:
+          fvm_config: ./webapp/frontend/.fvmrc
+          working_dir: ./webapp/frontend
       - name: Download Dart mocks directory
         uses: actions/download-artifact@v2
         with:
@@ -127,13 +125,10 @@ jobs:
       - name: Setup rust toolchain
         run: rustup show
       - uses: Swatinem/rust-cache@v2.2.0
-      - uses: subosito/flutter-action@v2
+      - uses: ./.github/actions/setup-fvm
         with:
-          flutter-version: ${{ env.FLUTTER_VERSION }}
-          channel: "stable"
-          cache: true
-          cache-key: flutter-${{ env.FLUTTER_VERSION }}
-          cache-path: ${{ runner.tool_cache }}/flutter
+          fvm_config: ./mobile/.fvmrc
+          working_dir: ./mobile
       - name: Download Rust generated FFI flutter bindings
         uses: actions/download-artifact@v2
         with:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -10,7 +10,6 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  FLUTTER_VERSION: "3.19.1"
 
 jobs:
   docker:
@@ -63,14 +62,10 @@ jobs:
       - uses: extractions/setup-just@v1
         if: matrix.bin == 'webapp'
 
-      - uses: subosito/flutter-action@v2
-        if: matrix.bin == 'webapp'
+      - uses: ./.github/actions/setup-fvm
         with:
-          flutter-version: ${{ env.FLUTTER_VERSION }}
-          channel: "stable"
-          cache: true
-          cache-key: flutter-${{ env.FLUTTER_VERSION }}
-          cache-path: ${{ runner.tool_cache }}/flutter
+          fvm_config: ./webapp/frontend/.fvmrc
+          working_dir: ./webapp/frontend
 
       - name: build flutter for webapp
         if: matrix.bin == 'webapp'

--- a/.github/workflows/ios-fastlane.yml
+++ b/.github/workflows/ios-fastlane.yml
@@ -74,9 +74,6 @@ on:
         description: "For regtest enter 'test' or mainnet enter 'Runner'"
         type: string
 
-env:
-  FLUTTER_VERSION: "3.19.1"
-
 jobs:
   build:
     runs-on: macos-14
@@ -96,13 +93,10 @@ jobs:
       - name: List used Xcode version
         run: /usr/bin/xcodebuild -version
 
-      - uses: subosito/flutter-action@v2
+      - uses: ./.github/actions/setup-fvm
         with:
-          flutter-version: ${{ env.FLUTTER_VERSION }}
-          channel: "stable"
-          cache: true
-          cache-key: flutter-${{ env.FLUTTER_VERSION }}-macos-14
-          cache-path: ${{ runner.tool_cache }}/flutter
+          fvm_config: ./mobile/.fvmrc
+          working_dir: ./mobile
 
       - name: Check cocoapods version
         run: /usr/local/bin/pod --version

--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,5 @@ mobile/ios/fastlane/README.md
 
 # esplora override environment variables
 .override.esplora.env
+
+.fvm/

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 To begin, ensure that you have a working installation of the following items:
 
 - [Docker](https://docs.docker.com/) and docker-compose
-- [Flutter SDK](https://docs.flutter.dev/get-started/install)
+- [Flutter Version Manager (FVM)](https://fvm.app/)
 - [Rust language](https://rustup.rs/)
 - Appropriate [Rust targets](https://rust-lang.github.io/rustup/cross-compilation.html) for cross-compiling to your device
 - For Android targets:
@@ -27,6 +27,16 @@ echo "ANDROID_NDK=.." >> ~/.gradle/gradle.properties
 - For iOS targets:
   - XCode
   - Cocoapods
+
+## FVM (Flutter Version Manager)
+
+We use FVM to be able to easily switch between different Flutter versions.
+Make sure to install it locally.
+Once installed, you can use your favorite flutter commands as before, just add `fvm` before, e.g.
+
+```bash
+fvm flutter run
+```
 
 You can see whether you have all the sufficient dependencies for your platform by running `flutter doctor`.
 

--- a/justfile
+++ b/justfile
@@ -56,7 +56,7 @@ gen:
     #!/usr/bin/env bash
     set -euxo pipefail
     cd mobile
-    flutter pub get
+    fvm flutter pub get
     RUST_LOG={{ rust_log_for_frb }} flutter_rust_bridge_codegen \
         --rust-input native/src/api.rs \
         --c-output ios/Runner/bridge_generated.h \
@@ -80,13 +80,13 @@ android-release:
 
 # Build flutter webapp for cargo run --bin webapp
 build-web args="":
-    cd webapp/frontend && flutter build web --web-renderer html {{args}}
+    cd webapp/frontend && fvm flutter build web {{args}}
 
 build-web-release:
-    cd webapp/frontend && flutter build web --web-renderer html --release
+    cd webapp/frontend && fvm flutter build web --release
 
 run-web:
-    cd webapp/frontend && flutter run -d chrome --web-browser-flag "--disable-web-security"
+    cd webapp/frontend && fvm flutter run -d chrome --web-browser-flag "--disable-web-security"
 
 # Build Rust library for iOS (debug mode)
 ios:
@@ -102,7 +102,7 @@ ios-release:
 run args="":
     #!/usr/bin/env bash
     cd mobile && \
-      flutter run {{args}} \
+      fvm flutter run {{args}} \
       --dart-define="COMMIT=$(git rev-parse HEAD)" \
       --dart-define="BRANCH=$(git rev-parse --abbrev-ref HEAD)" \
       --dart-define="REGTEST_FAUCET=http://localhost:8080" \
@@ -113,7 +113,7 @@ run args="":
 run-regtest args="":
     #!/usr/bin/env bash
     cd mobile && \
-      flutter run {{args}} \
+      fvm flutter run {{args}} \
         --dart-define="COMMIT=$(git rev-parse HEAD)" \
         --dart-define="BRANCH=$(git rev-parse --abbrev-ref HEAD)" \
         --dart-define="ELECTRS_ENDPOINT={{public_regtest_electrs}}" \
@@ -126,7 +126,7 @@ run-regtest args="":
 run-mainnet args="":
     #!/usr/bin/env bash
     cd mobile && \
-      flutter run {{args}} \
+      fvm flutter run {{args}} \
         --dart-define="COMMIT=$(git rev-parse HEAD)" \
         --dart-define="BRANCH=$(git rev-parse --abbrev-ref HEAD)" \
         --dart-define="ELECTRS_ENDPOINT=http://api.10101.finance:3000" \
@@ -140,7 +140,7 @@ run-mainnet args="":
 run-regtest-android args="":
     #!/usr/bin/env bash
     cd mobile && \
-      flutter run {{args}} \
+      fvm flutter run {{args}} \
         --dart-define="COMMIT=$(git rev-parse HEAD)" \
         --dart-define="BRANCH=$(git rev-parse --abbrev-ref HEAD)" \
         --dart-define="ELECTRS_ENDPOINT={{public_regtest_electrs}}" \
@@ -156,7 +156,7 @@ run-local-android args="":
     LOCAL_IP=$({{get_local_ip}})
     echo "Android app will connect to $LOCAL_IP for 10101 services"
     cd mobile && \
-      flutter run {{args}} \
+      fvm flutter run {{args}} \
         --dart-define="COMMIT=$(git rev-parse HEAD)" \
         --dart-define="BRANCH=$(git rev-parse --abbrev-ref HEAD)" \
         --dart-define="ELECTRS_ENDPOINT=http://${LOCAL_IP}:5050" \
@@ -178,7 +178,7 @@ clean:
     set -euxo pipefail
     cd mobile
     rm -rf mobile/android/app/src/main/jniLibs/*
-    flutter clean
+    fvm flutter clean
     cd native && cargo clean
 
 # Wipes everything
@@ -260,8 +260,8 @@ cargo-clippy:
     cargo clippy --all-targets -- -D warnings
 
 lint-flutter:
-    cd mobile && flutter analyze --fatal-infos .
-    cd webapp/frontend && flutter analyze --fatal-infos .
+    cd mobile && fvm flutter analyze --fatal-infos .
+    cd webapp/frontend && fvm flutter analyze --fatal-infos .
 
 alias flutter-lint := lint-flutter
 
@@ -307,7 +307,7 @@ maker args="":
     docker run {{run_maker_args}}
 
 flutter-test:
-    cd mobile && flutter pub run build_runner build --delete-conflicting-outputs && flutter test
+    cd mobile && fvm flutter pub run build_runner build --delete-conflicting-outputs && fvm flutter test
 
 # Tests for the `native` crate
 native-test:
@@ -460,7 +460,7 @@ build-ipa args="":
       args+=(--flavor test)
     fi
 
-    cd mobile && flutter build ipa "${args[@]}" \
+    cd mobile && fvm flutter build ipa "${args[@]}" \
            --dart-define="ELECTRS_ENDPOINT=${ELECTRS_ENDPOINT}" \
            --dart-define="COORDINATOR_P2P_ENDPOINT=${COORDINATOR_P2P_ENDPOINT}" \
            --dart-define="NETWORK=${NETWORK}" \
@@ -483,7 +483,7 @@ publish-testflight-fastlane:
 release-testflight: gen ios build-ipa publish-testflight
 
 version:
-    cargo --version && rustc --version && flutter --version
+    cargo --version && rustc --version && fvm flutter --version
 
 build-apk-regtest:
     #!/usr/bin/env bash
@@ -491,7 +491,7 @@ build-apk-regtest:
     BUILD_NUMBER=$(git rev-list HEAD --count)
     echo "build name: ${BUILD_NAME}"
     echo "build number: ${BUILD_NUMBER}"
-    cd mobile && flutter build apk  \
+    cd mobile && fvm flutter build apk  \
       --build-name=${BUILD_NAME} \
       --build-number=${BUILD_NUMBER} \
       --release \
@@ -512,7 +512,7 @@ build-app-bundle-regtest:
     BUILD_NUMBER=$(git rev-list HEAD --count)
     echo "build name: ${BUILD_NAME}"
     echo "build number: ${BUILD_NUMBER}"
-    cd mobile && flutter build appbundle \
+    cd mobile && fvm flutter build appbundle \
         --build-name=${BUILD_NAME} \
         --build-number=${BUILD_NUMBER} \
         --release \
@@ -544,7 +544,7 @@ build-android-app-bundle:
     os={{os()}}
     echo "building on '$os' for '$NETWORK'"
 
-    cd mobile && flutter build appbundle  \
+    cd mobile && fvm flutter build appbundle  \
       --build-name=${BUILD_NAME} \
       --build-number=${BUILD_NUMBER} \
       --release \
@@ -576,7 +576,7 @@ build-android-app-apk args="":
     os={{os()}}
     echo "building on '$os' for '$NETWORK'"
 
-    cd mobile && flutter build apk {{args}} \
+    cd mobile && fvm flutter build apk {{args}} \
       --build-name=${BUILD_NAME} \
       --build-number=${BUILD_NUMBER} \
       --release \

--- a/mobile/.fvmrc
+++ b/mobile/.fvmrc
@@ -1,0 +1,3 @@
+{
+  "flutter": "stable"
+}

--- a/webapp/.gitignore
+++ b/webapp/.gitignore
@@ -37,7 +37,6 @@ doc/api/
 ### Flutter ###
 # Flutter/Dart/Pub related
 **/doc/api/
-.fvm/flutter_sdk
 .pub-cache/
 .pub/
 coverage/

--- a/webapp/frontend/.fvmrc
+++ b/webapp/frontend/.fvmrc
@@ -1,0 +1,3 @@
+{
+  "flutter": "beta"
+}


### PR DESCRIPTION
This allows us to have different flutter versions for webapp and mobile. It is needed, because the webapp can be built best with the current `beta` version. Using latest `stable` will break the webapp in firefox and we would need to fall back to a different renderer which comes at the cost of performance.

This might be controversial but I was debugging issue #2234 and upgraded flutter to `beta` which solved an issue at least @holzeis is aware off: the latest flutter version does not work flawlessly in firefox - to make it work we had to switch to a different renderer (which was done in[`a8646e1` (#2081)](https://github.com/get10101/10101/pull/2081/commits/a8646e153e9768ad5da32ccd2a8d5bc64563e63d)). However, this actually comes at performance and responsiveness cost - which I thought was the problem for #2234 (but is not).

Long story short, this PR allows us to use canvaskit rendered on the latest version which provides better performance and responsiveness than html renderer. 

Let me know what you think. Alternatively we could simply use `beta` channel for all apps for the time being and upgrade once the next flutter version is released. 