### PR TITLE
chore(ci): Remove unused cache step

### DIFF
--- a/.github/workflows/android-fastlane.yml
+++ b/.github/workflows/android-fastlane.yml
@@ -78,11 +78,6 @@ jobs:
           fvm_config: ./mobile/.fvmrc
           working_dir: ./mobile
 
-      - uses: actions/cache@v4
-        id: cache-deps
-        with:
-          key: ${{ runner.os }}-cargo-build-release-android-${{ hashFiles('**/Cargo.lock') }}
-
       - name: Install just
         run: cargo install just --force
 

--- a/.github/workflows/ios-fastlane.yml
+++ b/.github/workflows/ios-fastlane.yml
@@ -104,11 +104,6 @@ jobs:
         run: sudo gem install cocoapods
       - name: Check cocoapods version
         run: /usr/local/bin/pod --version
-        id: cache-deps
-
-      - uses: actions/cache@v4
-        with:
-          key: ${{ runner.os }}-cargo-build-release-ios-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Install just
         run: cargo install just --force


### PR DESCRIPTION
The cache step was missing the path input, but apparently the cache wasn't even used anymore. Removing it hopefully fixes #2302 