### PR TITLE
chore(rollover): Directly propose rollover on p2p connection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1367,7 +1367,7 @@ dependencies = [
 [[package]]
 name = "dlc"
 version = "0.4.0"
-source = "git+https://github.com/get10101/rust-dlc?rev=1010f95#1010f95f930d98219f8c28c2854391fbbd081ff8"
+source = "git+https://github.com/get10101/rust-dlc?rev=a569d3e#a569d3e83ab11d17084b707aeff9866fc1824884"
 dependencies = [
  "bitcoin 0.29.2",
  "miniscript 8.0.2",
@@ -1379,7 +1379,7 @@ dependencies = [
 [[package]]
 name = "dlc-manager"
 version = "0.4.0"
-source = "git+https://github.com/get10101/rust-dlc?rev=1010f95#1010f95f930d98219f8c28c2854391fbbd081ff8"
+source = "git+https://github.com/get10101/rust-dlc?rev=a569d3e#a569d3e83ab11d17084b707aeff9866fc1824884"
 dependencies = [
  "async-trait",
  "bitcoin 0.29.2",
@@ -1395,7 +1395,7 @@ dependencies = [
 [[package]]
 name = "dlc-messages"
 version = "0.4.0"
-source = "git+https://github.com/get10101/rust-dlc?rev=1010f95#1010f95f930d98219f8c28c2854391fbbd081ff8"
+source = "git+https://github.com/get10101/rust-dlc?rev=a569d3e#a569d3e83ab11d17084b707aeff9866fc1824884"
 dependencies = [
  "bitcoin 0.29.2",
  "dlc",
@@ -1408,7 +1408,7 @@ dependencies = [
 [[package]]
 name = "dlc-trie"
 version = "0.4.0"
-source = "git+https://github.com/get10101/rust-dlc?rev=1010f95#1010f95f930d98219f8c28c2854391fbbd081ff8"
+source = "git+https://github.com/get10101/rust-dlc?rev=a569d3e#a569d3e83ab11d17084b707aeff9866fc1824884"
 dependencies = [
  "bitcoin 0.29.2",
  "dlc",
@@ -2928,7 +2928,7 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 [[package]]
 name = "p2pd-oracle-client"
 version = "0.1.0"
-source = "git+https://github.com/get10101/rust-dlc?rev=1010f95#1010f95f930d98219f8c28c2854391fbbd081ff8"
+source = "git+https://github.com/get10101/rust-dlc?rev=a569d3e#a569d3e83ab11d17084b707aeff9866fc1824884"
 dependencies = [
  "chrono",
  "dlc-manager",

--- a/coordinator/src/bin/coordinator.rs
+++ b/coordinator/src/bin/coordinator.rs
@@ -269,7 +269,7 @@ async fn main() -> Result<()> {
     );
     let _handle = rollover::monitor(
         pool.clone(),
-        tx_user_feed.clone(),
+        node_event_handler.subscribe(),
         auth_users_notifier.clone(),
         network,
         node.clone(),

--- a/coordinator/src/node/rollover.rs
+++ b/coordinator/src/node/rollover.rs
@@ -223,6 +223,13 @@ impl Node {
             if let Err(e) = notifier.send(message).await {
                 tracing::debug!("Failed to notify trader. Error: {e:#}");
             }
+
+            if self.is_connected(trader_id) {
+                tracing::info!(%trader_id, "Proposing to rollover dlc channel");
+                self.propose_rollover(&signed_channel.channel_id, self.inner.network)
+                    .await?;
+            } else {
+                tracing::warn!(%trader_id, "Skipping rollover, user is not connected.");
             }
         }
 

--- a/crates/tests-e2e/src/coordinator.rs
+++ b/crates/tests-e2e/src/coordinator.rs
@@ -52,8 +52,11 @@ impl Coordinator {
     }
 
     pub async fn rollover(&self, dlc_channel_id: &str) -> Result<reqwest::Response> {
-        self.post::<()>(format!("/api/rollover/{dlc_channel_id}").as_str(), None)
-            .await
+        self.post::<()>(
+            format!("/api/admin/rollover/{dlc_channel_id}").as_str(),
+            None,
+        )
+        .await
     }
 
     pub async fn collaborative_revert(

--- a/mobile/lib/features/trade/async_order_change_notifier.dart
+++ b/mobile/lib/features/trade/async_order_change_notifier.dart
@@ -26,7 +26,7 @@ class AsyncOrderChangeNotifier extends ChangeNotifier implements Subscriber {
   }
 
   @override
-  void notify(bridge.Event event) {
+  void notify(bridge.Event event) async {
     if (event is bridge.Event_BackgroundNotification) {
       if (event.field0 is! bridge.BackgroundTask_AsyncTrade) {
         // ignoring other kinds of background tasks
@@ -34,6 +34,11 @@ class AsyncOrderChangeNotifier extends ChangeNotifier implements Subscriber {
       }
       AsyncTrade asyncTrade = AsyncTrade.fromApi(event.field0 as bridge.BackgroundTask_AsyncTrade);
       logger.d("Received a async trade event. Reason: ${asyncTrade.orderReason}");
+
+      while (shellNavigatorKey.currentContext == null) {
+        await Future.delayed(const Duration(milliseconds: 100)); // Adjust delay as needed
+      }
+
       showDialog(
         context: shellNavigatorKey.currentContext!,
         builder: (context) {

--- a/mobile/lib/features/trade/rollover_change_notifier.dart
+++ b/mobile/lib/features/trade/rollover_change_notifier.dart
@@ -11,7 +11,7 @@ class RolloverChangeNotifier extends ChangeNotifier implements Subscriber {
   late TaskStatus taskStatus;
 
   @override
-  void notify(bridge.Event event) {
+  void notify(bridge.Event event) async {
     if (event is bridge.Event_BackgroundNotification) {
       if (event.field0 is! bridge.BackgroundTask_Rollover) {
         // ignoring other kinds of background tasks
@@ -24,6 +24,10 @@ class RolloverChangeNotifier extends ChangeNotifier implements Subscriber {
       taskStatus = rollover.taskStatus;
 
       if (taskStatus == TaskStatus.pending) {
+        while (shellNavigatorKey.currentContext == null) {
+          await Future.delayed(const Duration(milliseconds: 100)); // Adjust delay as needed
+        }
+
         // initialize dialog for the pending task
         showDialog(
           context: shellNavigatorKey.currentContext!,

--- a/mobile/native/src/ln_dlc/mod.rs
+++ b/mobile/native/src/ln_dlc/mod.rs
@@ -51,7 +51,6 @@ use lightning::ln::ChannelId;
 use lightning::sign::KeysManager;
 use ln_dlc_node::bitcoin_conversion::to_ecdsa_signature_30;
 use ln_dlc_node::bitcoin_conversion::to_script_29;
-use ln_dlc_node::bitcoin_conversion::to_secp_pk_29;
 use ln_dlc_node::bitcoin_conversion::to_secp_sk_30;
 use ln_dlc_node::bitcoin_conversion::to_tx_30;
 use ln_dlc_node::bitcoin_conversion::to_txid_29;
@@ -966,64 +965,6 @@ pub async fn estimate_payment_fee(amount: u64, address: &str, fee: Fee) -> Resul
     };
 
     Ok(fee)
-}
-
-/// initiates the rollover protocol with the coordinator
-pub async fn rollover(contract_id: Option<String>) -> Result<()> {
-    let node = state::get_node();
-
-    let dlc_channels = node.inner.list_signed_dlc_channels()?;
-
-    let dlc_channel = dlc_channels
-        .into_iter()
-        .find(|chan| chan.counter_party == to_secp_pk_29(config::get_coordinator_info().pubkey))
-        .context("Couldn't find dlc channel to rollover")?;
-
-    let dlc_channel_id = dlc_channel.channel_id;
-
-    let current_contract_id = dlc_channel.get_contract_id().map(hex::encode);
-    if current_contract_id != contract_id {
-        bail!("Rejecting to rollover a contract that we are not aware of. Expected: {current_contract_id:?}, Got: {contract_id:?}");
-    }
-
-    tracing::debug!(
-        channel_id = hex::encode(dlc_channel_id),
-        "Asking coordinator for rolling over DLC channel"
-    );
-
-    let client = reqwest_client();
-    let response = client
-        .post(format!(
-            "http://{}/api/rollover/{}",
-            config::get_http_endpoint(),
-            hex::encode(dlc_channel_id)
-        ))
-        .send()
-        .await
-        .with_context(|| {
-            format!(
-                "Failed to rollover dlc with id {}",
-                hex::encode(dlc_channel_id)
-            )
-        })?;
-
-    if !response.status().is_success() {
-        let response_text = match response.text().await {
-            Ok(text) => text,
-            Err(err) => {
-                format!("could not decode response {err:#}")
-            }
-        };
-
-        bail!(
-            "Failed to rollover dlc with id {}. Error: {response_text}",
-            hex::encode(dlc_channel_id)
-        )
-    }
-
-    tracing::info!("Sent rollover request to coordinator successfully");
-
-    Ok(())
 }
 
 fn ln_dlc_node_settings() -> LnDlcNodeSettings {

--- a/mobile/native/src/trade/position/handler.rs
+++ b/mobile/native/src/trade/position/handler.rs
@@ -2,7 +2,6 @@ use crate::calculations::calculate_margin;
 use crate::db;
 use crate::event;
 use crate::event::EventInternal;
-use crate::ln_dlc;
 use crate::trade::order::Order;
 use crate::trade::position::Position;
 use crate::trade::position::PositionState;
@@ -12,11 +11,6 @@ use anyhow::Result;
 use commons::Prices;
 use time::OffsetDateTime;
 use trade::ContractSymbol;
-
-/// Rollover dlc to new expiry timestamp
-pub async fn rollover(contract_id: Option<String>) -> Result<()> {
-    ln_dlc::rollover(contract_id).await
-}
 
 /// Fetch the positions from the database
 pub fn get_positions() -> Result<Vec<Position>> {


### PR DESCRIPTION
fixes #2226 
fixes #2200 

- Rollover api has been moved to admin
- The coordinator now checks on a p2p connection if the users position needs to get rolled over
- Combines the logic for checking rollover from job an on connect, fixing the issue of notifying the user about the rollover window if there is already an expired position. (Note, the job did not check if the position was already expired)
- Adds a small fix to wait for the current context to become available before opening a dialog (async match and rollover)
- Connects to the coordinator on the websocket before starting the node. That prevents a possible race condition where the p2p connection could be already established but the websocket connection isn't.