### PR TITLE
fix: allow to overwrite flutter version

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -73,7 +73,7 @@ jobs:
 
       - name: Generate FFI bindings
         if: matrix.bin == 'webapp'
-        run: just gen
+        run: just gen beta
 
       - name: Build ${{ matrix.bin }}
         run: cargo build --release --bin ${{ matrix.bin }} --target-dir ./target --target=${{ matrix.target }}

--- a/justfile
+++ b/justfile
@@ -52,11 +52,19 @@ deps-ios:
     cargo install cargo-lipo
     rustup target add aarch64-apple-ios x86_64-apple-ios
 
-gen:
+gen flutter_channel="":
     #!/usr/bin/env bash
     set -euxo pipefail
     cd mobile
-    fvm flutter pub get
+
+    if [ -n "{{flutter_channel}}" ]; then
+        echo "Flutter channel is set to: {{flutter_channel}}"
+        fvm spawn {{flutter_channel}} pub get
+    else
+        echo "Flutter channel is default"
+        fvm flutter pub get
+    fi
+
     RUST_LOG={{ rust_log_for_frb }} flutter_rust_bridge_codegen \
         --rust-input native/src/api.rs \
         --c-output ios/Runner/bridge_generated.h \


### PR DESCRIPTION
This is needed for CI where we can't interact with the terminal and answer the question with `yes`.

For local flutter version and channel use

```
just gen
```

For overwriting the channel use

```
just gen beta
```