### PR TITLE
fix: Calculate liquidation price from opposite direction if the position is reduced

### DIFF
--- a/mobile/lib/common/domain/model.dart
+++ b/mobile/lib/common/domain/model.dart
@@ -122,6 +122,13 @@ class Usd {
     return usd < other.usd;
   }
 
+  @override
+  bool operator ==(Object other) =>
+      other is Usd && other.runtimeType == runtimeType && other._usd == _usd;
+
+  @override
+  int get hashCode => _usd.hashCode;
+
   Usd.parseString(String? value) {
     if (value == null || value.isEmpty) {
       _usd = Decimal.zero;

--- a/mobile/lib/features/trade/domain/trade_values.dart
+++ b/mobile/lib/features/trade/domain/trade_values.dart
@@ -86,6 +86,7 @@ class TradeValues {
     this.contracts = contracts;
     _recalculateMargin();
     _recalculateFee();
+    _recalculateLiquidationPrice();
   }
 
   updateMargin(Amount margin) {
@@ -137,9 +138,16 @@ class TradeValues {
   }
 
   _recalculateLiquidationPrice() {
-    double? liquidationPrice = tradeValuesService.calculateLiquidationPrice(
-        price: price, leverage: leverage, direction: direction);
-    this.liquidationPrice = liquidationPrice;
+    if (quantity.usd == 0) {
+      // the user is only reducing his position hence we need to calculate the liquidation price based on the opposite direction.
+      double? liquidationPrice = tradeValuesService.calculateLiquidationPrice(
+          price: price, leverage: leverage, direction: direction.opposite());
+      this.liquidationPrice = liquidationPrice;
+    } else {
+      double? liquidationPrice = tradeValuesService.calculateLiquidationPrice(
+          price: price, leverage: leverage, direction: direction);
+      this.liquidationPrice = liquidationPrice;
+    }
   }
 
   _recalculateFee() {

--- a/mobile/lib/features/trade/domain/trade_values.dart
+++ b/mobile/lib/features/trade/domain/trade_values.dart
@@ -58,10 +58,8 @@ class TradeValues {
     Amount? margin =
         tradeValuesService.calculateMargin(price: price, quantity: quantity, leverage: leverage);
 
-    double? liquidationPrice = price != null
-        ? tradeValuesService.calculateLiquidationPrice(
-            price: price, leverage: leverage, direction: direction)
-        : null;
+    double? liquidationPrice = tradeValuesService.calculateLiquidationPrice(
+        price: price, leverage: leverage, direction: direction);
 
     Amount? fee = tradeValuesService.orderMatchingFee(quantity: quantity, price: price);
 

--- a/mobile/lib/features/trade/domain/trade_values.dart
+++ b/mobile/lib/features/trade/domain/trade_values.dart
@@ -5,6 +5,10 @@ import 'package:get_10101/features/trade/domain/leverage.dart';
 
 class TradeValues {
   /// Potential quantity already in an open position
+  ///
+  /// Note the open quantity is only set for the opposite direction.
+  /// So if you'd go 100 long the open quantity would be 0 for the long direction and 100 for the
+  /// short direction.
   Usd _openQuantity = Usd.zero();
 
   get openQuantity => _openQuantity;

--- a/mobile/lib/features/trade/trade_bottom_sheet_confirmation.dart
+++ b/mobile/lib/features/trade/trade_bottom_sheet_confirmation.dart
@@ -307,8 +307,8 @@ class TradeBottomSheetConfirmation extends StatelessWidget {
                             : const SizedBox(height: 0),
                       ],
                     ),
-                    !isClose ? const Divider() : const SizedBox(height: 0),
-                    !isClose
+                    !isClose && !isReduce ? const Divider() : const SizedBox(height: 0),
+                    !isClose && !isReduce
                         ? ValueDataRow(type: ValueType.amount, value: total, label: "Total")
                         : const SizedBox(height: 0),
                   ],

--- a/mobile/lib/features/trade/trade_bottom_sheet_confirmation.dart
+++ b/mobile/lib/features/trade/trade_bottom_sheet_confirmation.dart
@@ -141,6 +141,8 @@ class TradeBottomSheetConfirmation extends StatelessWidget {
 
     bool isClose = tradeAction == TradeAction.closePosition;
     bool isChannelOpen = tradeAction == TradeAction.openChannel;
+    bool isReduce = tradeAction == TradeAction.reducePosition;
+    bool isChangedDirection = tradeAction == TradeAction.changeDirection;
 
     final traderCollateral1 = traderCollateral ?? Amount.zero();
 
@@ -244,19 +246,20 @@ class TradeBottomSheetConfirmation extends StatelessWidget {
                                 label: 'Market Price')
                             : ValueDataRow(
                                 type: ValueType.amount, value: tradeValues.margin, label: 'Margin'),
-                        isClose
-                            ? ValueDataRow(
-                                type: ValueType.amount,
-                                value: pnl,
-                                label: 'Unrealized P/L',
-                                valueTextStyle: dataRowStyle.apply(
-                                    color:
-                                        pnl.sats.isNegative ? tradeTheme.loss : tradeTheme.profit))
-                            : ValueDataRow(
-                                type: ValueType.fiat,
-                                value: tradeValues.liquidationPrice ?? 0.0,
-                                label: 'Liquidation Price',
-                              ),
+                        if (isReduce || isClose || isChangedDirection)
+                          ValueDataRow(
+                              type: ValueType.amount,
+                              value: pnl,
+                              label: 'Unrealized P/L',
+                              valueTextStyle: dataRowStyle.apply(
+                                  color:
+                                      pnl.sats.isNegative ? tradeTheme.loss : tradeTheme.profit)),
+                        if (!isClose)
+                          ValueDataRow(
+                            type: ValueType.fiat,
+                            value: tradeValues.liquidationPrice ?? 0.0,
+                            label: 'Liquidation Price',
+                          ),
                         ValueDataRow(
                           type: ValueType.amount,
                           value: orderMatchingFee,

--- a/mobile/lib/features/trade/trade_bottom_sheet_confirmation.dart
+++ b/mobile/lib/features/trade/trade_bottom_sheet_confirmation.dart
@@ -76,7 +76,7 @@ tradeBottomSheetConfirmation(
             },
             child: SingleChildScrollView(
               child: SizedBox(
-                  height: TradeAction.closePosition == tradeAction ? 330 : 500,
+                  height: TradeAction.closePosition == tradeAction ? 380 : 500,
                   child: TradeBottomSheetConfirmation(
                     direction: direction,
                     sliderButtonKey: sliderButtonKey,

--- a/mobile/lib/features/trade/trade_bottom_sheet_confirmation.dart
+++ b/mobile/lib/features/trade/trade_bottom_sheet_confirmation.dart
@@ -239,13 +239,14 @@ class TradeBottomSheetConfirmation extends StatelessWidget {
                               type: ValueType.date,
                               value: tradeValues.expiry.toLocal(),
                               label: 'Expiry'),
-                        isClose
-                            ? ValueDataRow(
-                                type: ValueType.fiat,
-                                value: tradeValues.price ?? 0.0,
-                                label: 'Market Price')
-                            : ValueDataRow(
-                                type: ValueType.amount, value: tradeValues.margin, label: 'Margin'),
+                        if (isClose)
+                          ValueDataRow(
+                              type: ValueType.fiat,
+                              value: tradeValues.price ?? 0.0,
+                              label: 'Market Price'),
+                        if (!isReduce)
+                          ValueDataRow(
+                              type: ValueType.amount, value: tradeValues.margin, label: 'Margin'),
                         if (isReduce || isClose || isChangedDirection)
                           ValueDataRow(
                               type: ValueType.amount,

--- a/mobile/lib/features/trade/trade_bottom_sheet_confirmation.dart
+++ b/mobile/lib/features/trade/trade_bottom_sheet_confirmation.dart
@@ -195,6 +195,10 @@ class TradeBottomSheetConfirmation extends StatelessWidget {
                     Wrap(
                       runSpacing: 5,
                       children: [
+                        ValueDataRow(
+                            type: ValueType.fiat,
+                            value: tradeValues.contracts.asDouble(),
+                            label: "Quantity"),
                         if (!isClose)
                           ValueDataRow(
                               type: ValueType.date,

--- a/mobile/lib/features/trade/trade_bottom_sheet_tab.dart
+++ b/mobile/lib/features/trade/trade_bottom_sheet_tab.dart
@@ -351,8 +351,13 @@ class _TradeBottomSheetTabState extends State<TradeBottomSheetTab>
                     selector: (_, provider) =>
                         provider.fromDirection(direction).liquidationPrice ?? 0.0,
                     builder: (context, liquidationPrice, child) {
-                      return ValueDataRow(
-                          type: ValueType.fiat, value: liquidationPrice, label: "Liquidation:");
+                      if (tradeValues.openQuantity == tradeValues.contracts) {
+                        // the position would be closed at this quantity. It does not make sense to show the liquidation price.
+                        return const SizedBox(width: 135, child: Text('Liquidation: n/a'));
+                      } else {
+                        return ValueDataRow(
+                            type: ValueType.fiat, value: liquidationPrice, label: "Liquidation:");
+                      }
                     }),
                 const SizedBox(width: 55),
                 Selector<TradeValuesChangeNotifier, Amount>(

--- a/mobile/lib/features/trade/trade_bottom_sheet_tab.dart
+++ b/mobile/lib/features/trade/trade_bottom_sheet_tab.dart
@@ -149,7 +149,7 @@ class _TradeBottomSheetTabState extends State<TradeBottomSheetTab>
                     if (_formKey.currentState!.validate()) {
                       final submitOrderChangeNotifier = context.read<SubmitOrderChangeNotifier>();
 
-                      final tradeAction = hasChannel ? TradeAction.trade : TradeAction.openChannel;
+                      final tradeAction = getTradeAction(tradeValues, hasChannel);
 
                       switch (tradeAction) {
                         case TradeAction.openChannel:
@@ -173,7 +173,9 @@ class _TradeBottomSheetTabState extends State<TradeBottomSheetTab>
                             break;
                           }
                         case TradeAction.trade:
+                        case TradeAction.reducePosition:
                         case TradeAction.closePosition:
+                        case TradeAction.changeDirection:
                           tradeBottomSheetConfirmation(
                             context: context,
                             direction: direction,
@@ -396,4 +398,26 @@ class _TradeBottomSheetTabState extends State<TradeBottomSheetTab>
 
   @override
   bool get wantKeepAlive => true;
+
+  /// Returns the trade action depending on the trade values and if a channel exists
+  TradeAction getTradeAction(TradeValues tradeValues, bool hasChannel) {
+    if (!hasChannel) {
+      return TradeAction.openChannel;
+    }
+
+    if (tradeValues.openQuantity == tradeValues.contracts) {
+      return TradeAction.closePosition;
+    }
+
+    if (tradeValues.openQuantity > tradeValues.contracts) {
+      return TradeAction.reducePosition;
+    }
+
+    if (tradeValues.openQuantity != Usd.zero() &&
+        tradeValues.openQuantity < tradeValues.contracts) {
+      return TradeAction.changeDirection;
+    }
+
+    return TradeAction.trade;
+  }
 }


### PR DESCRIPTION
fixes #2403 

Additionally I reworked the confirmation screen a bit. Nothing fundamental, but tweaked a little bit what information is shown depending on the corresponding trade action.

https://github.com/get10101/10101/assets/382048/a06b0121-7122-4263-b410-14578368ba0b