### PR TITLE
fix: Do not create dlc protocol entry for force closed channels

### DIFF
--- a/coordinator/src/node/channel.rs
+++ b/coordinator/src/node/channel.rs
@@ -61,21 +61,19 @@ pub struct DlcChannel {
 }
 
 impl Node {
-    pub async fn close_dlc_channel(
-        &self,
-        channel_id: DlcChannelId,
-        is_force_close: bool,
-    ) -> Result<()> {
+    pub async fn force_close_dlc_channel(&self, channel_id: DlcChannelId) -> Result<()> {
+        self.inner.close_dlc_channel(channel_id, true).await?;
+        Ok(())
+    }
+
+    pub async fn close_dlc_channel(&self, channel_id: DlcChannelId) -> Result<()> {
         let channel = self.inner.get_dlc_channel_by_id(&channel_id)?;
         let previous_id = channel
             .get_reference_id()
             .map(ProtocolId::try_from)
             .transpose()?;
 
-        let protocol_id = self
-            .inner
-            .close_dlc_channel(channel_id, is_force_close)
-            .await?;
+        let protocol_id = self.inner.close_dlc_channel(channel_id, false).await?;
 
         let protocol_executor = dlc_protocol::DlcProtocolExecutor::new(self.pool.clone());
         protocol_executor.start_dlc_protocol(

--- a/coordinator/src/routes/admin.rs
+++ b/coordinator/src/routes/admin.rs
@@ -296,11 +296,11 @@ pub async fn close_channel(
 
     tracing::info!(channel_id = %channel_id_string, "Attempting to close channel");
 
-    state
-        .node
-        .close_dlc_channel(channel_id, params.force.unwrap_or_default())
-        .await
-        .map_err(|e| AppError::InternalServerError(format!("{e:#}")))?;
+    match params.force.unwrap_or_default() {
+        true => state.node.force_close_dlc_channel(channel_id).await,
+        false => state.node.close_dlc_channel(channel_id).await,
+    }
+    .map_err(|e| AppError::InternalServerError(format!("{e:#}")))?;
 
     Ok(())
 }


### PR DESCRIPTION
Force closing a channel should not get recorded as regular collab close dlc protocol.

This lead to an issue where the dlc channel did not get updated properly because the contract was missing.