### PR TITLE
fix: Make onboarding a bit more robust when coordinator is down

### DIFF
--- a/mobile/lib/common/routes.dart
+++ b/mobile/lib/common/routes.dart
@@ -39,7 +39,7 @@ GoRouter createRoutes() {
           path: LoadingScreen.route,
           pageBuilder: (context, state) => NoTransitionPage<void>(
             child: LoadingScreen(
-              future: state.extra as Future<void>?,
+              task: state.extra as LoadingScreenTask?,
             ),
           ),
         ),

--- a/mobile/lib/features/welcome/seed_import_screen.dart
+++ b/mobile/lib/features/welcome/seed_import_screen.dart
@@ -141,12 +141,10 @@ class SeedPhraseImporterState extends State<SeedPhraseImporter> {
                               getSeedFilePath().then((seedPath) {
                                 logger.i("Restoring seed into $seedPath");
 
-                                final restore = api
-                                    .restoreFromSeedPhrase(
-                                        seedPhrase: seedPhrase, targetSeedFilePath: seedPath)
-                                    .catchError((error) => showSnackBar(
-                                        ScaffoldMessenger.of(context),
-                                        "Failed to import from seed. $error"));
+                                final restore = LoadingScreenTask(
+                                    future: api.restoreFromSeedPhrase(
+                                        seedPhrase: seedPhrase, targetSeedFilePath: seedPath),
+                                    error: (err) => "Failed to import from seed. $err");
                                 // TODO(holzeis): Backup preferences and restore email from there.
                                 Preferences.instance.setContactDetails("restored");
                                 GoRouter.of(context).go(LoadingScreen.route, extra: restore);

--- a/mobile/lib/util/preferences.dart
+++ b/mobile/lib/util/preferences.dart
@@ -13,6 +13,10 @@ class Preferences {
   static const fullBackup = "fullBackup";
   static const logLevelTrace = "logLevelTrace";
   static const _hasSeenReferralDialogTimePassed = "hasSeenReferralDialogTimePassed";
+  static const registeredForBeta = "registeredForBeta";
+
+  /// The referral code that the user signed up with
+  static const referralCode = "referralCode";
 
   Future<bool> setLogLevelTrace(bool trace) async {
     SharedPreferences preferences = await SharedPreferences.getInstance();
@@ -52,6 +56,26 @@ class Preferences {
   unsetOpenPosition() async {
     SharedPreferences preferences = await SharedPreferences.getInstance();
     preferences.remove(openPosition);
+  }
+
+  Future<bool> setRegisteredForBeta() async {
+    SharedPreferences preferences = await SharedPreferences.getInstance();
+    return preferences.setBool(registeredForBeta, true);
+  }
+
+  Future<bool> isRegisteredForBeta() async {
+    SharedPreferences preferences = await SharedPreferences.getInstance();
+    return preferences.getBool(registeredForBeta) ?? false;
+  }
+
+  Future<bool> setReferralCode(String code) async {
+    SharedPreferences preferences = await SharedPreferences.getInstance();
+    return preferences.setString(referralCode, code);
+  }
+
+  Future<String> getReferralCode() async {
+    SharedPreferences preferences = await SharedPreferences.getInstance();
+    return preferences.getString(referralCode) ?? "";
   }
 
   Future<bool> setContactDetails(String value) async {


### PR DESCRIPTION
This PR adds two related commits which do the following:
1. Show an error to the user if the coordinator is down (or unavailable) during onboarding instead of just hanging
2. If the coordinator is down during onboarding, try to register them for the beta program the next time they launch the app instead of just leaving them unregistered.

This might address #2430 somewhat, but I'm currently unclear exactly what the issue with #2430 is.