### PR TITLE
fix: Ensure the max quantity is always calculated

### DIFF
--- a/mobile/lib/features/trade/domain/trade_values.dart
+++ b/mobile/lib/features/trade/domain/trade_values.dart
@@ -108,7 +108,7 @@ class TradeValues {
     this.margin = margin;
     _recalculateQuantity();
     _recalculateFee();
-    _recalculateMaxQuantity();
+    recalculateMaxQuantity();
   }
 
   updatePriceAndQuantity(double? price) {
@@ -116,7 +116,7 @@ class TradeValues {
     _recalculateQuantity();
     _recalculateLiquidationPrice();
     _recalculateFee();
-    _recalculateMaxQuantity();
+    recalculateMaxQuantity();
   }
 
   updatePriceAndMargin(double? price) {
@@ -124,14 +124,14 @@ class TradeValues {
     _recalculateMargin();
     _recalculateLiquidationPrice();
     _recalculateFee();
-    _recalculateMaxQuantity();
+    recalculateMaxQuantity();
   }
 
   updateLeverage(Leverage leverage) {
     this.leverage = leverage;
     _recalculateMargin();
     _recalculateLiquidationPrice();
-    _recalculateMaxQuantity();
+    recalculateMaxQuantity();
   }
 
   // Can be used to calculate the counterparty's margin, based on their
@@ -162,7 +162,7 @@ class TradeValues {
     fee = tradeValuesService.orderMatchingFee(quantity: quantity, price: price);
   }
 
-  _recalculateMaxQuantity() {
+  recalculateMaxQuantity() {
     final quantity = tradeValuesService.calculateMaxQuantity(price: price, leverage: leverage);
     if (quantity != null) {
       maxQuantity = quantity;

--- a/mobile/lib/features/trade/trade_bottom_sheet_tab.dart
+++ b/mobile/lib/features/trade/trade_bottom_sheet_tab.dart
@@ -54,6 +54,8 @@ class _TradeBottomSheetTabState extends State<TradeBottomSheetTab> {
   @override
   void initState() {
     provider = context.read<TradeValuesChangeNotifier>();
+    provider.updateMaxQuantity();
+
     tentenoneConfigChangeNotifier = context.read<TenTenOneConfigChangeNotifier>();
     positionChangeNotifier = context.read<PositionChangeNotifier>();
 

--- a/mobile/lib/features/trade/trade_value_change_notifier.dart
+++ b/mobile/lib/features/trade/trade_value_change_notifier.dart
@@ -89,6 +89,11 @@ class TradeValuesChangeNotifier extends ChangeNotifier implements Subscriber {
     notifyListeners();
   }
 
+  void updateMaxQuantity() {
+    _sellTradeValues.recalculateMaxQuantity();
+    _buyTradeValues.recalculateMaxQuantity();
+  }
+
   // Orderbook price updates both directions
   void updatePrice(double price, Direction direction) {
     bool update = false;


### PR DESCRIPTION
It's an edge case where the user funds their wallet for the first time and did not receive a new price after the balance was updated. This fix ensures that the max quantity is always calculated when the order view is opened.

fixes #2398 