### PR TITLE
fix: Unreserve utxos on wallet sync

### DIFF
--- a/crates/xxi-node/src/node/wallet.rs
+++ b/crates/xxi-node/src/node/wallet.rs
@@ -114,6 +114,10 @@ impl<D: BdkStorage, S: TenTenOneStorage, N: Storage + Send + Sync + 'static> Nod
         .await
         .expect("task to complete")?;
 
+        // On sync, we unlock our locked utxos, because we are syncing with the blockchain we will
+        // find already spent utxos and release those which were locked unnecessarily.
+        self.wallet.locked_utxos.lock().clear();
+
         Ok(())
     }
 


### PR DESCRIPTION
on each blockchain sync we clear the lcoked utxos. This is fine, because we are syncing with the blockchain and are learning about all acutally spent utxos.