### PR TITLE
chore: Wait for current context to get available when showing recover dlc dialog

### DIFF
--- a/mobile/lib/common/recover_dlc_change_notifier.dart
+++ b/mobile/lib/common/recover_dlc_change_notifier.dart
@@ -11,7 +11,7 @@ class RecoverDlcChangeNotifier extends ChangeNotifier implements Subscriber {
   late TaskStatus taskStatus;
 
   @override
-  void notify(bridge.Event event) {
+  void notify(bridge.Event event) async {
     if (event is bridge.Event_BackgroundNotification) {
       if (event.field0 is! bridge.BackgroundTask_RecoverDlc) {
         // ignoring other kinds of background tasks
@@ -23,6 +23,9 @@ class RecoverDlcChangeNotifier extends ChangeNotifier implements Subscriber {
       taskStatus = recoverDlc.taskStatus;
 
       if (taskStatus == TaskStatus.pending) {
+        while (shellNavigatorKey.currentContext == null) {
+          await Future.delayed(const Duration(milliseconds: 100)); // Adjust delay as needed
+        }
         // initialize dialog for the pending task
         showDialog(
           context: shellNavigatorKey.currentContext!,

--- a/mobile/lib/features/trade/submit_order_change_notifier.dart
+++ b/mobile/lib/features/trade/submit_order_change_notifier.dart
@@ -97,21 +97,23 @@ class SubmitOrderChangeNotifier extends ChangeNotifier implements Subscriber {
     if (event is bridge.Event_OrderUpdateNotification) {
       Order order = Order.fromApi(event.field0);
 
-      switch (order.state) {
-        case OrderState.open:
-        case OrderState.filling:
-          return;
-        case OrderState.filled:
-          _pendingOrder!.state = PendingOrderState.orderFilled;
-          break;
-        case OrderState.failed:
-        case OrderState.rejected:
-          _pendingOrder!.state = PendingOrderState.orderFailed;
-          break;
-      }
-      _pendingOrder!.failureReason = order.failureReason;
+      if (pendingOrder != null) {
+        switch (order.state) {
+          case OrderState.open:
+          case OrderState.filling:
+            return;
+          case OrderState.filled:
+            _pendingOrder!.state = PendingOrderState.orderFilled;
+            break;
+          case OrderState.failed:
+          case OrderState.rejected:
+            _pendingOrder!.state = PendingOrderState.orderFailed;
+            break;
+        }
+        _pendingOrder!.failureReason = order.failureReason;
 
-      notifyListeners();
+        notifyListeners();
+      }
     } else {
       logger.w("Received unexpected event: ${event.toString()}");
     }

--- a/mobile/native/src/ln_dlc/node.rs
+++ b/mobile/native/src/ln_dlc/node.rs
@@ -295,6 +295,11 @@ impl Node {
                                     expiry_timestamp,
                                 )
                                 .context("Failed to update position after DLC creation")?;
+
+                                // In case of a restart.
+                                event::publish(&EventInternal::BackgroundNotification(
+                                    BackgroundTask::RecoverDlc(TaskStatus::Success),
+                                ));
                             }
                             // If there is no order in `Filling` we must be rolling over.
                             None => {


### PR DESCRIPTION
fixes some issues with the recover dialog being displayed after the app got closed in the middle of a protocol.

fixes #2262 
fixes #2263 (169ad6b5c9de22d8a1f4af9783095d71805b59fb)