### PR TITLE
Calculate coordinator position PNL correctly

### DIFF
--- a/coordinator/src/db/positions.rs
+++ b/coordinator/src/db/positions.rs
@@ -266,13 +266,13 @@ impl Position {
     pub fn set_position_to_closed_with_pnl(
         conn: &mut PgConnection,
         id: i32,
-        pnl: i64,
+        trader_realized_pnl_sat: i64,
     ) -> QueryResult<crate::position::models::Position> {
         let position: Position = diesel::update(positions::table)
             .filter(positions::id.eq(id))
             .set((
                 positions::position_state.eq(PositionState::Closed),
-                positions::trader_realized_pnl_sat.eq(Some(pnl)),
+                positions::trader_realized_pnl_sat.eq(Some(trader_realized_pnl_sat)),
                 positions::update_timestamp.eq(OffsetDateTime::now_utc()),
             ))
             .get_result(conn)?;


### PR DESCRIPTION
We were using the closing trade trader direction instead of the position direction.