### PR TITLE
feat(webapp): introduce openapi/swagger specification

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -364,15 +364,15 @@ dependencies = [
 
 [[package]]
 name = "axum-login"
-version = "0.13.1"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df12ed681d759ff9c466e7dda53e34bf7f28d20edd3f66a5d9e1173e8eaf0257"
+checksum = "b0fbc0d7bd2577dda9aa9cac096e53b30342725d8eea5798169ff2537a214f45"
 dependencies = [
  "async-trait",
  "axum 0.7.4",
  "form_urlencoded",
- "ring 0.17.7",
  "serde",
+ "subtle",
  "thiserror",
  "tower-cookies",
  "tower-layer",
@@ -408,6 +408,12 @@ name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
+name = "base64"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9475866fec1451be56a3c2400fd081ff546538961565ccb5b7142cbd22bc7a51"
 
 [[package]]
 name = "bdk"
@@ -616,7 +622,7 @@ dependencies = [
  "anyhow",
  "hex",
  "reqwest",
- "ring 0.16.20",
+ "ring",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -633,7 +639,7 @@ dependencies = [
  "async-stream",
  "futures",
  "hex",
- "ring 0.16.20",
+ "ring",
  "serde",
  "serde_json",
  "tokio",
@@ -1390,9 +1396,9 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.10.6"
+version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
@@ -3485,23 +3491,9 @@ dependencies = [
  "libc",
  "once_cell",
  "spin 0.5.2",
- "untrusted 0.7.1",
+ "untrusted",
  "web-sys",
  "winapi",
-]
-
-[[package]]
-name = "ring"
-version = "0.17.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "688c63d65483050968b2a8937f7995f443e27041a0f7700aa59b0822aedebb74"
-dependencies = [
- "cc",
- "getrandom",
- "libc",
- "spin 0.9.8",
- "untrusted 0.9.0",
- "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -3649,7 +3641,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd8d6c9f025a446bc4d18ad9632e69aec8f287aa84499ee335599fabd20c3fd8"
 dependencies = [
  "log",
- "ring 0.16.20",
+ "ring",
  "rustls-webpki 0.101.4",
  "sct",
 ]
@@ -3669,8 +3661,8 @@ version = "0.100.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e98ff011474fa39949b7e5c0428f9b4937eda7da7848bbb947786b7be0b27dab"
 dependencies = [
- "ring 0.16.20",
- "untrusted 0.7.1",
+ "ring",
+ "untrusted",
 ]
 
 [[package]]
@@ -3679,8 +3671,8 @@ version = "0.101.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d93931baf2d282fff8d3a532bbfd7653f734643161b87e3e01e59a04439bf0d"
 dependencies = [
- "ring 0.16.20",
- "untrusted 0.7.1",
+ "ring",
+ "untrusted",
 ]
 
 [[package]]
@@ -3758,8 +3750,8 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
 dependencies = [
- "ring 0.16.20",
- "untrusted 0.7.1",
+ "ring",
+ "untrusted",
 ]
 
 [[package]]
@@ -4125,9 +4117,9 @@ checksum = "5ee073c9e4cd00e28217186dbe12796d692868f432bf2e97ee73bed0c56dfa01"
 
 [[package]]
 name = "subtle"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
+checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
 
 [[package]]
 name = "syn"
@@ -4634,9 +4626,9 @@ checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
 
 [[package]]
 name = "tower-sessions"
-version = "0.10.4"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5dfd131ee564762468250d3dbb8a04f3bc933bcc9bd4f0958ce8acbfb578b73"
+checksum = "c2d9b6f0c4938eed0eefd9cce19319b4bdad10e11ca9d8c3be373ce734bbfd63"
 dependencies = [
  "async-trait",
  "http 1.0.0",
@@ -4652,13 +4644,13 @@ dependencies = [
 
 [[package]]
 name = "tower-sessions-core"
-version = "0.10.4"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bed2607e4db384eed7a932a53c10f64202e73e9a970b6a7410bcbc018fd7c689"
+checksum = "38767064990c327ec1d92bba2576dce0944750e9c9ae021f12ebc72de77ac406"
 dependencies = [
  "async-trait",
  "axum-core 0.4.3",
- "base64 0.21.7",
+ "base64 0.22.0",
  "futures",
  "http 1.0.0",
  "parking_lot 0.12.1",
@@ -4673,9 +4665,9 @@ dependencies = [
 
 [[package]]
 name = "tower-sessions-memory-store"
-version = "0.10.4"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5768acf21f287baf2774468f544e472e30d75ade0d29617046655c463cd4306"
+checksum = "a8b09bbe2c138a9b0ebf307dc6e6a4f7723c59545e0f4fe5e329a89868164ae3"
 dependencies = [
  "async-trait",
  "time",
@@ -4892,12 +4884,6 @@ name = "untrusted"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
-
-[[package]]
-name = "untrusted"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "ureq"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4934,6 +4934,72 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
+name = "utoipa"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "272ebdfbc99111033031d2f10e018836056e4d2c8e2acda76450ec7974269fa7"
+dependencies = [
+ "indexmap 2.0.0",
+ "serde",
+ "serde_json",
+ "utoipa-gen",
+]
+
+[[package]]
+name = "utoipa-gen"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3c9f4d08338c1bfa70dde39412a040a884c6f318b3d09aaaf3437a1e52027fc"
+dependencies = [
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "syn 2.0.48",
+ "uuid",
+]
+
+[[package]]
+name = "utoipa-rapidoc"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e79a75396496e4fe41359375a67e8fcb9c28444cd1cb5e8ac54f47684e64290"
+dependencies = [
+ "axum 0.7.4",
+ "serde",
+ "serde_json",
+ "utoipa",
+]
+
+[[package]]
+name = "utoipa-redoc"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5ab3f28191a1881d747bc7c5205a2e51ce5647c97944ac67c23a3f4f1afae10"
+dependencies = [
+ "axum 0.7.4",
+ "serde",
+ "serde_json",
+ "utoipa",
+]
+
+[[package]]
+name = "utoipa-swagger-ui"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b39868d43c011961e04b41623e050aedf2cc93652562ff7935ce0f819aaf2da"
+dependencies = [
+ "axum 0.7.4",
+ "mime_guess",
+ "regex",
+ "rust-embed",
+ "serde",
+ "serde_json",
+ "utoipa",
+ "zip",
+]
+
+[[package]]
 name = "uuid"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5132,6 +5198,10 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "trade",
+ "utoipa",
+ "utoipa-rapidoc",
+ "utoipa-redoc",
+ "utoipa-swagger-ui",
  "uuid",
 ]
 
@@ -5420,3 +5490,15 @@ name = "zeroize"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a0956f1ba7c7909bfb66c2e9e4124ab6f6482560f6628b5aaeba39207c9aad9"
+
+[[package]]
+name = "zip"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "760394e246e4c28189f19d488c058bf16f564016aefac5d32bb1f3b51d5e9261"
+dependencies = [
+ "byteorder",
+ "crc32fast",
+ "crossbeam-utils",
+ "flate2",
+]

--- a/webapp/Cargo.toml
+++ b/webapp/Cargo.toml
@@ -35,4 +35,8 @@ tower-http = { version = "0.5", features = ["fs", "trace", "cors"] }
 tracing = "0.1.37"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 trade = { path = "../crates/trade" }
+utoipa = { version = "4.2.0", features = ["axum_extras", "decimal_float", "time", "uuid"] }
+utoipa-rapidoc = { version = "3.0.0", features = ["axum"] }
+utoipa-redoc = { version = "3.0.0", features = ["axum"] }
+utoipa-swagger-ui = { version = "6.0.0", features = ["axum"] }
 uuid = { version = "1.3.0", features = ["v4"] }

--- a/webapp/Cargo.toml
+++ b/webapp/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 anyhow = "1"
 atty = "0.2.14"
 axum = { version = "0.7", features = ["tracing"] }
-axum-login = "0.13.1"
+axum-login = "0.15.1"
 bitcoin = "0.30"
 clap = { version = "4", features = ["derive"] }
 commons = { path = "../crates/commons" }

--- a/webapp/src/api.rs
+++ b/webapp/src/api.rs
@@ -102,7 +102,7 @@ pub async fn version() -> Json<Version> {
     path = "/api/newaddress",
     responses(
        (status = 200, description = "Returns an unused on-chain address", body = String)
-)
+    )
 )]
 pub async fn get_unused_address() -> Result<impl IntoResponse, AppError> {
     let address = ln_dlc::get_unused_address()?;
@@ -120,7 +120,7 @@ pub struct Balance {
 get,
 path = "/api/balance",
 responses(
-(status = 200, description = "Returned on- and off-chain balance", body = Balance)
+(status = 200, description = "Returns on-chain and off-chain balance", body = Balance)
 )
 )]
 pub async fn get_balance(
@@ -149,7 +149,7 @@ pub struct OnChainPayment {
 get,
 path = "/api/history",
 responses(
-(status = 200, description = "Retrieved on-chain payment history", body = [OnChainPayment])
+(status = 200, description = "Retrieves on-chain payment history", body = [OnChainPayment])
 )
 )]
 pub async fn get_onchain_payment_history(

--- a/webapp/src/auth.rs
+++ b/webapp/src/auth.rs
@@ -12,6 +12,7 @@ use sha2::Sha256;
 use std::error::Error;
 use std::fmt::Display;
 use std::fmt::Formatter;
+use utoipa::ToSchema;
 
 #[derive(Clone)]
 pub struct Backend {
@@ -23,7 +24,7 @@ pub struct User {
     password: String,
 }
 
-#[derive(Clone, Deserialize)]
+#[derive(Clone, Deserialize, ToSchema)]
 pub struct Credentials {
     pub password: String,
 }
@@ -88,13 +89,21 @@ pub fn router() -> Router {
         .route("/api/logout", get(get::logout))
 }
 
-mod post {
+pub mod post {
     use super::*;
     use axum::http::StatusCode;
     use axum::response::IntoResponse;
     use axum::Json;
     use axum_login::AuthSession;
 
+    #[utoipa::path(
+        post,
+        path = "/api/login",
+        request_body = Credentials,
+        responses(
+        (status = 200, description = "If login was successfully", body = ())
+        )
+    )]
     pub async fn login(
         mut auth_session: AuthSession<Backend>,
         creds: Json<Credentials>,
@@ -115,11 +124,18 @@ mod post {
     }
 }
 
-mod get {
+pub mod get {
     use crate::api::AppError;
     use crate::auth::Backend;
     use axum_login::AuthSession;
 
+    #[utoipa::path(
+        get,
+        path = "/api/logout",
+        responses(
+        (status = 200, description = "If logout was successfully", body = ())
+        )
+    )]
     pub async fn logout(mut auth_session: AuthSession<Backend>) -> Result<(), AppError> {
         auth_session.logout().await?;
         Ok(())

--- a/webapp/src/auth.rs
+++ b/webapp/src/auth.rs
@@ -101,7 +101,7 @@ pub mod post {
         path = "/api/login",
         request_body = Credentials,
         responses(
-        (status = 200, description = "If login was successfully", body = ())
+        (status = 200, description = "If login was successful", body = ())
         )
     )]
     pub async fn login(
@@ -133,7 +133,7 @@ pub mod get {
         get,
         path = "/api/logout",
         responses(
-        (status = 200, description = "If logout was successfully", body = ())
+        (status = 200, description = "If logout was successful", body = ())
         )
     )]
     pub async fn logout(mut auth_session: AuthSession<Backend>) -> Result<(), AppError> {


### PR DESCRIPTION
It is a bit of manual work and boiler plates but once set up it's quite nice. 
I've enabled redoc and swagger UI for now but I guess one of them is enough

    
- OpenApi/Swagger can be found under: http://localhost:3001/swagger-ui
- Redoc can be found under: http://localhost:3001/redoc

Note: our authentication seems to be non-standard, and hence, it does not fit to the Swagger authentication. Imho we should fix this to have a fully working swagger client. Supported authentication schemes can be found [here](https://docs.rs/utoipa/latest/utoipa/openapi/security/enum.SecurityScheme.html) 

Helps with https://github.com/get10101/10101/issues/2284