### PR TITLE
feat: allow to configure coordinator leverage

### DIFF
--- a/coordinator/migrations/2024-06-06-045048_add-coordinator-leverage-table/down.sql
+++ b/coordinator/migrations/2024-06-06-045048_add-coordinator-leverage-table/down.sql
@@ -1,0 +1,1 @@
+drop table if exists coordinator_leverages;

--- a/coordinator/migrations/2024-06-06-045048_add-coordinator-leverage-table/up.sql
+++ b/coordinator/migrations/2024-06-06-045048_add-coordinator-leverage-table/up.sql
@@ -1,0 +1,13 @@
+CREATE TABLE coordinator_leverages
+(
+    id                   SERIAL PRIMARY KEY,
+    trader_leverage      INT NOT NULL,
+    coordinator_leverage INT NOT NULL
+);
+
+INSERT INTO coordinator_leverages (trader_leverage, coordinator_leverage)
+VALUES (1, 1),
+       (2, 2),
+       (3, 3),
+       (4, 4),
+       (5, 5);

--- a/coordinator/src/db/coordinator_leverages.rs
+++ b/coordinator/src/db/coordinator_leverages.rs
@@ -1,0 +1,72 @@
+use crate::schema::coordinator_leverages;
+use anyhow::Result;
+use diesel::dsl::max;
+use diesel::ExpressionMethods;
+use diesel::OptionalExtension;
+use diesel::PgConnection;
+use diesel::QueryDsl;
+use diesel::QueryResult;
+use diesel::Queryable;
+use diesel::RunQueryDsl;
+use rust_decimal::prelude::ToPrimitive;
+use std::collections::HashMap;
+
+#[derive(Queryable, Debug, Clone, PartialEq)]
+#[diesel(table_name = coordinator_leverages)]
+pub(crate) struct CoordinatorLeverage {
+    pub id: i32,
+    pub trader_leverage: i32,
+    pub coordinator_leverage: i32,
+}
+
+pub(crate) fn get_all(conn: &mut PgConnection) -> QueryResult<HashMap<u8, u8>> {
+    let all = coordinator_leverages::table.load::<CoordinatorLeverage>(conn)?;
+    Ok(all
+        .iter()
+        .map(|lev| {
+            (
+                lev.trader_leverage.to_u8().expect("to fit"),
+                lev.coordinator_leverage.to_u8().expect("to fit"),
+            )
+        })
+        .collect())
+}
+
+/// Looks up the coordinator leverage by trader leverage.
+///
+/// We assume we only have round numbers in the db and hence round `trader_leverage`. If no item can
+/// be found we take the max available coordinator_leverage
+pub fn find_coordinator_leverage_by_trader_leverage(
+    connection: &mut PgConnection,
+    trader_lev: f32,
+) -> f32 {
+    find_by_trader_leverage(connection, &trader_lev).unwrap_or_else(|err| {
+        tracing::error!("Failed at loading leverage from db. Falling back to 2.0 {err:#}");
+        2.0
+    })
+}
+
+fn find_by_trader_leverage(connection: &mut PgConnection, trader_lev: &f32) -> Result<f32> {
+    let result: Option<CoordinatorLeverage> = coordinator_leverages::table
+        .filter(
+            coordinator_leverages::trader_leverage
+                .eq(&trader_lev.round().to_i32().expect("to fit")),
+        )
+        .first(connection)
+        .optional()?;
+
+    let leverage = match result {
+        None => max_coordinator_leverage(connection),
+        Some(coordinator_leverages) => coordinator_leverages.coordinator_leverage,
+    };
+
+    Ok(leverage.to_f32().expect("to fit"))
+}
+
+pub fn max_coordinator_leverage(connection: &mut PgConnection) -> i32 {
+    coordinator_leverages::table
+        .select(max(coordinator_leverages::coordinator_leverage))
+        .first::<Option<i32>>(connection)
+        .expect("to be able to execute query")
+        .expect("to have at least one leverage in db")
+}

--- a/coordinator/src/db/liquidity_options.rs
+++ b/coordinator/src/db/liquidity_options.rs
@@ -21,7 +21,9 @@ pub(crate) struct LiquidityOption {
     /// min fee in sats
     pub min_fee_sats: Option<i64>,
     pub fee_percentage: f64,
-    pub coordinator_leverage: f32,
+    /// TODO(bonomat): we should use this field again for deciding the coordinator's channel size
+    #[diesel(column_name = "coordinator_leverage")]
+    pub _coordinator_leverage: f32,
     pub active: bool,
     pub created_at: OffsetDateTime,
     pub updated_at: OffsetDateTime,
@@ -47,7 +49,6 @@ impl From<LiquidityOption> for commons::LiquidityOption {
             max_deposit_sats: value.max_deposit_sats as u64,
             min_fee_sats: value.min_fee_sats.unwrap_or(0) as u64,
             fee_percentage: value.fee_percentage,
-            coordinator_leverage: value.coordinator_leverage,
             created_at: value.created_at,
             updated_at: value.updated_at,
             active: value.active,

--- a/coordinator/src/db/mod.rs
+++ b/coordinator/src/db/mod.rs
@@ -2,6 +2,7 @@ pub mod bonus_status;
 pub mod bonus_tiers;
 pub mod channel_opening_params;
 pub mod collaborative_reverts;
+pub mod coordinator_leverages;
 pub mod custom_types;
 pub mod dlc_channels;
 pub mod dlc_messages;

--- a/coordinator/src/dlc_protocol.rs
+++ b/coordinator/src/dlc_protocol.rs
@@ -60,7 +60,7 @@ impl TradeParams {
             protocol_id,
             trader: trade_params.pubkey,
             quantity: trade_params.quantity,
-            leverage: trade_params.leverage,
+            leverage: trade_params.trader_leverage,
             average_price: trade_params
                 .average_execution_price()
                 .to_f32()

--- a/coordinator/src/orderbook/async_match.rs
+++ b/coordinator/src/orderbook/async_match.rs
@@ -97,6 +97,12 @@ async fn process_pending_match(
     if let Some(order) =
         orders::get_by_trader_id_and_state(&mut conn, trader_id, OrderState::Matched)?
     {
+        let coordinator_leverage =
+            db::coordinator_leverages::find_coordinator_leverage_by_trader_leverage(
+                &mut conn,
+                order.leverage,
+            );
+
         tracing::debug!(%trader_id, order_id=%order.id, "Executing pending match");
 
         let matches = matches::get_matches_by_order_id(&mut conn, order.id)?;
@@ -112,7 +118,8 @@ async fn process_pending_match(
                 trade_params: TradeParams {
                     pubkey: trader_id,
                     contract_symbol: ContractSymbol::BtcUsd,
-                    leverage: order.leverage,
+                    trader_leverage: order.leverage,
+                    coordinator_leverage,
                     quantity: order.quantity.to_f32().expect("to fit into f32"),
                     direction: order.direction,
                     filled_with,

--- a/coordinator/src/schema.rs
+++ b/coordinator/src/schema.rs
@@ -161,6 +161,14 @@ diesel::table! {
 }
 
 diesel::table! {
+    coordinator_leverages (id) {
+        id -> Int4,
+        trader_leverage -> Int4,
+        coordinator_leverage -> Int4,
+    }
+}
+
+diesel::table! {
     use diesel::sql_types::*;
     use super::sql_types::DlcChannelStateType;
 
@@ -217,23 +225,6 @@ diesel::table! {
 }
 
 diesel::table! {
-    use diesel::sql_types::*;
-    use super::sql_types::InvoiceStateType;
-
-    hodl_invoices (id) {
-        id -> Int4,
-        trader_pubkey -> Text,
-        r_hash -> Text,
-        amount_sats -> Int8,
-        pre_image -> Nullable<Text>,
-        created_at -> Timestamptz,
-        updated_at -> Nullable<Timestamptz>,
-        invoice_state -> InvoiceStateType,
-        order_id -> Nullable<Uuid>,
-    }
-}
-
-diesel::table! {
     funding_fee_events (id) {
         id -> Int4,
         amount_sats -> Int8,
@@ -254,6 +245,23 @@ diesel::table! {
         end_date -> Timestamptz,
         rate -> Float4,
         timestamp -> Timestamptz,
+    }
+}
+
+diesel::table! {
+    use diesel::sql_types::*;
+    use super::sql_types::InvoiceStateType;
+
+    hodl_invoices (id) {
+        id -> Int4,
+        trader_pubkey -> Text,
+        r_hash -> Text,
+        amount_sats -> Int8,
+        pre_image -> Nullable<Text>,
+        created_at -> Timestamptz,
+        updated_at -> Nullable<Timestamptz>,
+        invoice_state -> InvoiceStateType,
+        order_id -> Nullable<Uuid>,
     }
 }
 
@@ -571,6 +579,7 @@ diesel::allow_tables_to_appear_in_same_query!(
     channels,
     choices,
     collaborative_reverts,
+    coordinator_leverages,
     dlc_channels,
     dlc_messages,
     dlc_protocols,

--- a/coordinator/src/trade/mod.rs
+++ b/coordinator/src/trade/mod.rs
@@ -459,8 +459,8 @@ impl TradeExecutor {
     ) -> Result<()> {
         let peer_id = trade_params.pubkey;
 
-        let leverage_trader = trade_params.leverage;
-        let leverage_coordinator = coordinator_leverage_for_trade(&trade_params.pubkey)?;
+        let leverage_trader = trade_params.trader_leverage;
+        let leverage_coordinator = trade_params.coordinator_leverage;
 
         let margin_trader = margin_trader(trade_params);
         let margin_coordinator = margin_coordinator(trade_params, leverage_coordinator);
@@ -631,8 +631,8 @@ impl TradeExecutor {
 
         let initial_price = trade_params.filled_with.average_execution_price();
 
-        let leverage_coordinator = coordinator_leverage_for_trade(&trade_params.pubkey)?;
-        let leverage_trader = trade_params.leverage;
+        let leverage_coordinator = trade_params.coordinator_leverage;
+        let leverage_trader = trade_params.trader_leverage;
 
         let margin_coordinator = margin_coordinator(trade_params, leverage_coordinator);
         let margin_trader = margin_trader(trade_params);
@@ -998,7 +998,7 @@ impl TradeExecutor {
 
         let trader_liquidation_price = liquidation_price(
             price,
-            Decimal::try_from(trade_params.leverage).expect("to fit into decimal"),
+            Decimal::try_from(trade_params.trader_leverage).expect("to fit into decimal"),
             trade_params.direction,
             maintenance_margin_rate,
         );
@@ -1020,7 +1020,7 @@ impl TradeExecutor {
 
         let new_position = NewPosition {
             contract_symbol: trade_params.contract_symbol,
-            trader_leverage: trade_params.leverage,
+            trader_leverage: trade_params.trader_leverage,
             quantity: trade_params.quantity,
             trader_direction: trade_params.direction,
             trader: trade_params.pubkey,
@@ -1695,7 +1695,7 @@ fn margin_trader(trade_params: &TradeParams) -> Amount {
     calculate_margin(
         trade_params.average_execution_price(),
         trade_params.quantity,
-        trade_params.leverage,
+        trade_params.trader_leverage,
     )
 }
 
@@ -1717,26 +1717,6 @@ pub fn liquidation_price(
         Direction::Long => calculate_long_liquidation_price(leverage, price, maintenance_margin),
         Direction::Short => calculate_short_liquidation_price(leverage, price, maintenance_margin),
     }
-}
-
-pub fn coordinator_leverage_for_trade(_counterparty_peer_id: &PublicKey) -> Result<f32> {
-    // TODO(bonomat): we will need to configure the leverage on the coordinator differently now
-    // let channel_details = self.get_counterparty_channel(*counterparty_peer_id)?;
-    // let user_channel_id = Uuid::from_u128(channel_details.user_channel_id).to_string();
-    // let channel = db::channels::get(&user_channel_id, &mut conn)?.with_context(|| {
-    //     format!("Couldn't find shadow channel with user channel ID {user_channel_id}",)
-    // })?;
-    // let leverage_coordinator = match channel.liquidity_option_id {
-    //     Some(liquidity_option_id) => {
-    //         let liquidity_option = db::liquidity_options::get(&mut conn,
-    // liquidity_option_id)?;         liquidity_option.coordinator_leverage
-    //     }
-    //     None => 1.0,
-    // };
-
-    let leverage_coordinator = 2.0;
-
-    Ok(leverage_coordinator)
 }
 
 #[cfg(test)]

--- a/crates/dev-maker/src/main.rs
+++ b/crates/dev-maker/src/main.rs
@@ -113,7 +113,7 @@ async fn post_order(
                 id: uuid,
                 contract_symbol: ContractSymbol::BtcUsd,
                 price,
-                quantity: Decimal::from(5000),
+                quantity: Decimal::from(10000),
                 trader_id: public_key,
                 direction,
                 leverage: Decimal::from(2),

--- a/crates/xxi-node/src/commons/liquidity_option.rs
+++ b/crates/xxi-node/src/commons/liquidity_option.rs
@@ -17,7 +17,6 @@ pub struct LiquidityOption {
     /// min fee in sats
     pub min_fee_sats: u64,
     pub fee_percentage: f64,
-    pub coordinator_leverage: f32,
     #[serde(with = "time::serde::rfc3339")]
     pub created_at: OffsetDateTime,
     #[serde(with = "time::serde::rfc3339")]
@@ -61,7 +60,6 @@ mod test {
             max_deposit_sats: 500_000,
             min_fee_sats: 10_000,
             fee_percentage: 1.0,
-            coordinator_leverage: 2.0,
             created_at: OffsetDateTime::now_utc(),
             updated_at: OffsetDateTime::now_utc(),
             active: true,

--- a/crates/xxi-node/src/commons/message.rs
+++ b/crates/xxi-node/src/commons/message.rs
@@ -12,6 +12,7 @@ use bitcoin::Amount;
 use rust_decimal::Decimal;
 use serde::Deserialize;
 use serde::Serialize;
+use std::collections::HashMap;
 use std::fmt::Display;
 use thiserror::Error;
 use tokio_tungstenite_wasm as tungstenite;
@@ -81,6 +82,11 @@ pub struct TenTenOneConfig {
     pub order_matching_fee_rate: f32,
     pub referral_status: ReferralStatus,
     pub max_leverage: u8,
+    pub default_coordinator_leverage: u8,
+    /// Coordinator leverage according to trader's leverage.
+    ///
+    /// Key=trader_leverage, value=coordinator_leverage
+    pub coordinator_leverages: HashMap<u8, u8>,
 }
 
 #[derive(Serialize, Clone, Deserialize, Debug)]

--- a/crates/xxi-node/src/commons/trade.rs
+++ b/crates/xxi-node/src/commons/trade.rs
@@ -37,7 +37,10 @@ pub struct TradeParams {
     /// The leverage of the trader
     ///
     /// This has to correspond to our order's leverage.
-    pub leverage: f32,
+    pub trader_leverage: f32,
+
+    /// The leverage of the coordinator
+    pub coordinator_leverage: f32,
 
     /// The quantity of the trader
     ///

--- a/mobile/lib/common/application/channel_info_service.dart
+++ b/mobile/lib/common/application/channel_info_service.dart
@@ -6,4 +6,16 @@ class ChannelInfoService {
   rust.TradeConstraints getTradeConstraints() {
     return rust.api.channelTradeConstraints();
   }
+
+  double findCoordinatorLeverage(int traderLeverage) {
+    var channelTradeConstraints = getTradeConstraints();
+    try {
+      return channelTradeConstraints.coordinatorLeverages
+          .firstWhere((item) => item.traderLeverage == traderLeverage)
+          .coordinatorLeverage
+          .toDouble();
+    } catch (e) {
+      return channelTradeConstraints.defaultCoordinatorLeverage.toDouble();
+    }
+  }
 }

--- a/mobile/lib/common/domain/liquidity_option.dart
+++ b/mobile/lib/common/domain/liquidity_option.dart
@@ -23,7 +23,6 @@ class LiquidityOption {
   final Amount minDeposit;
   final Amount maxDeposit;
   final ProportionalFee fee;
-  final double coordinatorLeverage;
 
   LiquidityOption(
       {required this.active,
@@ -33,8 +32,7 @@ class LiquidityOption {
       required this.tradeUpTo,
       required this.minDeposit,
       required this.maxDeposit,
-      required this.fee,
-      required this.coordinatorLeverage});
+      required this.fee});
 
   static LiquidityOption from(bridge.LiquidityOption option) {
     return LiquidityOption(
@@ -46,7 +44,6 @@ class LiquidityOption {
       minDeposit: Amount(option.minDepositSats),
       maxDeposit: Amount(option.maxDepositSats),
       fee: ProportionalFee(percentage: option.feePercentage, minSats: option.minFeeSats),
-      coordinatorLeverage: option.coordinatorLeverage,
     );
   }
 }

--- a/mobile/lib/features/trade/channel_configuration.dart
+++ b/mobile/lib/features/trade/channel_configuration.dart
@@ -101,7 +101,8 @@ class _ChannelConfiguration extends State<ChannelConfiguration> {
     super.initState();
 
     tentenoneConfigChangeNotifier = context.read<TenTenOneConfigChangeNotifier>();
-    var tradeConstraints = tentenoneConfigChangeNotifier.channelInfoService.getTradeConstraints();
+    var channelInfoService = tentenoneConfigChangeNotifier.channelInfoService;
+    var tradeConstraints = channelInfoService.getTradeConstraints();
 
     DlcChannelService dlcChannelService =
         context.read<DlcChannelChangeNotifier>().dlcChannelService;
@@ -109,7 +110,9 @@ class _ChannelConfiguration extends State<ChannelConfiguration> {
     maxCounterpartyCollateral = Amount(tradeConstraints.maxCounterpartyBalanceSats);
 
     maxOnChainSpending = Amount(tradeConstraints.maxLocalBalanceSats);
-    counterpartyLeverage = tradeConstraints.coordinatorLeverage;
+
+    counterpartyLeverage =
+        channelInfoService.findCoordinatorLeverage(widget.tradeValues.leverage.leverage.round());
 
     counterpartyMargin = widget.tradeValues.calculateMargin(Leverage(counterpartyLeverage));
 

--- a/mobile/lib/features/trade/channel_creation_flow/channel_configuration_screen.dart
+++ b/mobile/lib/features/trade/channel_creation_flow/channel_configuration_screen.dart
@@ -108,7 +108,8 @@ class _ChannelConfiguration extends State<ChannelConfiguration> {
     super.initState();
 
     tentenoneConfigChangeNotifier = context.read<TenTenOneConfigChangeNotifier>();
-    var tradeConstraints = tentenoneConfigChangeNotifier.channelInfoService.getTradeConstraints();
+    var channelInfoService = tentenoneConfigChangeNotifier.channelInfoService;
+    var tradeConstraints = channelInfoService.getTradeConstraints();
 
     DlcChannelService dlcChannelService =
         context.read<DlcChannelChangeNotifier>().dlcChannelService;
@@ -120,7 +121,9 @@ class _ChannelConfiguration extends State<ChannelConfiguration> {
     maxCounterpartyCollateral = Amount(tradeConstraints.maxCounterpartyBalanceSats);
 
     maxOnChainSpending = Amount(tradeConstraints.maxLocalBalanceSats);
-    counterpartyLeverage = tradeConstraints.coordinatorLeverage;
+
+    counterpartyLeverage =
+        channelInfoService.findCoordinatorLeverage(widget.tradeValues.leverage.leverage.round());
 
     counterpartyMargin = widget.tradeValues.calculateMargin(Leverage(counterpartyLeverage));
 

--- a/mobile/native/src/api.rs
+++ b/mobile/native/src/api.rs
@@ -585,7 +585,6 @@ pub struct LiquidityOption {
     /// min fee in sats
     pub min_fee_sats: u64,
     pub fee_percentage: f64,
-    pub coordinator_leverage: f32,
     pub active: bool,
 }
 
@@ -600,7 +599,6 @@ impl From<xxi_node::commons::LiquidityOption> for LiquidityOption {
             max_deposit_sats: value.max_deposit_sats,
             min_fee_sats: value.min_fee_sats,
             fee_percentage: value.fee_percentage,
-            coordinator_leverage: value.coordinator_leverage,
             active: value.active,
         }
     }

--- a/mobile/native/src/max_quantity.rs
+++ b/mobile/native/src/max_quantity.rs
@@ -40,6 +40,9 @@ pub fn max_quantity(
     let max_coordinator_balance =
         Amount::from_sat(channel_trade_constraints.max_counterparty_balance_sats);
 
+    let coordinator_leverage =
+        channel_trade_constraints.coordinator_leverage_by_f32(trader_leverage);
+
     // If the trader has a channel, his max balance is the channel balance and we continue,
     // otherwise we can return here as the max amount to trade depends on what the coordinator can
     // provide
@@ -49,7 +52,7 @@ pub fn max_quantity(
         return Ok(Decimal::from_f32(calculations::calculate_quantity(
             price.to_f32().expect("to fit"),
             max_coordinator_balance.to_sat(),
-            channel_trade_constraints.coordinator_leverage,
+            coordinator_leverage,
         ))
         .expect("to fit"));
     };
@@ -129,7 +132,7 @@ pub fn max_quantity(
         max_coordinator_margin,
         max_trader_margin,
         on_chain_fee_estimate,
-        channel_trade_constraints.coordinator_leverage,
+        coordinator_leverage,
         trader_leverage,
         order_matching_fee_rate,
         accumulated_order_matching_fees,

--- a/mobile/test/trade_test.dart
+++ b/mobile/test/trade_test.dart
@@ -203,12 +203,13 @@ void main() {
         const bridge.TradeConstraints(
             maxLocalBalanceSats: 20000000000,
             maxCounterpartyBalanceSats: 200000000000,
-            coordinatorLeverage: 2,
+            defaultCoordinatorLeverage: 2,
             minQuantity: 1,
             isChannelBalance: true,
             minMargin: 1,
             maintenanceMarginRate: 0.1,
-            orderMatchingFeeRate: 0.003));
+            orderMatchingFeeRate: 0.003,
+            coordinatorLeverages: []));
 
     // We start the trade screen
     await tester.pumpWidget(MultiProvider(
@@ -378,12 +379,13 @@ void main() {
         const bridge.TradeConstraints(
             maxLocalBalanceSats: 10000000,
             maxCounterpartyBalanceSats: 20000000,
-            coordinatorLeverage: 2,
+            defaultCoordinatorLeverage: 2,
             minQuantity: 1,
             isChannelBalance: true,
             minMargin: 1,
             maintenanceMarginRate: 0.1,
-            orderMatchingFeeRate: 0.003));
+            orderMatchingFeeRate: 0.003,
+            coordinatorLeverages: []));
 
     // We start the trade screen
     await tester.pumpWidget(MultiProvider(
@@ -462,12 +464,13 @@ void main() {
         const bridge.TradeConstraints(
             maxLocalBalanceSats: 20000000000,
             maxCounterpartyBalanceSats: 200000000000,
-            coordinatorLeverage: 2,
+            defaultCoordinatorLeverage: 2,
             minQuantity: 1,
             isChannelBalance: true,
             minMargin: 1,
             maintenanceMarginRate: 0.1,
-            orderMatchingFeeRate: 0.003));
+            orderMatchingFeeRate: 0.003,
+            coordinatorLeverages: []));
 
     when(dlcChannelService.getEstimatedChannelFeeReserve()).thenReturn((Amount(500)));
 

--- a/webapp/src/api.rs
+++ b/webapp/src/api.rs
@@ -27,6 +27,7 @@ use serde::de;
 use serde::Deserialize;
 use serde::Deserializer;
 use serde::Serialize;
+use std::collections::HashMap;
 use std::fmt;
 use std::str::FromStr;
 use std::sync::Arc;
@@ -956,17 +957,18 @@ where
     }
 }
 
-#[derive(Serialize, Copy, Clone, Debug, ToSchema)]
+#[derive(Serialize, Clone, Debug, ToSchema)]
 pub struct TradeConstraints {
     pub max_local_balance_sats: u64,
     pub max_counterparty_balance_sats: u64,
-    pub coordinator_leverage: f32,
+    pub default_coordinator_leverage: u8,
     pub min_quantity: u64,
     pub is_channel_balance: bool,
     pub min_margin_sats: u64,
     pub estimated_funding_tx_fee_sats: u64,
     pub channel_fee_reserve_sats: u64,
     pub max_leverage: u8,
+    pub coordinator_leverages: HashMap<u8, u8>,
 }
 
 #[utoipa::path(
@@ -984,13 +986,14 @@ pub async fn get_trade_constraints() -> Result<Json<TradeConstraints>, AppError>
     Ok(Json(TradeConstraints {
         max_local_balance_sats: trade_constraints.max_local_balance_sats,
         max_counterparty_balance_sats: trade_constraints.max_counterparty_balance_sats,
-        coordinator_leverage: trade_constraints.coordinator_leverage,
+        default_coordinator_leverage: trade_constraints.default_coordinator_leverage,
         min_quantity: trade_constraints.min_quantity,
         is_channel_balance: trade_constraints.is_channel_balance,
         min_margin_sats: trade_constraints.min_margin,
         estimated_funding_tx_fee_sats: fee.to_sat(),
         channel_fee_reserve_sats: channel_fee_reserve.to_sat(),
         max_leverage: ten_one_config.max_leverage,
+        coordinator_leverages: ten_one_config.coordinator_leverages.clone(),
     }))
 }
 


### PR DESCRIPTION
With this patch we introduce a new table: `coordinator_leverages`.
It contains two fields:
- trader_leverage
- coordinator_leverage

i.e. we can define a coordinator leverage for each possible trader_leverage. For simplcitiy reasons we only have round numbers in the database and no floating points, hence, when looking up a coordinator leverage for a trader leverage, we need to round. If no match is found, we fall back and take the max allowed leverage of the coordinator. This allows us to not have an entry from 1 - 100 but stop at e.g. 10 with a max coordinator leverage of 10. If a user then goes a 100x, we still pick leverage 10.

There is one downside of this patch: The coordinator's reserve now depends on the trader's leverage which we might not want.