### PR TITLE
chore: Move trading pair to app bar title

### DIFF
--- a/mobile/lib/common/app_bar_wrapper.dart
+++ b/mobile/lib/common/app_bar_wrapper.dart
@@ -1,6 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:get_10101/common/color.dart';
 import 'package:get_10101/common/settings/settings_screen.dart';
+import 'package:get_10101/features/trade/contract_symbol_icon.dart';
+import 'package:get_10101/features/trade/domain/contract_symbol.dart';
+import 'package:get_10101/features/trade/trade_screen.dart';
 import 'package:go_router/go_router.dart';
 
 class AppBarWrapper extends StatelessWidget {
@@ -11,27 +14,38 @@ class AppBarWrapper extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     const appBarHeight = 35.0;
-
+    final String location = GoRouterState.of(context).location;
     final leadingButton = Row(mainAxisSize: MainAxisSize.min, children: [
       IconButton(
         icon: const Icon(Icons.settings),
         tooltip: 'Settings',
         onPressed: () {
-          final String location = GoRouterState.of(context).location;
           GoRouter.of(context).go(SettingsScreen.route, extra: location);
         },
       )
     ]);
 
     return Container(
-        margin: const EdgeInsets.only(left: 10.0, right: 5.0),
-        child: AppBar(
-            elevation: 0,
-            backgroundColor: const Color(0xFFFAFAFA),
-            iconTheme: const IconThemeData(
-                color: tenTenOnePurple,
-                // Without adjustment, the icon appears off-center from the title (logo)
-                size: appBarHeight - 8.0),
-            leading: leadingButton));
+      margin: const EdgeInsets.only(left: 10.0, right: 5.0),
+      child: AppBar(
+          centerTitle: true,
+          elevation: 0,
+          backgroundColor: const Color(0xFFFAFAFA),
+          iconTheme: const IconThemeData(color: tenTenOnePurple, size: appBarHeight - 8.0),
+          leading: leadingButton,
+          title: location == TradeScreen.route
+              ? Row(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                      const ContractSymbolIcon(height: 23, width: 23),
+                      const SizedBox(width: 5),
+                      Text(
+                        ContractSymbol.btcusd.label,
+                        style: const TextStyle(fontSize: 17),
+                      )
+                    ])
+              : null),
+    );
   }
 }

--- a/mobile/lib/features/trade/trade_screen.dart
+++ b/mobile/lib/features/trade/trade_screen.dart
@@ -2,8 +2,6 @@ import 'package:candlesticks/candlesticks.dart';
 import 'package:flutter/material.dart';
 import 'package:get_10101/common/domain/model.dart';
 import 'package:get_10101/features/trade/candlestick_change_notifier.dart';
-import 'package:get_10101/features/trade/contract_symbol_icon.dart';
-import 'package:get_10101/features/trade/domain/contract_symbol.dart';
 import 'package:get_10101/features/trade/domain/direction.dart';
 import 'package:get_10101/features/trade/domain/order.dart';
 import 'package:get_10101/features/trade/domain/position.dart';
@@ -60,10 +58,7 @@ class TradeScreen extends StatelessWidget {
           padding: const EdgeInsets.only(left: 15, right: 15),
           child: Column(
             children: [
-              Row(
-                mainAxisAlignment: MainAxisAlignment.center,
-                children: [const ContractSymbolIcon(), Text(ContractSymbol.btcusd.label)],
-              ),
+              const SizedBox(height: 5),
               Selector<TradeValuesChangeNotifier, Price?>(selector: (_, provider) {
                 return provider.getPrice();
               }, builder: (context, price, child) {
@@ -81,6 +76,7 @@ class TradeScreen extends StatelessWidget {
                   ],
                 );
               }),
+              const SizedBox(height: 5),
               Column(
                 crossAxisAlignment: CrossAxisAlignment.stretch,
                 children: [


### PR DESCRIPTION
I think it looks better if the trading pair is shown in the app bar instead directly below it. It makes the components a little bit better aligned. Happy to drop that PR if you disagree.. (but I hope you don't :))

| before |	after |
|:-:|:-:|
| ![IMG_A3F1E78B6A77-1](https://github.com/get10101/10101/assets/382048/0ddbeacc-3e81-4b2b-a641-eb0799e3cd66) | ![image](https://github.com/get10101/10101/assets/382048/da04d92f-8dac-4b22-b301-0e801cf65d55) |

