### PR TITLE
Do not hog `chain_monitor` lock during `periodic_check`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,11 +21,11 @@ resolver = "2"
 # We are using our own fork of `rust-dlc` at least until we can drop all the LN-DLC features. Also,
 # `p2pderivatives/rust-dlc#master` is missing certain patches that can only be found in the LN-DLC
 # branch.
-dlc-manager = { git = "https://github.com/get10101/rust-dlc", rev = "a569d3e" }
-dlc-messages = { git = "https://github.com/get10101/rust-dlc", rev = "a569d3e" }
-dlc = { git = "https://github.com/get10101/rust-dlc", rev = "a569d3e" }
-p2pd-oracle-client = { git = "https://github.com/get10101/rust-dlc", rev = "a569d3e" }
-dlc-trie = { git = "https://github.com/get10101/rust-dlc", rev = "a569d3e" }
+dlc-manager = { git = "https://github.com/get10101/rust-dlc", rev = "8d9920d" }
+dlc-messages = { git = "https://github.com/get10101/rust-dlc", rev = "8d9920d" }
+dlc = { git = "https://github.com/get10101/rust-dlc", rev = "8d9920d" }
+p2pd-oracle-client = { git = "https://github.com/get10101/rust-dlc", rev = "8d9920d" }
+dlc-trie = { git = "https://github.com/get10101/rust-dlc", rev = "8d9920d" }
 
 # We should usually track the `p2pderivatives/split-tx-experiment[-10101]` branch. For now we depend
 # on a special fork which removes a panic in `rust-lightning`.


### PR DESCRIPTION
Fixes #2377.

The fix is in `rust-dlc`, hence the dependency update. See https://github.com/p2pderivatives/rust-dlc/commit/974c56b.