### PR TITLE
chore: Do not spawn on trade execution

### DIFF
--- a/coordinator/src/orderbook/async_match.rs
+++ b/coordinator/src/orderbook/async_match.rs
@@ -128,23 +128,20 @@ async fn process_pending_match(
 
         tracing::info!(trader_id = %order.trader_id, order_id = %order.id, order_reason = ?order.order_reason, "Executing trade for match");
         let trade_executor = TradeExecutor::new(node, notifier);
-
-        tokio::spawn(async move {
-            trade_executor
-                .execute(&TradeAndChannelParams {
-                    trade_params: TradeParams {
-                        pubkey: trader_id,
-                        contract_symbol: ContractSymbol::BtcUsd,
-                        leverage: order.leverage,
-                        quantity: order.quantity.to_f32().expect("to fit into f32"),
-                        direction: order.direction,
-                        filled_with,
-                    },
-                    trader_reserve: channel_opening_params.map(|c| c.trader_reserve),
-                    coordinator_reserve: channel_opening_params.map(|c| c.coordinator_reserve),
-                })
-                .await;
-        });
+        trade_executor
+            .execute(&TradeAndChannelParams {
+                trade_params: TradeParams {
+                    pubkey: trader_id,
+                    contract_symbol: ContractSymbol::BtcUsd,
+                    leverage: order.leverage,
+                    quantity: order.quantity.to_f32().expect("to fit into f32"),
+                    direction: order.direction,
+                    filled_with,
+                },
+                trader_reserve: channel_opening_params.map(|c| c.trader_reserve),
+                coordinator_reserve: channel_opening_params.map(|c| c.coordinator_reserve),
+            })
+            .await;
     }
 
     Ok(())

--- a/coordinator/src/orderbook/trading.rs
+++ b/coordinator/src/orderbook/trading.rs
@@ -321,23 +321,20 @@ pub async fn process_new_market_order(
     if node.inner.is_connected(order.trader_id) {
         tracing::info!(trader_id = %order.trader_id, order_id = %order.id, order_reason = ?order.order_reason, "Executing trade for match");
         let trade_executor = TradeExecutor::new(node.clone(), notifier);
-
-        tokio::spawn(async move {
-            trade_executor
-                .execute(&TradeAndChannelParams {
-                    trade_params: TradeParams {
-                        pubkey: order.trader_id,
-                        contract_symbol: ContractSymbol::BtcUsd,
-                        leverage: order.leverage,
-                        quantity: order.quantity.to_f32().expect("to fit into f32"),
-                        direction: order.direction,
-                        filled_with: matched_orders.taker_match.filled_with,
-                    },
-                    trader_reserve: channel_opening_params.map(|p| p.trader_reserve),
-                    coordinator_reserve: channel_opening_params.map(|p| p.coordinator_reserve),
-                })
-                .await;
-        });
+        trade_executor
+            .execute(&TradeAndChannelParams {
+                trade_params: TradeParams {
+                    pubkey: order.trader_id,
+                    contract_symbol: ContractSymbol::BtcUsd,
+                    leverage: order.leverage,
+                    quantity: order.quantity.to_f32().expect("to fit into f32"),
+                    direction: order.direction,
+                    filled_with: matched_orders.taker_match.filled_with,
+                },
+                trader_reserve: channel_opening_params.map(|p| p.trader_reserve),
+                coordinator_reserve: channel_opening_params.map(|p| p.coordinator_reserve),
+            })
+            .await;
     } else {
         match order.order_reason {
             OrderReason::Manual => {


### PR DESCRIPTION
This must have been somehow slipped through. We don't need to spawn a thread here anymore, since the trade is already executed in a dedicated thread.