### PR TITLE
feat: Sync wallet when contract is not confirmed yet.

### DIFF
--- a/coordinator/src/node/liquidated_positions.rs
+++ b/coordinator/src/node/liquidated_positions.rs
@@ -106,7 +106,8 @@ async fn check_if_positions_need_to_get_liquidated(
             // liquidation.
             match node
                 .inner
-                .is_signed_dlc_channel_confirmed_by_trader_id(position.trader)
+                .check_if_signed_channel_is_confirmed(position.trader)
+                .await
             {
                 Ok(true) => {
                     tracing::debug!(trader_id=%position.trader, "Traders dlc channel is confirmed. Continuing with the liquidation");

--- a/coordinator/src/trade/mod.rs
+++ b/coordinator/src/trade/mod.rs
@@ -804,8 +804,13 @@ impl TradeExecutor {
         trade_params: &TradeParams,
         resize_action: ResizeAction,
     ) -> Result<()> {
-        if !self.node.inner.is_dlc_channel_confirmed(&dlc_channel_id)? {
-            bail!("Underlying DLC channel not yet confirmed");
+        if !self
+            .node
+            .inner
+            .check_if_signed_channel_is_confirmed(position.trader)
+            .await?
+        {
+            bail!("Underlying DLC channel not yet confirmed.");
         }
 
         let peer_id = trade_params.pubkey;
@@ -1045,8 +1050,13 @@ impl TradeExecutor {
         trade_params: &TradeParams,
         channel_id: DlcChannelId,
     ) -> Result<()> {
-        if !self.node.inner.is_dlc_channel_confirmed(&channel_id)? {
-            bail!("Underlying DLC channel not yet confirmed");
+        if !self
+            .node
+            .inner
+            .check_if_signed_channel_is_confirmed(position.trader)
+            .await?
+        {
+            bail!("Underlying DLC channel not yet confirmed.");
         }
 
         let closing_price = trade_params.average_execution_price();

--- a/mobile/native/src/dlc/mod.rs
+++ b/mobile/native/src/dlc/mod.rs
@@ -907,18 +907,17 @@ pub fn delete_dlc_channel(dlc_channel_id: &DlcChannelId) -> Result<()> {
     Ok(())
 }
 
-pub fn is_dlc_channel_confirmed() -> Result<bool> {
+pub async fn check_if_signed_channel_is_confirmed() -> Result<bool> {
     let node = match state::try_get_node() {
         Some(node) => node,
         None => return Ok(false),
     };
 
-    let dlc_channel = match get_signed_dlc_channel()? {
-        Some(dlc_channel) => dlc_channel,
-        None => return Ok(false),
-    };
+    let counterparty = config::get_coordinator_info().pubkey;
 
-    node.inner.is_dlc_channel_confirmed(&dlc_channel.channel_id)
+    node.inner
+        .check_if_signed_channel_is_confirmed(counterparty)
+        .await
 }
 
 pub fn get_fee_rate_for_target(target: ConfirmationTarget) -> FeeRate {

--- a/webapp/src/api.rs
+++ b/webapp/src/api.rs
@@ -18,7 +18,6 @@ use native::api::WalletHistoryItemType;
 use native::calculations::calculate_pnl;
 use native::channel_trade_constraints;
 use native::dlc;
-use native::dlc::is_dlc_channel_confirmed;
 use native::trade::order::FailureReason;
 use native::trade::order::InvalidSubchannelOffer;
 use rust_decimal::prelude::ToPrimitive;
@@ -358,7 +357,7 @@ pub async fn post_new_order(params: Json<NewOrderParams>) -> Result<Json<OrderId
         .try_into()
         .context("Could not parse order request")?;
 
-    let is_dlc_channel_confirmed = is_dlc_channel_confirmed()?;
+    let is_dlc_channel_confirmed = dlc::check_if_signed_channel_is_confirmed().await?;
 
     let channel_opening_params = if is_dlc_channel_confirmed {
         None


### PR DESCRIPTION
This is covering an edge case where the user opens a dlc channel and wants to close the position within the sync window of the coordinator.

It allows to instantly close the position without having to manually sync the wallet after the dlc channel has been created.

---

It's probably not the most important feature for prod, but it makes testing a bit easier... Happy to close this PR if the reviewer thinks that this is an unnecessary overhead.