### PR TITLE
fix: ensure filling/filled orders have matching fee

### DIFF
--- a/mobile/native/migrations/2024-04-09-105312_ensure_old_orders_have_matching_fee/down.sql
+++ b/mobile/native/migrations/2024-04-09-105312_ensure_old_orders_have_matching_fee/down.sql
@@ -1,0 +1,3 @@
+-- This file should undo anything in `up.sql`
+-- no need to undo but we need some dummy sql query here;
+select 1 where 1 != 1;

--- a/mobile/native/migrations/2024-04-09-105312_ensure_old_orders_have_matching_fee/up.sql
+++ b/mobile/native/migrations/2024-04-09-105312_ensure_old_orders_have_matching_fee/up.sql
@@ -1,6 +1,6 @@
 -- Your SQL goes here
 update orders
-set matching_fee_sats = quantity / (execution_price * leverage) * 100000000
+set matching_fee_sats = quantity / (execution_price * leverage) * 100000000 * 0.003
 where matching_fee_sats IS NOT NULL
     and execution_price IS NOT NULL
     and matching_fee_sats IS NULL

--- a/mobile/native/migrations/2024-04-09-105312_ensure_old_orders_have_matching_fee/up.sql
+++ b/mobile/native/migrations/2024-04-09-105312_ensure_old_orders_have_matching_fee/up.sql
@@ -1,0 +1,17 @@
+-- Your SQL goes here
+update orders
+set matching_fee_sats = quantity / (execution_price * leverage) * 100000000
+where matching_fee_sats IS NOT NULL
+    and execution_price IS NOT NULL
+    and matching_fee_sats IS NULL
+    and state = 'filling'
+   or 'filled';
+
+-- if one of the values has not been set, we set this matching fee to 0.
+update orders
+set matching_fee_sats = 0
+where matching_fee_sats IS NULL
+   or execution_price IS NULL
+    and matching_fee_sats IS NULL
+    and state = 'filling'
+   or 'filled';


### PR DESCRIPTION
resolves #2382 (hopefully). 

It ensures that this bug cannot happen again and sets the matching fee for existing orders in the db. 
My interpretation is that this error came from the fact that we introduced a new field `matching_fee_sats` which was obviously not set for existing orders.