### PR TITLE
Overestimate funding TX fee when calculating max usable on-chain balance

### DIFF
--- a/mobile/lib/features/trade/channel_configuration.dart
+++ b/mobile/lib/features/trade/channel_configuration.dart
@@ -141,8 +141,12 @@ class _ChannelConfiguration extends State<ChannelConfiguration> {
 
   @override
   Widget build(BuildContext context) {
+    // We add a buffer because the `fundingTxFee` is just an estimate. This
+    // estimate will undershoot if we end up using more inputs or change
+    // outputs.
+    final Amount fundingTxFeeWithBuffer = Amount(fundingTxFee.sats * 2);
     final maxUsableOnChainBalance =
-        maxOnChainSpending - orderMatchingFees - fundingTxFee - channelFeeReserve;
+        maxOnChainSpending - orderMatchingFees - fundingTxFeeWithBuffer - channelFeeReserve;
     final maxCounterpartyCollateralSats =
         (maxCounterpartyCollateral.sats * counterpartyLeverage).toInt();
 

--- a/mobile/native/src/ln_dlc/node.rs
+++ b/mobile/native/src/ln_dlc/node.rs
@@ -477,7 +477,12 @@ impl Node {
     pub fn process_dlc_channel_offer(&self, channel_id: &DlcChannelId) -> Result<()> {
         // TODO(holzeis): We should check if the offered amounts are expected.
 
-        match self.inner.dlc_manager.accept_channel(channel_id) {
+        match self
+            .inner
+            .dlc_manager
+            .accept_channel(channel_id)
+            .map_err(anyhow::Error::new)
+        {
             Ok((accept_channel, _, _, node_id)) => {
                 self.send_dlc_message(
                     to_secp_pk_30(node_id),
@@ -485,7 +490,7 @@ impl Node {
                 )?;
             }
             Err(e) => {
-                tracing::error!("Failed to accept dlc channel offer. {e:#}");
+                tracing::error!("Failed to accept DLC channel offer: {e:#}");
                 self.reject_dlc_channel_offer(channel_id)?;
             }
         }


### PR DESCRIPTION
Fixes https://github.com/get10101/10101/issues/2309.

With an overestimation we can be sure that the user won't run into problems during coin selection. Obviously they will not be able to use the true maximum, but the difference is small. We can never realistically hit the true maximum anyway.