### PR TITLE
chore: Add admin api to resend renew revoke message

### DIFF
--- a/coordinator/src/admin.rs
+++ b/coordinator/src/admin.rs
@@ -543,6 +543,27 @@ pub async fn rollover(
     Ok(())
 }
 
+pub async fn resend_renew_revoke_message(
+    State(state): State<Arc<AppState>>,
+    Path(trader_pubkey): Path<String>,
+) -> Result<(), AppError> {
+    let trader = trader_pubkey.parse().map_err(|err| {
+        AppError::BadRequest(format!("Invalid public key {trader_pubkey}. Error: {err}"))
+    })?;
+
+    state
+        .node
+        .resend_renew_revoke_message_internal(trader)
+        .map_err(|e| {
+            AppError::InternalServerError(format!(
+                "Failed to resend renew revoke message for {}: {e:#}",
+                trader_pubkey
+            ))
+        })?;
+
+    Ok(())
+}
+
 impl From<ln_dlc_node::TransactionDetails> for TransactionDetails {
     fn from(value: ln_dlc_node::TransactionDetails) -> Self {
         Self {

--- a/coordinator/src/emergency_kit.rs
+++ b/coordinator/src/emergency_kit.rs
@@ -1,0 +1,43 @@
+use crate::node::Node;
+use anyhow::Result;
+use bitcoin::secp256k1::PublicKey;
+use bitcoin_old::secp256k1::SecretKey;
+use dlc_manager::Signer;
+use dlc_messages::channel::RenewRevoke;
+use dlc_messages::ChannelMessage;
+use dlc_messages::Message;
+use lightning::ln::chan_utils::build_commitment_secret;
+use ln_dlc_node::node::event::NodeEvent;
+
+impl Node {
+    pub fn resend_renew_revoke_message_internal(&self, trader: PublicKey) -> Result<()> {
+        tracing::warn!("Executing emergency kit! Resending renew revoke message");
+
+        let signed_channel = self.inner.get_signed_channel_by_trader_id(trader)?;
+
+        let per_update_seed_pk = signed_channel.own_per_update_seed;
+        let per_update_seed = self
+            .inner
+            .dlc_wallet
+            .get_secret_key_for_pubkey(&per_update_seed_pk)?;
+        let prev_per_update_secret = SecretKey::from_slice(&build_commitment_secret(
+            per_update_seed.as_ref(),
+            signed_channel.update_idx + 1,
+        ))?;
+
+        let msg = Message::Channel(ChannelMessage::RenewRevoke(RenewRevoke {
+            channel_id: signed_channel.channel_id,
+            per_update_secret: prev_per_update_secret,
+            reference_id: signed_channel.reference_id,
+        }));
+
+        self.inner
+            .event_handler
+            .publish(NodeEvent::SendDlcMessage {
+                peer: trader,
+                msg: msg.clone(),
+            })?;
+
+        Ok(())
+    }
+}

--- a/coordinator/src/lib.rs
+++ b/coordinator/src/lib.rs
@@ -27,6 +27,7 @@ pub mod cli;
 pub mod db;
 pub mod dlc_handler;
 pub mod dlc_protocol;
+mod emergency_kit;
 mod leaderboard;
 pub mod logger;
 pub mod message;

--- a/coordinator/src/routes.rs
+++ b/coordinator/src/routes.rs
@@ -9,6 +9,7 @@ use crate::admin::is_connected;
 use crate::admin::list_dlc_channels;
 use crate::admin::list_on_chain_transactions;
 use crate::admin::list_peers;
+use crate::admin::resend_renew_revoke_message;
 use crate::admin::roll_back_dlc_channel;
 use crate::admin::rollover;
 use crate::admin::sign_message;
@@ -199,6 +200,10 @@ pub fn router(
         )
         .route("/api/admin/sync", post(post_sync))
         .route("/api/admin/campaign/push", post(post_push_campaign))
+        .route(
+            "/api/admin/resend_renew_revoke_message/:trader_pubkey",
+            post(resend_renew_revoke_message),
+        )
         .route("/metrics", get(get_metrics))
         .route("/health", get(get_health))
         .route("/api/leaderboard", get(get_leaderboard))


### PR DESCRIPTION
- Adds an admin api to resent the renew revoke message
- Adds an emergency kit to recreate the position from the signed channel and last failed order. This might be needed if the app set the order to fail, which will block the app from recreating the app. I opted to not make the code smarter when processing the `RenewRevoke` message but rather add an emergency kit feature. That will hopefully be less failure prune.


fixes https://github.com/get10101/meta/issues/413