### PR TITLE
fix: Post correct order direction

### DIFF
--- a/webapp/frontend/lib/trade/create_order_confirmation_dialog.dart
+++ b/webapp/frontend/lib/trade/create_order_confirmation_dialog.dart
@@ -120,7 +120,7 @@ class CreateOrderConfirmationDialog extends StatelessWidget {
                             ElevatedButton(
                               onPressed: () async {
                                 await NewOrderService.postNewOrder(
-                                        leverage, quantity, direction == Direction.long.opposite())
+                                        leverage, quantity, direction == Direction.long)
                                     .then((orderId) {
                                   showSnackBar(
                                       messenger, "Market order created. Order id: $orderId.");


### PR DESCRIPTION
It looks like we always posted an order with the opposite direction from the webapp.

I guess it was a copy and paste error from the close trade dialog.