### PR TITLE
fix: Make margin box size match quantity

### DIFF
--- a/mobile/lib/common/amount_text_field.dart
+++ b/mobile/lib/common/amount_text_field.dart
@@ -22,7 +22,6 @@ class _AmountTextState extends State<AmountTextField> {
 
     return InputDecorator(
       decoration: InputDecoration(
-          contentPadding: const EdgeInsets.fromLTRB(12, 24, 12, 17),
           border: const OutlineInputBorder(),
           labelText: widget.label,
           labelStyle: const TextStyle(color: Colors.black87),


### PR DESCRIPTION
Fixes #2592. For some reason we had different padding here. Here's how it looks now:
![image](https://github.com/get10101/10101/assets/6688948/812b1f00-364b-4945-b542-7d529bee5ef5)
