### PR TITLE
fix: drain on-chain wallet

### DIFF
--- a/crates/xxi-node/src/on_chain_wallet.rs
+++ b/crates/xxi-node/src/on_chain_wallet.rs
@@ -299,7 +299,7 @@ where
         amount_sat_or_drain: u64,
         fee_config: FeeConfig,
     ) -> Result<Transaction> {
-        if amount_sat_or_drain.is_dust(&recipient.script_pubkey()) {
+        if amount_sat_or_drain > 0 && amount_sat_or_drain.is_dust(&recipient.script_pubkey()) {
             bail!("Send amount below dust: {amount_sat_or_drain} sat");
         }
 

--- a/mobile/lib/features/wallet/application/wallet_service.dart
+++ b/mobile/lib/features/wallet/application/wallet_service.dart
@@ -72,7 +72,7 @@ class WalletService {
   Future<String> sendOnChainPayment(Destination destination, Amount? amount,
       {FeeConfig? feeConfig}) {
     var feeConfigApi = feeConfig!.toAPI();
-    var sats = amount!.sats;
+    var sats = amount?.sats ?? 0;
     var address = destination.raw;
     logger.i("Sending payment of $amount to $address with fee $feeConfigApi");
 


### PR DESCRIPTION
there were two bugs:

1. we need to check if `amount` is `null` and set the sending amount to 0. This is because if we click `Max` we set `amount` to null
2. in the backend we checked if the sending amount is below dust. Sending 0 is an edge case which is clearly below dust but will be checked later to drain the wallet.

 fixes #2542