### PR TITLE
feat: Handle error when requesting a hodl invoice

### DIFF
--- a/mobile/lib/features/trade/application/order_service.dart
+++ b/mobile/lib/features/trade/application/order_service.dart
@@ -7,9 +7,9 @@ import 'package:get_10101/ffi.dart' as rust;
 
 class ExternalFunding {
   final String bitcoinAddress;
-  final String paymentRequest;
+  final String? paymentRequest;
 
-  const ExternalFunding({required this.bitcoinAddress, required this.paymentRequest});
+  const ExternalFunding({required this.bitcoinAddress, this.paymentRequest});
 
   static ExternalFunding fromApi(rust.ExternalFunding funding) {
     return ExternalFunding(

--- a/mobile/lib/features/trade/channel_creation_flow/channel_funding_screen.dart
+++ b/mobile/lib/features/trade/channel_creation_flow/channel_funding_screen.dart
@@ -67,8 +67,12 @@ class _ChannelFunding extends State<ChannelFunding> {
 
     final qrCode = switch (selectedBox) {
       FundingType.lightning => CustomQrCode(
-          data: widget.funding.paymentRequest,
-          embeddedImage: const AssetImage("assets/10101_logo_icon_white_background.png"),
+          data: widget.funding.paymentRequest ?? "https://x.com/get10101",
+          embeddedImage: widget.funding.paymentRequest != null
+              ? const AssetImage("assets/10101_logo_icon_white_background.png")
+              : const AssetImage("assets/coming_soon.png"),
+          embeddedImageSizeHeight: widget.funding.paymentRequest != null ? 50 : 350,
+          embeddedImageSizeWidth: widget.funding.paymentRequest != null ? 50 : 350,
           dimension: 300,
         ),
       FundingType.onchain => CustomQrCode(
@@ -87,9 +91,10 @@ class _ChannelFunding extends State<ChannelFunding> {
     };
 
     final qrCodeSubTitle = switch (selectedBox) {
-      FundingType.lightning => widget.funding.paymentRequest,
+      FundingType.lightning =>
+        widget.funding.paymentRequest ?? "Currently not available. Try again later.",
       FundingType.onchain => widget.funding.bitcoinAddress,
-      FundingType.unified || FundingType.external => "Follow us on social media for updates",
+      FundingType.unified || FundingType.external => "Follow us on social media for updates.",
     };
 
     return Scaffold(

--- a/mobile/native/src/hodl_invoice.rs
+++ b/mobile/native/src/hodl_invoice.rs
@@ -7,6 +7,7 @@ use bitcoin::Amount;
 use reqwest::Url;
 use xxi_node::commons;
 
+#[derive(Clone)]
 pub struct HodlInvoice {
     pub payment_request: String,
     pub pre_image: String,


### PR DESCRIPTION
If we can't receive a hodl invoice the app gracefully handles that scenario and shows an according message instead of the invoice.

https://github.com/get10101/10101/assets/382048/0998f5d2-a3a1-4782-9716-bc84544edb8c

