### PR TITLE
fix: Only send dlc messages if processing was successful

### DIFF
--- a/coordinator/src/emergency_kit.rs
+++ b/coordinator/src/emergency_kit.rs
@@ -31,12 +31,10 @@ impl Node {
             reference_id: signed_channel.reference_id,
         }));
 
-        self.inner
-            .event_handler
-            .publish(NodeEvent::SendDlcMessage {
-                peer: trader,
-                msg: msg.clone(),
-            })?;
+        self.inner.event_handler.publish(NodeEvent::SendDlcMessage {
+            peer: trader,
+            msg: msg.clone(),
+        });
 
         Ok(())
     }

--- a/coordinator/src/node.rs
+++ b/coordinator/src/node.rs
@@ -210,16 +210,12 @@ impl Node {
                 if let Some(resp) = resp.clone() {
                     // store dlc message immediately so we do not lose the response if something
                     // goes wrong afterwards.
-                    if let Err(e) = self
-                        .inner
+                    self.inner
                         .event_handler
                         .publish(NodeEvent::StoreDlcMessage {
                             peer: node_id,
                             msg: resp,
-                        })
-                    {
-                        tracing::error!(%node_id, "Failed to send store last dlc message event. Error: {e:#}");
-                    }
+                        });
                 }
 
                 {
@@ -470,7 +466,7 @@ impl Node {
 
             self.inner
                 .event_handler
-                .publish(NodeEvent::SendLastDlcMessage { peer: node_id })?;
+                .publish(NodeEvent::SendLastDlcMessage { peer: node_id });
         }
 
         Ok(())

--- a/coordinator/src/node/channel.rs
+++ b/coordinator/src/node/channel.rs
@@ -41,8 +41,10 @@ impl Node {
                                 tracing::error!("Failed to get connection. Error: {e:#}");
                             }
                         }
-                        Ok(NodeEvent::Connected { .. }) => {} // ignored
-                        Ok(NodeEvent::SendDlcMessage { .. }) => {} // ignored
+                        Ok(NodeEvent::Connected { .. })
+                        | Ok(NodeEvent::SendDlcMessage { .. })
+                        | Ok(NodeEvent::StoreDlcMessage { .. })
+                        | Ok(NodeEvent::SendLastDlcMessage { .. }) => {} // ignored
                         Err(RecvError::Lagged(skipped)) => {
                             tracing::warn!("Skipped {skipped} messages");
                         }

--- a/coordinator/src/node/rollover.rs
+++ b/coordinator/src/node/rollover.rs
@@ -278,7 +278,15 @@ impl Node {
             &mut connection,
             rollover.counterparty_pubkey.to_string(),
             &rollover.maturity_time(),
-        )
+        )?;
+
+        self.inner
+            .event_handler
+            .publish(NodeEvent::SendLastDlcMessage {
+                peer: rollover.counterparty_pubkey,
+            })?;
+
+        Ok(())
     }
 
     pub fn is_in_rollover(&self, trader_id: PublicKey) -> Result<bool> {

--- a/coordinator/src/node/rollover.rs
+++ b/coordinator/src/node/rollover.rs
@@ -284,7 +284,7 @@ impl Node {
             .event_handler
             .publish(NodeEvent::SendLastDlcMessage {
                 peer: rollover.counterparty_pubkey,
-            })?;
+            });
 
         Ok(())
     }

--- a/coordinator/src/trade/mod.rs
+++ b/coordinator/src/trade/mod.rs
@@ -96,16 +96,12 @@ impl TradeExecutor {
                         %order_id,"Failed to update order and match state. Error: {e:#}");
                 }
 
-                // Everything has been processed successfully, we can safely send the last dlc message,
-                // that has been stored before.
-                if let Err(e) = self
-                    .node
+                // Everything has been processed successfully, we can safely send the last dlc
+                // message, that has been stored before.
+                self.node
                     .inner
                     .event_handler
-                    .publish(NodeEvent::SendLastDlcMessage { peer: trader_id })
-                {
-                    tracing::error!(%trader_id, "Failed to send last dlc message event. Error: {e:#}");
-                }
+                    .publish(NodeEvent::SendLastDlcMessage { peer: trader_id });
             }
             Err(e) => {
                 tracing::error!(%trader_id, %order_id,"Failed to execute trade. Error: {e:#}");

--- a/coordinator/src/trade/mod.rs
+++ b/coordinator/src/trade/mod.rs
@@ -38,6 +38,7 @@ use dlc_manager::DlcChannelId;
 use lightning::chain::chaininterface::ConfirmationTarget;
 use ln_dlc_node::bitcoin_conversion::to_secp_pk_29;
 use ln_dlc_node::bitcoin_conversion::to_xonly_pk_29;
+use ln_dlc_node::node::event::NodeEvent;
 use ln_dlc_node::node::signed_channel_state_name;
 use rust_decimal::prelude::ToPrimitive;
 use rust_decimal::Decimal;
@@ -93,6 +94,17 @@ impl TradeExecutor {
                 {
                     tracing::error!(%trader_id,
                         %order_id,"Failed to update order and match state. Error: {e:#}");
+                }
+
+                // Everything has been processed successfully, we can safely send the last dlc message,
+                // that has been stored before.
+                if let Err(e) = self
+                    .node
+                    .inner
+                    .event_handler
+                    .publish(NodeEvent::SendLastDlcMessage { peer: trader_id })
+                {
+                    tracing::error!(%trader_id, "Failed to send last dlc message event. Error: {e:#}");
                 }
             }
             Err(e) => {

--- a/crates/ln-dlc-node/src/networking/tcp.rs
+++ b/crates/ln-dlc-node/src/networking/tcp.rs
@@ -31,8 +31,8 @@
 
 // Prefix these with `rustdoc::` when we update our MSRV to be >= 1.52 to remove warnings.
 #![allow(clippy::unwrap_used)]
-#![deny(broken_intra_doc_links)]
-#![deny(private_intra_doc_links)]
+#![deny(rustdoc::broken_intra_doc_links)]
+#![deny(rustdoc::private_intra_doc_links)]
 #![deny(missing_docs)]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 

--- a/crates/ln-dlc-node/src/node/connection.rs
+++ b/crates/ln-dlc-node/src/node/connection.rs
@@ -61,11 +61,9 @@ impl OnionMessageHandler for TenTenOneOnionMessageHandler {
     ) -> Result<(), ()> {
         tracing::info!(%their_node_id, inbound, "Peer connected!");
 
-        if let Err(e) = self.handler.publish(NodeEvent::Connected {
+        self.handler.publish(NodeEvent::Connected {
             peer: to_secp_pk_30(*their_node_id),
-        }) {
-            tracing::error!(%their_node_id, "Failed to broadcast connected peer. {e:#}");
-        }
+        });
 
         Ok(())
     }

--- a/crates/ln-dlc-node/src/node/dlc_channel.rs
+++ b/crates/ln-dlc-node/src/node/dlc_channel.rs
@@ -87,9 +87,7 @@ impl<D: BdkStorage, S: TenTenOneStorage + 'static, N: LnDlcStorage + Sync + Send
                 let temporary_contract_id = offer_channel.temporary_contract_id;
                 let temporary_channel_id = offer_channel.temporary_channel_id;
 
-                // TODO(holzeis): We should send the dlc message last to make sure that we have
-                // finished updating the 10101 meta data before the app responds to the message.
-                event_handler.publish(NodeEvent::SendDlcMessage {
+                event_handler.publish(NodeEvent::StoreDlcMessage {
                     peer: counterparty,
                     msg: Message::Channel(ChannelMessage::Offer(offer_channel)),
                 })?;
@@ -230,9 +228,7 @@ impl<D: BdkStorage, S: TenTenOneStorage + 'static, N: LnDlcStorage + Sync + Send
                     Some(protocol_id),
                 )?;
 
-                // TODO(holzeis): We should send the dlc message last to make sure that we have
-                // finished updating the 10101 meta data before the app responds to the message.
-                event_handler.publish(NodeEvent::SendDlcMessage {
+                event_handler.publish(NodeEvent::StoreDlcMessage {
                     peer: to_secp_pk_30(counterparty),
                     msg: Message::Channel(ChannelMessage::SettleOffer(settle_offer)),
                 })?;
@@ -297,9 +293,7 @@ impl<D: BdkStorage, S: TenTenOneStorage + 'static, N: LnDlcStorage + Sync + Send
                     Some(protocol_id),
                 )?;
 
-                // TODO(holzeis): We should send the dlc message last to make sure that we have
-                // finished updating the 10101 meta data before the app responds to the message.
-                event_handler.publish(NodeEvent::SendDlcMessage {
+                event_handler.publish(NodeEvent::StoreDlcMessage {
                     msg: Message::Channel(ChannelMessage::RenewOffer(renew_offer)),
                     peer: to_secp_pk_30(counterparty_pubkey),
                 })?;

--- a/crates/ln-dlc-node/src/node/dlc_channel.rs
+++ b/crates/ln-dlc-node/src/node/dlc_channel.rs
@@ -98,6 +98,7 @@ impl<D: BdkStorage, S: TenTenOneStorage + 'static, N: LnDlcStorage + Sync + Send
         .await?
     }
 
+    #[cfg(test)]
     pub fn accept_dlc_channel_offer(&self, channel_id: &DlcChannelId) -> Result<()> {
         let channel_id_hex = hex::encode(channel_id);
 

--- a/crates/ln-dlc-node/src/node/dlc_channel.rs
+++ b/crates/ln-dlc-node/src/node/dlc_channel.rs
@@ -90,7 +90,7 @@ impl<D: BdkStorage, S: TenTenOneStorage + 'static, N: LnDlcStorage + Sync + Send
                 event_handler.publish(NodeEvent::StoreDlcMessage {
                     peer: counterparty,
                     msg: Message::Channel(ChannelMessage::Offer(offer_channel)),
-                })?;
+                });
 
                 Ok((temporary_contract_id, temporary_channel_id))
             }
@@ -109,7 +109,7 @@ impl<D: BdkStorage, S: TenTenOneStorage + 'static, N: LnDlcStorage + Sync + Send
         self.event_handler.publish(NodeEvent::SendDlcMessage {
             peer: to_secp_pk_30(counter_party),
             msg: Message::Channel(ChannelMessage::Accept(msg)),
-        })?;
+        });
 
         Ok(())
     }
@@ -186,7 +186,7 @@ impl<D: BdkStorage, S: TenTenOneStorage + 'static, N: LnDlcStorage + Sync + Send
                             msg: Message::Channel(ChannelMessage::CollaborativeCloseOffer(
                                 settle_offer,
                             )),
-                        })?;
+                        });
 
                         anyhow::Ok(())
                     }
@@ -231,7 +231,7 @@ impl<D: BdkStorage, S: TenTenOneStorage + 'static, N: LnDlcStorage + Sync + Send
                 event_handler.publish(NodeEvent::StoreDlcMessage {
                     peer: to_secp_pk_30(counterparty),
                     msg: Message::Channel(ChannelMessage::SettleOffer(settle_offer)),
-                })?;
+                });
 
                 Ok(())
             }
@@ -264,7 +264,7 @@ impl<D: BdkStorage, S: TenTenOneStorage + 'static, N: LnDlcStorage + Sync + Send
         self.event_handler.publish(NodeEvent::SendDlcMessage {
             peer: to_secp_pk_30(counterparty_pk),
             msg: Message::Channel(ChannelMessage::SettleAccept(settle_offer)),
-        })?;
+        });
 
         Ok(())
     }
@@ -296,7 +296,7 @@ impl<D: BdkStorage, S: TenTenOneStorage + 'static, N: LnDlcStorage + Sync + Send
                 event_handler.publish(NodeEvent::StoreDlcMessage {
                     msg: Message::Channel(ChannelMessage::RenewOffer(renew_offer)),
                     peer: to_secp_pk_30(counterparty_pubkey),
-                })?;
+                });
 
                 let offered_contracts = dlc_manager.get_store().get_contract_offers()?;
 

--- a/crates/ln-dlc-node/src/node/event.rs
+++ b/crates/ln-dlc-node/src/node/event.rs
@@ -13,6 +13,8 @@ use tokio::task::spawn_blocking;
 pub enum NodeEvent {
     Connected { peer: PublicKey },
     SendDlcMessage { peer: PublicKey, msg: Message },
+    StoreDlcMessage { peer: PublicKey, msg: Message },
+    SendLastDlcMessage { peer: PublicKey },
     DlcChannelEvent { dlc_channel_event: DlcChannelEvent },
 }
 

--- a/mobile/native/src/emergency_kit.rs
+++ b/mobile/native/src/emergency_kit.rs
@@ -169,12 +169,10 @@ pub fn resend_settle_finalize_message() -> Result<()> {
         reference_id: signed_channel.reference_id,
     }));
 
-    node.inner
-        .event_handler
-        .publish(NodeEvent::SendDlcMessage {
-            peer: coordinator_pubkey,
-            msg: msg.clone(),
-        })?;
+    node.inner.event_handler.publish(NodeEvent::SendDlcMessage {
+        peer: coordinator_pubkey,
+        msg: msg.clone(),
+    });
 
     Ok(())
 }

--- a/mobile/native/src/ln_dlc/node.rs
+++ b/mobile/native/src/ln_dlc/node.rs
@@ -244,16 +244,12 @@ impl Node {
                 if let Some(resp) = resp.clone() {
                     // store dlc message immediately so we do not lose the response if something
                     // goes wrong afterwards.
-                    if let Err(e) = self
-                        .inner
+                    self.inner
                         .event_handler
                         .publish(NodeEvent::StoreDlcMessage {
                             peer: node_id,
                             msg: resp,
-                        })
-                    {
-                        tracing::error!(%node_id, "Failed to send store last dlc message event. Error: {e:#}");
-                    }
+                        });
                 }
 
                 {
@@ -402,7 +398,7 @@ impl Node {
 
             self.inner
                 .event_handler
-                .publish(NodeEvent::SendLastDlcMessage { peer: node_id })?;
+                .publish(NodeEvent::SendLastDlcMessage { peer: node_id });
         }
 
         Ok(())
@@ -584,7 +580,7 @@ impl Node {
         self.inner.event_handler.publish(NodeEvent::SendDlcMessage {
             peer: node_id,
             msg: msg.clone(),
-        })?;
+        });
 
         Ok(())
     }

--- a/mobile/native/src/ln_dlc/node.rs
+++ b/mobile/native/src/ln_dlc/node.rs
@@ -241,6 +241,21 @@ impl Node {
                     }
                 };
 
+                if let Some(resp) = resp.clone() {
+                    // store dlc message immediately so we do not lose the response if something
+                    // goes wrong afterwards.
+                    if let Err(e) = self
+                        .inner
+                        .event_handler
+                        .publish(NodeEvent::StoreDlcMessage {
+                            peer: node_id,
+                            msg: resp,
+                        })
+                    {
+                        tracing::error!(%node_id, "Failed to send store last dlc message event. Error: {e:#}");
+                    }
+                }
+
                 {
                     let mut conn = db::connection()?;
                     db::dlc_messages::DlcMessage::insert(&mut conn, inbound_msg)?;
@@ -377,7 +392,17 @@ impl Node {
         };
 
         if let Some(msg) = resp {
-            self.send_dlc_message(node_id, msg.clone())?;
+            // Everything has been processed successfully, we can safely send the last dlc message,
+            // that has been stored before.
+            tracing::info!(
+                to = %node_id,
+                kind = %dlc_message_name(&msg),
+                "Sending message"
+            );
+
+            self.inner
+                .event_handler
+                .publish(NodeEvent::SendLastDlcMessage { peer: node_id })?;
         }
 
         Ok(())
@@ -556,12 +581,10 @@ impl Node {
             "Sending message"
         );
 
-        self.inner
-            .event_handler
-            .publish(NodeEvent::SendDlcMessage {
-                peer: node_id,
-                msg: msg.clone(),
-            })?;
+        self.inner.event_handler.publish(NodeEvent::SendDlcMessage {
+            peer: node_id,
+            msg: msg.clone(),
+        })?;
 
         Ok(())
     }


### PR DESCRIPTION
The message will firstly be stored into the last outbound dlc messages table. This will ensure as well that once we create a response we won't lose it anymore if something goes wrong afterwards.

Once the processing was successful the last dlc message is sent.

resolves #2127 