### PR TITLE
fix: Add reference id to dlc channel

### DIFF
--- a/mobile/lib/common/dlc_channel_change_notifier.dart
+++ b/mobile/lib/common/dlc_channel_change_notifier.dart
@@ -177,7 +177,18 @@ class DlcChannelChangeNotifier extends ChangeNotifier implements Subscriber {
   void notify(bridge.Event event) {
     if (event is bridge.Event_DlcChannelEvent) {
       DlcChannel channel = DlcChannel.fromApi(event.field0);
-      channels[channel.id] = channel;
+
+      if (channels.containsKey(event.field0.referenceId)) {
+        // if we can find the channel on the reference id we can remove it now as we have the correct
+        // channel id
+        channels.remove(event.field0.referenceId);
+      } else if (event.field0.channelState is bridge.ChannelState_Offered) {
+        // if the channel state is in offered we save the channel on the reference id as the channel
+        // id will change.
+        channels[event.field0.referenceId] = channel;
+      } else {
+        channels[channel.id] = channel;
+      }
 
       notifyListeners();
     } else {

--- a/mobile/lib/common/domain/dlc_channel.dart
+++ b/mobile/lib/common/domain/dlc_channel.dart
@@ -12,7 +12,7 @@ class DlcChannel {
 
   static bridge.DlcChannel apiDummy() {
     return const bridge.DlcChannel(
-        dlcChannelId: '', channelState: bridge.ChannelState.failedAccept());
+        dlcChannelId: '', channelState: bridge.ChannelState.failedAccept(), referenceId: '');
   }
 
   static DlcChannel fromApi(bridge.DlcChannel dlcChannel) {

--- a/mobile/native/src/dlc/mod.rs
+++ b/mobile/native/src/dlc/mod.rs
@@ -6,6 +6,7 @@ mod subscriber;
 
 #[derive(Clone, Debug)]
 pub struct DlcChannel {
+    pub reference_id: String,
     pub channel_id: String,
     pub channel_state: ChannelState,
 }
@@ -136,7 +137,13 @@ impl From<&Channel> for DlcChannel {
             },
         };
 
+        let reference_id = value
+            .get_reference_id()
+            .map(hex::encode)
+            .unwrap_or(hex::encode(value.get_id()));
+
         Self {
+            reference_id,
             channel_id: hex::encode(value.get_id()),
             channel_state,
         }

--- a/mobile/native/src/dlc_channel.rs
+++ b/mobile/native/src/dlc_channel.rs
@@ -4,6 +4,7 @@ use flutter_rust_bridge::frb;
 #[frb]
 #[derive(Clone)]
 pub struct DlcChannel {
+    pub reference_id: String,
     pub dlc_channel_id: String,
     pub channel_state: ChannelState,
 }
@@ -69,6 +70,7 @@ pub enum SignedChannelState {
 impl From<dlc::DlcChannel> for DlcChannel {
     fn from(value: dlc::DlcChannel) -> Self {
         DlcChannel {
+            reference_id: value.reference_id,
             dlc_channel_id: value.channel_id,
             channel_state: value.channel_state.into(),
         }


### PR DESCRIPTION
The channel id is unfortunately not unique throughout the whole lifecycle of creating a channel.

The offered channel has a "temporary" channel id, which is different to the channel id. Using the reference id we can link those ids together and ensure that the `OfferedChannel` get removed once the correct channel id is known.

fixes #2358 