### PR TITLE
fix(webapp): favicon and title

### DIFF
--- a/webapp/frontend/web/index.html
+++ b/webapp/frontend/web/index.html
@@ -23,7 +23,7 @@
     <!-- iOS meta tags & icons -->
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-status-bar-style" content="black">
-    <meta name="apple-mobile-web-app-title" content="frontend">
+    <meta name="apple-mobile-web-app-title" content="10101">
     <link rel="apple-touch-icon" href="icons/Icon-192.png">
 
     <!-- Websupoort for WebView -->
@@ -31,9 +31,9 @@
             defer></script>
 
     <!-- Favicon -->
-    <link rel="icon" type="image/png" href="favicon.png"/>
+    <link rel="icon" type="image/png" href="/assets/assets/10101_logo_icon.png"/>
 
-    <title>frontend</title>
+    <title>10101</title>
     <link rel="manifest" href="manifest.json">
 
     <script>


### PR DESCRIPTION
`/favicon.png` didn't seem to have been copied over. This works though.