### PR TITLE
fix: don't truncate sats

### DIFF
--- a/mobile/lib/common/fiat_text.dart
+++ b/mobile/lib/common/fiat_text.dart
@@ -9,7 +9,7 @@ class FiatText extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final formatter = NumberFormat("#,###,##0.00", "en");
+    final formatter = NumberFormat("#,###,##0", "en");
     return Text("\$${formatter.format(amount)}", style: textStyle);
   }
 }

--- a/mobile/lib/features/wallet/send/fee_text.dart
+++ b/mobile/lib/features/wallet/send/fee_text.dart
@@ -26,7 +26,7 @@ class FeeText extends StatelessWidget {
         Wrap(children: [
           Text("~", style: TextStyle(color: Colors.grey.shade700, fontSize: 15)),
           FiatText(
-              amount: fee.total.btc / price,
+              amount: (fee.total.btc / price).toDouble(),
               textStyle: TextStyle(color: Colors.grey.shade700, fontSize: 15))
         ])
       ]),

--- a/mobile/lib/features/wallet/wallet_history_item.dart
+++ b/mobile/lib/features/wallet/wallet_history_item.dart
@@ -442,8 +442,8 @@ class DlcChannelFundingHistoryItem extends WalletHistoryItem {
           value: data.fundingTxid,
           displayWidget: TransactionIdText(data.fundingTxid)),
       HistoryDetail(label: "Confirmations", value: data.confirmations.toString()),
-      HistoryDetail(label: "Channel input", value: formatSats(data.ourChannelInputAmountSats)),
-      HistoryDetail(label: "Funding TX fee estimate", value: formatSats(data.fundingTxFee)),
+      HistoryDetail(label: "Channel input", value: formatSats(data.ourChannelInputAmountSats), truncate: false,),
+      HistoryDetail(label: "Funding TX fee estimate", value: formatSats(data.fundingTxFee), truncate: false,),
     ];
 
     return details;

--- a/mobile/lib/features/wallet/wallet_history_item.dart
+++ b/mobile/lib/features/wallet/wallet_history_item.dart
@@ -442,8 +442,16 @@ class DlcChannelFundingHistoryItem extends WalletHistoryItem {
           value: data.fundingTxid,
           displayWidget: TransactionIdText(data.fundingTxid)),
       HistoryDetail(label: "Confirmations", value: data.confirmations.toString()),
-      HistoryDetail(label: "Channel input", value: formatSats(data.ourChannelInputAmountSats), truncate: false,),
-      HistoryDetail(label: "Funding TX fee estimate", value: formatSats(data.fundingTxFee), truncate: false,),
+      HistoryDetail(
+        label: "Channel input",
+        value: formatSats(data.ourChannelInputAmountSats),
+        truncate: false,
+      ),
+      HistoryDetail(
+        label: "Funding TX fee estimate",
+        value: formatSats(data.fundingTxFee),
+        truncate: false,
+      ),
     ];
 
     return details;


### PR DESCRIPTION
Fixes truncation of sats here: 

<img width="333" alt="image" src="https://github.com/get10101/10101/assets/224613/d26ed475-f492-4f81-b6bd-36ff634d1741">

And overall wherever we are using Fiat values we remove the decimal place, e.g. here: 

<img width="311" alt="image" src="https://github.com/get10101/10101/assets/224613/dcaf9a60-2ccb-401d-a75d-9120b947250c">
