### PR TITLE
fix: Subscribe to the websocket after the node has started

### DIFF
--- a/mobile/lib/features/trade/domain/trade_values.dart
+++ b/mobile/lib/features/trade/domain/trade_values.dart
@@ -163,6 +163,9 @@ class TradeValues {
   }
 
   _recalculateMaxQuantity() {
-    maxQuantity = tradeValuesService.calculateMaxQuantity(price: price, leverage: leverage);
+    final quantity = tradeValuesService.calculateMaxQuantity(price: price, leverage: leverage);
+    if (quantity != null) {
+      maxQuantity = quantity;
+    }
   }
 }

--- a/mobile/native/src/api.rs
+++ b/mobile/native/src/api.rs
@@ -20,7 +20,6 @@ use crate::ln_dlc;
 use crate::ln_dlc::get_storage;
 use crate::logger;
 use crate::max_quantity::max_quantity;
-use crate::orderbook;
 use crate::polls;
 use crate::trade::order;
 use crate::trade::order::api::NewOrder;
@@ -522,15 +521,7 @@ fn run_internal(
 
     let (_health, tx) = health::Health::new(runtime);
 
-    orderbook::subscribe(
-        ln_dlc::get_node_key(),
-        runtime,
-        tx.orderbook,
-        fcm_token,
-        tx_websocket,
-    )?;
-
-    ln_dlc::run(runtime)
+    ln_dlc::run(runtime, tx, fcm_token, tx_websocket)
 }
 
 pub fn get_new_address() -> Result<String> {


### PR DESCRIPTION
The max quantity could be set to 0 at startup as it is only recalculated when we get a price update. Before that patch we could have received a price before the node was started, for which the on-chain balance could not get determined. Leaving the max quantity at 0 until the next price is received.

Additionally the max quantity was set to 0 when we only received an ask or bid price.

fixes #2353 