### PR TITLE
fix: Don't refresh TradingView when switching from wallet to trading tab

### DIFF
--- a/mobile/lib/common/routes.dart
+++ b/mobile/lib/common/routes.dart
@@ -174,55 +174,58 @@ GoRouter createRoutes() {
                       },
                     )
                   ]),
-              ShellRoute(
-                navigatorKey: shellNavigatorKey,
+              StatefulShellRoute.indexedStack(
                 builder: (BuildContext context, GoRouterState state, Widget child) {
                   return ScaffoldWithNavBar(
                     child: child,
                   );
                 },
-                routes: <RouteBase>[
-                  GoRoute(
-                    path: WalletScreen.route,
-                    builder: (BuildContext context, GoRouterState state) {
-                      return const WalletScreen();
-                    },
-                    routes: <RouteBase>[
-                      GoRoute(
-                        path: SendOnChainScreen.subRouteName,
-                        // Use root navigator so the screen overlays the application shell
-                        parentNavigatorKey: rootNavigatorKey,
-                        builder: (BuildContext context, GoRouterState state) {
-                          return SendOnChainScreen(destination: state.extra as OnChainAddress);
-                        },
-                      ),
-                      GoRoute(
-                        path: ReceiveScreen.subRouteName,
-                        // Use root navigator so the screen overlays the application shell
-                        parentNavigatorKey: rootNavigatorKey,
-                        builder: (BuildContext context, GoRouterState state) {
-                          if (state.extra != null) {
-                            return ReceiveScreen(walletType: state.extra as WalletType);
-                          }
-                          return const ReceiveScreen();
-                        },
-                      ),
-                      GoRoute(
-                        path: ScannerScreen.subRouteName,
-                        parentNavigatorKey: rootNavigatorKey,
-                        builder: (BuildContext context, GoRouterState state) {
-                          return const ScannerScreen();
-                        },
-                      ),
-                    ],
-                  ),
-                  GoRoute(
-                    path: TradeScreen.route,
-                    builder: (BuildContext context, GoRouterState state) {
-                      return const TradeScreen();
-                    },
-                    routes: const [],
-                  ),
+                branches: <StatefulShellBranch>[
+                  StatefulShellBranch(routes: [
+                    GoRoute(
+                      path: WalletScreen.route,
+                      builder: (BuildContext context, GoRouterState state) {
+                        return const WalletScreen();
+                      },
+                      routes: <RouteBase>[
+                        GoRoute(
+                          path: SendOnChainScreen.subRouteName,
+                          // Use root navigator so the screen overlays the application shell
+                          parentNavigatorKey: rootNavigatorKey,
+                          builder: (BuildContext context, GoRouterState state) {
+                            return SendOnChainScreen(destination: state.extra as OnChainAddress);
+                          },
+                        ),
+                        GoRoute(
+                          path: ReceiveScreen.subRouteName,
+                          // Use root navigator so the screen overlays the application shell
+                          parentNavigatorKey: rootNavigatorKey,
+                          builder: (BuildContext context, GoRouterState state) {
+                            if (state.extra != null) {
+                              return ReceiveScreen(walletType: state.extra as WalletType);
+                            }
+                            return const ReceiveScreen();
+                          },
+                        ),
+                        GoRoute(
+                          path: ScannerScreen.subRouteName,
+                          parentNavigatorKey: rootNavigatorKey,
+                          builder: (BuildContext context, GoRouterState state) {
+                            return const ScannerScreen();
+                          },
+                        ),
+                      ],
+                    ),
+                  ]),
+                  StatefulShellBranch(routes: [
+                    GoRoute(
+                      path: TradeScreen.route,
+                      builder: (BuildContext context, GoRouterState state) {
+                        return const TradeScreen();
+                      },
+                      routes: const [],
+                    ),
+                  ])
                 ],
               ),
             ]),


### PR DESCRIPTION
Fixes #2525 

I can say for certain that going into settings still triggers a refresh - I'm not sure if we care about this, though. Otherwise, it seems to work and it does not refresh when swapping from wallet to trading tab. If this general approach is acceptable (which maybe has wider-reaching impacts?), then I can re-add the animation to swap from wallet to trade tabs and we can merge this.