### PR TITLE
fix: Ignore missing order id when rejecting a rollover offer

### DIFF
--- a/coordinator/src/db/positions.rs
+++ b/coordinator/src/db/positions.rs
@@ -166,29 +166,6 @@ impl Position {
         Ok(crate::position::models::Position::from(position))
     }
 
-    /// sets the status of the position in state `Closing` to a new state
-    pub fn update_closing_position(
-        conn: &mut PgConnection,
-        trader_pubkey: String,
-        state: crate::position::models::PositionState,
-    ) -> Result<()> {
-        let state = PositionState::from(state);
-        let affected_rows = diesel::update(positions::table)
-            .filter(positions::trader_pubkey.eq(trader_pubkey.clone()))
-            .filter(positions::position_state.eq(PositionState::Closing))
-            .set((
-                positions::position_state.eq(state),
-                positions::update_timestamp.eq(OffsetDateTime::now_utc()),
-            ))
-            .execute(conn)?;
-
-        if affected_rows == 0 {
-            bail!("Could not update position to {state:?} for {trader_pubkey}")
-        }
-
-        Ok(())
-    }
-
     /// sets the status of all open position to closing (note, we expect that number to be always
     /// exactly 1)
     pub fn set_open_position_to_closing(

--- a/coordinator/src/node.rs
+++ b/coordinator/src/node.rs
@@ -481,9 +481,14 @@ impl Node {
                                     "DLC Channel settle offer has been rejected. Setting position to back to open."
                                 );
 
-                        db::positions::Position::update_closing_position(
+                        db::positions::Position::update_position_state(
                             &mut connection,
                             node_id.to_string(),
+                            vec![
+                                // the closing price doesn't matter here.
+                                PositionState::Closing { closing_price: 0.0 },
+                                PositionState::Rollover,
+                            ],
                             PositionState::Open,
                         )?;
                     }

--- a/mobile/native/src/dlc/dlc_handler.rs
+++ b/mobile/native/src/dlc/dlc_handler.rs
@@ -206,6 +206,11 @@ impl DlcHandler {
                         BackgroundTask::RecoverDlc(TaskStatus::Pending),
                     ));
 
+                    // FIXME(holzeis): We need to be able to differentiate between a
+                    // SignedChannelState::RenewOffered and a RolloverOffer. This differentiation
+                    // currently only lives in 10101 and in the dlc messages, but not on the channel
+                    // state. Hence at the moment we also reject pending `RolloverOffers` the same
+                    // way we reject `RenewOffers`
                     self.node
                         .reject_renew_offer(None, channel_id)
                         .context("Failed to reject pending renew offer")?;


### PR DESCRIPTION
In case of a rollover we do not have an order id or and order in filling. As a result this logic failed when trying to reject a rollover offer.

The solution is still hacky as with the correct context information we shouldn't even try to set the order to failed, but that context is missing when we are reconnecting in the `on_connect` function and finding a dlc channel in state `RenewOffered`.

fixes #2554 