### PR TITLE
Add `unique_end_date` constraint to `funding_rates` table

### DIFF
--- a/coordinator/migrations/2024-06-06-045129_add_unique_end_date_constraint/down.sql
+++ b/coordinator/migrations/2024-06-06-045129_add_unique_end_date_constraint/down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE funding_rates
+DROP CONSTRAINT IF EXISTS unique_end_date;

--- a/coordinator/migrations/2024-06-06-045129_add_unique_end_date_constraint/up.sql
+++ b/coordinator/migrations/2024-06-06-045129_add_unique_end_date_constraint/up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE funding_rates
+ADD CONSTRAINT unique_end_date UNIQUE (end_date);

--- a/coordinator/src/funding_fee/db/funding_rates.rs
+++ b/coordinator/src/funding_fee/db/funding_rates.rs
@@ -1,5 +1,4 @@
 use crate::schema::funding_rates;
-use anyhow::bail;
 use anyhow::Result;
 use diesel::prelude::*;
 use rust_decimal::prelude::FromPrimitive;
@@ -37,13 +36,11 @@ pub fn insert_funding_rates(
         .map(NewFundingRate::from)
         .collect::<Vec<_>>();
 
-    let affected_rows = diesel::insert_into(funding_rates::table)
+    diesel::insert_into(funding_rates::table)
         .values(funding_rates)
+        .on_conflict(funding_rates::end_date)
+        .do_nothing()
         .execute(conn)?;
-
-    if affected_rows == 0 {
-        bail!("Failed to insert funding rates");
-    }
 
     Ok(())
 }


### PR DESCRIPTION
We only need one funding rate entry per `end_date`.

Without this change we were getting a new duplicate entry per maker restart.