### PR TITLE
fix: Watch for specific r_hash

### DIFF
--- a/crates/tests-e2e/src/test_subscriber.rs
+++ b/crates/tests-e2e/src/test_subscriber.rs
@@ -194,7 +194,7 @@ impl Senders {
             native::event::EventInternal::FundingChannelNotification(_) => {
                 // ignored
             }
-            native::event::EventInternal::LnPaymentReceived => {
+            native::event::EventInternal::LnPaymentReceived { .. } => {
                 // ignored
             }
         }

--- a/mobile/native/src/dlc/mod.rs
+++ b/mobile/native/src/dlc/mod.rs
@@ -25,6 +25,7 @@ use crate::trade::order::OrderReason;
 use crate::trade::order::OrderState;
 use crate::trade::order::OrderType;
 use crate::trade::position;
+use crate::watcher::InvoiceWatcher;
 use anyhow::anyhow;
 use anyhow::Context;
 use anyhow::Result;
@@ -289,6 +290,12 @@ pub fn run(
 
         event::subscribe(DBBackupSubscriber::new(storage.clone().client));
         event::subscribe(ForceCloseDlcChannelSubscriber);
+
+        let (ln_sender, _) = broadcast::channel::<String>(5);
+        event::subscribe(InvoiceWatcher {
+            sender: ln_sender.clone(),
+        });
+        state::set_ln_payment_watcher(ln_sender);
 
         let node_event_handler = Arc::new(NodeEventHandler::new());
 

--- a/mobile/native/src/event/api.rs
+++ b/mobile/native/src/event/api.rs
@@ -31,7 +31,7 @@ pub enum Event {
     Authenticated(TenTenOneConfig),
     DlcChannelEvent(DlcChannel),
     FundingChannelNotification(FundingChannelTask),
-    LnPaymentReceived,
+    LnPaymentReceived { r_hash: String },
 }
 
 #[frb]
@@ -93,7 +93,7 @@ impl From<EventInternal> for Event {
             EventInternal::FundingChannelNotification(status) => {
                 Event::FundingChannelNotification(status.into())
             }
-            EventInternal::LnPaymentReceived => Event::LnPaymentReceived,
+            EventInternal::LnPaymentReceived { r_hash } => Event::LnPaymentReceived { r_hash },
         }
     }
 }

--- a/mobile/native/src/event/api.rs
+++ b/mobile/native/src/event/api.rs
@@ -132,7 +132,6 @@ impl Subscriber for FlutterSubscriber {
             EventType::ChannelStatusUpdate,
             EventType::BackgroundNotification,
             EventType::FundingChannelNotification,
-            EventType::LnPaymentReceived,
             EventType::Authenticated,
             EventType::DlcChannelEvent,
         ]

--- a/mobile/native/src/event/mod.rs
+++ b/mobile/native/src/event/mod.rs
@@ -40,7 +40,7 @@ pub enum EventInternal {
     SpendableOutputs,
     DlcChannelEvent(DlcChannel),
     FundingChannelNotification(FundingChannelTask),
-    LnPaymentReceived,
+    LnPaymentReceived { r_hash: String },
 }
 
 #[derive(Clone, Debug)]
@@ -86,7 +86,7 @@ impl fmt::Display for EventInternal {
             EventInternal::AskPriceUpdateNotification(_) => "AskPriceUpdateNotification",
             EventInternal::BidPriceUpdateNotification(_) => "BidPriceUpdateNotification",
             EventInternal::FundingChannelNotification(_) => "FundingChannelNotification",
-            EventInternal::LnPaymentReceived => "LnPaymentReceived",
+            EventInternal::LnPaymentReceived { .. } => "LnPaymentReceived",
         }
         .fmt(f)
     }
@@ -111,7 +111,7 @@ impl From<EventInternal> for EventType {
             EventInternal::AskPriceUpdateNotification(_) => EventType::AskPriceUpdateNotification,
             EventInternal::BidPriceUpdateNotification(_) => EventType::BidPriceUpdateNotification,
             EventInternal::FundingChannelNotification(_) => EventType::FundingChannelNotification,
-            EventInternal::LnPaymentReceived => EventType::LnPaymentReceived,
+            EventInternal::LnPaymentReceived { .. } => EventType::LnPaymentReceived,
         }
     }
 }

--- a/mobile/native/src/event/subscriber.rs
+++ b/mobile/native/src/event/subscriber.rs
@@ -2,6 +2,10 @@ use crate::event::EventInternal;
 use crate::event::EventType;
 
 pub trait Subscriber {
+    /// Notifies the subcriber about an event. If false is returned the subscriber will be
+    /// unsubscribed, if true the subscriber will remain subscribed.
     fn notify(&self, event: &EventInternal);
+
+    /// Returns a list of events the subscriber wants to subscribe to.
     fn events(&self) -> Vec<EventType>;
 }

--- a/mobile/native/src/orderbook.rs
+++ b/mobile/native/src/orderbook.rs
@@ -286,7 +286,7 @@ async fn handle_orderbook_message(
         }
         Message::LnPaymentReceived { r_hash, amount } => {
             tracing::info!(r_hash, %amount, "Received a payment received event.");
-            event::publish(&EventInternal::LnPaymentReceived)
+            event::publish(&EventInternal::LnPaymentReceived { r_hash })
         }
     };
 

--- a/mobile/native/src/state.rs
+++ b/mobile/native/src/state.rs
@@ -26,6 +26,7 @@ static RUNTIME: Storage<Runtime> = Storage::new();
 static WEBSOCKET: Storage<RwLock<Sender<OrderbookRequest>>> = Storage::new();
 static LOG_STREAM_SINK: Storage<RwLock<Arc<StreamSink<LogEntry>>>> = Storage::new();
 static TENTENONE_CONFIG: Storage<RwLock<TenTenOneConfig>> = Storage::new();
+static LN_PAYMENT_WATCHER: Storage<RwLock<Sender<String>>> = Storage::new();
 
 pub fn set_config(config: ConfigInternal) {
     match CONFIG.try_get() {
@@ -145,4 +146,19 @@ pub fn set_tentenone_config(config: TenTenOneConfig) {
 
 pub fn try_get_tentenone_config() -> Option<TenTenOneConfig> {
     TENTENONE_CONFIG.try_get().map(|w| w.read().clone())
+}
+
+pub fn set_ln_payment_watcher(ln_payment_watcher: Sender<String>) {
+    match LN_PAYMENT_WATCHER.try_get() {
+        None => {
+            LN_PAYMENT_WATCHER.set(RwLock::new(ln_payment_watcher));
+        }
+        Some(s) => {
+            *s.write() = ln_payment_watcher;
+        }
+    }
+}
+
+pub fn get_ln_payment_watcher() -> Sender<String> {
+    LN_PAYMENT_WATCHER.get().read().clone()
 }


### PR DESCRIPTION
This PR fixes two issues.

1. Any paid invoice that has been created by the coordinator will produce a `LnPaymentReceived` event. Before that change we would have simply assumed that this was the payment we've been waiting for. But it could have happened that the users went back and forth multiple times and thus created multiple invoices. So if an old invoice would have been paid, we would have triggered the order creation which would have failed, because the shared pre-image would have been incorrect. We do now verify that the received r_hash is equal to the watched r_hash.

2. On every creation of a hodl invoice we subscribed the `InvoiceWatcher` for `LnPaymentReceived` events. These subscribers lived forever and never got cancelled, producing various error messages since the receiver has already been gone. The invoice watcher is now subscribed at the app startup and the broadcast::Sender is stored in the apps state - so that only a single Subscriber can do the job.