### PR TITLE
Remove insane `compile_error!`

### DIFF
--- a/coordinator/src/funding_fee.rs
+++ b/coordinator/src/funding_fee.rs
@@ -14,7 +14,6 @@ use diesel::PgConnection;
 use rust_decimal::prelude::ToPrimitive;
 use rust_decimal::Decimal;
 use rust_decimal::RoundingStrategy;
-use rust_decimal_macros::dec;
 use std::time::Duration;
 use time::ext::NumericalDuration;
 use time::format_description;
@@ -144,9 +143,10 @@ fn generate_funding_fee_events(
         })?,
         IndexPriceSource::Test => {
             #[cfg(not(debug_assertions))]
-            compile_error!("Cannot use a test index price in release mode");
+            panic!("Cannot use a test index price in release mode");
 
-            dec!(50_000)
+            #[cfg(debug_assertions)]
+            rust_decimal_macros::dec!(50_000)
         }
     };
 


### PR DESCRIPTION
I was trying to fail at compile time based on a runtime value (the settings). This is dumb.

We now fail at runtime if we try to use a fixed index price in release mode. Production always runs on release, so this exists to prevent using a fixed index price in production.

Obviously, release does not always equal production, but using the real index price from BitMEX is fine in most scenarios (except for the e2e tests and some instances of local testing).

---

This should fix problems like [this one](https://github.com/get10101/10101/actions/runs/9367310775/job/25786706679), which were preventing us from building the coordinator in release mode 🤦