### PR TITLE
fix: Set quantity to zero when initiation order view with open position

### DIFF
--- a/mobile/lib/features/trade/trade_bottom_sheet_tab.dart
+++ b/mobile/lib/features/trade/trade_bottom_sheet_tab.dart
@@ -86,7 +86,7 @@ class _TradeBottomSheetTabState extends State<TradeBottomSheetTab>
       final tradeValues = provider.fromDirection(position.direction.opposite());
 
       tradeValues.openQuantity = position.quantity;
-      tradeValues.updateQuantity(tradeValues.maxQuantity - tradeValues.openQuantity);
+      tradeValues.updateQuantity(Usd.zero());
 
       // by default the contracts are set to the amount of open contracts of the current position.
       tradeValues.updateContracts(tradeValues.openQuantity);


### PR DESCRIPTION
If we don't have a position we default the quantity to the max quantity. If we have an open position we default the quantity to zero because the contracts will be defaulted to the open quantity.

The behaviour should be that in case of an open position the default contracts on the opposite direction is to close the position.

fixes #2465 