### PR TITLE
fix: Post correct order direction

### DIFF
--- a/webapp/frontend/lib/trade/create_channel_confirmation_dialog.dart
+++ b/webapp/frontend/lib/trade/create_channel_confirmation_dialog.dart
@@ -305,10 +305,8 @@ class _CreateChannelConfirmationDialogState extends State<CreateChannelConfirmat
                               onPressed: notEnoughOnchainBalance
                                   ? null
                                   : () async {
-                                      await NewOrderService.postNewOrder(
-                                              widget.leverage,
-                                              widget.quantity,
-                                              widget.direction == Direction.long.opposite(),
+                                      await NewOrderService.postNewOrder(widget.leverage,
+                                              widget.quantity, widget.direction == Direction.long,
                                               channelOpeningParams: ChannelOpeningParams(
                                                   Amount.max(
                                                       Amount.zero(),

--- a/webapp/frontend/lib/trade/create_order_confirmation_dialog.dart
+++ b/webapp/frontend/lib/trade/create_order_confirmation_dialog.dart
@@ -120,7 +120,7 @@ class CreateOrderConfirmationDialog extends StatelessWidget {
                             ElevatedButton(
                               onPressed: () async {
                                 await NewOrderService.postNewOrder(
-                                        leverage, quantity, direction == Direction.long.opposite())
+                                        leverage, quantity, direction == Direction.long)
                                     .then((orderId) {
                                   showSnackBar(
                                       messenger, "Market order created. Order id: $orderId.");


### PR DESCRIPTION
It looks like we always posted an order with the opposite direction from the webapp.