### PR TITLE
Feature/BREAKING(app):  introduce margin orders

### DIFF
--- a/coordinator/migrations/2024-03-18-054329_add_margin_orders/down.sql
+++ b/coordinator/migrations/2024-03-18-054329_add_margin_orders/down.sql
@@ -1,0 +1,4 @@
+-- This file should undo anything in `up.sql`
+
+ALTER TABLE
+    orders DROP COLUMN margin_sats;

--- a/coordinator/migrations/2024-03-18-054329_add_margin_orders/up.sql
+++ b/coordinator/migrations/2024-03-18-054329_add_margin_orders/up.sql
@@ -1,0 +1,8 @@
+-- Note that the `IF NOT EXISTS` is essential because there is no `down` migration for removing this value because it is not really feasible to remove enum values!
+-- In order to allow re-running this migration we thus have to make sure to only add the value if it does not exist yet.
+ALTER TYPE "OrderType_Type"
+ADD
+    VALUE IF NOT EXISTS 'margin';
+
+ALTER TABLE
+    orders ADD COLUMN margin_sats REAL DEFAULT null;

--- a/coordinator/src/node/expired_positions.rs
+++ b/coordinator/src/node/expired_positions.rs
@@ -7,6 +7,7 @@ use crate::position::models::PositionState;
 use anyhow::Context;
 use anyhow::Result;
 use commons::average_execution_price;
+use commons::LimitOrder;
 use commons::Match;
 use commons::MatchState;
 use commons::NewOrder;
@@ -78,7 +79,7 @@ pub async fn close(node: Node, trading_sender: mpsc::Sender<NewOrderMessage>) ->
 
         tracing::debug!(trader_pk=%position.trader, %position.expiry_timestamp, "Attempting to close expired position");
 
-        let new_order = NewOrder {
+        let new_order = LimitOrder {
             id: uuid::Uuid::new_v4(),
             contract_symbol: position.contract_symbol,
             // TODO(holzeis): we should not have to set the price for a market order. we propably
@@ -97,7 +98,7 @@ pub async fn close(node: Node, trading_sender: mpsc::Sender<NewOrderMessage>) ->
         };
 
         let message = NewOrderMessage {
-            new_order: new_order.clone(),
+            new_order: NewOrder::Market(new_order.clone()),
             channel_opening_params: None,
             order_reason: OrderReason::Expired,
         };

--- a/coordinator/src/node/expired_positions.rs
+++ b/coordinator/src/node/expired_positions.rs
@@ -7,7 +7,7 @@ use crate::position::models::PositionState;
 use anyhow::Context;
 use anyhow::Result;
 use commons::average_execution_price;
-use commons::LimitOrder;
+use commons::MarketOrder;
 use commons::Match;
 use commons::MatchState;
 use commons::NewOrder;
@@ -79,12 +79,9 @@ pub async fn close(node: Node, trading_sender: mpsc::Sender<NewOrderMessage>) ->
 
         tracing::debug!(trader_pk=%position.trader, %position.expiry_timestamp, "Attempting to close expired position");
 
-        let new_order = LimitOrder {
+        let new_order = MarketOrder {
             id: uuid::Uuid::new_v4(),
             contract_symbol: position.contract_symbol,
-            // TODO(holzeis): we should not have to set the price for a market order. we propably
-            // need separate models for a limit and a market order.
-            price: Decimal::ZERO,
             quantity: Decimal::try_from(position.quantity).expect("to fit into decimal"),
             trader_id: position.trader,
             direction: position.trader_direction.opposite(),

--- a/coordinator/src/node/expired_positions.rs
+++ b/coordinator/src/node/expired_positions.rs
@@ -13,7 +13,6 @@ use commons::MatchState;
 use commons::NewOrder;
 use commons::OrderReason;
 use commons::OrderState;
-use commons::OrderType;
 use rust_decimal::prelude::FromPrimitive;
 use rust_decimal::prelude::ToPrimitive;
 use rust_decimal::Decimal;
@@ -86,7 +85,6 @@ pub async fn close(node: Node, trading_sender: mpsc::Sender<NewOrderMessage>) ->
             trader_id: position.trader,
             direction: position.trader_direction.opposite(),
             leverage: Decimal::from_f32(position.trader_leverage).expect("to fit into decimal"),
-            order_type: OrderType::Market,
             // This order can basically not expire, but if the user does not come back online within
             // a certain time period we can assume the channel to be abandoned and we should force
             // close.

--- a/coordinator/src/orderbook/db/custom_types.rs
+++ b/coordinator/src/orderbook/db/custom_types.rs
@@ -58,6 +58,7 @@ impl FromSql<DirectionType, Pg> for Direction {
 pub enum OrderType {
     Market,
     Limit,
+    Margin,
 }
 
 impl QueryId for OrderTypeType {
@@ -74,6 +75,7 @@ impl ToSql<OrderTypeType, Pg> for OrderType {
         match *self {
             OrderType::Market => out.write_all(b"market")?,
             OrderType::Limit => out.write_all(b"limit")?,
+            OrderType::Margin => out.write_all(b"margin")?,
         }
         Ok(IsNull::No)
     }
@@ -84,6 +86,7 @@ impl FromSql<OrderTypeType, Pg> for OrderType {
         match bytes.as_bytes() {
             b"market" => Ok(OrderType::Market),
             b"limit" => Ok(OrderType::Limit),
+            b"margin" => Ok(OrderType::Margin),
             _ => Err("Unrecognized enum variant".into()),
         }
     }

--- a/coordinator/src/orderbook/db/orders.rs
+++ b/coordinator/src/orderbook/db/orders.rs
@@ -176,7 +176,7 @@ impl From<LimitOrder> for NewOrder {
                 .round_dp(2)
                 .to_f32()
                 .expect("To be able to convert decimal to f32"),
-            order_type: value.order_type.into(),
+            order_type: OrderType::Limit,
             expiry: value.expiry,
             order_reason: OrderReason::Manual,
             contract_symbol: value.contract_symbol.into(),
@@ -202,7 +202,7 @@ impl From<MarketOrder> for NewOrder {
                 .round_dp(2)
                 .to_f32()
                 .expect("To be able to convert decimal to f32"),
-            order_type: value.order_type.into(),
+            order_type: OrderType::Market,
             expiry: value.expiry,
             order_reason: OrderReason::Manual,
             contract_symbol: value.contract_symbol.into(),

--- a/coordinator/src/orderbook/routes.rs
+++ b/coordinator/src/orderbook/routes.rs
@@ -95,8 +95,15 @@ pub async fn post_order(
         }
     }
 
+    tracing::debug!(
+        channel_opening_params = ?new_order_request.channel_opening_params,
+        "Opening channel with "
+    );
+
     let message = NewOrderMessage {
         new_order,
+        // TODO(bonomat): we should do a check on the `new_order_request.channel_opening_params` if
+        // they adhere to our channel creation criteria
         channel_opening_params: new_order_request.channel_opening_params,
         order_reason: OrderReason::Manual,
     };

--- a/coordinator/src/orderbook/tests/sample_test.rs
+++ b/coordinator/src/orderbook/tests/sample_test.rs
@@ -4,9 +4,9 @@ use crate::orderbook::tests::setup_db;
 use crate::orderbook::tests::start_postgres;
 use bitcoin::secp256k1::PublicKey;
 use commons::LimitOrder;
+use commons::MarketOrder;
 use commons::OrderReason;
 use commons::OrderState;
-use commons::OrderType;
 use rust_decimal_macros::dec;
 use std::str::FromStr;
 use testcontainers::clients::Cli;
@@ -26,10 +26,7 @@ async fn crud_test() {
 
     let order = orders::insert_limit_order(
         &mut conn,
-        dummy_order(
-            OffsetDateTime::now_utc() + Duration::minutes(1),
-            OrderType::Market,
-        ),
+        dummy_limit_order(OffsetDateTime::now_utc() + Duration::minutes(1)),
         OrderReason::Manual,
     )
     .unwrap();
@@ -50,42 +47,38 @@ async fn test_all_limit_orders() {
     let orders = orders::all_limit_orders(&mut conn).unwrap();
     assert!(orders.is_empty());
 
-    orders::insert_limit_order(
-        &mut conn,
-        dummy_order(
-            OffsetDateTime::now_utc() + Duration::minutes(1),
-            OrderType::Market,
-        ),
-        OrderReason::Manual,
-    )
-    .unwrap();
+    let order_1 = dummy_limit_order(OffsetDateTime::now_utc() + Duration::minutes(1));
+    orders::insert_limit_order(&mut conn, order_1, OrderReason::Manual).unwrap();
 
-    let second_order = orders::insert_limit_order(
-        &mut conn,
-        dummy_order(
-            OffsetDateTime::now_utc() + Duration::minutes(1),
-            OrderType::Limit,
-        ),
-        OrderReason::Manual,
-    )
-    .unwrap();
-    orders::set_order_state(&mut conn, second_order.id, OrderState::Failed).unwrap();
+    let order_2 = dummy_market_order(OffsetDateTime::now_utc() + Duration::minutes(1));
+    orders::insert_market_order(&mut conn, order_2, OrderReason::Manual).unwrap();
 
-    orders::insert_limit_order(
-        &mut conn,
-        dummy_order(
-            OffsetDateTime::now_utc() + Duration::minutes(1),
-            OrderType::Limit,
-        ),
-        OrderReason::Manual,
-    )
-    .unwrap();
+    let order_3 = dummy_limit_order(OffsetDateTime::now_utc() + Duration::minutes(1));
+    let second_limit_order =
+        orders::insert_limit_order(&mut conn, order_3, OrderReason::Manual).unwrap();
+    orders::set_order_state(&mut conn, second_limit_order.id, OrderState::Failed).unwrap();
 
     let orders = orders::all_limit_orders(&mut conn).unwrap();
     assert_eq!(orders.len(), 1);
 }
 
-fn dummy_order(expiry: OffsetDateTime, order_type: OrderType) -> LimitOrder {
+fn dummy_market_order(expiry: OffsetDateTime) -> MarketOrder {
+    MarketOrder {
+        id: Uuid::new_v4(),
+        trader_id: PublicKey::from_str(
+            "027f31ebc5462c1fdce1b737ecff52d37d75dea43ce11c74d25aa297165faa2007",
+        )
+        .unwrap(),
+        direction: Direction::Long,
+        quantity: dec!(100.0),
+        expiry,
+        contract_symbol: trade::ContractSymbol::BtcUsd,
+        leverage: dec!(1.0),
+        stable: false,
+    }
+}
+
+fn dummy_limit_order(expiry: OffsetDateTime) -> LimitOrder {
     LimitOrder {
         id: Uuid::new_v4(),
         price: dec!(20000.00),
@@ -95,7 +88,6 @@ fn dummy_order(expiry: OffsetDateTime, order_type: OrderType) -> LimitOrder {
         .unwrap(),
         direction: Direction::Long,
         quantity: dec!(100.0),
-        order_type,
         expiry,
         contract_symbol: trade::ContractSymbol::BtcUsd,
         leverage: dec!(1.0),

--- a/coordinator/src/orderbook/tests/sample_test.rs
+++ b/coordinator/src/orderbook/tests/sample_test.rs
@@ -3,7 +3,7 @@ use crate::orderbook::db::orders;
 use crate::orderbook::tests::setup_db;
 use crate::orderbook::tests::start_postgres;
 use bitcoin::secp256k1::PublicKey;
-use commons::NewOrder;
+use commons::LimitOrder;
 use commons::OrderReason;
 use commons::OrderState;
 use commons::OrderType;
@@ -24,7 +24,7 @@ async fn crud_test() {
 
     let mut conn = setup_db(conn_spec);
 
-    let order = orders::insert(
+    let order = orders::insert_limit_order(
         &mut conn,
         dummy_order(
             OffsetDateTime::now_utc() + Duration::minutes(1),
@@ -50,7 +50,7 @@ async fn test_all_limit_orders() {
     let orders = orders::all_limit_orders(&mut conn).unwrap();
     assert!(orders.is_empty());
 
-    orders::insert(
+    orders::insert_limit_order(
         &mut conn,
         dummy_order(
             OffsetDateTime::now_utc() + Duration::minutes(1),
@@ -60,7 +60,7 @@ async fn test_all_limit_orders() {
     )
     .unwrap();
 
-    let second_order = orders::insert(
+    let second_order = orders::insert_limit_order(
         &mut conn,
         dummy_order(
             OffsetDateTime::now_utc() + Duration::minutes(1),
@@ -71,7 +71,7 @@ async fn test_all_limit_orders() {
     .unwrap();
     orders::set_order_state(&mut conn, second_order.id, OrderState::Failed).unwrap();
 
-    orders::insert(
+    orders::insert_limit_order(
         &mut conn,
         dummy_order(
             OffsetDateTime::now_utc() + Duration::minutes(1),
@@ -85,8 +85,8 @@ async fn test_all_limit_orders() {
     assert_eq!(orders.len(), 1);
 }
 
-fn dummy_order(expiry: OffsetDateTime, order_type: OrderType) -> NewOrder {
-    NewOrder {
+fn dummy_order(expiry: OffsetDateTime, order_type: OrderType) -> LimitOrder {
+    LimitOrder {
         id: Uuid::new_v4(),
         price: dec!(20000.00),
         trader_id: PublicKey::from_str(

--- a/coordinator/src/orderbook/trading.rs
+++ b/coordinator/src/orderbook/trading.rs
@@ -15,6 +15,7 @@ use bitcoin::Network;
 use commons::ChannelOpeningParams;
 use commons::FilledWith;
 use commons::LimitOrder;
+use commons::MarketOrder;
 use commons::Match;
 use commons::Message;
 use commons::Message::TradeError;
@@ -194,7 +195,7 @@ pub async fn process_new_limit_order(
 pub async fn process_new_market_order(
     node: Node,
     notifier: mpsc::Sender<OrderbookMessage>,
-    new_order: LimitOrder,
+    new_order: MarketOrder,
     order_reason: OrderReason,
     network: Network,
     oracle_pk: XOnlyPublicKey,

--- a/coordinator/src/schema.rs
+++ b/coordinator/src/schema.rs
@@ -242,6 +242,7 @@ diesel::table! {
         leverage -> Float4,
         order_reason -> OrderReasonType,
         stable -> Bool,
+        margin_sats -> Nullable<Float4>,
     }
 }
 

--- a/crates/commons/src/order.rs
+++ b/crates/commons/src/order.rs
@@ -79,7 +79,6 @@ pub struct MarketOrder {
     pub direction: Direction,
     #[serde(with = "rust_decimal::serde::float")]
     pub leverage: Decimal,
-    pub order_type: OrderType,
     #[serde(with = "time::serde::timestamp")]
     pub expiry: OffsetDateTime,
     pub stable: bool,
@@ -97,7 +96,6 @@ pub struct LimitOrder {
     pub direction: Direction,
     #[serde(with = "rust_decimal::serde::float")]
     pub leverage: Decimal,
-    pub order_type: OrderType,
     #[serde(with = "time::serde::timestamp")]
     pub expiry: OffsetDateTime,
     pub stable: bool,
@@ -112,8 +110,6 @@ impl LimitOrder {
 
         let symbol = self.contract_symbol.label();
         let symbol = symbol.as_bytes();
-        let order_type = self.order_type.label();
-        let order_type = order_type.as_bytes();
         let direction = self.direction.to_string();
         let direction = direction.as_bytes();
         let quantity = format!("{:.2}", self.quantity);
@@ -126,7 +122,6 @@ impl LimitOrder {
         vec.append(&mut id);
         vec.append(&mut seconds);
         vec.append(&mut symbol.to_vec());
-        vec.append(&mut order_type.to_vec());
         vec.append(&mut direction.to_vec());
         vec.append(&mut quantity.to_vec());
         vec.append(&mut price.to_vec());
@@ -145,8 +140,6 @@ impl MarketOrder {
 
         let symbol = self.contract_symbol.label();
         let symbol = symbol.as_bytes();
-        let order_type = self.order_type.label();
-        let order_type = order_type.as_bytes();
         let direction = self.direction.to_string();
         let direction = direction.as_bytes();
         let quantity = format!("{:.2}", self.quantity);
@@ -157,7 +150,6 @@ impl MarketOrder {
         vec.append(&mut id);
         vec.append(&mut seconds);
         vec.append(&mut symbol.to_vec());
-        vec.append(&mut order_type.to_vec());
         vec.append(&mut direction.to_vec());
         vec.append(&mut quantity.to_vec());
         vec.append(&mut leverage.to_vec());
@@ -237,7 +229,6 @@ pub mod tests {
     use crate::LimitOrder;
     use crate::NewOrder;
     use crate::NewOrderRequest;
-    use crate::OrderType;
     use secp256k1::rand;
     use secp256k1::Secp256k1;
     use secp256k1::SecretKey;
@@ -262,7 +253,6 @@ pub mod tests {
             trader_id: public_key,
             direction: Direction::Long,
             leverage: rust_decimal_macros::dec!(2.0),
-            order_type: OrderType::Market,
             expiry: OffsetDateTime::now_utc(),
             stable: false,
         };
@@ -289,7 +279,6 @@ pub mod tests {
             trader_id: public_key,
             direction: Direction::Long,
             leverage: rust_decimal_macros::dec!(2.0),
-            order_type: OrderType::Market,
             // Note: the last 5 is too much as it does not get serialized
             expiry: OffsetDateTime::UNIX_EPOCH + 1.1010101015.seconds(),
             stable: false,

--- a/crates/commons/src/price.rs
+++ b/crates/commons/src/price.rs
@@ -99,6 +99,7 @@ mod test {
             leverage: 1.0,
             contract_symbol: BtcUsd,
             quantity: 100.into(),
+            margin_sats: Default::default(),
             order_type: OrderType::Market,
             timestamp: OffsetDateTime::now_utc(),
             expiry: OffsetDateTime::now_utc(),

--- a/crates/tests-e2e/src/setup.rs
+++ b/crates/tests-e2e/src/setup.rs
@@ -163,5 +163,6 @@ pub fn dummy_order() -> NewOrder {
         quantity: 1000.0,
         order_type: Box::new(OrderType::Market),
         stable: false,
+        margin_sats: 0.0,
     }
 }

--- a/crates/tests-e2e/tests/e2e_close_position.rs
+++ b/crates/tests-e2e/tests/e2e_close_position.rs
@@ -67,6 +67,7 @@ async fn can_open_close_open_close_position() {
         quantity: 500.0,
         order_type: Box::new(OrderType::Market),
         stable: false,
+        margin_sats: 0.0,
     };
 
     submit_order(order.clone());

--- a/crates/tests-e2e/tests/e2e_open_position.rs
+++ b/crates/tests-e2e/tests/e2e_open_position.rs
@@ -22,6 +22,7 @@ async fn can_open_position() {
         quantity: 1.0,
         order_type: Box::new(OrderType::Market),
         stable: false,
+        margin_sats: 0.0,
     };
     submit_channel_opening_order(order.clone(), 10_000, 10_000);
 

--- a/crates/tests-e2e/tests/e2e_open_position_small_utxos.rs
+++ b/crates/tests-e2e/tests/e2e_open_position_small_utxos.rs
@@ -32,6 +32,7 @@ async fn can_open_position_with_multiple_small_utxos() {
         quantity: 100.0,
         order_type: Box::new(OrderType::Market),
         stable: false,
+        margin_sats: 0.0,
     };
 
     // We take the ask price because the app is going long.

--- a/crates/tests-e2e/tests/e2e_reject_offer.rs
+++ b/crates/tests-e2e/tests/e2e_reject_offer.rs
@@ -28,6 +28,7 @@ async fn reject_offer() {
         quantity: 2000.0,
         order_type: Box::new(OrderType::Market),
         stable: false,
+        margin_sats: 0.0,
     };
 
     // submit order for which the app does not have enough liquidity. will fail with `Failed to
@@ -64,6 +65,7 @@ async fn reject_offer() {
         quantity: 100.0,
         order_type: Box::new(OrderType::Market),
         stable: false,
+        margin_sats: 0.0,
     };
 
     // give the coordinator some time to process the reject message, before submitting the next

--- a/mobile/lib/common/amount_input_modalised.dart
+++ b/mobile/lib/common/amount_input_modalised.dart
@@ -110,7 +110,7 @@ class _EnterAmountModalState extends State<EnterAmountModal> {
           crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
             AmountInputField(
-              value: widget.amount != null ? Amount(widget.amount!) : Amount.zero(),
+              initialValue: widget.amount != null ? Amount(widget.amount!) : Amount.zero(),
               hint: "e.g. $hint",
               label: "Amount",
               validator: widget.validator,

--- a/mobile/lib/common/amount_text.dart
+++ b/mobile/lib/common/amount_text.dart
@@ -40,5 +40,5 @@ String formatSats(Amount amount) {
 
 String formatUsd(Usd usd) {
   final formatter = NumberFormat("\$ #,###,###,###,###", "en");
-  return formatter.format(usd.usd);
+  return formatter.format(usd.usd.toDouble());
 }

--- a/mobile/lib/common/amount_text_input_form_field.dart
+++ b/mobile/lib/common/amount_text_input_form_field.dart
@@ -13,7 +13,7 @@ class AmountInputField extends StatelessWidget {
       this.label = '',
       this.hint = '',
       this.onChanged,
-      required this.value,
+      required this.initialValue,
       this.isLoading = false,
       this.infoText,
       this.controller,
@@ -24,7 +24,7 @@ class AmountInputField extends StatelessWidget {
 
   final TextEditingController? controller;
   final TextStyle? style;
-  final Amount value;
+  final Amount initialValue;
   final bool enabled;
   final String label;
   final String hint;
@@ -42,7 +42,7 @@ class AmountInputField extends StatelessWidget {
       style: style ?? const TextStyle(color: Colors.black87, fontSize: 16),
       enabled: enabled,
       controller: controller,
-      initialValue: controller != null ? null : value.formatted(),
+      initialValue: controller != null ? null : initialValue.formatted(),
       keyboardType: TextInputType.number,
       decoration: decoration ??
           InputDecoration(

--- a/mobile/lib/common/amount_text_input_form_field.dart
+++ b/mobile/lib/common/amount_text_input_form_field.dart
@@ -13,7 +13,7 @@ class AmountInputField extends StatelessWidget {
       this.label = '',
       this.hint = '',
       this.onChanged,
-      required this.initialValue,
+      this.initialValue,
       this.isLoading = false,
       this.infoText,
       this.controller,
@@ -24,7 +24,7 @@ class AmountInputField extends StatelessWidget {
 
   final TextEditingController? controller;
   final TextStyle? style;
-  final Amount initialValue;
+  final Amount? initialValue;
   final bool enabled;
   final String label;
   final String hint;
@@ -42,7 +42,7 @@ class AmountInputField extends StatelessWidget {
       style: style ?? const TextStyle(color: Colors.black87, fontSize: 16),
       enabled: enabled,
       controller: controller,
-      initialValue: controller != null ? null : initialValue.formatted(),
+      initialValue: controller != null ? null : initialValue?.formatted() ?? "",
       keyboardType: TextInputType.number,
       decoration: decoration ??
           InputDecoration(

--- a/mobile/lib/common/domain/model.dart
+++ b/mobile/lib/common/domain/model.dart
@@ -74,13 +74,17 @@ class Usd {
 
   int get usd => _usd.toBigInt().toInt();
 
-  int get toInt => _usd.toBigInt().toInt();
-
   Usd.zero() : _usd = Decimal.zero;
 
-  double asDouble() => _usd.toDouble();
+  // we take at most 2 decimal places
+  double asDouble() => double.parse(_usd.toStringAsFixed(2));
 
-  Usd.fromDouble(double value) : _usd = Decimal.parse(value.toString());
+  Usd.fromDouble(double value) {
+    // Limit the number of decimal places to at most 2
+    String formattedValue = value.toStringAsFixed(2);
+    _usd = Decimal.parse(formattedValue);
+  }
+
   Usd.parse(dynamic value) : _usd = Decimal.parse(value);
 
   Usd.parseString(String? value) {
@@ -102,8 +106,9 @@ class Usd {
   }
 
   String formatted() {
-    final formatter = NumberFormat("#,###,###,###,###", "en");
-    return formatter.format(_usd.toDouble());
+    var asDouble = this.asDouble();
+    final formatter = NumberFormat("#,###,###,###,##0.00", "en");
+    return formatter.format(asDouble);
   }
 
   @override

--- a/mobile/lib/common/domain/model.dart
+++ b/mobile/lib/common/domain/model.dart
@@ -103,7 +103,7 @@ class Usd {
 
   String formatted() {
     final formatter = NumberFormat("#,###,###,###,###", "en");
-    return formatter.format(_usd);
+    return formatter.format(_usd.toDouble());
   }
 
   @override

--- a/mobile/lib/common/init_service.dart
+++ b/mobile/lib/common/init_service.dart
@@ -71,7 +71,8 @@ List<SingleChildWidget> createProviders() {
     Provider(create: (context) => config),
     Provider(create: (context) => channelInfoService),
     Provider(create: (context) => pollService),
-    Provider(create: (context) => githubService)
+    Provider(create: (context) => githubService),
+    Provider(create: (context) => tradeValuesService)
   ];
   if (config.network == "regtest") {
     providers.add(Provider(create: (context) => FaucetService()));

--- a/mobile/lib/features/trade/application/order_service.dart
+++ b/mobile/lib/features/trade/application/order_service.dart
@@ -6,8 +6,8 @@ import 'package:get_10101/features/trade/domain/order.dart';
 import 'package:get_10101/ffi.dart' as rust;
 
 class OrderService {
-  Future<String> submitMarketOrder(Leverage leverage, Amount quantity,
-      ContractSymbol contractSymbol, Direction direction, bool stable) async {
+  Future<String> submitMarketOrder(Leverage leverage, Usd quantity, ContractSymbol contractSymbol,
+      Direction direction, bool stable) async {
     rust.NewOrder order = rust.NewOrder(
         leverage: leverage.leverage,
         quantity: quantity.asDouble(),
@@ -21,7 +21,7 @@ class OrderService {
 
   Future<String> submitChannelOpeningMarketOrder(
       Leverage leverage,
-      Amount quantity,
+      Usd quantity,
       ContractSymbol contractSymbol,
       Direction direction,
       bool stable,

--- a/mobile/lib/features/trade/application/order_service.dart
+++ b/mobile/lib/features/trade/application/order_service.dart
@@ -7,14 +7,24 @@ import 'package:get_10101/ffi.dart' as rust;
 
 class OrderService {
   Future<String> submitMarketOrder(Leverage leverage, Usd quantity, ContractSymbol contractSymbol,
-      Direction direction, bool stable) async {
+      Direction direction, bool stable, Amount margin, bool isMarginOrder) async {
+    Usd updatedQuantity = quantity;
+    rust.OrderType orderType = const rust.OrderType.market();
+
+    if (isMarginOrder) {
+      // just to be on the safe side we set quantity to 0
+      updatedQuantity = Usd.zero();
+      orderType = const rust.OrderType.margin();
+    }
+
     rust.NewOrder order = rust.NewOrder(
         leverage: leverage.leverage,
-        quantity: quantity.asDouble(),
+        quantity: updatedQuantity.asDouble(),
         contractSymbol: contractSymbol.toApi(),
         direction: direction.toApi(),
-        orderType: const rust.OrderType.market(),
-        stable: stable);
+        orderType: orderType,
+        stable: stable,
+        marginSats: margin.asDouble());
 
     return await rust.api.submitOrder(order: order);
   }
@@ -26,14 +36,26 @@ class OrderService {
       Direction direction,
       bool stable,
       Amount coordinatorReserve,
-      Amount traderReserve) async {
+      Amount traderReserve,
+      Amount margin,
+      bool isMarginOrder) async {
+    Usd updatedQuantity = quantity;
+    rust.OrderType orderType = const rust.OrderType.market();
+
+    if (isMarginOrder) {
+      // just to be on the safe side we set quantity to 0
+      updatedQuantity = Usd.zero();
+      orderType = const rust.OrderType.margin();
+    }
+
     rust.NewOrder order = rust.NewOrder(
         leverage: leverage.leverage,
-        quantity: quantity.asDouble(),
+        quantity: updatedQuantity.asDouble(),
         contractSymbol: contractSymbol.toApi(),
         direction: direction.toApi(),
-        orderType: const rust.OrderType.market(),
-        stable: stable);
+        orderType: orderType,
+        stable: stable,
+        marginSats: margin.asDouble());
 
     return await rust.api.submitChannelOpeningOrder(
         order: order,

--- a/mobile/lib/features/trade/application/trade_values_service.dart
+++ b/mobile/lib/features/trade/application/trade_values_service.dart
@@ -5,10 +5,7 @@ import 'package:get_10101/ffi.dart' as rust;
 
 class TradeValuesService {
   Amount? calculateMargin(
-      {required double? price,
-      required Amount? quantity,
-      required Leverage leverage,
-      dynamic hint}) {
+      {required double? price, required Usd? quantity, required Leverage leverage, dynamic hint}) {
     if (price == null || quantity == null) {
       return null;
     } else {
@@ -17,14 +14,14 @@ class TradeValuesService {
     }
   }
 
-  Amount? calculateQuantity(
+  Usd? calculateQuantity(
       {required double? price, required Amount? margin, required Leverage leverage, dynamic hint}) {
     if (price == null || margin == null) {
       return null;
     } else {
       final quantity = rust.api
           .calculateQuantity(price: price, margin: margin.sats, leverage: leverage.leverage);
-      return Amount(quantity.ceil());
+      return Usd(quantity.ceil());
     }
   }
 
@@ -41,7 +38,7 @@ class TradeValuesService {
     }
   }
 
-  Amount? orderMatchingFee({required Amount? quantity, required double? price}) {
+  Amount? orderMatchingFee({required Usd? quantity, required double? price}) {
     return quantity != null && price != null
         ? Amount(rust.api.orderMatchingFee(quantity: quantity.asDouble(), price: price))
         : null;

--- a/mobile/lib/features/trade/channel_configuration.dart
+++ b/mobile/lib/features/trade/channel_configuration.dart
@@ -168,7 +168,7 @@ class _ChannelConfiguration extends State<ChannelConfiguration> {
                               children: [
                                 Flexible(
                                     child: AmountInputField(
-                                  value: ownTotalCollateral,
+                                  initialValue: ownTotalCollateral,
                                   label: 'Your collateral (sats)',
                                   onChanged: (value) {
                                     setState(() {

--- a/mobile/lib/features/trade/domain/order.dart
+++ b/mobile/lib/features/trade/domain/order.dart
@@ -97,21 +97,26 @@ class FailureReason {
 }
 
 enum OrderType {
-  market;
+  market,
+  margin;
 
   static OrderType fromApi(bridge.OrderType orderType) {
     if (orderType is bridge.OrderType_Market) {
       return OrderType.market;
     }
+    if (orderType is bridge.OrderType_Margin) {
+      return OrderType.margin;
+    }
 
-    throw Exception("Only market orders are supported! Received unexpected order type $orderType");
+    throw Exception(
+        "Only market or margin orders are supported! Received unexpected order type $orderType");
   }
 }
 
 class Order {
   late String id;
   final Leverage leverage;
-  final Amount quantity;
+  final Usd quantity;
   final ContractSymbol contractSymbol;
   final Direction direction;
   final OrderState state;
@@ -138,7 +143,7 @@ class Order {
     return Order(
         id: order.id,
         leverage: Leverage(order.leverage),
-        quantity: Amount(order.quantity.ceil()),
+        quantity: Usd.fromDouble(order.quantity),
         contractSymbol: ContractSymbol.fromApi(order.contractSymbol),
         direction: Direction.fromApi(order.direction),
         state: OrderState.fromApi(order.state),

--- a/mobile/lib/features/trade/domain/position.dart
+++ b/mobile/lib/features/trade/domain/position.dart
@@ -65,7 +65,7 @@ class Position {
   static Position fromApi(bridge.Position position) {
     return Position(
       leverage: Leverage(position.leverage),
-      quantity: Usd(position.quantity.ceil()),
+      quantity: Usd.fromDouble(position.quantity),
       contractSymbol: ContractSymbol.fromApi(position.contractSymbol),
       direction: Direction.fromApi(position.direction),
       positionState: PositionState.fromApi(position.positionState),

--- a/mobile/lib/features/trade/domain/position.dart
+++ b/mobile/lib/features/trade/domain/position.dart
@@ -26,7 +26,7 @@ enum PositionState {
 
 class Position {
   final Leverage leverage;
-  final Amount quantity;
+  final Usd quantity;
   final ContractSymbol contractSymbol;
   final Direction direction;
   final double averageEntryPrice;
@@ -65,7 +65,7 @@ class Position {
   static Position fromApi(bridge.Position position) {
     return Position(
       leverage: Leverage(position.leverage),
-      quantity: Amount(position.quantity.ceil()),
+      quantity: Usd(position.quantity.ceil()),
       contractSymbol: ContractSymbol.fromApi(position.contractSymbol),
       direction: Direction.fromApi(position.direction),
       positionState: PositionState.fromApi(position.positionState),

--- a/mobile/lib/features/trade/domain/trade_values.dart
+++ b/mobile/lib/features/trade/domain/trade_values.dart
@@ -9,7 +9,7 @@ class TradeValues {
   Direction direction;
 
   // These values  can be null if coordinator is down
-  Amount? quantity;
+  Usd? quantity;
   double? price;
   double? liquidationPrice;
   Amount? fee; // This fee is an estimate of the order-matching fee.
@@ -33,7 +33,7 @@ class TradeValues {
       required this.tradeValuesService});
 
   factory TradeValues.fromQuantity(
-      {required Amount quantity,
+      {required Usd quantity,
       required Leverage leverage,
       required double? price,
       required double fundingRate,
@@ -70,7 +70,7 @@ class TradeValues {
       required double fundingRate,
       required Direction direction,
       required TradeValuesService tradeValuesService}) {
-    Amount? quantity =
+    Usd? quantity =
         tradeValuesService.calculateQuantity(price: price, margin: margin, leverage: leverage);
     double? liquidationPrice = price != null
         ? tradeValuesService.calculateLiquidationPrice(
@@ -94,7 +94,7 @@ class TradeValues {
         tradeValuesService: tradeValuesService);
   }
 
-  updateQuantity(Amount quantity) {
+  updateQuantity(Usd quantity) {
     this.quantity = quantity;
     _recalculateMargin();
     _recalculateFee();
@@ -139,7 +139,7 @@ class TradeValues {
   }
 
   _recalculateQuantity() {
-    Amount? quantity =
+    Usd? quantity =
         tradeValuesService.calculateQuantity(price: price, margin: margin, leverage: leverage);
     this.quantity = quantity;
   }

--- a/mobile/lib/features/trade/order_list_item.dart
+++ b/mobile/lib/features/trade/order_list_item.dart
@@ -63,7 +63,7 @@ class OrderListItem extends StatelessWidget {
                               order.direction == Direction.long ? tradeTheme.buy : tradeTheme.sell,
                           fontWeight: FontWeight.bold)),
                   TextSpan(
-                      text: " ${formatter.format(order.quantity.toInt)} ",
+                      text: " ${order.quantity.formatted()} ",
                       style: const TextStyle(fontWeight: FontWeight.bold)),
                   const TextSpan(text: "contracts")
                 ],

--- a/mobile/lib/features/trade/position_list_item.dart
+++ b/mobile/lib/features/trade/position_list_item.dart
@@ -201,7 +201,7 @@ class _PositionListItemState extends State<PositionListItem> {
                   ),
                   ValueDataRow(
                     type: ValueType.contracts,
-                    value: formatter.format(notNullPosition.quantity.toInt),
+                    value: notNullPosition.quantity.formatted(),
                     label: "Quantity",
                     valueTextStyle: dataRowStyle,
                     labelTextStyle: dataRowStyle,

--- a/mobile/lib/features/trade/submit_order_change_notifier.dart
+++ b/mobile/lib/features/trade/submit_order_change_notifier.dart
@@ -75,10 +75,18 @@ class SubmitOrderChangeNotifier extends ChangeNotifier implements Subscriber {
             tradeValues.direction,
             stable,
             Amount(coordinatorReserve),
-            Amount(traderReserve));
+            Amount(traderReserve),
+            tradeValues.margin!,
+            tradeValues.isMarginOrder);
       } else {
-        _pendingOrder!.id = await orderService.submitMarketOrder(tradeValues.leverage,
-            tradeValues.quantity!, ContractSymbol.btcusd, tradeValues.direction, stable);
+        _pendingOrder!.id = await orderService.submitMarketOrder(
+            tradeValues.leverage,
+            tradeValues.quantity!,
+            ContractSymbol.btcusd,
+            tradeValues.direction,
+            stable,
+            tradeValues.margin!,
+            tradeValues.isMarginOrder);
       }
 
       _pendingOrder!.state = PendingOrderState.submittedSuccessfully;
@@ -119,20 +127,25 @@ class SubmitOrderChangeNotifier extends ChangeNotifier implements Subscriber {
     }
   }
 
-  Future<void> closePosition(Position position, double? closingPrice, Amount? fee,
+  Future<void> closePosition(Position position, TradeValues tradeValues,
       {bool stable = false}) async {
     await submitPendingOrder(
         TradeValues(
-            direction: position.direction.opposite(),
-            margin: position.collateral,
-            quantity: position.quantity,
-            leverage: position.leverage,
-            price: closingPrice,
-            liquidationPrice: position.liquidationPrice,
-            fee: fee,
-            fundingRate: 0,
-            expiry: position.expiry,
-            tradeValuesService: TradeValuesService()),
+          direction: position.direction.opposite(),
+          margin: position.collateral,
+          quantity: position.quantity,
+          leverage: position.leverage,
+          price: tradeValues.price,
+          liquidationPrice: position.liquidationPrice,
+          fee: tradeValues.fee,
+          fundingRate: 0,
+          expiry: position.expiry,
+          tradeValuesService: TradeValuesService(),
+          isMarginOrder: false,
+          quantityController: tradeValues.quantityController,
+          marginController: tradeValues.marginController,
+          priceController: tradeValues.priceController,
+        ),
         PositionAction.close,
         pnl: position.unrealizedPnl,
         stable: stable);

--- a/mobile/lib/features/trade/trade_bottom_sheet_confirmation.dart
+++ b/mobile/lib/features/trade/trade_bottom_sheet_confirmation.dart
@@ -12,7 +12,6 @@ import 'package:get_10101/features/trade/domain/direction.dart';
 import 'package:get_10101/features/trade/domain/trade_values.dart';
 import 'package:get_10101/features/trade/position_change_notifier.dart';
 import 'package:get_10101/features/trade/trade_theme.dart';
-import 'package:get_10101/features/trade/trade_value_change_notifier.dart';
 import 'package:get_10101/util/constants.dart';
 import 'package:provider/provider.dart';
 import 'package:slide_to_confirm/slide_to_confirm.dart';
@@ -28,7 +27,8 @@ tradeBottomSheetConfirmation(
     required Direction direction,
     required TradeAction tradeAction,
     required Function() onConfirmation,
-    required ChannelOpeningParams? channelOpeningParams}) {
+    required ChannelOpeningParams? channelOpeningParams,
+    required TradeValues tradeValues}) {
   final sliderKey = direction == Direction.long
       ? tradeScreenBottomSheetConfirmationSliderBuy
       : tradeScreenBottomSheetConfirmationSliderSell;
@@ -85,6 +85,7 @@ tradeBottomSheetConfirmation(
                     traderCollateral: channelOpeningParams?.traderCollateral,
                     channelFeeReserve: channelFeeReserve,
                     fundingTxFee: fundingTxFee,
+                    tradeValues: tradeValues,
                   )),
             ),
           ),
@@ -124,6 +125,7 @@ class TradeBottomSheetConfirmation extends StatelessWidget {
   final Key sliderButtonKey;
   final Function() onConfirmation;
   final TradeAction tradeAction;
+  final TradeValues tradeValues;
 
   final Amount? traderCollateral;
   final Amount? channelFeeReserve;
@@ -139,15 +141,13 @@ class TradeBottomSheetConfirmation extends StatelessWidget {
     this.traderCollateral,
     this.channelFeeReserve,
     this.fundingTxFee,
+    required this.tradeValues,
   });
 
   @override
   Widget build(BuildContext context) {
     TradeTheme tradeTheme = Theme.of(context).extension<TradeTheme>()!;
     Color color = direction == Direction.long ? tradeTheme.buy : tradeTheme.sell;
-
-    TradeValues tradeValues =
-        Provider.of<TradeValuesChangeNotifier>(context).fromDirection(direction);
 
     bool isClose = tradeAction == TradeAction.closePosition;
     bool isChannelOpen = tradeAction == TradeAction.openChannel;

--- a/mobile/lib/features/trade/trade_bottom_sheet_tab.dart
+++ b/mobile/lib/features/trade/trade_bottom_sheet_tab.dart
@@ -224,7 +224,7 @@ class _TradeBottomSheetTabState extends State<TradeBottomSheetTab> {
           children: [
             Flexible(
                 child: AmountInputField(
-              value: tradeValues.quantity ?? Amount.zero(),
+              initialValue: tradeValues.quantity ?? Amount.zero(),
               hint: "e.g. 100 USD",
               label: "Quantity (USD)",
               onChanged: (value) {

--- a/mobile/lib/features/trade/trade_bottom_sheet_tab.dart
+++ b/mobile/lib/features/trade/trade_bottom_sheet_tab.dart
@@ -49,6 +49,11 @@ class _TradeBottomSheetTabState extends State<TradeBottomSheetTab> {
 
   bool showCapacityInfo = false;
 
+  bool marginInputFieldEnabled = false;
+  bool quantityInputFieldEnabled = true;
+
+  // Amount quantity = Amount(sats);
+
   @override
   void initState() {
     provider = context.read<TradeValuesChangeNotifier>();

--- a/mobile/lib/features/trade/trade_screen.dart
+++ b/mobile/lib/features/trade/trade_screen.dart
@@ -152,8 +152,7 @@ class TradeScreen extends StatelessWidget {
                                 direction: direction,
                                 channelOpeningParams: null,
                                 onConfirmation: () {
-                                  submitOrderChangeNotifier.closePosition(
-                                      position, tradeValues.price, tradeValues.fee);
+                                  submitOrderChangeNotifier.closePosition(position, tradeValues);
 
                                   // Return to the trade screen before submitting the pending order so that the dialog is displayed correctly
                                   GoRouter.of(context).pop();
@@ -168,7 +167,8 @@ class TradeScreen extends StatelessWidget {
                                         return const TradeDialog();
                                       });
                                 },
-                                tradeAction: TradeAction.closePosition);
+                                tradeAction: TradeAction.closePosition,
+                                tradeValues: tradeValues);
                           },
                         );
                       },

--- a/mobile/lib/features/trade/trade_value_change_notifier.dart
+++ b/mobile/lib/features/trade/trade_value_change_notifier.dart
@@ -35,7 +35,8 @@ class TradeValuesChangeNotifier extends ChangeNotifier implements Subscriber {
             price: null,
             fundingRate: fundingRateBuy,
             direction: direction,
-            tradeValuesService: tradeValuesService);
+            tradeValuesService: tradeValuesService,
+            isMarginOrder: false);
       case Direction.short:
         return TradeValues.fromQuantity(
             quantity: defaultQuantity,
@@ -43,26 +44,21 @@ class TradeValuesChangeNotifier extends ChangeNotifier implements Subscriber {
             price: null,
             fundingRate: fundingRateSell,
             direction: direction,
-            tradeValuesService: tradeValuesService);
+            tradeValuesService: tradeValuesService,
+            isMarginOrder: false);
     }
   }
 
-  /// Calculates the counterparty margin based on leverage one
-  int? counterpartyMargin(Direction direction, double leverage) {
+  /// Calculates the counterparty margin
+  int? counterpartyMargin(Direction direction, double leverage, double price, Usd quantity) {
     switch (direction) {
       case Direction.long:
         return tradeValuesService
-            .calculateMargin(
-                price: _buyTradeValues.price,
-                quantity: _buyTradeValues.quantity,
-                leverage: Leverage(leverage))
+            .calculateMargin(price: price, quantity: quantity, leverage: Leverage(leverage))
             ?.sats;
       case Direction.short:
         return tradeValuesService
-            .calculateMargin(
-                price: _sellTradeValues.price,
-                quantity: _sellTradeValues.quantity,
-                leverage: Leverage(leverage))
+            .calculateMargin(price: price, quantity: quantity, leverage: Leverage(leverage))
             ?.sats;
     }
   }
@@ -103,6 +99,11 @@ class TradeValuesChangeNotifier extends ChangeNotifier implements Subscriber {
     if (update) {
       notifyListeners();
     }
+  }
+
+  void updateIsMargin(Direction direction, bool isMargin) {
+    fromDirection(direction).updateIsMargin(isMargin);
+    notifyListeners();
   }
 
   Price? getPrice() {

--- a/mobile/lib/features/trade/trade_value_change_notifier.dart
+++ b/mobile/lib/features/trade/trade_value_change_notifier.dart
@@ -24,7 +24,7 @@ class TradeValuesChangeNotifier extends ChangeNotifier implements Subscriber {
   }
 
   TradeValues _initOrder(Direction direction) {
-    Amount defaultQuantity = Amount(500);
+    Usd defaultQuantity = Usd(500);
     Leverage defaultLeverage = Leverage(2);
 
     switch (direction) {
@@ -71,7 +71,7 @@ class TradeValuesChangeNotifier extends ChangeNotifier implements Subscriber {
     return fromDirection(direction).fee;
   }
 
-  void updateQuantity(Direction direction, Amount quantity) {
+  void updateQuantity(Direction direction, Usd quantity) {
     fromDirection(direction).updateQuantity(quantity);
     notifyListeners();
   }

--- a/mobile/lib/features/wallet/receive/receive_usdp_dialog.dart
+++ b/mobile/lib/features/wallet/receive/receive_usdp_dialog.dart
@@ -66,7 +66,7 @@ Widget createSubmitWidget(
       bottomText = "Sorry, we couldn't match your order. Please try again later.";
       break;
     case PendingOrderState.orderFilled:
-      var amount = pendingOrder.tradeValues?.quantity?.toInt ?? "0";
+      var amount = pendingOrder.tradeValues?.quantity?.formatted() ?? "0";
       bottomText = "Congratulations! You received $amount USDP.";
       break;
   }
@@ -80,7 +80,9 @@ Widget createSubmitWidget(
           runSpacing: 10,
           children: [
             ValueDataRow(
-                type: ValueType.fiat, value: pendingOrderValues?.quantity?.toInt, label: "USDP"),
+                type: ValueType.fiat,
+                value: pendingOrderValues?.quantity?.formatted(),
+                label: "USDP"),
             ValueDataRow(
                 type: ValueType.amount, value: pendingOrderValues?.margin, label: "Margin"),
             ValueDataRow(

--- a/mobile/lib/features/wallet/receive/receive_usdp_dialog.dart
+++ b/mobile/lib/features/wallet/receive/receive_usdp_dialog.dart
@@ -66,7 +66,7 @@ Widget createSubmitWidget(
       bottomText = "Sorry, we couldn't match your order. Please try again later.";
       break;
     case PendingOrderState.orderFilled:
-      var amount = pendingOrder.tradeValues?.quantity?.sats ?? "0";
+      var amount = pendingOrder.tradeValues?.quantity?.toInt ?? "0";
       bottomText = "Congratulations! You received $amount USDP.";
       break;
   }
@@ -80,9 +80,7 @@ Widget createSubmitWidget(
           runSpacing: 10,
           children: [
             ValueDataRow(
-                type: ValueType.fiat,
-                value: pendingOrderValues?.quantity?.sats.toDouble(),
-                label: "USDP"),
+                type: ValueType.fiat, value: pendingOrderValues?.quantity?.toInt, label: "USDP"),
             ValueDataRow(
                 type: ValueType.amount, value: pendingOrderValues?.margin, label: "Margin"),
             ValueDataRow(

--- a/mobile/lib/features/wallet/send/confirm_payment_modal.dart
+++ b/mobile/lib/features/wallet/send/confirm_payment_modal.dart
@@ -113,7 +113,8 @@ class ConfirmPayment extends StatelessWidget {
                           child: Row(
                             mainAxisAlignment: MainAxisAlignment.spaceBetween,
                             children: [
-                              Text("~ \$ ${formatter.format(tradeValues.quantity?.toInt ?? 0)}",
+                              Text(
+                                  "~ \$ ${formatter.format(tradeValues.quantity?.formatted() ?? 0)}",
                                   style: const TextStyle(fontSize: 16)),
                               Text(amt.toString(),
                                   style: const TextStyle(fontSize: 16, color: Colors.grey))

--- a/mobile/lib/features/wallet/send/confirm_payment_modal.dart
+++ b/mobile/lib/features/wallet/send/confirm_payment_modal.dart
@@ -17,7 +17,7 @@ import 'package:provider/provider.dart';
 import 'package:slide_to_confirm/slide_to_confirm.dart';
 
 void showConfirmPaymentModal(
-    BuildContext context, Destination destination, bool payWithUsdp, Amount sats, Amount usdp,
+    BuildContext context, Destination destination, bool payWithUsdp, Amount sats, Usd usdp,
     {Fee? fee}) {
   logger.i(fee);
   showModalBottomSheet<void>(
@@ -45,7 +45,7 @@ class ConfirmPayment extends StatelessWidget {
   final Destination destination;
   final bool payWithUsdp;
   final Amount sats;
-  final Amount usdp;
+  final Usd usdp;
   final Fee? fee;
 
   const ConfirmPayment(

--- a/mobile/lib/features/wallet/send/fee_picker.dart
+++ b/mobile/lib/features/wallet/send/fee_picker.dart
@@ -198,7 +198,7 @@ class _FeePickerModalState extends State<_FeePickerModal> {
                       "sats/vbyte",
                       style: TextStyle(fontSize: 16, color: Color(0xff878787)),
                     )),
-                value: Amount(1)),
+                initialValue: Amount(1)),
           ),
         ),
         const SizedBox(height: 25),

--- a/mobile/lib/features/wallet/send/send_onchain_screen.dart
+++ b/mobile/lib/features/wallet/send/send_onchain_screen.dart
@@ -320,8 +320,15 @@ class _SendOnChainScreenState extends State<SendOnChainScreen> {
                       width: MediaQuery.of(context).size.width * 0.9,
                       child: ElevatedButton(
                           onPressed: (_formKey.currentState?.validate() ?? false)
-                              ? () => showConfirmPaymentModal(context, widget.destination, false,
-                                  _amount ?? Amount.zero(), _amount ?? Amount.zero(), fee: _fee)
+                              ? () => showConfirmPaymentModal(
+                                  context,
+                                  widget.destination,
+                                  false,
+                                  _amount ?? Amount.zero(),
+                                  // this value doesn't matter at the moment because we do not support USDP sending
+                                  // TODO: remove USDP leftovers
+                                  Usd.zero(),
+                                  fee: _fee)
                               : null,
                           style: ButtonStyle(
                               padding:

--- a/mobile/native/migrations/2024-03-18-054329_add_margin_orders/down.sql
+++ b/mobile/native/migrations/2024-03-18-054329_add_margin_orders/down.sql
@@ -1,0 +1,4 @@
+-- This file should undo anything in `up.sql`
+
+ALTER TABLE
+    orders DROP COLUMN margin_sats;

--- a/mobile/native/migrations/2024-03-18-054329_add_margin_orders/up.sql
+++ b/mobile/native/migrations/2024-03-18-054329_add_margin_orders/up.sql
@@ -1,0 +1,3 @@
+
+ALTER TABLE
+    orders ADD COLUMN margin_sats REAL DEFAULT null;

--- a/mobile/native/src/db/custom_types.rs
+++ b/mobile/native/src/db/custom_types.rs
@@ -23,6 +23,7 @@ impl ToSql<Text, Sqlite> for OrderType {
         let text = match *self {
             OrderType::Market => "market".to_string(),
             OrderType::Limit => "limit".to_string(),
+            OrderType::Margin => "margin".to_string(),
         };
         out.set_value(text);
         Ok(IsNull::No)
@@ -36,6 +37,7 @@ impl FromSql<Text, Sqlite> for OrderType {
         return match string.as_str() {
             "market" => Ok(OrderType::Market),
             "limit" => Ok(OrderType::Limit),
+            "margin" => Ok(OrderType::Margin),
             _ => Err("Unrecognized enum variant".into()),
         };
     }

--- a/mobile/native/src/db/mod.rs
+++ b/mobile/native/src/db/mod.rs
@@ -160,6 +160,16 @@ pub fn update_order_state(
 
     Ok(order.try_into()?)
 }
+pub fn update_order_quantity(order_id: Uuid, quantity: f32) -> Result<trade::order::Order> {
+    let mut db = connection()?;
+
+    // we ensure that the quantity in the db as only 2 decimal places
+    let rounded_quantity = (quantity * 100.0).round() / 100.0;
+    let order = Order::update_quantity(order_id.to_string(), rounded_quantity, &mut db)
+        .context("Failed to update order state")?;
+
+    Ok(order.try_into()?)
+}
 
 pub fn get_order(order_id: Uuid) -> Result<Option<trade::order::Order>> {
     let mut db = connection()?;

--- a/mobile/native/src/ln_dlc/mod.rs
+++ b/mobile/native/src/ln_dlc/mod.rs
@@ -805,6 +805,7 @@ fn update_state_after_collab_revert(
                 id: Uuid::new_v4(),
                 leverage: position.leverage,
                 quantity: position.quantity,
+                margin_sats: position.collateral as f32,
                 contract_symbol: position.contract_symbol,
                 direction: position.direction.opposite(),
                 order_type: OrderType::Market,

--- a/mobile/native/src/schema.rs
+++ b/mobile/native/src/schema.rs
@@ -68,6 +68,7 @@ diesel::table! {
         order_expiry_timestamp -> BigInt,
         reason -> Text,
         stable -> Bool,
+        margin_sats -> Nullable<Float>,
     }
 }
 

--- a/mobile/native/src/trade/order/api.rs
+++ b/mobile/native/src/trade/order/api.rs
@@ -9,6 +9,7 @@ use uuid::Uuid;
 #[derive(Debug, Clone, Copy)]
 pub enum OrderType {
     Market,
+    Margin,
     Limit { price: f32 },
 }
 
@@ -56,6 +57,8 @@ pub struct NewOrder {
     #[frb(non_final)]
     pub quantity: f32,
     #[frb(non_final)]
+    pub margin_sats: f32,
+    #[frb(non_final)]
     pub contract_symbol: ContractSymbol,
     #[frb(non_final)]
     pub direction: Direction,
@@ -89,6 +92,7 @@ impl From<order::OrderType> for OrderType {
         match value {
             order::OrderType::Market => OrderType::Market,
             order::OrderType::Limit { price } => OrderType::Limit { price },
+            order::OrderType::Margin => OrderType::Margin,
         }
     }
 }
@@ -156,6 +160,7 @@ impl From<OrderType> for order::OrderType {
         match value {
             OrderType::Market => order::OrderType::Market,
             OrderType::Limit { price } => order::OrderType::Limit { price },
+            OrderType::Margin => order::OrderType::Margin,
         }
     }
 }
@@ -181,6 +186,7 @@ impl From<NewOrder> for order::Order {
             id: Uuid::new_v4(),
             leverage: value.leverage,
             quantity: value.quantity,
+            margin_sats: value.margin_sats,
             contract_symbol: value.contract_symbol,
             direction: value.direction,
             order_type: (*value.order_type).into(),

--- a/mobile/native/src/trade/order/handler.rs
+++ b/mobile/native/src/trade/order/handler.rs
@@ -92,7 +92,7 @@ pub async fn submit_order(
     let orderbook_client = OrderbookClient::new(url);
 
     if let Err(err) = orderbook_client
-        .post_new_order(order.clone().into(), channel_opening_params)
+        .post_new_market_order(order.clone().into(), channel_opening_params)
         .await
     {
         let order_id = order.id.clone().to_string();

--- a/mobile/native/src/trade/order/mod.rs
+++ b/mobile/native/src/trade/order/mod.rs
@@ -187,11 +187,11 @@ impl Order {
     }
 }
 
-impl From<Order> for commons::NewOrder {
+impl From<Order> for commons::LimitOrder {
     fn from(order: Order) -> Self {
         let quantity = Decimal::try_from(order.quantity).expect("to parse into decimal");
         let trader_id = ln_dlc::get_node_pubkey();
-        commons::NewOrder {
+        commons::LimitOrder {
             id: order.id,
             contract_symbol: order.contract_symbol,
             // todo: this is left out intentionally as market orders do not set a price. this field

--- a/mobile/native/src/trade/order/mod.rs
+++ b/mobile/native/src/trade/order/mod.rs
@@ -198,7 +198,6 @@ impl From<Order> for commons::MarketOrder {
             trader_id,
             direction: order.direction,
             leverage: Decimal::from_f32(order.leverage).expect("to fit into f32"),
-            order_type: order.order_type.into(),
             expiry: order.order_expiry_timestamp,
             stable: order.stable,
         }

--- a/mobile/native/src/trade/order/mod.rs
+++ b/mobile/native/src/trade/order/mod.rs
@@ -187,16 +187,13 @@ impl Order {
     }
 }
 
-impl From<Order> for commons::LimitOrder {
+impl From<Order> for commons::MarketOrder {
     fn from(order: Order) -> Self {
         let quantity = Decimal::try_from(order.quantity).expect("to parse into decimal");
         let trader_id = ln_dlc::get_node_pubkey();
-        commons::LimitOrder {
+        commons::MarketOrder {
             id: order.id,
             contract_symbol: order.contract_symbol,
-            // todo: this is left out intentionally as market orders do not set a price. this field
-            // should either be an option or differently modelled for a market order.
-            price: Decimal::ZERO,
             quantity,
             trader_id,
             direction: order.direction,

--- a/mobile/native/src/trade/order/orderbook_client.rs
+++ b/mobile/native/src/trade/order/orderbook_client.rs
@@ -1,7 +1,11 @@
 use crate::commons::reqwest_client;
 use crate::ln_dlc::get_node_key;
+use crate::trade::order::Order;
+use crate::trade::order::OrderType;
+use anyhow::bail;
 use anyhow::Result;
 use commons::ChannelOpeningParams;
+use commons::MarginOrder;
 use commons::MarketOrder;
 use commons::NewOrder;
 use commons::NewOrderRequest;
@@ -16,17 +20,24 @@ impl OrderbookClient {
         Self { url }
     }
 
-    pub(crate) async fn post_new_market_order(
+    pub(crate) async fn post_new_order(
         &self,
-        // TODO: use market order
-        order: MarketOrder,
+        order: Order,
         channel_opening_params: Option<ChannelOpeningParams>,
     ) -> Result<()> {
+        let order = match order.order_type {
+            OrderType::Margin => NewOrder::Margin(MarginOrder::from(order)),
+            OrderType::Market => NewOrder::Market(MarketOrder::from(order)),
+            OrderType::Limit { .. } => {
+                bail!("Limit orders are not yet implemented");
+            }
+        };
+
         let secret_key = get_node_key();
         let message = order.message();
         let signature = secret_key.sign_ecdsa(message);
         let new_order_request = NewOrderRequest {
-            value: NewOrder::Market(order),
+            value: order,
             signature,
             channel_opening_params,
         };

--- a/mobile/native/src/trade/order/orderbook_client.rs
+++ b/mobile/native/src/trade/order/orderbook_client.rs
@@ -2,7 +2,7 @@ use crate::commons::reqwest_client;
 use crate::ln_dlc::get_node_key;
 use anyhow::Result;
 use commons::ChannelOpeningParams;
-use commons::LimitOrder;
+use commons::MarketOrder;
 use commons::NewOrder;
 use commons::NewOrderRequest;
 use reqwest::Url;
@@ -16,10 +16,10 @@ impl OrderbookClient {
         Self { url }
     }
 
-    pub(crate) async fn post_new_order(
+    pub(crate) async fn post_new_market_order(
         &self,
         // TODO: use market order
-        order: LimitOrder,
+        order: MarketOrder,
         channel_opening_params: Option<ChannelOpeningParams>,
     ) -> Result<()> {
         let secret_key = get_node_key();

--- a/mobile/native/src/trade/order/orderbook_client.rs
+++ b/mobile/native/src/trade/order/orderbook_client.rs
@@ -2,6 +2,7 @@ use crate::commons::reqwest_client;
 use crate::ln_dlc::get_node_key;
 use anyhow::Result;
 use commons::ChannelOpeningParams;
+use commons::LimitOrder;
 use commons::NewOrder;
 use commons::NewOrderRequest;
 use reqwest::Url;
@@ -17,14 +18,15 @@ impl OrderbookClient {
 
     pub(crate) async fn post_new_order(
         &self,
-        order: NewOrder,
+        // TODO: use market order
+        order: LimitOrder,
         channel_opening_params: Option<ChannelOpeningParams>,
     ) -> Result<()> {
         let secret_key = get_node_key();
         let message = order.message();
         let signature = secret_key.sign_ecdsa(message);
         let new_order_request = NewOrderRequest {
-            value: order,
+            value: NewOrder::Market(order),
             signature,
             channel_opening_params,
         };

--- a/mobile/native/src/trade/position/mod.rs
+++ b/mobile/native/src/trade/position/mod.rs
@@ -93,7 +93,9 @@ impl Position {
 
         let contracts = decimal_from_f32(order.quantity);
 
-        {
+        // we care about checking the margin only if it is not a margin order. If it is a margin
+        // order, then the margin has been defined in the order
+        if OrderType::Margin != order.order_type {
             let leverage = decimal_from_f32(order.leverage);
             let average_entry_price = decimal_from_f32(average_entry_price);
 
@@ -107,7 +109,12 @@ impl Position {
                 .expect("collateral to fit into Amount")
                 .to_sat();
 
-            debug_assert!(actual_collateral_sat == calculated_collateral_sat);
+            debug_assert!(
+                actual_collateral_sat == calculated_collateral_sat,
+                "actual_collateral_sat = {}, calculated_collateral_sat = {}",
+                actual_collateral_sat,
+                calculated_collateral_sat
+            );
 
             if actual_collateral_sat != calculated_collateral_sat {
                 tracing::debug!(
@@ -627,6 +634,7 @@ mod tests {
             id: Uuid::new_v4(),
             leverage: 1.0,
             quantity: 25.0,
+            margin_sats: 0.0,
             contract_symbol: ContractSymbol::BtcUsd,
             direction: Direction::Short,
             order_type: OrderType::Market,
@@ -688,6 +696,7 @@ mod tests {
             id: Uuid::new_v4(),
             leverage: 2.0,
             quantity: 10.0,
+            margin_sats: 0.0,
             contract_symbol: ContractSymbol::BtcUsd,
             direction: Direction::Short,
             order_type: OrderType::Market,
@@ -750,6 +759,7 @@ mod tests {
             id: Uuid::new_v4(),
             leverage: 2.0,
             quantity: 5.0,
+            margin_sats: 0.0,
             contract_symbol: ContractSymbol::BtcUsd,
             direction: Direction::Long,
             order_type: OrderType::Market,
@@ -821,6 +831,7 @@ mod tests {
             id: Uuid::new_v4(),
             leverage: 2.0,
             quantity: 5.0,
+            margin_sats: 0.0,
             contract_symbol: ContractSymbol::BtcUsd,
             direction: Direction::Short,
             order_type: OrderType::Market,
@@ -898,6 +909,7 @@ mod tests {
             id: Uuid::new_v4(),
             leverage: 2.0,
             quantity: 20.0,
+            margin_sats: 0.0,
             contract_symbol: ContractSymbol::BtcUsd,
             direction: Direction::Short,
             order_type: OrderType::Market,

--- a/mobile/test/trade_test.dart
+++ b/mobile/test/trade_test.dart
@@ -102,7 +102,7 @@ void main() {
         .thenReturn(10000);
     when(tradeValueService.calculateQuantity(
             price: anyNamed('price'), leverage: anyNamed('leverage'), margin: anyNamed('margin')))
-        .thenReturn(Amount(1));
+        .thenReturn(Usd(1));
     when(tradeValueService.getExpiryTimestamp()).thenReturn(DateTime.now());
     when(tradeValueService.orderMatchingFee(
             quantity: anyNamed('quantity'), price: anyNamed('price')))
@@ -214,7 +214,7 @@ void main() {
         .thenReturn(10000);
     when(tradeValueService.calculateQuantity(
             price: anyNamed('price'), leverage: anyNamed('leverage'), margin: anyNamed('margin')))
-        .thenReturn(Amount(1));
+        .thenReturn(Usd(1));
     when(tradeValueService.getExpiryTimestamp()).thenReturn(DateTime.now());
     when(tradeValueService.orderMatchingFee(
             quantity: anyNamed('quantity'), price: anyNamed('price')))

--- a/mobile/test/trade_test.dart
+++ b/mobile/test/trade_test.dart
@@ -197,7 +197,8 @@ void main() {
         sliderLocation + const Offset(10, -15), const Offset(280, 0), const Duration(seconds: 2),
         pointer: 7);
 
-    verify(orderService.submitChannelOpeningMarketOrder(any, any, any, any, any, any, any))
+    verify(orderService.submitChannelOpeningMarketOrder(
+            any, any, any, any, any, any, any, any, any))
         .called(1);
   });
 
@@ -208,10 +209,10 @@ void main() {
             leverage: anyNamed('leverage')))
         .thenReturn(Amount(1000));
     when(tradeValueService.calculateLiquidationPrice(
-            price: anyNamed('price'),
-            leverage: anyNamed('leverage'),
-            direction: anyNamed('direction')))
-        .thenReturn(10000);
+      price: anyNamed('price'),
+      leverage: anyNamed('leverage'),
+      direction: anyNamed('direction'),
+    )).thenReturn(10000);
     when(tradeValueService.calculateQuantity(
             price: anyNamed('price'), leverage: anyNamed('leverage'), margin: anyNamed('margin')))
         .thenReturn(Usd(1));
@@ -303,7 +304,7 @@ void main() {
         const Offset(275, 0), const Duration(seconds: 2),
         pointer: 7);
 
-    verify(orderService.submitMarketOrder(any, any, any, any, any)).called(1);
+    verify(orderService.submitMarketOrder(any, any, any, any, any, any, any)).called(1);
   });
 }
 

--- a/webapp/frontend/lib/common/amount_text_input_form_field.dart
+++ b/webapp/frontend/lib/common/amount_text_input_form_field.dart
@@ -13,7 +13,7 @@ class AmountInputField extends StatelessWidget {
     this.label = '',
     this.hint = '',
     this.onChanged,
-    this.value,
+    this.initialValue,
     this.isLoading = false,
     this.infoText,
     this.controller,
@@ -27,7 +27,7 @@ class AmountInputField extends StatelessWidget {
 
   final TextEditingController? controller;
   final TextStyle? style;
-  final Formattable? value;
+  final Formattable? initialValue;
   final bool enabled;
   final String label;
   final String hint;
@@ -48,7 +48,7 @@ class AmountInputField extends StatelessWidget {
       enabled: enabled,
       controller: controller,
       textAlign: textAlign,
-      initialValue: controller != null ? null : value?.formatted(),
+      initialValue: controller != null ? null : initialValue?.formatted(),
       keyboardType: TextInputType.number,
       decoration: decoration ??
           InputDecoration(

--- a/webapp/frontend/lib/trade/trade_screen_order_form.dart
+++ b/webapp/frontend/lib/trade/trade_screen_order_form.dart
@@ -57,7 +57,7 @@ class _NewOrderForm extends State<NewOrderForm> {
         Align(
           alignment: AlignmentDirectional.centerEnd,
           child: AmountInputField(
-            value: _quantity,
+            initialValue: _quantity,
             enabled: true,
             label: "Quantity",
             textAlign: TextAlign.right,

--- a/webapp/frontend/lib/wallet/send_screen.dart
+++ b/webapp/frontend/lib/wallet/send_screen.dart
@@ -73,7 +73,7 @@ class _SendScreenState extends State<SendScreen> {
                 ),
                 const SizedBox(height: 20),
                 AmountInputField(
-                  value: amount != null ? amount! : Amount.zero(),
+                  initialValue: amount != null ? amount! : Amount.zero(),
                   label: "Amount in sats",
                   controller: _amountController,
                   validator: (value) {
@@ -88,7 +88,7 @@ class _SendScreenState extends State<SendScreen> {
                 ),
                 const SizedBox(height: 20),
                 AmountInputField(
-                  value: fee != null ? fee! : Amount.zero(),
+                  initialValue: fee != null ? fee! : Amount.zero(),
                   label: "Sats/vb",
                   controller: _feeController,
                   validator: (value) {

--- a/webapp/src/api.rs
+++ b/webapp/src/api.rs
@@ -201,6 +201,7 @@ pub struct NewOrderParams {
     pub direction: Direction,
 }
 
+// TODO: support margin orders in webapp as well
 impl TryFrom<NewOrderParams> for native::trade::order::Order {
     type Error = anyhow::Error;
     fn try_from(value: NewOrderParams) -> Result<Self> {
@@ -214,6 +215,7 @@ impl TryFrom<NewOrderParams> for native::trade::order::Order {
                 .quantity
                 .to_f32()
                 .context("To be able to parse leverage into f32")?,
+            margin_sats: 0.0,
             contract_symbol: ContractSymbol::BtcUsd,
             direction: value.direction,
             // We only support market orders for now


### PR DESCRIPTION
This patch introduces margin orders, i.e. a trader can define the margin they want to use for opening a order instead of defining the quantity. 

Check commit messages for more details.

Overall I'm happy that it works but our code based really didn't make it easy to add this feature. 

Let me know what you think, if deemed to brittle, I'm happy to drop this PR.

https://github.com/get10101/10101/assets/224613/de832a8a-c0d4-43c1-83fc-9cfdeae68a59


