### PR TITLE
feat: add version and timestamp to error logs

### DIFF
--- a/coordinator/migrations/2024-05-09-051816_add_timestamp_and_version_to_error_logs/down.sql
+++ b/coordinator/migrations/2024-05-09-051816_add_timestamp_and_version_to_error_logs/down.sql
@@ -1,0 +1,4 @@
+ALTER TABLE reported_errors
+    DROP COLUMN timestamp;
+ALTER TABLE reported_errors
+    DROP COLUMN version;

--- a/coordinator/migrations/2024-05-09-051816_add_timestamp_and_version_to_error_logs/up.sql
+++ b/coordinator/migrations/2024-05-09-051816_add_timestamp_and_version_to_error_logs/up.sql
@@ -1,0 +1,5 @@
+-- Your SQL goes here
+ALTER TABLE reported_errors
+    ADD COLUMN timestamp TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP;
+ALTER TABLE reported_errors
+    ADD COLUMN version TEXT NOT NULL DEFAULT '<2.3.1';

--- a/coordinator/src/db/reported_errors.rs
+++ b/coordinator/src/db/reported_errors.rs
@@ -7,6 +7,7 @@ use xxi_node::commons::ReportedError;
 struct NewReportedError {
     trader_pubkey: String,
     error: String,
+    version: String,
 }
 
 pub(crate) fn insert(conn: &mut PgConnection, error: ReportedError) -> QueryResult<()> {
@@ -22,6 +23,7 @@ impl From<ReportedError> for NewReportedError {
         Self {
             trader_pubkey: value.trader_pk.to_string(),
             error: value.msg,
+            version: value.version.unwrap_or("<2.3.1".to_owned()),
         }
     }
 }

--- a/coordinator/src/schema.rs
+++ b/coordinator/src/schema.rs
@@ -389,6 +389,8 @@ diesel::table! {
         id -> Int4,
         trader_pubkey -> Text,
         error -> Text,
+        timestamp -> Timestamptz,
+        version -> Text,
     }
 }
 

--- a/crates/xxi-node/src/commons/reported_error.rs
+++ b/crates/xxi-node/src/commons/reported_error.rs
@@ -6,4 +6,5 @@ use serde::Serialize;
 pub struct ReportedError {
     pub trader_pk: PublicKey,
     pub msg: String,
+    pub version: Option<String>,
 }

--- a/mobile/native/src/report_error.rs
+++ b/mobile/native/src/report_error.rs
@@ -5,6 +5,8 @@ use crate::state::get_or_create_tokio_runtime;
 use reqwest::Url;
 
 pub fn report_error_to_coordinator<E: ToString>(error: &E) {
+    let version = env!("CARGO_PKG_VERSION").to_string();
+
     let client = reqwest_client();
     let pk = get_node().inner.info.pubkey;
 
@@ -23,6 +25,7 @@ pub fn report_error_to_coordinator<E: ToString>(error: &E) {
                     .json(&xxi_node::commons::ReportedError {
                         trader_pk: pk,
                         msg: error_string,
+                        version: Some(version),
                     })
                     .send()
                     .await


### PR DESCRIPTION
I opted for not introducing a breaking change. If a user fails and posts an error prior 2.3.1 (which will be the next release hopefully), we will see `<2.3.1` in the db.

resolves #2435 