### PR TITLE
fix: Set node state once node is created

### DIFF
--- a/mobile/native/src/ln_dlc/mod.rs
+++ b/mobile/native/src/ln_dlc/mod.rs
@@ -311,7 +311,9 @@ pub fn run(runtime: &Runtime) -> Result<()> {
 
         let event_handler = AppEventHandler::new(node.clone(), Some(event_sender));
         let _running = node.start(event_handler, true)?;
+
         let node = Arc::new(Node::new(node, _running));
+        state::set_node(node.clone());
 
         let dlc_handler = DlcHandler::new(node.clone());
         runtime.spawn(async move {
@@ -384,8 +386,6 @@ pub fn run(runtime: &Runtime) -> Result<()> {
                 tokio::time::sleep(CHECK_OPEN_ORDERS_INTERVAL).await;
             }
         });
-
-        state::set_node(node.clone());
 
         event::publish(&EventInternal::Init("10101 is ready.".to_string()));
 


### PR DESCRIPTION
With https://github.com/get10101/10101/pull/2198/ we are now depending on the node to be set in the state when syncing the node.

This can end up in a race condition during startup as the task might already try to run a sync before the node is actually set into the state.

This fix moves setting the node state right after the node is constructed, ensuring that the node is available for `sync_node` when needed.

fixes #2245 