### PR TITLE
bump: outdated java version

### DIFF
--- a/.github/workflows/android-fastlane.yml
+++ b/.github/workflows/android-fastlane.yml
@@ -92,7 +92,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: "temurin"
-          java-version: "11.x"
+          java-version: "17.x"
           cache: "gradle"
 
       - name: Install fastlane


### PR DESCRIPTION
our CI started failing because of

 Error: LinkageError occurred while loading main class com.android.sdklib.tool.sdkmanager.SdkManagerCli
	java.lang.UnsupportedClassVersionError: com/android/sdklib/tool/sdkmanager/SdkManagerCli has been compiled by a more recent version of the Java Runtime (class file version 61.0), this version of the Java Runtime only recognizes class file versions up to 55.0

which might be because of an outdated java version

fix: #2479 