### PR TITLE
Forward `SubmitOrderErrors` from app to coordinator

### DIFF
--- a/coordinator/migrations/2024-04-16-035239_add_reported_errors/down.sql
+++ b/coordinator/migrations/2024-04-16-035239_add_reported_errors/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE reported_errors;

--- a/coordinator/migrations/2024-04-16-035239_add_reported_errors/up.sql
+++ b/coordinator/migrations/2024-04-16-035239_add_reported_errors/up.sql
@@ -1,0 +1,5 @@
+CREATE TABLE reported_errors (
+    id SERIAL PRIMARY KEY NOT NULL,
+    trader_pubkey TEXT NOT NULL,
+    error TEXT NOT NULL
+);

--- a/coordinator/src/db/mod.rs
+++ b/coordinator/src/db/mod.rs
@@ -12,6 +12,7 @@ pub mod liquidity_options;
 pub mod orders_helper;
 pub mod polls;
 pub mod positions;
+pub mod reported_errors;
 pub mod spendable_outputs;
 pub mod trade_params;
 pub mod trades;

--- a/coordinator/src/db/reported_errors.rs
+++ b/coordinator/src/db/reported_errors.rs
@@ -1,0 +1,27 @@
+use crate::schema::reported_errors;
+use commons::ReportedError;
+use diesel::prelude::*;
+
+#[derive(Insertable, Debug, Clone)]
+#[diesel(table_name = reported_errors)]
+struct NewReportedError {
+    trader_pubkey: String,
+    error: String,
+}
+
+pub(crate) fn insert(conn: &mut PgConnection, error: ReportedError) -> QueryResult<()> {
+    diesel::insert_into(reported_errors::table)
+        .values(NewReportedError::from(error))
+        .execute(conn)?;
+
+    Ok(())
+}
+
+impl From<ReportedError> for NewReportedError {
+    fn from(value: ReportedError) -> Self {
+        Self {
+            trader_pubkey: value.trader_pk.to_string(),
+            error: value.msg,
+        }
+    }
+}

--- a/coordinator/src/routes.rs
+++ b/coordinator/src/routes.rs
@@ -61,6 +61,7 @@ use commons::Message;
 use commons::Poll;
 use commons::PollAnswers;
 use commons::RegisterParams;
+use commons::ReportedError;
 use commons::Restore;
 use commons::UpdateUsernameParams;
 use diesel::r2d2::ConnectionManager;
@@ -164,6 +165,7 @@ pub fn router(
         .route("/api/users", post(post_register))
         .route("/api/users/:trader_pubkey", get(get_user))
         .route("/api/users/nickname", put(update_nickname))
+        .route("/api/report-error", post(post_error))
         // TODO: we should move this back into public once we add signing to this function
         .route(
             "/api/admin/orderbook/orders/:order_id",
@@ -582,4 +584,13 @@ pub async fn get_leaderboard(
     Ok(Json(LeaderBoard {
         entries: leader_board,
     }))
+}
+
+async fn post_error(
+    State(_state): State<Arc<AppState>>,
+    app_error: Json<ReportedError>,
+) -> Result<(), AppError> {
+    tracing::info!(error = app_error.msg, trader_pk = %app_error.trader_pk, "User reported error");
+
+    Ok(())
 }

--- a/coordinator/src/schema.rs
+++ b/coordinator/src/schema.rs
@@ -385,6 +385,14 @@ diesel::table! {
 }
 
 diesel::table! {
+    reported_errors (id) {
+        id -> Int4,
+        trader_pubkey -> Text,
+        error -> Text,
+    }
+}
+
+diesel::table! {
     routing_fees (id) {
         id -> Int4,
         amount_msats -> Int8,
@@ -493,6 +501,7 @@ diesel::allow_tables_to_appear_in_same_query!(
     polls,
     polls_whitelist,
     positions,
+    reported_errors,
     routing_fees,
     spendable_outputs,
     trade_params,

--- a/crates/commons/src/lib.rs
+++ b/crates/commons/src/lib.rs
@@ -11,6 +11,7 @@ mod order;
 mod order_matching_fee;
 mod polls;
 mod price;
+mod reported_error;
 mod rollover;
 mod signature;
 mod trade;
@@ -28,6 +29,7 @@ pub use price::best_bid_price;
 pub use price::best_current_price;
 pub use price::Price;
 pub use price::Prices;
+pub use reported_error::ReportedError;
 pub use rollover::*;
 pub use signature::*;
 

--- a/crates/commons/src/reported_error.rs
+++ b/crates/commons/src/reported_error.rs
@@ -1,0 +1,9 @@
+use bitcoin::secp256k1::PublicKey;
+use serde::Deserialize;
+use serde::Serialize;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ReportedError {
+    pub trader_pk: PublicKey,
+    pub msg: String,
+}

--- a/crates/ln-dlc-node/src/networking/tcp.rs
+++ b/crates/ln-dlc-node/src/networking/tcp.rs
@@ -72,7 +72,7 @@ static ID_COUNTER: AtomicU64 = AtomicU64::new(0);
 
 pub(crate) enum SelectorOutput {
     A(Option<()>),
-    B(Option<()>),
+    B,
     C(tokio::io::Result<usize>),
 }
 
@@ -96,8 +96,8 @@ impl<A: Future<Output = Option<()>> + Unpin, B: Future<Output = Option<()>> + Un
             Poll::Pending => {}
         }
         match Pin::new(&mut self.b).poll(ctx) {
-            Poll::Ready(res) => {
-                return Poll::Ready(SelectorOutput::B(res));
+            Poll::Ready(_) => {
+                return Poll::Ready(SelectorOutput::B);
             }
             Poll::Pending => {}
         }
@@ -130,8 +130,8 @@ impl<
             Poll::Pending => {}
         }
         match Pin::new(&mut self.b).poll(ctx) {
-            Poll::Ready(res) => {
-                return Poll::Ready(SelectorOutput::B(res));
+            Poll::Ready(_) => {
+                return Poll::Ready(SelectorOutput::B);
             }
             Poll::Pending => {}
         }
@@ -253,7 +253,7 @@ impl Connection {
                         break Disconnect::CloseConnection;
                     }
                 }
-                SelectorOutput::B(_) => {}
+                SelectorOutput::B => {}
                 SelectorOutput::C(read) => match read {
                     Ok(0) => break Disconnect::PeerDisconnected,
                     Ok(len) => {

--- a/justfile
+++ b/justfile
@@ -347,7 +347,11 @@ run-coordinator-detached:
 
     just wait-for-electrs-to-be-ready
 
-    echo "Starting (and building) coordinator"
+    echo "Building coordinator first"
+    cargo build --bin coordinator
+
+    echo "Starting coordinator"
+
     just coordinator &> {{coordinator_log_file}} &
     just wait-for-coordinator-to-be-ready
     echo "Coordinator successfully started. You can inspect the logs at {{coordinator_log_file}}"
@@ -359,7 +363,8 @@ run-maker-detached:
 
     echo "Building maker first"
     cargo build --bin dev-maker
-    echo "Starting (and building) maker"
+
+    echo "Starting maker"
 
     just maker &> {{maker_log_file}} &
     just wait-for-maker-to-be-ready

--- a/mobile/native/src/lib.rs
+++ b/mobile/native/src/lib.rs
@@ -5,6 +5,7 @@ pub mod trade;
 
 pub mod api;
 pub mod calculations;
+pub mod channel_trade_constraints;
 pub mod commons;
 pub mod config;
 pub mod dlc;
@@ -15,7 +16,6 @@ pub mod schema;
 pub mod state;
 
 mod backup;
-pub mod channel_trade_constraints;
 mod cipher;
 mod destination;
 mod dlc_channel;
@@ -24,9 +24,11 @@ mod max_quantity;
 mod names;
 mod orderbook;
 mod polls;
+mod report_error;
 mod storage;
 
 pub use ln_dlc::get_maintenance_margin_rate;
+pub use report_error::report_error_to_coordinator;
 
 #[allow(
     clippy::all,

--- a/mobile/native/src/report_error.rs
+++ b/mobile/native/src/report_error.rs
@@ -1,0 +1,38 @@
+use crate::commons::reqwest_client;
+use crate::config;
+use crate::state::get_node;
+use crate::state::get_or_create_tokio_runtime;
+use reqwest::Url;
+
+pub fn report_error_to_coordinator<E: ToString>(error: &E) {
+    let client = reqwest_client();
+    let pk = get_node().inner.info.pubkey;
+
+    let url = Url::parse(&format!("http://{}", config::get_http_endpoint()))
+        .expect("valid URL")
+        .join("/api/report-error")
+        .expect("valid URL");
+
+    let error_string = error.to_string();
+
+    match get_or_create_tokio_runtime() {
+        Ok(runtime) => {
+            runtime.spawn(async move {
+                if let Err(e) = client
+                    .post(url)
+                    .json(&commons::ReportedError {
+                        trader_pk: pk,
+                        msg: error_string,
+                    })
+                    .send()
+                    .await
+                {
+                    tracing::error!("Failed to report error to coordinator: {e}");
+                }
+            });
+        }
+        Err(e) => {
+            tracing::error!("Failed to report error to coordinator, missing runtime: {e}");
+        }
+    }
+}

--- a/mobile/native/src/trade/order/handler.rs
+++ b/mobile/native/src/trade/order/handler.rs
@@ -6,6 +6,7 @@ use crate::event;
 use crate::event::EventInternal;
 use crate::ln_dlc;
 use crate::ln_dlc::is_dlc_channel_confirmed;
+use crate::report_error_to_coordinator;
 use crate::trade::order::orderbook_client::OrderbookClient;
 use crate::trade::order::FailureReason;
 use crate::trade::order::Order;
@@ -63,6 +64,15 @@ pub enum SubmitOrderError {
 }
 
 pub async fn submit_order(
+    order: Order,
+    channel_opening_params: Option<ChannelOpeningParams>,
+) -> Result<Uuid, SubmitOrderError> {
+    submit_order_internal(order, channel_opening_params)
+        .await
+        .inspect_err(report_error_to_coordinator)
+}
+
+pub async fn submit_order_internal(
     order: Order,
     channel_opening_params: Option<ChannelOpeningParams>,
 ) -> Result<Uuid, SubmitOrderError> {

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.76"
+channel = "1.77.2"
 components = ["clippy", "rustfmt"]


### PR DESCRIPTION
Fixes https://github.com/get10101/meta/issues/269.

It's just a start, but we should be able to build on this.

### Example

User runs into this error twice:

![image](https://github.com/get10101/10101/assets/9418575/232c80d6-120c-4c04-af15-e3e1d6756f1f)

Database looks like this:

```
orderbook=# select * from reported_errors;
 id |                           trader_pubkey                            |                            error                            
----+--------------------------------------------------------------------+-------------------------------------------------------------
  1 | 0315bb4b3561fc219c2ace72018600049a556ad788db430318cdeedd76a4281634 | DLC channel not yet confirmed: has 0 confirmations, needs 1
  2 | 0315bb4b3561fc219c2ace72018600049a556ad788db430318cdeedd76a4281634 | DLC channel not yet confirmed: has 0 confirmations, needs 1
(2 rows)
```