### PR TITLE
fix: Calculate max quantity for resizing

### DIFF
--- a/mobile/lib/common/domain/model.dart
+++ b/mobile/lib/common/domain/model.dart
@@ -50,6 +50,10 @@ class Amount {
     return Amount(sats * other.sats);
   }
 
+  bool operator >(Amount other) {
+    return sats > other.sats;
+  }
+
   Amount.parseAmount(String? value) {
     if (value == null || value.isEmpty) {
       _sats = Decimal.zero;
@@ -97,6 +101,26 @@ class Usd {
   Usd.fromDouble(double value) : _usd = Decimal.parse(value.toString());
 
   Usd.parse(dynamic value) : _usd = Decimal.parse(value);
+
+  Usd operator +(Usd other) {
+    return Usd(usd + other.usd);
+  }
+
+  Usd operator -(Usd other) {
+    return Usd(usd - other.usd);
+  }
+
+  bool operator >(Usd other) {
+    return usd > other.usd;
+  }
+
+  bool operator >=(Usd other) {
+    return usd >= other.usd;
+  }
+
+  bool operator <(Usd other) {
+    return usd < other.usd;
+  }
 
   Usd.parseString(String? value) {
     if (value == null || value.isEmpty) {

--- a/mobile/lib/common/dummy_values.dart
+++ b/mobile/lib/common/dummy_values.dart
@@ -1,6 +1,0 @@
-// Assorted dummy values for expedience with prototyping.
-// Eventually we should replace them with the real values from the backend.
-
-// TODO replace dummy funding rate with funding rate from backend
-const double fundingRateBuy = 0.003;
-const double fundingRateSell = -0.003;

--- a/mobile/lib/features/trade/application/trade_values_service.dart
+++ b/mobile/lib/features/trade/application/trade_values_service.dart
@@ -27,12 +27,13 @@ class TradeValuesService {
     }
   }
 
-  Usd? calculateMaxQuantity({required double? price, required Leverage leverage}) {
+  Usd? calculateMaxQuantity(
+      {required double? price, required Leverage leverage, required Direction direction}) {
     if (price == null) {
       return null;
     } else {
-      final quantity =
-          rust.api.calculateMaxQuantity(price: price, traderLeverage: leverage.leverage);
+      final quantity = rust.api.calculateMaxQuantity(
+          price: price, traderLeverage: leverage.leverage, traderDirection: direction.toApi());
 
       return Usd(quantity);
     }

--- a/mobile/lib/features/trade/channel_configuration.dart
+++ b/mobile/lib/features/trade/channel_configuration.dart
@@ -106,9 +106,9 @@ class _ChannelConfiguration extends State<ChannelConfiguration> {
     DlcChannelService dlcChannelService =
         context.read<DlcChannelChangeNotifier>().dlcChannelService;
 
-    maxCounterpartyCollateral = Amount(tradeConstraints.maxCounterpartyMarginSats);
+    maxCounterpartyCollateral = Amount(tradeConstraints.maxCounterpartyBalanceSats);
 
-    maxOnChainSpending = Amount(tradeConstraints.maxLocalMarginSats);
+    maxOnChainSpending = Amount(tradeConstraints.maxLocalBalanceSats);
     counterpartyLeverage = tradeConstraints.coordinatorLeverage;
 
     counterpartyMargin = widget.tradeValues.calculateMargin(Leverage(counterpartyLeverage));

--- a/mobile/lib/features/trade/domain/trade_values.dart
+++ b/mobile/lib/features/trade/domain/trade_values.dart
@@ -15,7 +15,6 @@ class TradeValues {
   Amount? fee; // This fee is an estimate of the order-matching fee.
   Usd? maxQuantity;
 
-  double fundingRate;
   DateTime expiry;
 
   // no final so it can be mocked in tests
@@ -29,7 +28,6 @@ class TradeValues {
     required this.price,
     required this.liquidationPrice,
     required this.fee,
-    required this.fundingRate,
     required this.expiry,
     required this.tradeValuesService,
   });
@@ -38,7 +36,6 @@ class TradeValues {
     required Usd quantity,
     required Leverage leverage,
     required double? price,
-    required double fundingRate,
     required Direction direction,
     required TradeValuesService tradeValuesService,
   }) {
@@ -59,39 +56,6 @@ class TradeValues {
         quantity: quantity,
         leverage: leverage,
         price: price,
-        fundingRate: fundingRate,
-        liquidationPrice: liquidationPrice,
-        fee: fee,
-        expiry: expiry,
-        tradeValuesService: tradeValuesService);
-  }
-
-  factory TradeValues.fromMargin({
-    required Amount? margin,
-    required Leverage leverage,
-    required double? price,
-    required double fundingRate,
-    required Direction direction,
-    required TradeValuesService tradeValuesService,
-  }) {
-    Usd? quantity =
-        tradeValuesService.calculateQuantity(price: price, margin: margin, leverage: leverage);
-    double? liquidationPrice = price != null
-        ? tradeValuesService.calculateLiquidationPrice(
-            price: price, leverage: leverage, direction: direction)
-        : null;
-
-    Amount? fee = tradeValuesService.orderMatchingFee(quantity: quantity, price: price);
-
-    DateTime expiry = tradeValuesService.getExpiryTimestamp();
-
-    return TradeValues(
-        direction: direction,
-        margin: margin,
-        quantity: quantity,
-        leverage: leverage,
-        price: price,
-        fundingRate: fundingRate,
         liquidationPrice: liquidationPrice,
         fee: fee,
         expiry: expiry,

--- a/mobile/lib/features/trade/domain/trade_values.dart
+++ b/mobile/lib/features/trade/domain/trade_values.dart
@@ -163,9 +163,10 @@ class TradeValues {
   }
 
   recalculateMaxQuantity() {
-    final quantity = tradeValuesService.calculateMaxQuantity(price: price, leverage: leverage);
+    final quantity = tradeValuesService.calculateMaxQuantity(
+        price: price, leverage: leverage, direction: direction);
     if (quantity != null) {
-      maxQuantity = quantity;
+      _maxQuantity = quantity;
     }
   }
 }

--- a/mobile/lib/features/trade/submit_order_change_notifier.dart
+++ b/mobile/lib/features/trade/submit_order_change_notifier.dart
@@ -57,8 +57,6 @@ class SubmitOrderChangeNotifier extends ChangeNotifier implements Subscriber {
     notifyListeners();
 
     try {
-      assert(tradeValues.quantity != null, 'Quantity cannot be null when submitting order');
-
       if (channelOpeningParams != null) {
         // TODO(holzeis): The coordinator leverage should not be hard coded here.
         final coordinatorCollateral = tradeValues.calculateMargin(Leverage(2.0));
@@ -70,7 +68,7 @@ class SubmitOrderChangeNotifier extends ChangeNotifier implements Subscriber {
 
         _pendingOrder!.id = await orderService.submitChannelOpeningMarketOrder(
             tradeValues.leverage,
-            tradeValues.quantity!,
+            tradeValues.contracts,
             ContractSymbol.btcusd,
             tradeValues.direction,
             stable,
@@ -78,7 +76,7 @@ class SubmitOrderChangeNotifier extends ChangeNotifier implements Subscriber {
             Amount(traderReserve));
       } else {
         _pendingOrder!.id = await orderService.submitMarketOrder(tradeValues.leverage,
-            tradeValues.quantity!, ContractSymbol.btcusd, tradeValues.direction, stable);
+            tradeValues.contracts, ContractSymbol.btcusd, tradeValues.direction, stable);
       }
 
       _pendingOrder!.state = PendingOrderState.submittedSuccessfully;
@@ -131,6 +129,7 @@ class SubmitOrderChangeNotifier extends ChangeNotifier implements Subscriber {
         fee: fee,
         expiry: position.expiry,
         tradeValuesService: const TradeValuesService());
+    tradeValues.contracts = position.quantity;
     await submitPendingOrder(tradeValues, PositionAction.close,
         pnl: position.unrealizedPnl, stable: stable);
   }

--- a/mobile/lib/features/trade/submit_order_change_notifier.dart
+++ b/mobile/lib/features/trade/submit_order_change_notifier.dart
@@ -121,21 +121,18 @@ class SubmitOrderChangeNotifier extends ChangeNotifier implements Subscriber {
 
   Future<void> closePosition(Position position, double? closingPrice, Amount? fee,
       {bool stable = false}) async {
-    await submitPendingOrder(
-        TradeValues(
-            direction: position.direction.opposite(),
-            margin: position.collateral,
-            quantity: position.quantity,
-            leverage: position.leverage,
-            price: closingPrice,
-            liquidationPrice: position.liquidationPrice,
-            fee: fee,
-            fundingRate: 0,
-            expiry: position.expiry,
-            tradeValuesService: const TradeValuesService()),
-        PositionAction.close,
-        pnl: position.unrealizedPnl,
-        stable: stable);
+    final tradeValues = TradeValues(
+        direction: position.direction.opposite(),
+        margin: position.collateral,
+        quantity: position.quantity,
+        leverage: position.leverage,
+        price: closingPrice,
+        liquidationPrice: position.liquidationPrice,
+        fee: fee,
+        expiry: position.expiry,
+        tradeValuesService: const TradeValuesService());
+    await submitPendingOrder(tradeValues, PositionAction.close,
+        pnl: position.unrealizedPnl, stable: stable);
   }
 
   PendingOrder? get pendingOrder => _pendingOrder;

--- a/mobile/lib/features/trade/trade_bottom_sheet_confirmation.dart
+++ b/mobile/lib/features/trade/trade_bottom_sheet_confirmation.dart
@@ -166,7 +166,6 @@ class TradeBottomSheetConfirmation extends StatelessWidget {
     // Fallback to 0 if we can't get the fee or the margin
     Amount total =
         tradeValues.margin != null ? Amount(tradeValues.margin!.sats).add(reserve) : Amount(0);
-    total = total.add(tradeValues.fee ?? Amount.zero());
 
     Amount pnl = Amount(0);
     if (context.read<PositionChangeNotifier>().positions.containsKey(ContractSymbol.btcusd)) {

--- a/mobile/lib/features/trade/trade_bottom_sheet_tab.dart
+++ b/mobile/lib/features/trade/trade_bottom_sheet_tab.dart
@@ -37,7 +37,8 @@ class TradeBottomSheetTab extends StatefulWidget {
   State<TradeBottomSheetTab> createState() => _TradeBottomSheetTabState();
 }
 
-class _TradeBottomSheetTabState extends State<TradeBottomSheetTab> {
+class _TradeBottomSheetTabState extends State<TradeBottomSheetTab>
+    with AutomaticKeepAliveClientMixin<TradeBottomSheetTab> {
   late final TradeValuesChangeNotifier provider;
   late final TenTenOneConfigChangeNotifier tentenoneConfigChangeNotifier;
   late final PositionChangeNotifier positionChangeNotifier;
@@ -106,6 +107,8 @@ class _TradeBottomSheetTabState extends State<TradeBottomSheetTab> {
 
   @override
   Widget build(BuildContext context) {
+    super.build(context);
+
     TradeTheme tradeTheme = Theme.of(context).extension<TradeTheme>()!;
     DlcChannelChangeNotifier dlcChannelChangeNotifier = context.watch<DlcChannelChangeNotifier>();
 
@@ -384,4 +387,7 @@ class _TradeBottomSheetTabState extends State<TradeBottomSheetTab> {
       ],
     );
   }
+
+  @override
+  bool get wantKeepAlive => true;
 }

--- a/mobile/lib/features/trade/trade_value_change_notifier.dart
+++ b/mobile/lib/features/trade/trade_value_change_notifier.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:get_10101/bridge_generated/bridge_definitions.dart' as bridge;
 import 'package:get_10101/common/application/event_service.dart';
 import 'package:get_10101/common/domain/model.dart';
-import 'package:get_10101/common/dummy_values.dart';
 import 'package:get_10101/features/trade/application/trade_values_service.dart';
 import 'package:get_10101/features/trade/domain/direction.dart';
 import 'package:get_10101/features/trade/domain/leverage.dart';
@@ -35,7 +34,6 @@ class TradeValuesChangeNotifier extends ChangeNotifier implements Subscriber {
             quantity: defaultQuantity,
             leverage: defaultLeverage,
             price: null,
-            fundingRate: fundingRateBuy,
             direction: direction,
             tradeValuesService: tradeValuesService);
       case Direction.short:
@@ -43,7 +41,6 @@ class TradeValuesChangeNotifier extends ChangeNotifier implements Subscriber {
             quantity: defaultQuantity,
             leverage: defaultLeverage,
             price: null,
-            fundingRate: fundingRateSell,
             direction: direction,
             tradeValuesService: tradeValuesService);
     }

--- a/mobile/lib/features/wallet/receive/receive_usdp_dialog.dart
+++ b/mobile/lib/features/wallet/receive/receive_usdp_dialog.dart
@@ -66,7 +66,7 @@ Widget createSubmitWidget(
       bottomText = "Sorry, we couldn't match your order. Please try again later.";
       break;
     case PendingOrderState.orderFilled:
-      var amount = pendingOrder.tradeValues?.quantity?.toInt ?? "0";
+      var amount = pendingOrder.tradeValues?.quantity.toInt ?? "0";
       bottomText = "Congratulations! You received $amount USDP.";
       break;
   }
@@ -80,7 +80,7 @@ Widget createSubmitWidget(
           runSpacing: 10,
           children: [
             ValueDataRow(
-                type: ValueType.fiat, value: pendingOrderValues?.quantity?.toInt, label: "USDP"),
+                type: ValueType.fiat, value: pendingOrderValues?.quantity.toInt, label: "USDP"),
             ValueDataRow(
                 type: ValueType.amount, value: pendingOrderValues?.margin, label: "Margin"),
             ValueDataRow(

--- a/mobile/lib/features/wallet/send/confirm_payment_modal.dart
+++ b/mobile/lib/features/wallet/send/confirm_payment_modal.dart
@@ -113,7 +113,7 @@ class ConfirmPayment extends StatelessWidget {
                           child: Row(
                             mainAxisAlignment: MainAxisAlignment.spaceBetween,
                             children: [
-                              Text("~ \$ ${formatter.format(tradeValues.quantity?.toInt ?? 0)}",
+                              Text("~ \$ ${formatter.format(tradeValues.quantity.toInt)}",
                                   style: const TextStyle(fontSize: 16)),
                               Text(amt.toString(),
                                   style: const TextStyle(fontSize: 16, color: Colors.grey))

--- a/mobile/native/migrations/2024-04-16-144000_add_accumulated_order_matching_fee_to_position/down.sql
+++ b/mobile/native/migrations/2024-04-16-144000_add_accumulated_order_matching_fee_to_position/down.sql
@@ -1,0 +1,2 @@
+-- This file should undo anything in `up.sql`
+ALTER TABLE positions DROP COLUMN "order_matching_fees";

--- a/mobile/native/migrations/2024-04-16-144000_add_accumulated_order_matching_fee_to_position/up.sql
+++ b/mobile/native/migrations/2024-04-16-144000_add_accumulated_order_matching_fee_to_position/up.sql
@@ -1,0 +1,11 @@
+-- Your SQL goes here
+ALTER TABLE positions
+    ADD COLUMN order_matching_fees BIGINT NOT NULL DEFAULT 0;
+
+-- To avoid division by zero.
+UPDATE positions
+SET order_matching_fees = 0 where average_entry_price=0;
+
+-- Before this migration, the taker fee was hard-coded to 0.30%.
+UPDATE positions
+SET order_matching_fees = quantity * (1 / average_entry_price) * 0.0030 where average_entry_price!=0;

--- a/mobile/native/src/api.rs
+++ b/mobile/native/src/api.rs
@@ -340,11 +340,16 @@ pub fn order_matching_fee(quantity: f32, price: f32) -> SyncReturn<u64> {
 
 /// Calculates the max quantity the user is able to trade considering the trader and the coordinator
 /// balances and constraints. Note, this is not an exact maximum, but a very close approximation.
-pub fn calculate_max_quantity(price: f32, trader_leverage: f32) -> SyncReturn<u64> {
-    let price = Decimal::from_f32(price).expect("price to fit in Decimal");
+pub fn calculate_max_quantity(
+    price: f32,
+    trader_leverage: f32,
+    trader_direction: Direction,
+) -> SyncReturn<u64> {
+    let price = Decimal::from_f32(price).expect("to fit");
 
-    let max_quantity = max_quantity(price, trader_leverage).unwrap_or(Decimal::ZERO);
-    let max_quantity = max_quantity.floor().to_u64().expect("to fit into u64");
+    let max_quantity =
+        max_quantity(price, trader_leverage, trader_direction).unwrap_or(Decimal::ZERO);
+    let max_quantity = max_quantity.floor().to_u64().expect("to fit");
 
     SyncReturn(max_quantity)
 }

--- a/mobile/native/src/db/models.rs
+++ b/mobile/native/src/db/models.rs
@@ -414,6 +414,7 @@ pub(crate) struct Position {
     pub expiry_timestamp: i64,
     pub updated_timestamp: i64,
     pub stable: bool,
+    pub order_matching_fees: i64,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, FromSqlRow, AsExpression)]
@@ -499,6 +500,7 @@ impl Position {
             creation_timestamp: _,
             expiry_timestamp,
             updated_timestamp,
+            order_matching_fees,
             ..
         } = position;
 
@@ -513,6 +515,7 @@ impl Position {
                 positions::state.eq(state),
                 positions::collateral.eq(collateral),
                 positions::expiry_timestamp.eq(expiry_timestamp),
+                positions::order_matching_fees.eq(order_matching_fees),
                 positions::updated_timestamp.eq(updated_timestamp),
             ))
             .execute(conn)?;
@@ -549,6 +552,7 @@ impl From<Position> for crate::trade::position::Position {
             created: OffsetDateTime::from_unix_timestamp(value.creation_timestamp)
                 .expect("to fit into unix timestamp"),
             stable: value.stable,
+            order_matching_fees: Amount::from_sat(value.order_matching_fees as u64),
         }
     }
 }
@@ -568,6 +572,7 @@ impl From<crate::trade::position::Position> for Position {
             updated_timestamp: OffsetDateTime::now_utc().unix_timestamp(),
             expiry_timestamp: value.expiry.unix_timestamp(),
             stable: value.stable,
+            order_matching_fees: value.order_matching_fees.to_sat() as i64,
         }
     }
 }

--- a/mobile/native/src/emergency_kit.rs
+++ b/mobile/native/src/emergency_kit.rs
@@ -14,6 +14,7 @@ use anyhow::ensure;
 use anyhow::Context;
 use anyhow::Result;
 use bitcoin::secp256k1::SecretKey;
+use bitcoin::Amount;
 use dlc_manager::channel::signed_channel::SignedChannelState;
 use dlc_manager::contract::Contract;
 use dlc_manager::DlcChannelId;
@@ -134,6 +135,7 @@ pub fn recreate_position() -> Result<()> {
         updated: OffsetDateTime::now_utc(),
         created: OffsetDateTime::now_utc(),
         stable: false,
+        order_matching_fees: order.matching_fee().unwrap_or(Amount::ZERO),
     };
     db::insert_position(position.clone())?;
 

--- a/mobile/native/src/max_quantity.rs
+++ b/mobile/native/src/max_quantity.rs
@@ -139,7 +139,7 @@ mod tests {
         let max_trader_margin = Amount::from_sat(1_048_951);
 
         let trader_leverage = 2.0;
-        let coordinator_levarage = 2.0;
+        let coordinator_leverage = 2.0;
         let order_matching_fee_rate = dec!(0.003);
 
         let max_quantity = calculate_max_quantity(
@@ -147,7 +147,7 @@ mod tests {
             max_coordinator_margin,
             max_trader_margin,
             None,
-            coordinator_levarage,
+            coordinator_leverage,
             trader_leverage,
             order_matching_fee_rate,
             Amount::from_sat(4500),
@@ -166,7 +166,7 @@ mod tests {
         let on_chain_fee_estimate = Amount::from_sat(13_500);
 
         let trader_leverage = 2.0;
-        let coordinator_levarage = 2.0;
+        let coordinator_leverage = 2.0;
         let order_matching_fee_rate = dec!(0.003);
 
         let max_quantity = calculate_max_quantity(
@@ -174,7 +174,7 @@ mod tests {
             max_coordinator_margin,
             max_trader_margin,
             Some(on_chain_fee_estimate),
-            coordinator_levarage,
+            coordinator_leverage,
             trader_leverage,
             order_matching_fee_rate,
             Amount::ZERO,
@@ -216,7 +216,7 @@ mod tests {
         let coordinator_margin = calculations::calculate_margin(
             price.to_f32().unwrap(),
             max_quantity.to_f32().unwrap(),
-            coordinator_levarage,
+            coordinator_leverage,
         );
         assert!(Amount::from_sat(coordinator_margin) < max_coordinator_margin);
     }
@@ -229,7 +229,7 @@ mod tests {
         let max_trader_margin = Amount::from_sat(280_001);
 
         let trader_leverage = 2.0;
-        let coordinator_levarage = 2.0;
+        let coordinator_leverage = 2.0;
         let order_matching_fee_rate = dec!(0.003);
 
         let max_quantity = calculate_max_quantity(
@@ -237,7 +237,7 @@ mod tests {
             max_coordinator_margin,
             max_trader_margin,
             None,
-            coordinator_levarage,
+            coordinator_leverage,
             trader_leverage,
             order_matching_fee_rate,
             Amount::ZERO,
@@ -268,7 +268,7 @@ mod tests {
         let coordinator_margin = calculations::calculate_margin(
             price.to_f32().unwrap(),
             max_quantity.to_f32().unwrap(),
-            coordinator_levarage,
+            coordinator_leverage,
         );
         assert!(
             Amount::from_sat(coordinator_margin) < max_coordinator_margin,
@@ -286,7 +286,7 @@ mod tests {
         let max_trader_margin = Amount::from_sat(280_000);
 
         let trader_leverage = 5.0;
-        let coordinator_levarage = 2.0;
+        let coordinator_leverage = 2.0;
         let order_matching_fee_rate = dec!(0.003);
 
         let max_quantity = calculate_max_quantity(
@@ -294,7 +294,7 @@ mod tests {
             max_coordinator_margin,
             max_trader_margin,
             None,
-            coordinator_levarage,
+            coordinator_leverage,
             trader_leverage,
             order_matching_fee_rate,
             Amount::ZERO,
@@ -325,7 +325,7 @@ mod tests {
         let coordinator_margin = calculations::calculate_margin(
             price.to_f32().unwrap(),
             max_quantity.to_f32().unwrap(),
-            coordinator_levarage,
+            coordinator_leverage,
         );
 
         // Note this is not the max coordinator balance, but the closest we can get.
@@ -343,7 +343,7 @@ mod tests {
         let max_trader_margin = Amount::from_sat(0);
 
         let trader_leverage = 2.0;
-        let coordinator_levarage = 2.0;
+        let coordinator_leverage = 2.0;
         let order_matching_fee_rate = dec!(0.003);
 
         let on_chain_fee_estimate = Amount::from_sat(1515);
@@ -353,7 +353,7 @@ mod tests {
             max_coordinator_margin,
             max_trader_margin,
             Some(on_chain_fee_estimate),
-            coordinator_levarage,
+            coordinator_leverage,
             trader_leverage,
             order_matching_fee_rate,
             Amount::ZERO,
@@ -370,7 +370,7 @@ mod tests {
         let max_trader_margin = Amount::from_btc(1.0).unwrap();
 
         let trader_leverage = 2.0;
-        let coordinator_levarage = 2.0;
+        let coordinator_leverage = 2.0;
         let order_matching_fee_rate = dec!(0.003);
 
         let on_chain_fee_estimate = Amount::from_sat(1515);
@@ -380,7 +380,7 @@ mod tests {
             max_coordinator_margin,
             max_trader_margin,
             Some(on_chain_fee_estimate),
-            coordinator_levarage,
+            coordinator_leverage,
             trader_leverage,
             order_matching_fee_rate,
             Amount::ZERO,
@@ -411,7 +411,7 @@ mod tests {
         let coordinator_margin = calculations::calculate_margin(
             price.to_f32().unwrap(),
             max_quantity.to_f32().unwrap(),
-            coordinator_levarage,
+            coordinator_leverage,
         );
 
         // Note this is not the max coordinator balance, but the closest we can get.

--- a/mobile/native/src/max_quantity.rs
+++ b/mobile/native/src/max_quantity.rs
@@ -34,8 +34,8 @@ pub fn max_quantity(
     };
 
     let max_coordinator_margin =
-        Amount::from_sat(channel_trade_constraints.max_counterparty_margin_sats);
-    let max_trader_margin = Amount::from_sat(channel_trade_constraints.max_local_margin_sats);
+        Amount::from_sat(channel_trade_constraints.max_counterparty_balance_sats);
+    let max_trader_margin = Amount::from_sat(channel_trade_constraints.max_local_balance_sats);
     let order_matching_fee_rate = channel_trade_constraints.order_matching_fee_rate;
     let order_matching_fee_rate =
         Decimal::try_from(order_matching_fee_rate).expect("to fit into decimal");

--- a/mobile/native/src/schema.rs
+++ b/mobile/native/src/schema.rs
@@ -104,6 +104,7 @@ diesel::table! {
         expiry_timestamp -> BigInt,
         updated_timestamp -> BigInt,
         stable -> Bool,
+        order_matching_fees -> BigInt,
     }
 }
 

--- a/mobile/native/src/trade/position/mod.rs
+++ b/mobile/native/src/trade/position/mod.rs
@@ -75,6 +75,8 @@ pub struct Position {
     #[serde(with = "time::serde::rfc3339")]
     pub created: OffsetDateTime,
     pub stable: bool,
+    #[serde(with = "bitcoin::amount::serde::as_sat")]
+    pub order_matching_fees: Amount,
 }
 
 impl Position {
@@ -121,6 +123,7 @@ impl Position {
             updated: now_timestamp,
             created: now_timestamp,
             stable: order.stable,
+            order_matching_fees: matching_fee,
         };
 
         let average_entry_price = decimal_from_f32(average_entry_price);
@@ -279,6 +282,7 @@ impl Position {
 
                     let position = Position {
                         quantity: 0.0,
+                        order_matching_fees: self.order_matching_fees + matching_fee,
                         ..self
                     };
 
@@ -330,6 +334,7 @@ impl Position {
                         updated: now_timestamp,
                         created: self.created,
                         stable: self.stable,
+                        order_matching_fees: self.order_matching_fees + matching_fee,
                     };
 
                     let pnl = {
@@ -441,6 +446,7 @@ impl Position {
 
                     let position = Position {
                         quantity: 0.0,
+                        order_matching_fees: self.order_matching_fees + matching_fee_this_trade,
                         ..self
                     };
 
@@ -505,6 +511,7 @@ impl Position {
                     updated: now_timestamp,
                     created: self.created,
                     stable,
+                    order_matching_fees: self.order_matching_fees + matching_fee,
                 };
 
                 let margin_diff = {
@@ -627,6 +634,7 @@ mod tests {
         assert_eq!(position.position_state, PositionState::Open);
         assert_eq!(position.collateral, 78_125);
         assert!(position.stable);
+        assert_eq!(position.order_matching_fees, Amount::from_sat(1000));
 
         assert_eq!(opening_trade.order_id, order.id);
         assert_eq!(opening_trade.contract_symbol, order.contract_symbol);
@@ -658,6 +666,7 @@ mod tests {
             updated: now,
             created: now,
             stable: false,
+            order_matching_fees: Amount::from_sat(1000),
         };
 
         let order = Order {
@@ -717,6 +726,7 @@ mod tests {
             updated: now,
             created: now,
             stable: false,
+            order_matching_fees: Amount::from_sat(1000),
         };
 
         let order = Order {
@@ -749,6 +759,7 @@ mod tests {
         assert_eq!(updated_position.position_state, PositionState::Open);
         assert_eq!(updated_position.collateral, 20_578);
         assert!(!updated_position.stable);
+        assert_eq!(updated_position.order_matching_fees, Amount::from_sat(2000));
 
         let trade = match trades.as_slice() {
             [trade] => trade,
@@ -785,6 +796,7 @@ mod tests {
             updated: now,
             created: now,
             stable: false,
+            order_matching_fees: Amount::from_sat(1000),
         };
 
         let order = Order {
@@ -823,6 +835,7 @@ mod tests {
         assert_eq!(updated_position.position_state, PositionState::Open);
         assert_eq!(updated_position.collateral, 6_855);
         assert!(!updated_position.stable);
+        assert_eq!(updated_position.order_matching_fees, Amount::from_sat(2000));
 
         let trade = match trades.as_slice() {
             [trade] => trade,
@@ -859,6 +872,7 @@ mod tests {
             updated: now,
             created: now,
             stable: false,
+            order_matching_fees: Amount::from_sat(1000),
         };
 
         let order = Order {
@@ -891,6 +905,7 @@ mod tests {
         assert_eq!(updated_position.position_state, PositionState::Open);
         assert_eq!(updated_position.collateral, 13_736);
         assert!(!updated_position.stable);
+        assert_eq!(updated_position.order_matching_fees, Amount::from_sat(2000));
 
         let (closing_trade, opening_trade) = match trades.as_slice() {
             [closing_trade, opening_trade] => (closing_trade, opening_trade),

--- a/mobile/test/trade_test.dart
+++ b/mobile/test/trade_test.dart
@@ -117,8 +117,8 @@ void main() {
 
     when(channelConstraintsService.getTradeConstraints()).thenAnswer((_) =>
         const bridge.TradeConstraints(
-            maxLocalMarginSats: 20000000000,
-            maxCounterpartyMarginSats: 200000000000,
+            maxLocalBalanceSats: 20000000000,
+            maxCounterpartyBalanceSats: 200000000000,
             coordinatorLeverage: 2,
             minQuantity: 1,
             isChannelBalance: true,
@@ -233,13 +233,15 @@ void main() {
             quantity: anyNamed('quantity'), price: anyNamed('price')))
         .thenReturn(Amount(42));
     when(tradeValueService.calculateMaxQuantity(
-            price: anyNamed('price'), leverage: anyNamed('leverage')))
+            price: anyNamed('price'),
+            leverage: anyNamed('leverage'),
+            direction: anyNamed('direction')))
         .thenReturn(Usd(2500));
 
     when(channelConstraintsService.getTradeConstraints()).thenAnswer((_) =>
         const bridge.TradeConstraints(
-            maxLocalMarginSats: 20000000000,
-            maxCounterpartyMarginSats: 200000000000,
+            maxLocalBalanceSats: 20000000000,
+            maxCounterpartyBalanceSats: 200000000000,
             coordinatorLeverage: 2,
             minQuantity: 1,
             isChannelBalance: true,

--- a/mobile/test/trade_test.dart
+++ b/mobile/test/trade_test.dart
@@ -108,7 +108,9 @@ void main() {
             quantity: anyNamed('quantity'), price: anyNamed('price')))
         .thenReturn(Amount(42));
     when(tradeValueService.calculateMaxQuantity(
-            price: anyNamed('price'), leverage: anyNamed('leverage')))
+            price: anyNamed('price'),
+            leverage: anyNamed('leverage'),
+            direction: anyNamed('direction')))
         .thenReturn(Usd(2500));
 
     when(dlcChannelService.getEstimatedChannelFeeReserve()).thenReturn((Amount(500)));

--- a/webapp/frontend/lib/services/trade_constraints_service.dart
+++ b/webapp/frontend/lib/services/trade_constraints_service.dart
@@ -23,20 +23,20 @@ class TradeConstraintsService {
 
 @JsonSerializable()
 class TradeConstraints {
-  /// Max margin the local party can use
+  /// Max balance the local party can use
   ///
   /// This depends on whether the user has a channel or not. If he has a channel, then his
   /// channel balance is the max amount, otherwise his on-chain balance dictates the max amount
-  @JsonKey(name: 'max_local_margin_sats')
-  final int maxLocalMarginSats;
+  @JsonKey(name: 'max_local_balance_sats')
+  final int maxLocalBalanceSats;
 
   /// Max amount the counterparty is willing to put.
   ///
   /// This depends whether the user has a channel or not, i.e. if he has a channel then the max
   /// amount is what the counterparty has in the channel, otherwise, it's a fixed amount what
   /// the counterparty is willing to provide.
-  @JsonKey(name: 'max_counterparty_margin_sats')
-  final int maxCounterpartyMarginSats;
+  @JsonKey(name: 'max_counterparty_balance_sats')
+  final int maxCounterpartyBalanceSats;
 
   /// The leverage the coordinator will take
   @JsonKey(name: 'coordinator_leverage')
@@ -65,8 +65,8 @@ class TradeConstraints {
   final int channelFeeReserveSats;
 
   const TradeConstraints({
-    required this.maxLocalMarginSats,
-    required this.maxCounterpartyMarginSats,
+    required this.maxLocalBalanceSats,
+    required this.maxCounterpartyBalanceSats,
     required this.coordinatorLeverage,
     required this.minQuantity,
     required this.isChannelBalance,
@@ -76,5 +76,6 @@ class TradeConstraints {
   });
 
   factory TradeConstraints.fromJson(Map<String, dynamic> json) => _$TradeConstraintsFromJson(json);
+
   Map<String, dynamic> toJson() => _$TradeConstraintsToJson(this);
 }

--- a/webapp/frontend/lib/services/trade_constraints_service.g.dart
+++ b/webapp/frontend/lib/services/trade_constraints_service.g.dart
@@ -7,8 +7,8 @@ part of 'trade_constraints_service.dart';
 // **************************************************************************
 
 TradeConstraints _$TradeConstraintsFromJson(Map<String, dynamic> json) => TradeConstraints(
-      maxLocalMarginSats: json['max_local_margin_sats'] as int,
-      maxCounterpartyMarginSats: json['max_counterparty_margin_sats'] as int,
+      maxLocalBalanceSats: json['max_local_balance_sats'] as int,
+      maxCounterpartyBalanceSats: json['max_counterparty_balance_sats'] as int,
       coordinatorLeverage: (json['coordinator_leverage'] as num).toDouble(),
       minQuantity: json['min_quantity'] as int,
       isChannelBalance: json['is_channel_balance'] as bool,
@@ -18,8 +18,8 @@ TradeConstraints _$TradeConstraintsFromJson(Map<String, dynamic> json) => TradeC
     );
 
 Map<String, dynamic> _$TradeConstraintsToJson(TradeConstraints instance) => <String, dynamic>{
-      'max_local_margin_sats': instance.maxLocalMarginSats,
-      'max_counterparty_margin_sats': instance.maxCounterpartyMarginSats,
+      'max_local_balance_sats': instance.maxLocalBalanceSats,
+      'max_counterparty_balance_sats': instance.maxCounterpartyBalanceSats,
       'coordinator_leverage': instance.coordinatorLeverage,
       'min_quantity': instance.minQuantity,
       'is_channel_balance': instance.isChannelBalance,

--- a/webapp/frontend/lib/trade/create_channel_confirmation_dialog.dart
+++ b/webapp/frontend/lib/trade/create_channel_confirmation_dialog.dart
@@ -102,9 +102,9 @@ class _CreateChannelConfirmationDialogState extends State<CreateChannelConfirmat
     Amount counterpartyMargin = calculateMargin(widget.quantity, widget.bestQuote,
         Leverage(coordinatorLeverage), widget.direction == Direction.short);
 
-    final maxCounterpartyCollateral = Amount(tradeConstraints.maxCounterpartyMarginSats);
+    final maxCounterpartyCollateral = Amount(tradeConstraints.maxCounterpartyBalanceSats);
 
-    final maxOnChainSpending = Amount(tradeConstraints.maxLocalMarginSats);
+    final maxOnChainSpending = Amount(tradeConstraints.maxLocalBalanceSats);
     final counterpartyLeverage = tradeConstraints.coordinatorLeverage;
 
     final minMargin = Amount(max(tradeConstraints.minMarginSats, widget.margin.sats));

--- a/webapp/src/api.rs
+++ b/webapp/src/api.rs
@@ -954,8 +954,8 @@ where
 
 #[derive(Serialize, Copy, Clone, Debug, ToSchema)]
 pub struct TradeConstraints {
-    pub max_local_margin_sats: u64,
-    pub max_counterparty_margin_sats: u64,
+    pub max_local_balance_sats: u64,
+    pub max_counterparty_balance_sats: u64,
     pub coordinator_leverage: f32,
     pub min_quantity: u64,
     pub is_channel_balance: bool,
@@ -976,8 +976,8 @@ pub async fn get_trade_constraints() -> Result<Json<TradeConstraints>, AppError>
     let fee = ln_dlc::estimated_funding_tx_fee()?;
     let channel_fee_reserve = ln_dlc::estimated_fee_reserve()?;
     Ok(Json(TradeConstraints {
-        max_local_margin_sats: trade_constraints.max_local_margin_sats,
-        max_counterparty_margin_sats: trade_constraints.max_counterparty_margin_sats,
+        max_local_balance_sats: trade_constraints.max_local_balance_sats,
+        max_counterparty_balance_sats: trade_constraints.max_counterparty_balance_sats,
         coordinator_leverage: trade_constraints.coordinator_leverage,
         min_quantity: trade_constraints.min_quantity,
         is_channel_balance: trade_constraints.is_channel_balance,


### PR DESCRIPTION
Calculates the max quantity considering

- open quantity: Quantity of an existing position of the opposite direction. (needed for fee calculation)
- accumulated order matching fee: As the coordinator is not using already collected order matching fees as collateral for new trades, this has to be deducted from the max coordinator margin.

fixes #2391 
