### PR TITLE
fix: Refresh dlc channels when opening force close channel screen

### DIFF
--- a/mobile/lib/common/settings/force_close_screen.dart
+++ b/mobile/lib/common/settings/force_close_screen.dart
@@ -24,6 +24,12 @@ class _ForceCloseScreenState extends State<ForceCloseScreen> {
   bool isCloseChannelButtonDisabled = false;
 
   @override
+  void initState() {
+    super.initState();
+    context.read<DlcChannelChangeNotifier>().refreshDlcChannels();
+  }
+
+  @override
   Widget build(BuildContext context) {
     DlcChannelChangeNotifier dlcChannelChangeNotifier = context.watch<DlcChannelChangeNotifier>();
 


### PR DESCRIPTION
Otherwise it could happen that we don't see the swipe button as the state is not yet refreshed.