### PR TITLE
Remove unneeded Flutter dependency override

### DIFF
--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -596,10 +596,10 @@ packages:
     dependency: "direct main"
     description:
       name: intl
-      sha256: "3bc132a9dbce73a7e4a21a17d06e1878839ffbf975568bc875c60537824b0c4d"
+      sha256: d6f56758b7d3014a48af9701c085700aac781a92a87a62b1333b46d8879661cf
       url: "https://pub.dev"
     source: hosted
-    version: "0.18.1"
+    version: "0.19.0"
   io:
     dependency: transitive
     description:
@@ -1185,10 +1185,10 @@ packages:
     dependency: "direct main"
     description:
       name: timeago
-      sha256: "46c128312ab0ea144b146c0ac6426ddd96810efec2de3fccc425d00179cd8254"
+      sha256: d3204eb4c788214883380253da7f23485320a58c11d145babc82ad16bf4e7764
       url: "https://pub.dev"
     source: hosted
-    version: "3.3.0"
+    version: "3.6.1"
   timezone:
     dependency: transitive
     description:

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
   flutter_native_splash: ^2.2.19
   flutter_svg: ^2.0.5
   provider: ^6.0.5
-  intl: ^0.18.0
+  intl: ^0.19.0
   decimal: ^2.3.2
   slide_to_confirm: ^1.1.0
   path_provider: ^2.0.15
@@ -49,8 +49,6 @@ dependencies:
   screenshot: ^2.1.0
   syncfusion_flutter_sliders: ^24.2.9
   syncfusion_flutter_core: ^24.2.9
-dependency_overrides:
-  intl: ^0.18.0
 dev_dependencies:
   analyzer: ^6.4.1
   flutter_launcher_icons: ^0.13.1

--- a/webapp/frontend/lib/common/scaffold_with_nav.dart
+++ b/webapp/frontend/lib/common/scaffold_with_nav.dart
@@ -136,12 +136,12 @@ class ScaffoldWithNavigationBar extends StatelessWidget {
     return Scaffold(
       body: body,
       bottomNavigationBar: NavigationBar(
-        overlayColor: MaterialStateColor.resolveWith(
-          (Set<MaterialState> states) {
-            if (states.contains(MaterialState.focused)) {
+        overlayColor: WidgetStateColor.resolveWith(
+          (Set<WidgetState> states) {
+            if (states.contains(WidgetState.focused)) {
               return Colors.green;
             }
-            if (states.contains(MaterialState.error)) {
+            if (states.contains(WidgetState.error)) {
               return Colors.red;
             }
             return Colors.grey;

--- a/webapp/frontend/lib/main.dart
+++ b/webapp/frontend/lib/main.dart
@@ -100,12 +100,12 @@ class _TenTenOneAppState extends State<TenTenOneApp> {
           ),
         ),
         inputDecorationTheme: InputDecorationTheme(
-          prefixIconColor: MaterialStateColor.resolveWith(
-            (Set<MaterialState> states) {
-              if (states.contains(MaterialState.focused)) {
+          prefixIconColor: WidgetStateColor.resolveWith(
+            (Set<WidgetState> states) {
+              if (states.contains(WidgetState.focused)) {
                 return tenTenOnePurple;
               }
-              if (states.contains(MaterialState.error)) {
+              if (states.contains(WidgetState.error)) {
                 return Colors.red;
               }
               return Colors.grey;
@@ -115,9 +115,9 @@ class _TenTenOneAppState extends State<TenTenOneApp> {
         elevatedButtonTheme: ElevatedButtonThemeData(
           style: ButtonStyle(
             // this is the button background color
-            backgroundColor: MaterialStateProperty.resolveWith<Color>(
-              (Set<MaterialState> states) {
-                if (states.contains(MaterialState.disabled)) {
+            backgroundColor: WidgetStateProperty.resolveWith<Color>(
+              (Set<WidgetState> states) {
+                if (states.contains(WidgetState.disabled)) {
                   // Return grey color when the button is disabled
                   return Colors.grey;
                 }
@@ -126,8 +126,8 @@ class _TenTenOneAppState extends State<TenTenOneApp> {
               },
             ),
             // this is the button text color
-            foregroundColor: MaterialStateProperty.all<Color>(Colors.white),
-            shape: MaterialStateProperty.all<RoundedRectangleBorder>(
+            foregroundColor: WidgetStateProperty.all<Color>(Colors.white),
+            shape: WidgetStateProperty.all<RoundedRectangleBorder>(
               RoundedRectangleBorder(
                 borderRadius: BorderRadius.circular(5.0),
               ),

--- a/webapp/frontend/lib/wallet/send_screen.dart
+++ b/webapp/frontend/lib/wallet/send_screen.dart
@@ -137,17 +137,16 @@ class _SendScreenState extends State<SendScreen> {
                               }
                             : null,
                         style: ButtonStyle(
-                            padding:
-                                MaterialStateProperty.all<EdgeInsets>(const EdgeInsets.all(15)),
-                            backgroundColor: MaterialStateProperty.resolveWith((states) {
-                              if (states.contains(MaterialState.disabled)) {
+                            padding: WidgetStateProperty.all<EdgeInsets>(const EdgeInsets.all(15)),
+                            backgroundColor: WidgetStateProperty.resolveWith((states) {
+                              if (states.contains(WidgetState.disabled)) {
                                 return tenTenOnePurple.shade100;
                               } else {
                                 return tenTenOnePurple;
                               }
                             }),
-                            shape: MaterialStateProperty.resolveWith((states) {
-                              if (states.contains(MaterialState.disabled)) {
+                            shape: WidgetStateProperty.resolveWith((states) {
+                              if (states.contains(WidgetState.disabled)) {
                                 return RoundedRectangleBorder(
                                   borderRadius: BorderRadius.circular(10.0),
                                   side: BorderSide(color: tenTenOnePurple.shade100),

--- a/webapp/frontend/pubspec.yaml
+++ b/webapp/frontend/pubspec.yaml
@@ -41,7 +41,7 @@ dependencies:
   font_awesome_flutter: 10.6.0
   qr_flutter: ^4.0.0
   bitcoin_icons: ^0.0.4
-  intl: ^0.18.0
+  intl: ^0.19.0
   decimal: ^2.3.3
   logger: ^2.0.2+1
   timeago: ^3.3.0


### PR DESCRIPTION
Since we no longer use `Flogs`, we don't need this dependency override[^1]. It was creating problems in CI[^2] (and locally too I suppose).

[^1]: https://github.com/zubairehman/Flogs/issues/87.
[^2]: https://github.com/get10101/10101/actions/runs/8565195140/job/23472971318?pr=2352#step:9:357.