### PR TITLE
chore: Do not show rollover task as failed after timeout

### DIFF
--- a/mobile/lib/features/trade/rollover_change_notifier.dart
+++ b/mobile/lib/features/trade/rollover_change_notifier.dart
@@ -37,12 +37,6 @@ class RolloverChangeNotifier extends ChangeNotifier implements Subscriber {
             return TaskStatusDialog(title: "Catching up!", status: status, content: content);
           },
         );
-
-        // setting the task status to failed after a timeout of 30 seconds.
-        Future.delayed(const Duration(seconds: 30), () {
-          taskStatus = TaskStatus.failed;
-          notifyListeners();
-        });
       } else {
         // notify dialog about changed task status
         notifyListeners();


### PR DESCRIPTION
The task dialog will show the close button if the state will remain in pending after it timed out.