### PR TITLE
Fix Flutter versions

### DIFF
--- a/mobile/.fvmrc
+++ b/mobile/.fvmrc
@@ -1,3 +1,3 @@
 {
-  "flutter": "stable"
+  "flutter": "3.19.4"
 }

--- a/webapp/frontend/.fvmrc
+++ b/webapp/frontend/.fvmrc
@@ -1,3 +1,3 @@
 {
-  "flutter": "beta"
+  "flutter": "3.22.0"
 }


### PR DESCRIPTION
To avoid random breaking changes showing up in CI.

AFAIK these were the versions we were using before `stable` was updated.