### PR TITLE
fix: return only wallet unspent utxos

### DIFF
--- a/crates/xxi-node/src/on_chain_wallet.rs
+++ b/crates/xxi-node/src/on_chain_wallet.rs
@@ -151,9 +151,8 @@ impl<D> OnChainWallet<D> {
     pub(crate) fn get_utxos(&self) -> Vec<(OutPoint, TxOut)> {
         let bdk = self.bdk.read();
 
-        bdk.tx_graph()
-            .all_txouts()
-            .map(|(outpoint, txout)| (outpoint, txout.clone()))
+        bdk.list_unspent()
+            .map(|local_output| (local_output.outpoint, local_output.txout))
             .collect()
     }
 


### PR DESCRIPTION
Before we were printing all known utxos, even not from our own wallet.