### PR TITLE
Let the coordinator open single-funded DLC channels

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1371,7 +1371,7 @@ dependencies = [
 [[package]]
 name = "dlc"
 version = "0.4.0"
-source = "git+https://github.com/get10101/rust-dlc?rev=8d9920d#8d9920d937e985c5eb3a53779dc6c43d635bf8ba"
+source = "git+https://github.com/get10101/rust-dlc?rev=2545d6e#2545d6e90da92cc86eb8673a0cf6856bfb82d40d"
 dependencies = [
  "bitcoin 0.29.2",
  "miniscript 8.0.2",
@@ -1383,7 +1383,7 @@ dependencies = [
 [[package]]
 name = "dlc-manager"
 version = "0.4.0"
-source = "git+https://github.com/get10101/rust-dlc?rev=8d9920d#8d9920d937e985c5eb3a53779dc6c43d635bf8ba"
+source = "git+https://github.com/get10101/rust-dlc?rev=2545d6e#2545d6e90da92cc86eb8673a0cf6856bfb82d40d"
 dependencies = [
  "async-trait",
  "bitcoin 0.29.2",
@@ -1399,7 +1399,7 @@ dependencies = [
 [[package]]
 name = "dlc-messages"
 version = "0.4.0"
-source = "git+https://github.com/get10101/rust-dlc?rev=8d9920d#8d9920d937e985c5eb3a53779dc6c43d635bf8ba"
+source = "git+https://github.com/get10101/rust-dlc?rev=2545d6e#2545d6e90da92cc86eb8673a0cf6856bfb82d40d"
 dependencies = [
  "bitcoin 0.29.2",
  "dlc",
@@ -1412,7 +1412,7 @@ dependencies = [
 [[package]]
 name = "dlc-trie"
 version = "0.4.0"
-source = "git+https://github.com/get10101/rust-dlc?rev=8d9920d#8d9920d937e985c5eb3a53779dc6c43d635bf8ba"
+source = "git+https://github.com/get10101/rust-dlc?rev=2545d6e#2545d6e90da92cc86eb8673a0cf6856bfb82d40d"
 dependencies = [
  "bitcoin 0.29.2",
  "dlc",
@@ -2816,7 +2816,7 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 [[package]]
 name = "p2pd-oracle-client"
 version = "0.1.0"
-source = "git+https://github.com/get10101/rust-dlc?rev=8d9920d#8d9920d937e985c5eb3a53779dc6c43d635bf8ba"
+source = "git+https://github.com/get10101/rust-dlc?rev=2545d6e#2545d6e90da92cc86eb8673a0cf6856bfb82d40d"
 dependencies = [
  "chrono",
  "dlc-manager",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,11 +19,11 @@ resolver = "2"
 # We are using our own fork of `rust-dlc` at least until we can drop all the LN-DLC features. Also,
 # `p2pderivatives/rust-dlc#master` is missing certain patches that can only be found in the LN-DLC
 # branch.
-dlc-manager = { git = "https://github.com/get10101/rust-dlc", rev = "8d9920d" }
-dlc-messages = { git = "https://github.com/get10101/rust-dlc", rev = "8d9920d" }
-dlc = { git = "https://github.com/get10101/rust-dlc", rev = "8d9920d" }
-p2pd-oracle-client = { git = "https://github.com/get10101/rust-dlc", rev = "8d9920d" }
-dlc-trie = { git = "https://github.com/get10101/rust-dlc", rev = "8d9920d" }
+dlc-manager = { git = "https://github.com/get10101/rust-dlc", rev = "2545d6e" }
+dlc-messages = { git = "https://github.com/get10101/rust-dlc", rev = "2545d6e" }
+dlc = { git = "https://github.com/get10101/rust-dlc", rev = "2545d6e" }
+p2pd-oracle-client = { git = "https://github.com/get10101/rust-dlc", rev = "2545d6e" }
+dlc-trie = { git = "https://github.com/get10101/rust-dlc", rev = "2545d6e" }
 
 # We should usually track the `p2pderivatives/split-tx-experiment[-10101]` branch. For now we depend
 # on a special fork which removes a panic in `rust-lightning`.

--- a/crates/tests-e2e/src/setup.rs
+++ b/crates/tests-e2e/src/setup.rs
@@ -157,7 +157,17 @@ impl TestSetup {
         // Wait for coordinator to open position.
         tokio::time::sleep(std::time::Duration::from_secs(10)).await;
 
-        setup.bitcoind.mine(NB_CONFIRMATIONS as u16).await.unwrap();
+        if NB_CONFIRMATIONS == 0 {
+            // No confirmations are required to get the channel/contract `Confirmed`, but the change
+            // output won't be added to the on-chain balance until we get one confirmation because
+            // of https://github.com/get10101/10101/issues/2286.
+            //
+            // We need to know about funding transaction change outputs so that we can accurately
+            // assert on on-chain balance changes after DLC channels are closed on-chain.
+            setup.bitcoind.mine(1).await.unwrap();
+        } else {
+            setup.bitcoind.mine(NB_CONFIRMATIONS as u16).await.unwrap();
+        }
 
         tokio::time::sleep(std::time::Duration::from_secs(10)).await;
 

--- a/crates/xxi-node/src/dlc_wallet.rs
+++ b/crates/xxi-node/src/dlc_wallet.rs
@@ -213,6 +213,10 @@ impl<D: BdkStorage, S: TenTenOneStorage, N> dlc_manager::Wallet for DlcWallet<D,
         base_weight_wu: u64,
         lock_utxos: bool,
     ) -> Result<Vec<dlc_manager::Utxo>, dlc_manager::error::Error> {
+        if amount == 0 {
+            return Ok(Vec::new());
+        }
+
         let network = self.on_chain_wallet.network();
 
         let fee_rate = fee_rate.expect("always set by rust-dlc");

--- a/crates/xxi-node/src/node/dlc_channel.rs
+++ b/crates/xxi-node/src/node/dlc_channel.rs
@@ -47,6 +47,7 @@ impl<D: BdkStorage, S: TenTenOneStorage + 'static, N: LnDlcStorage + Sync + Send
         contract_input: ContractInput,
         counterparty: PublicKey,
         protocol_id: ProtocolId,
+        fee_config: dlc::FeeConfig,
     ) -> Result<(ContractId, DlcChannelId)> {
         tracing::info!(
             trader_id = %counterparty,
@@ -90,6 +91,7 @@ impl<D: BdkStorage, S: TenTenOneStorage + 'static, N: LnDlcStorage + Sync + Send
                 let offer_channel = dlc_manager.offer_channel(
                     &contract_input,
                     to_secp_pk_29(counterparty),
+                    fee_config,
                     Some(protocol_id.into()),
                 )?;
 
@@ -122,8 +124,9 @@ impl<D: BdkStorage, S: TenTenOneStorage + 'static, N: LnDlcStorage + Sync + Send
 
         tracing::info!(channel_id = %channel_id_hex, "Accepting DLC channel offer");
 
-        let (accept_channel, _channel_id, _contract_id, counter_party) =
-            self.dlc_manager.accept_channel(channel_id)?;
+        let (accept_channel, _channel_id, _contract_id, counter_party) = self
+            .dlc_manager
+            .accept_channel(channel_id, dlc::FeeConfig::EvenSplit)?;
 
         self.event_handler.publish(NodeEvent::SendDlcMessage {
             peer: to_secp_pk_30(counter_party),

--- a/crates/xxi-node/src/tests/dlc_channel.rs
+++ b/crates/xxi-node/src/tests/dlc_channel.rs
@@ -465,6 +465,7 @@ async fn open_channel_and_position_and_settle_position(
             contract_input,
             app.info.pubkey,
             ProtocolId::new(),
+            dlc::FeeConfig::EvenSplit,
         )
         .await
         .unwrap();

--- a/mobile/native/src/dlc/node.rs
+++ b/mobile/native/src/dlc/node.rs
@@ -540,7 +540,14 @@ impl Node {
         match self
             .inner
             .dlc_manager
-            .accept_channel(&channel_id)
+            .accept_channel(
+                &channel_id,
+                offer
+                    .offer_channel
+                    .fee_config
+                    .map(dlc::FeeConfig::from)
+                    .unwrap_or(dlc::FeeConfig::EvenSplit),
+            )
             .map_err(anyhow::Error::new)
         {
             Ok((accept_channel, _, _, node_id)) => {


### PR DESCRIPTION
With the `TradeAction::OpenSingleFundedDlcChannel`, the coordinator can choose to open a DLC channel with a trader, without using any trader UTXOs. This is useful if the coordinator wants to onboard trading through alternate means, such as Lightning.

`rust-dlc` now allows to configure the TX fee split between the offer party and the accept party.

The feature has been tested locally, but is currently disabled as we need a different flow to trigger the creation of a single-funded DLC channel.

Also, the DLC channel is now 0-conf: the trader can keep trading as soon as the fund transaction is found in mempool.

https://github.com/get10101/10101/assets/9418575/c8457061-b249-4ad1-b137-db85f9a81ee7

In the video you can see that we still have to fund the on-chain wallet, because the app still thinks that on-chain funds are needed to open a channel. But once the channel is created, you can see that the on-chain funds were not used!

---

See https://github.com/get10101/rust-dlc/pull/18 for the matching PR in `rust-dlc`.