### PR TITLE
Keep context for `TradingError::Other`

### DIFF
--- a/crates/commons/src/message.rs
+++ b/crates/commons/src/message.rs
@@ -60,7 +60,7 @@ pub enum TradingError {
 
 impl From<anyhow::Error> for TradingError {
     fn from(value: anyhow::Error) -> Self {
-        TradingError::Other(value.to_string())
+        TradingError::Other(format!("{value:#}"))
     }
 }
 


### PR DESCRIPTION
Fixes https://github.com/get10101/10101/issues/2261.

Does this do it, @holzeis?