### PR TITLE
feat: Get rid of buy and sell tabs

### DIFF
--- a/webapp/frontend/lib/common/calculations.dart
+++ b/webapp/frontend/lib/common/calculations.dart
@@ -27,13 +27,17 @@ Amount calculateMargin(Usd quantity, BestQuote quote, Leverage leverage, bool is
 }
 
 Amount calculateLiquidationPrice(
-    Usd quantity, BestQuote quote, Leverage leverage, double maintenanceMargin, bool isLong) {
-  if (isLong && quote.ask != null) {
+    Usd quantity, BestQuote quote, Leverage leverage, double maintenanceMarginRate, bool isLong) {
+  if (isLong && quote.bid != null) {
     return Amount((quote.bid!.asDouble * leverage.asDouble) ~/
-        (leverage.asDouble + 1.0 + (maintenanceMargin * leverage.asDouble)));
-  } else if (!isLong && quote.bid != null) {
+        (leverage.asDouble + 1.0 - (maintenanceMarginRate * leverage.asDouble)));
+  } else if (!isLong && quote.ask != null) {
+    if (leverage.asDouble == 1.0) {
+      return Amount(1048575);
+    }
+
     return Amount((quote.ask!.asDouble * leverage.asDouble) ~/
-        (leverage.asDouble - 1.0 + (maintenanceMargin * leverage.asDouble)));
+        (leverage.asDouble - 1.0 + (maintenanceMarginRate * leverage.asDouble)));
   } else {
     return Amount.zero();
   }

--- a/webapp/frontend/lib/services/trade_constraints_service.dart
+++ b/webapp/frontend/lib/services/trade_constraints_service.dart
@@ -64,6 +64,10 @@ class TradeConstraints {
   @JsonKey(name: 'channel_fee_reserve_sats')
   final int channelFeeReserveSats;
 
+  /// The rate of margin that needs to stay as collateral on the trader side.
+  @JsonKey(name: 'maintenance_margin_rate')
+  final double maintenanceMarginRate;
+
   const TradeConstraints({
     required this.maxLocalMarginSats,
     required this.maxCounterpartyMarginSats,
@@ -73,8 +77,10 @@ class TradeConstraints {
     required this.minMarginSats,
     required this.estimatedFundingTxFeeSats,
     required this.channelFeeReserveSats,
+    required this.maintenanceMarginRate,
   });
 
   factory TradeConstraints.fromJson(Map<String, dynamic> json) => _$TradeConstraintsFromJson(json);
+
   Map<String, dynamic> toJson() => _$TradeConstraintsToJson(this);
 }

--- a/webapp/frontend/lib/services/trade_constraints_service.g.dart
+++ b/webapp/frontend/lib/services/trade_constraints_service.g.dart
@@ -15,6 +15,7 @@ TradeConstraints _$TradeConstraintsFromJson(Map<String, dynamic> json) => TradeC
       minMarginSats: json['min_margin_sats'] as int,
       estimatedFundingTxFeeSats: json['estimated_funding_tx_fee_sats'] as int,
       channelFeeReserveSats: json['channel_fee_reserve_sats'] as int,
+      maintenanceMarginRate: json['maintenance_margin_rate'] as double,
     );
 
 Map<String, dynamic> _$TradeConstraintsToJson(TradeConstraints instance) => <String, dynamic>{
@@ -26,4 +27,5 @@ Map<String, dynamic> _$TradeConstraintsToJson(TradeConstraints instance) => <Str
       'min_margin_sats': instance.minMarginSats,
       'estimated_funding_tx_fee_sats': instance.estimatedFundingTxFeeSats,
       'channel_fee_reserve_sats': instance.channelFeeReserveSats,
+      'maintenance_margin_rate': instance.maintenanceMarginRate,
     };

--- a/webapp/frontend/lib/trade/create_channel_confirmation_dialog.dart
+++ b/webapp/frontend/lib/trade/create_channel_confirmation_dialog.dart
@@ -8,13 +8,13 @@ import 'package:get_10101/common/calculations.dart';
 import 'package:get_10101/common/contract_symbol_icon.dart';
 import 'package:get_10101/common/direction.dart';
 import 'package:get_10101/common/model.dart';
-import 'package:get_10101/common/snack_bar.dart';
 import 'package:get_10101/common/theme.dart';
 import 'package:get_10101/common/value_data_row.dart';
 import 'package:get_10101/services/new_order_service.dart';
 import 'package:get_10101/services/quote_service.dart';
 import 'package:get_10101/services/trade_constraints_service.dart';
 import 'package:get_10101/trade/collateral_slider.dart';
+import 'package:get_10101/trade/create_order_confirmation_dialog.dart';
 import 'package:provider/provider.dart';
 
 class CreateChannelConfirmationDialog extends StatefulWidget {
@@ -304,29 +304,30 @@ class _CreateChannelConfirmationDialogState extends State<CreateChannelConfirmat
                             ElevatedButton(
                               onPressed: notEnoughOnchainBalance
                                   ? null
-                                  : () async {
-                                      await NewOrderService.postNewOrder(
-                                              widget.leverage,
-                                              widget.quantity,
-                                              widget.direction == Direction.long.opposite(),
-                                              channelOpeningParams: ChannelOpeningParams(
-                                                  Amount.max(
-                                                      Amount.zero(),
-                                                      (_counterpartyChannelCollateral -
-                                                          counterpartyMargin)),
-                                                  Amount.max(Amount.zero(),
-                                                      _ownChannelCollateral - widget.margin)))
-                                          .then((orderId) {
-                                        showSnackBar(
-                                            messenger, "Market order created. Order id: $orderId.");
-                                        Navigator.pop(context);
-                                      }).catchError((error) {
-                                        showSnackBar(
-                                            messenger, "Failed creating market order: $error.");
-                                      }).whenComplete(widget.onConfirmation);
+                                  : () {
+                                      Navigator.pop(context);
+                                      showDialog(
+                                          context: context,
+                                          builder: (BuildContext context) {
+                                            return CreateOrderConfirmationDialog(
+                                                direction: widget.direction,
+                                                onConfirmation: () {},
+                                                onCancel: () {},
+                                                bestQuote: widget.bestQuote,
+                                                fee: widget.fee,
+                                                leverage: widget.leverage,
+                                                quantity: widget.quantity,
+                                                channelOpeningParams: ChannelOpeningParams(
+                                                    Amount.max(
+                                                        Amount.zero(),
+                                                        (_counterpartyChannelCollateral -
+                                                            counterpartyMargin)),
+                                                    Amount.max(Amount.zero(),
+                                                        _ownChannelCollateral - widget.margin)));
+                                          });
                                     },
                               style: ElevatedButton.styleFrom(fixedSize: const Size(100, 20)),
-                              child: const Text('Accept'),
+                              child: const Text('Next'),
                             ),
                           ],
                         ),

--- a/webapp/frontend/lib/trade/create_order_confirmation_dialog.dart
+++ b/webapp/frontend/lib/trade/create_order_confirmation_dialog.dart
@@ -120,7 +120,7 @@ class CreateOrderConfirmationDialog extends StatelessWidget {
                             ElevatedButton(
                               onPressed: () async {
                                 await NewOrderService.postNewOrder(
-                                        leverage, quantity, direction == Direction.long.opposite())
+                                        leverage, quantity, direction == Direction.long)
                                     .then((orderId) {
                                   showSnackBar(
                                       messenger, "Market order created. Order id: $orderId.");

--- a/webapp/frontend/lib/trade/trade_screen.dart
+++ b/webapp/frontend/lib/trade/trade_screen.dart
@@ -14,14 +14,7 @@ class TradeScreen extends StatefulWidget {
   State<TradeScreen> createState() => _TradeScreenState();
 }
 
-class _TradeScreenState extends State<TradeScreen> with SingleTickerProviderStateMixin {
-  late final _tabController = TabController(length: 2, vsync: this);
-
-  @override
-  void initState() {
-    super.initState();
-  }
-
+class _TradeScreenState extends State<TradeScreen> {
   @override
   Widget build(BuildContext context) {
     return LayoutBuilder(builder: (context, constraints) {
@@ -39,18 +32,24 @@ class _TradeScreenState extends State<TradeScreen> with SingleTickerProviderStat
         child: Column(
           mainAxisAlignment: MainAxisAlignment.start,
           children: [
-            Row(
+            const Row(
               mainAxisAlignment: MainAxisAlignment.spaceBetween,
               children: [
                 SizedBox(
                   height: 500,
                   width: 350,
-                  child: NewOrderWidget(tabController: _tabController),
+                  child: Column(
+                    mainAxisAlignment: MainAxisAlignment.start,
+                    crossAxisAlignment: CrossAxisAlignment.center,
+                    children: <Widget>[
+                      SizedBox(height: 420, width: 300, child: NewOrderForm()),
+                    ],
+                  ),
                 ),
-                const SizedBox(
+                SizedBox(
                   height: 10,
                 ),
-                const Expanded(
+                Expanded(
                     child:
                         SizedBox(height: 500, child: TradingViewWidgetHtml(cryptoName: "BTCUSD"))),
               ],
@@ -137,7 +136,13 @@ class _TradeScreenState extends State<TradeScreen> with SingleTickerProviderStat
                           borderRadius: BorderRadius.circular(8),
                           color: Colors.grey[100],
                         ),
-                        child: NewOrderWidget(tabController: _tabController),
+                        child: const Column(
+                          mainAxisAlignment: MainAxisAlignment.start,
+                          crossAxisAlignment: CrossAxisAlignment.center,
+                          children: <Widget>[
+                            SizedBox(height: 420, width: 300, child: NewOrderForm()),
+                          ],
+                        ),
                       ),
                       const SizedBox(
                         height: 10,
@@ -159,48 +164,5 @@ class _TradeScreenState extends State<TradeScreen> with SingleTickerProviderStat
                     ],
                   ),
                 ))));
-  }
-}
-
-class NewOrderWidget extends StatelessWidget {
-  const NewOrderWidget({
-    super.key,
-    required TabController tabController,
-  }) : _tabController = tabController;
-
-  final TabController _tabController;
-
-  @override
-  Widget build(BuildContext context) {
-    return Column(
-      mainAxisAlignment: MainAxisAlignment.start,
-      crossAxisAlignment: CrossAxisAlignment.center,
-      children: <Widget>[
-        SizedBox(
-          width: 300,
-          child: TabBar(
-            unselectedLabelColor: Colors.black,
-            labelColor: tenTenOnePurple,
-            controller: _tabController,
-            tabs: const [
-              Tab(
-                text: 'Buy',
-              ),
-              Tab(
-                text: 'Sell',
-              ),
-            ],
-          ),
-        ),
-        SizedBox(
-          height: 420,
-          width: 300,
-          child: TabBarView(
-            controller: _tabController,
-            children: const <Widget>[NewOrderForm(isLong: true), NewOrderForm(isLong: false)],
-          ),
-        ),
-      ],
-    );
   }
 }

--- a/webapp/frontend/lib/trade/trade_screen_order_form.dart
+++ b/webapp/frontend/lib/trade/trade_screen_order_form.dart
@@ -1,4 +1,3 @@
-import 'package:bitcoin_icons/bitcoin_icons.dart';
 import 'package:flutter/material.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 import 'package:get_10101/change_notifier/channel_change_notifier.dart';
@@ -16,12 +15,7 @@ import 'package:get_10101/services/quote_service.dart';
 import 'package:provider/provider.dart';
 
 class NewOrderForm extends StatefulWidget {
-  final bool isLong;
-
-  // for now just to avoid division by 0 errors, later we should introduce a maintenance margin
-  final double maintenanceMargin = 0.001;
-
-  const NewOrderForm({super.key, required this.isLong});
+  const NewOrderForm({super.key});
 
   @override
   State<NewOrderForm> createState() => _NewOrderForm();
@@ -31,30 +25,19 @@ class _NewOrderForm extends State<NewOrderForm> {
   BestQuote? _quote;
   Usd? _quantity = Usd(100);
   Leverage _leverage = Leverage(1);
-  bool isBuy = true;
   DlcChannel? _openChannel;
-
-  final TextEditingController _marginController = TextEditingController();
-  final TextEditingController _liquidationPriceController = TextEditingController();
-  final TextEditingController _latestPriceController = TextEditingController();
 
   @override
   void initState() {
     super.initState();
-    isBuy = widget.isLong;
   }
 
   @override
   Widget build(BuildContext context) {
     TenTenOneTheme theme = Theme.of(context).extension<TenTenOneTheme>()!;
-    Color buyButtonColor = isBuy ? theme.buy : theme.inactiveButtonColor;
-    Color sellButtonColor = isBuy ? theme.inactiveButtonColor : theme.sell;
-    final direction = isBuy ? Direction.long : Direction.short;
 
     _quote = context.watch<QuoteChangeNotifier>().getBestQuote();
     _openChannel = context.watch<ChannelChangeNotifier>().getOpenChannel();
-
-    updateOrderValues();
 
     const spaceBetweenRows = SizedBox(height: 10);
     return Column(
@@ -70,7 +53,6 @@ class _NewOrderForm extends State<NewOrderForm> {
             suffixIcon: const Icon(FontAwesomeIcons.dollarSign),
             onChanged: (quantity) => setState(() {
               _quantity = Usd.parseString(quantity);
-              updateOrderValues();
             }),
           ),
         ),
@@ -80,102 +62,94 @@ class _NewOrderForm extends State<NewOrderForm> {
           child: LeverageSlider(
             onLeverageChanged: (leverage) => setState(() {
               _leverage = Leverage(leverage);
-              updateOrderValues();
             }),
             initialValue: _leverage.asDouble,
           ),
         ),
         spaceBetweenRows,
-        Align(
-          alignment: AlignmentDirectional.centerEnd,
-          child: AmountInputField(
-            enabled: false,
-            label: isBuy ? "Ask Price" : "Bid Price",
-            textAlign: TextAlign.right,
-            suffixIcon: const Icon(FontAwesomeIcons.dollarSign),
-            controller: _latestPriceController,
-          ),
-        ),
         spaceBetweenRows,
-        Align(
-          alignment: AlignmentDirectional.centerEnd,
-          child: AmountInputField(
-            enabled: false,
-            label: "Margin",
-            suffixIcon: const Icon(BitcoinIcons.satoshi_v1),
-            textAlign: TextAlign.right,
-            controller: _marginController,
-          ),
-        ),
-        spaceBetweenRows,
-        Align(
-          alignment: AlignmentDirectional.centerEnd,
-          child: AmountInputField(
-            enabled: false,
-            label: "Liquidation",
-            suffixIcon: const Icon(FontAwesomeIcons.dollarSign),
-            textAlign: TextAlign.right,
-            controller: _liquidationPriceController,
-          ),
-        ),
-        spaceBetweenRows,
-        spaceBetweenRows,
-        Align(
-          alignment: AlignmentDirectional.center,
-          child: ElevatedButton(
-              onPressed: () {
-                Amount? fee = calculateFee(_quantity, _quote, isBuy);
-                showDialog(
-                    context: context,
-                    builder: (BuildContext context) {
-                      if (_openChannel != null) {
-                        return CreateOrderConfirmationDialog(
-                          direction: direction,
-                          onConfirmation: () {},
-                          onCancel: () {},
-                          bestQuote: _quote,
-                          fee: fee,
-                          leverage: _leverage,
-                          quantity: _quantity ?? Usd.zero(),
-                        );
-                      } else {
-                        return CreateChannelConfirmationDialog(
-                            direction: direction,
-                            onConfirmation: () {},
-                            onCancel: () {},
-                            bestQuote: _quote == null
-                                ? BestQuote(ask: Price.zero(), bid: Price.zero(), fee: 0.0)
-                                : _quote!,
-                            fee: fee,
-                            leverage: _leverage,
-                            quantity: _quantity ?? Usd.zero(),
-                            margin: (_quantity != null && _quote != null)
-                                ? calculateMargin(_quantity!, _quote!, _leverage, isBuy)
-                                : Amount.zero());
-                      }
-                    });
-              },
-              style: ElevatedButton.styleFrom(
-                  backgroundColor: isBuy ? buyButtonColor : sellButtonColor,
-                  minimumSize: const Size.fromHeight(50)),
-              child: (isBuy ? const Text("Buy") : const Text("Sell"))),
+        Row(
+          children: [
+            Flexible(
+              child: ElevatedButton(
+                  onPressed: _quote != null
+                      ? () {
+                          Amount? fee = calculateFee(_quantity, _quote, true);
+                          showDialog(
+                              context: context,
+                              builder: (BuildContext context) {
+                                if (_openChannel != null) {
+                                  return CreateOrderConfirmationDialog(
+                                    direction: Direction.long,
+                                    onConfirmation: () {},
+                                    onCancel: () {},
+                                    bestQuote: _quote!,
+                                    fee: fee,
+                                    leverage: _leverage,
+                                    quantity: _quantity ?? Usd.zero(),
+                                  );
+                                } else {
+                                  return CreateChannelConfirmationDialog(
+                                      direction: Direction.long,
+                                      onConfirmation: () {},
+                                      onCancel: () {},
+                                      bestQuote: _quote!,
+                                      fee: fee,
+                                      leverage: _leverage,
+                                      quantity: _quantity ?? Usd.zero(),
+                                      margin: (_quantity != null && _quote != null)
+                                          ? calculateMargin(_quantity!, _quote!, _leverage, true)
+                                          : Amount.zero());
+                                }
+                              });
+                        }
+                      : null,
+                  style: ElevatedButton.styleFrom(
+                      backgroundColor: theme.buy, minimumSize: const Size.fromHeight(50)),
+                  child: const Text("Buy")),
+            ),
+            const SizedBox(width: 5),
+            Flexible(
+              child: ElevatedButton(
+                  onPressed: _quote != null
+                      ? () {
+                          Amount? fee = calculateFee(_quantity, _quote, false);
+                          showDialog(
+                              context: context,
+                              builder: (BuildContext context) {
+                                if (_openChannel != null) {
+                                  return CreateOrderConfirmationDialog(
+                                    direction: Direction.short,
+                                    onConfirmation: () {},
+                                    onCancel: () {},
+                                    bestQuote: _quote!,
+                                    fee: fee,
+                                    leverage: _leverage,
+                                    quantity: _quantity ?? Usd.zero(),
+                                  );
+                                } else {
+                                  return CreateChannelConfirmationDialog(
+                                      direction: Direction.short,
+                                      onConfirmation: () {},
+                                      onCancel: () {},
+                                      bestQuote: _quote!,
+                                      fee: fee,
+                                      leverage: _leverage,
+                                      quantity: _quantity ?? Usd.zero(),
+                                      margin: (_quantity != null)
+                                          ? calculateMargin(_quantity!, _quote!, _leverage, false)
+                                          : Amount.zero());
+                                }
+                              });
+                        }
+                      : null,
+                  style: ElevatedButton.styleFrom(
+                      backgroundColor: theme.sell, minimumSize: const Size.fromHeight(50)),
+                  child: const Text("Sell")),
+            ),
+          ],
         ),
       ],
     );
-  }
-
-  void updateOrderValues() {
-    if (_quantity != null && _quote != null) {
-      _marginController.text = calculateMargin(_quantity!, _quote!, _leverage, isBuy).formatted();
-      _liquidationPriceController.text =
-          calculateLiquidationPrice(_quantity!, _quote!, _leverage, widget.maintenanceMargin, isBuy)
-              .formatted();
-    }
-
-    if (isBuy && _quote != null && _quote!.ask != null) {
-      _latestPriceController.text = _quote!.ask!.formatted();
-    } else if (!isBuy && _quote != null && _quote!.bid != null) {
-      _latestPriceController.text = _quote!.bid!.formatted();
-    }
   }
 }

--- a/webapp/src/api.rs
+++ b/webapp/src/api.rs
@@ -770,6 +770,7 @@ pub struct TradeConstraints {
     pub min_margin_sats: u64,
     pub estimated_funding_tx_fee_sats: u64,
     pub channel_fee_reserve_sats: u64,
+    pub maintenance_margin_rate: f32,
 }
 
 pub async fn get_trade_constraints() -> Result<Json<TradeConstraints>, AppError> {
@@ -785,5 +786,6 @@ pub async fn get_trade_constraints() -> Result<Json<TradeConstraints>, AppError>
         min_margin_sats: trade_constraints.min_margin,
         estimated_funding_tx_fee_sats: fee.to_sat(),
         channel_fee_reserve_sats: channel_fee_reserve.to_sat(),
+        maintenance_margin_rate: trade_constraints.maintenance_margin_rate,
     }))
 }


### PR DESCRIPTION
Since we do not know the direction, the liquidation price and margin has been moved to the confirmation dialog.

Therefore, the new order confirmation dialog has also been introduced when opening a new channel.

|	|	|
|:-:|:-:|
| ![Screenshot 2024-04-09 at 13 18 23](https://github.com/get10101/10101/assets/382048/c611f48e-e5fd-4b8a-882a-5b783f3daca9) |  ![Screenshot 2024-04-09 at 16 05 38](https://github.com/get10101/10101/assets/382048/6802c3c9-97ad-4fde-aa32-d4cfe689088b) |

fixes #2351 
