### PR TITLE
Release version 2.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -973,7 +973,7 @@ dependencies = [
 
 [[package]]
 name = "coordinator"
-version = "2.1.0"
+version = "2.1.1"
 dependencies = [
  "anyhow",
  "atty",
@@ -2632,7 +2632,7 @@ dependencies = [
 
 [[package]]
 name = "native"
-version = "2.1.0"
+version = "2.1.1"
 dependencies = [
  "aes-gcm-siv",
  "anyhow",
@@ -5068,7 +5068,7 @@ dependencies = [
 
 [[package]]
 name = "webapp"
-version = "2.1.0"
+version = "2.1.1"
 dependencies = [
  "anyhow",
  "atty",

--- a/coordinator/Cargo.toml
+++ b/coordinator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coordinator"
-version = "2.1.0"
+version = "2.1.1"
 edition = "2021"
 
 [dependencies]

--- a/mobile/native/Cargo.toml
+++ b/mobile/native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "native"
-version = "2.1.0"
+version = "2.1.1"
 edition = "2021"
 
 [lib]

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -1,7 +1,7 @@
 name: get_10101
 description: 10101 combines the power of a self-custodial on-chain and off-chain wallet with the vast world of trading.
 publish_to: none
-version: 2.1.0
+version: 2.1.1
 environment:
   sdk: '>=3.1.2 <4.0.0'
 dependencies:

--- a/webapp/Cargo.toml
+++ b/webapp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "webapp"
-version = "2.1.0"
+version = "2.1.1"
 build = "build.rs"
 edition = "2021"
 


### PR DESCRIPTION
Hi @holzeis!
This PR was created in response to a manual trigger of the release workflow here: https://github.com/get10101/10101/actions/runs/8575214332.
I've bumped the versions in the manifest files in this commit: 76708dc9cd5e5d78a4652f26f4967f883131e591.
Merging this PR will create a GitHub release!