### PR TITLE
fix: Do not publish recover dlc background task if settled closing

### DIFF
--- a/mobile/native/src/dlc_handler.rs
+++ b/mobile/native/src/dlc_handler.rs
@@ -242,6 +242,7 @@ impl DlcHandler {
                         signed_channel.state,
                         SignedChannelState::Established { .. }
                             | SignedChannelState::Settled { .. }
+                            | SignedChannelState::SettledClosing { .. }
                             | SignedChannelState::Closing { .. }
                             | SignedChannelState::CollaborativeCloseOffered { .. }
                     ) {


### PR DESCRIPTION
fixes #2268 