### PR TITLE
Compute confirmations correctly

### DIFF
--- a/crates/ln-dlc-node/src/on_chain_wallet.rs
+++ b/crates/ln-dlc-node/src/on_chain_wallet.rs
@@ -125,10 +125,8 @@ impl<D> OnChainWallet<D> {
 
         let tip = self.get_tip();
         let n_confirmations = match tip.checked_sub(confirmation_height) {
-            Some(diff) => NonZeroU32::new(diff).unwrap_or({
-                // Being included in a block counts as a confirmation!
-                NonZeroU32::new(1).expect("non-zero value")
-            }),
+            // Being included in a block counts as a confirmation!
+            Some(diff) => NonZeroU32::new(diff + 1).expect("non-zero"),
             None => {
                 // The transaction shouldn't be ahead of the tip!
                 debug_assert!(false);


### PR DESCRIPTION
Fixes #2222.

The original logic was flawed because it would correctly show 1 confirmation when the transaction was included in a block, but it would subsequently deduct 1 confirmation after the second confirmation.

We were already doing this correctly for the `Blockchain` struct, so there is nothing to fix there.