### PR TITLE
fix: don't overflow UI on small screens

### DIFF
--- a/mobile/lib/common/custom_qr_code.dart
+++ b/mobile/lib/common/custom_qr_code.dart
@@ -19,24 +19,27 @@ class CustomQrCode extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return SizedBox.square(
-      dimension: dimension,
-      child: QrImageView(
-        data: data,
-        eyeStyle: const QrEyeStyle(
-          eyeShape: QrEyeShape.square,
-          color: Colors.black,
+    return AspectRatio(
+      aspectRatio: 1,
+      child: SizedBox.square(
+        dimension: dimension,
+        child: QrImageView(
+          data: data,
+          eyeStyle: const QrEyeStyle(
+            eyeShape: QrEyeShape.square,
+            color: Colors.black,
+          ),
+          dataModuleStyle: const QrDataModuleStyle(
+            dataModuleShape: QrDataModuleShape.square,
+            color: Colors.black,
+          ),
+          embeddedImage: embeddedImage,
+          embeddedImageStyle: QrEmbeddedImageStyle(
+            size: Size(embeddedImageSizeHeight, embeddedImageSizeWidth),
+          ),
+          version: QrVersions.auto,
+          padding: const EdgeInsets.all(5),
         ),
-        dataModuleStyle: const QrDataModuleStyle(
-          dataModuleShape: QrDataModuleShape.square,
-          color: Colors.black,
-        ),
-        embeddedImage: embeddedImage,
-        embeddedImageStyle: QrEmbeddedImageStyle(
-          size: Size(embeddedImageSizeHeight, embeddedImageSizeWidth),
-        ),
-        version: QrVersions.auto,
-        padding: const EdgeInsets.all(5),
       ),
     );
   }

--- a/mobile/lib/common/secondary_action_button.dart
+++ b/mobile/lib/common/secondary_action_button.dart
@@ -4,6 +4,7 @@ ButtonStyle secondaryActionButtonStyle() {
   ColorScheme greyScheme = ColorScheme.fromSwatch(primarySwatch: Colors.grey);
 
   return IconButton.styleFrom(
+    padding: const EdgeInsets.symmetric(vertical: 4.0, horizontal: 12.0),
     foregroundColor: Colors.black,
     backgroundColor: Colors.grey.shade200,
     disabledBackgroundColor: greyScheme.onSurface.withOpacity(0.12),

--- a/mobile/lib/common/settings/app_info_screen.dart
+++ b/mobile/lib/common/settings/app_info_screen.dart
@@ -60,169 +60,161 @@ class _AppInfoScreenState extends State<AppInfoScreen> {
       body: Container(
           padding: const EdgeInsets.only(top: 20, left: 10, right: 10),
           child: SafeArea(
-            child: Column(
+            child: SingleChildScrollView(
+                child: Column(
               children: [
-                SingleChildScrollView(
-                    child: Column(
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.center,
                   children: [
-                    Row(
-                      mainAxisAlignment: MainAxisAlignment.center,
-                      children: [
-                        Expanded(
-                          child: Stack(
+                    Expanded(
+                      child: Stack(
+                        children: [
+                          GestureDetector(
+                            child: Container(
+                                alignment: AlignmentDirectional.topStart,
+                                decoration: BoxDecoration(
+                                    color: Colors.transparent,
+                                    borderRadius: BorderRadius.circular(10)),
+                                width: 70,
+                                child: const Icon(
+                                  Icons.arrow_back_ios_new_rounded,
+                                  size: 22,
+                                )),
+                            onTap: () {
+                              GoRouter.of(context).pop();
+                            },
+                          ),
+                          const Row(
+                            mainAxisAlignment: MainAxisAlignment.center,
                             children: [
-                              GestureDetector(
-                                child: Container(
-                                    alignment: AlignmentDirectional.topStart,
-                                    decoration: BoxDecoration(
-                                        color: Colors.transparent,
-                                        borderRadius: BorderRadius.circular(10)),
-                                    width: 70,
-                                    child: const Icon(
-                                      Icons.arrow_back_ios_new_rounded,
-                                      size: 22,
-                                    )),
-                                onTap: () {
-                                  GoRouter.of(context).pop();
-                                },
-                              ),
-                              const Row(
-                                mainAxisAlignment: MainAxisAlignment.center,
-                                children: [
-                                  Text(
-                                    "App Info",
-                                    style: TextStyle(fontWeight: FontWeight.w500, fontSize: 20),
-                                  ),
-                                ],
+                              Text(
+                                "App Info",
+                                style: TextStyle(fontWeight: FontWeight.w500, fontSize: 20),
                               ),
                             ],
                           ),
-                        ),
-                      ],
-                    ),
-                    Container(
-                      margin: const EdgeInsets.only(top: 20, left: 10, right: 10, bottom: 10),
-                      child: Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: [
-                          const Text(
-                            "NODE INFO",
-                            style: TextStyle(color: Colors.grey, fontSize: 17),
-                          ),
-                          const SizedBox(
-                            height: 10,
-                          ),
-                          Container(
-                              decoration: BoxDecoration(
-                                  color: Colors.white, borderRadius: BorderRadius.circular(15)),
-                              child: Column(
-                                children: [
-                                  moreInfo(context,
-                                      title: "Node Id", info: _nodeId, showCopyButton: true)
-                                ],
-                              ))
-                        ],
-                      ),
-                    ),
-                    Container(
-                      margin: const EdgeInsets.all(10),
-                      child: Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: [
-                          const Text(
-                            "BUILD INFO",
-                            style: TextStyle(color: Colors.grey, fontSize: 18),
-                          ),
-                          const SizedBox(
-                            height: 10,
-                          ),
-                          Container(
-                              decoration: BoxDecoration(
-                                  color: Colors.white, borderRadius: BorderRadius.circular(15)),
-                              child: Column(
-                                children: [
-                                  moreInfo(context, title: "Number", info: _buildNumber),
-                                  moreInfo(context, title: "Version", info: _version),
-                                  moreInfo(context,
-                                      title: "Commit Hash", info: commit, showCopyButton: true),
-                                  moreInfo(context,
-                                      title: "Branch", info: branch, showCopyButton: kDebugMode)
-                                ],
-                              ))
                         ],
                       ),
                     ),
                   ],
-                )),
-                Expanded(
-                  child: Row(
-                    mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-                    crossAxisAlignment: CrossAxisAlignment.end,
+                ),
+                Container(
+                  margin: const EdgeInsets.only(top: 20, left: 10, right: 10, bottom: 10),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
-                      IconButton(
-                        icon: const Icon(FontAwesomeIcons.twitter),
-                        iconSize: 22,
-                        onPressed: () async {
-                          final messenger = ScaffoldMessenger.of(context);
-                          final httpsUri = Uri(scheme: "https", host: "x.com", path: "get10101");
-                          if (await canLaunchUrl(httpsUri)) {
-                            await launchUrl(httpsUri, mode: LaunchMode.externalApplication);
-                          } else {
-                            showSnackBar(messenger, "Failed to open link");
-                          }
-                        },
+                      const Text(
+                        "NODE INFO",
+                        style: TextStyle(color: Colors.grey, fontSize: 17),
                       ),
-                      IconButton(
-                        icon: const Icon(FontAwesomeIcons.github, size: 22),
-                        onPressed: () async {
-                          final messenger = ScaffoldMessenger.of(context);
-                          final httpsUri =
-                              Uri(scheme: "https", host: "github.com", path: "get10101");
-                          if (await canLaunchUrl(httpsUri)) {
-                            await launchUrl(httpsUri, mode: LaunchMode.externalApplication);
-                          } else {
-                            showSnackBar(messenger, "Failed to open link");
-                          }
-                        },
+                      const SizedBox(
+                        height: 10,
                       ),
-                      IconButton(
-                        icon: const Icon(FontAwesomeIcons.telegram, size: 22),
-                        onPressed: () async {
-                          await openTelegram(context);
-                        },
-                      ),
-                      IconButton(
-                        icon: const Icon(FontAwesomeIcons.earthEurope, size: 22),
-                        onPressed: () async {
-                          final messenger = ScaffoldMessenger.of(context);
-                          final httpsUri =
-                              Uri(scheme: "https", host: "10101.finance", path: "blog");
-                          if (await canLaunchUrl(httpsUri)) {
-                            await launchUrl(httpsUri, mode: LaunchMode.externalApplication);
-                          } else {
-                            showSnackBar(messenger, "Failed to open link");
-                          }
-                        },
-                      ),
-                      IconButton(
-                        icon: const Icon(FontAwesomeIcons.question, size: 22),
-                        onPressed: () async {
-                          final messenger = ScaffoldMessenger.of(context);
-                          final httpsUri =
-                              Uri(scheme: "https", host: "10101.finance", path: "docs/faq");
-                          if (await canLaunchUrl(httpsUri)) {
-                            await launchUrl(httpsUri, mode: LaunchMode.externalApplication);
-                          } else {
-                            showSnackBar(messenger, "Failed to open link");
-                          }
-                        },
-                      )
+                      Container(
+                          decoration: BoxDecoration(
+                              color: Colors.white, borderRadius: BorderRadius.circular(15)),
+                          child: Column(
+                            children: [
+                              moreInfo(context,
+                                  title: "Node Id", info: _nodeId, showCopyButton: true)
+                            ],
+                          ))
                     ],
                   ),
                 ),
+                Container(
+                  margin: const EdgeInsets.all(10),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      const Text(
+                        "BUILD INFO",
+                        style: TextStyle(color: Colors.grey, fontSize: 18),
+                      ),
+                      const SizedBox(
+                        height: 10,
+                      ),
+                      Container(
+                          decoration: BoxDecoration(
+                              color: Colors.white, borderRadius: BorderRadius.circular(15)),
+                          child: Column(
+                            children: [
+                              moreInfo(context, title: "Number", info: _buildNumber),
+                              moreInfo(context, title: "Version", info: _version),
+                              moreInfo(context,
+                                  title: "Commit Hash", info: commit, showCopyButton: true),
+                              moreInfo(context,
+                                  title: "Branch", info: branch, showCopyButton: kDebugMode)
+                            ],
+                          ))
+                    ],
+                  ),
+                ),
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                  crossAxisAlignment: CrossAxisAlignment.end,
+                  children: [
+                    IconButton(
+                      icon: const Icon(FontAwesomeIcons.twitter),
+                      iconSize: 22,
+                      onPressed: () async {
+                        final messenger = ScaffoldMessenger.of(context);
+                        final httpsUri = Uri(scheme: "https", host: "x.com", path: "get10101");
+                        if (await canLaunchUrl(httpsUri)) {
+                          await launchUrl(httpsUri, mode: LaunchMode.externalApplication);
+                        } else {
+                          showSnackBar(messenger, "Failed to open link");
+                        }
+                      },
+                    ),
+                    IconButton(
+                      icon: const Icon(FontAwesomeIcons.github, size: 22),
+                      onPressed: () async {
+                        final messenger = ScaffoldMessenger.of(context);
+                        final httpsUri = Uri(scheme: "https", host: "github.com", path: "get10101");
+                        if (await canLaunchUrl(httpsUri)) {
+                          await launchUrl(httpsUri, mode: LaunchMode.externalApplication);
+                        } else {
+                          showSnackBar(messenger, "Failed to open link");
+                        }
+                      },
+                    ),
+                    IconButton(
+                      icon: const Icon(FontAwesomeIcons.telegram, size: 22),
+                      onPressed: () async {
+                        await openTelegram(context);
+                      },
+                    ),
+                    IconButton(
+                      icon: const Icon(FontAwesomeIcons.earthEurope, size: 22),
+                      onPressed: () async {
+                        final messenger = ScaffoldMessenger.of(context);
+                        final httpsUri = Uri(scheme: "https", host: "10101.finance", path: "blog");
+                        if (await canLaunchUrl(httpsUri)) {
+                          await launchUrl(httpsUri, mode: LaunchMode.externalApplication);
+                        } else {
+                          showSnackBar(messenger, "Failed to open link");
+                        }
+                      },
+                    ),
+                    IconButton(
+                      icon: const Icon(FontAwesomeIcons.question, size: 22),
+                      onPressed: () async {
+                        final messenger = ScaffoldMessenger.of(context);
+                        final httpsUri =
+                            Uri(scheme: "https", host: "10101.finance", path: "docs/faq");
+                        if (await canLaunchUrl(httpsUri)) {
+                          await launchUrl(httpsUri, mode: LaunchMode.externalApplication);
+                        } else {
+                          showSnackBar(messenger, "Failed to open link");
+                        }
+                      },
+                    )
+                  ],
+                ),
                 const SizedBox(height: 10)
               ],
-            ),
+            )),
           )),
     );
   }

--- a/mobile/lib/common/settings/seed_screen.dart
+++ b/mobile/lib/common/settings/seed_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:get_10101/common/scrollable_safe_area.dart';
 import 'package:get_10101/common/settings/seed_words.dart';
 import 'package:get_10101/common/settings/settings_screen.dart';
 import 'package:go_router/go_router.dart';
@@ -29,7 +30,7 @@ class _SeedScreenState extends State<SeedScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      body: SafeArea(
+      body: ScrollableSafeArea(
           child: Padding(
         padding: const EdgeInsets.only(top: 20, left: 10, right: 10),
         child: Column(

--- a/mobile/lib/common/settings/user_screen.dart
+++ b/mobile/lib/common/settings/user_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter/services.dart';
 import 'package:get_10101/common/application/tentenone_config_change_notifier.dart';
 import 'package:get_10101/common/color.dart';
 import 'package:get_10101/common/domain/referral_status.dart';
+import 'package:get_10101/common/scrollable_safe_area.dart';
 import 'package:get_10101/common/settings/settings_screen.dart';
 import 'package:get_10101/common/snack_bar.dart';
 import 'package:go_router/go_router.dart';
@@ -26,7 +27,7 @@ class _UserSettingsState extends State<UserSettings> {
     final referralStatus = context.read<TenTenOneConfigChangeNotifier>().referralStatus;
 
     return Scaffold(
-      body: SafeArea(
+      body: ScrollableSafeArea(
           child: Padding(
         padding: const EdgeInsets.only(top: 20, left: 18, right: 18),
         child: Column(

--- a/mobile/lib/features/trade/channel_creation_flow/channel_configuration_screen.dart
+++ b/mobile/lib/features/trade/channel_creation_flow/channel_configuration_screen.dart
@@ -193,343 +193,347 @@ class _ChannelConfiguration extends State<ChannelConfiguration> {
 
     return Scaffold(
       body: SafeArea(
-        child: Form(
-          key: _formKey,
-          child: Container(
-            padding: const EdgeInsets.only(top: 20, left: 15, right: 15),
-            child: Column(
-              children: [
-                Column(
-                  children: [
-                    Row(
-                      mainAxisAlignment: MainAxisAlignment.center,
-                      children: [
-                        Expanded(
-                          child: Stack(
-                            children: [
-                              GestureDetector(
-                                child: Container(
-                                    alignment: AlignmentDirectional.topStart,
-                                    decoration: BoxDecoration(
-                                        color: Colors.transparent,
-                                        borderRadius: BorderRadius.circular(10)),
-                                    width: 70,
-                                    child: const Icon(
-                                      Icons.arrow_back_ios_new_rounded,
-                                      size: 22,
-                                    )),
-                                onTap: () {
-                                  GoRouter.of(context).go(TradeScreen.route);
-                                },
-                              ),
-                              const Row(
-                                mainAxisAlignment: MainAxisAlignment.center,
-                                children: [
-                                  Text(
-                                    "Fund Channel",
-                                    style: TextStyle(fontWeight: FontWeight.w500, fontSize: 20),
-                                  ),
-                                ],
-                              ),
-                            ],
-                          ),
-                        ),
-                      ],
-                    ),
-                    const SizedBox(height: 10),
-                    Center(
-                      child: Text.rich(
-                        textAlign: TextAlign.justify,
-                        TextSpan(
-                          children: [
-                            TextSpan(
-                              text:
-                                  "🔔 This is your first trade and you do not have a channel yet. "
-                                  "In 10101 we use DLC-Channels for fast and low-cost off-chain trading. "
-                                  "You can read more about this technology ",
-                              style: DefaultTextStyle.of(context).style,
-                            ),
-                            TextSpan(
-                              text: 'here.',
-                              style: const TextStyle(
-                                color: tenTenOnePurple,
-                                decoration: TextDecoration.underline,
-                              ),
-                              recognizer: TapGestureRecognizer()
-                                ..onTap = () async {
-                                  final httpsUri = Uri(
-                                      scheme: 'https',
-                                      host: '10101.finance',
-                                      path: '/blog/dlc-channels-demystified');
-
-                                  canLaunchUrl(httpsUri).then((canLaunch) async {
-                                    if (canLaunch) {
-                                      launchUrl(httpsUri, mode: LaunchMode.externalApplication);
-                                    } else {
-                                      showSnackBar(
-                                          ScaffoldMessenger.of(context), "Failed to open link");
-                                    }
-                                  });
-                                },
-                            ),
-                          ],
-                        ),
-                      ),
-                    ),
-                  ],
-                ),
-                Expanded(
-                  child: Container(),
-                ),
-                Column(
-                  children: [
-                    CustomFramedContainer(
-                        text: 'Channel size',
-                        child: Column(
-                          mainAxisAlignment: MainAxisAlignment.center,
-                          children: [
-                            Padding(
-                              padding: const EdgeInsets.only(top: 5),
-                              child: slider_theme.SfSliderTheme(
-                                data: slider_theme.SfSliderThemeData(
-                                  activeLabelStyle:
-                                      const TextStyle(color: Colors.black, fontSize: 12),
-                                  inactiveLabelStyle:
-                                      const TextStyle(color: Colors.black, fontSize: 12),
-                                  activeTrackColor: tenTenOnePurple.shade50,
-                                  inactiveTrackColor: tenTenOnePurple.shade50,
-                                  tickOffset: const Offset(0.0, 10.0),
+        child: SingleChildScrollView(
+          child: Form(
+            key: _formKey,
+            child: Container(
+              padding: const EdgeInsets.only(top: 20, left: 15, right: 15),
+              child: Column(
+                children: [
+                  Column(
+                    children: [
+                      Row(
+                        mainAxisAlignment: MainAxisAlignment.center,
+                        children: [
+                          Expanded(
+                            child: Stack(
+                              children: [
+                                GestureDetector(
+                                  child: Container(
+                                      alignment: AlignmentDirectional.topStart,
+                                      decoration: BoxDecoration(
+                                          color: Colors.transparent,
+                                          borderRadius: BorderRadius.circular(10)),
+                                      width: 70,
+                                      child: const Icon(
+                                        Icons.arrow_back_ios_new_rounded,
+                                        size: 22,
+                                      )),
+                                  onTap: () {
+                                    GoRouter.of(context).go(TradeScreen.route);
+                                  },
                                 ),
-                                child: SfSlider(
-                                  // TODO(bonomat): don't hard code this value
-                                  min: 250000,
-                                  max: maxCounterpartyCollateralSats,
-                                  value: ownTotalCollateral.sats,
-                                  stepSize: 100000,
-                                  interval: 10000,
-                                  showTicks: false,
-                                  showLabels: true,
-                                  enableTooltip: true,
-                                  labelFormatterCallback:
-                                      (dynamic actualValue, String formattedText) {
-                                    if (actualValue == 250000) {
-                                      return "Min";
-                                    }
+                                const Row(
+                                  mainAxisAlignment: MainAxisAlignment.center,
+                                  children: [
+                                    Text(
+                                      "Fund Channel",
+                                      style: TextStyle(fontWeight: FontWeight.w500, fontSize: 20),
+                                    ),
+                                  ],
+                                ),
+                              ],
+                            ),
+                          ),
+                        ],
+                      ),
+                      const SizedBox(height: 10),
+                      Center(
+                        child: Text.rich(
+                          textAlign: TextAlign.justify,
+                          TextSpan(
+                            children: [
+                              TextSpan(
+                                text:
+                                    "🔔 This is your first trade and you do not have a channel yet. "
+                                    "In 10101 we use DLC-Channels for fast and low-cost off-chain trading. "
+                                    "You can read more about this technology ",
+                                style: DefaultTextStyle.of(context).style,
+                              ),
+                              TextSpan(
+                                text: 'here.',
+                                style: const TextStyle(
+                                  color: tenTenOnePurple,
+                                  decoration: TextDecoration.underline,
+                                ),
+                                recognizer: TapGestureRecognizer()
+                                  ..onTap = () async {
+                                    final httpsUri = Uri(
+                                        scheme: 'https',
+                                        host: '10101.finance',
+                                        path: '/blog/dlc-channels-demystified');
 
-                                    if (actualValue == maxCounterpartyCollateralSats) {
-                                      return "Max";
-                                    }
-
-                                    return "";
-                                  },
-                                  tooltipShape: const SfPaddleTooltipShape(),
-                                  tooltipTextFormatterCallback:
-                                      (dynamic actualValue, String formattedText) {
-                                    return "${(actualValue as double).toInt()} sats";
-                                  },
-                                  onChanged: (dynamic value) {
-                                    setState(() {
-                                      if (value < minMargin.sats) {
-                                        value = minMargin.sats.toDouble();
+                                    canLaunchUrl(httpsUri).then((canLaunch) async {
+                                      if (canLaunch) {
+                                        launchUrl(httpsUri, mode: LaunchMode.externalApplication);
+                                      } else {
+                                        showSnackBar(
+                                            ScaffoldMessenger.of(context), "Failed to open link");
                                       }
-
-                                      ownTotalCollateral = Amount((value as double).toInt());
-                                      fundWithWalletEnabled =
-                                          maxUsableOnChainBalance.sats >= ownTotalCollateral.sats;
-                                      if (!fundWithWalletEnabled) {
-                                        useInnerWallet = false;
-                                      }
-
-                                      updateCounterpartyCollateral();
                                     });
                                   },
-                                ),
                               ),
-                            ),
-                            Padding(
-                              padding:
-                                  const EdgeInsets.only(top: 15, bottom: 5, left: 10, right: 10),
-                              child: ValueDataRow(
-                                  type: ValueType.amount,
-                                  value: counterpartyCollateral,
-                                  label: 'Win up to'),
-                            )
-                          ],
-                        )),
-                    CustomFramedContainer(
-                        text: 'Order details',
-                        child: Padding(
-                          padding: const EdgeInsets.only(top: 15, bottom: 5, left: 10, right: 10),
-                          child: Column(
-                            mainAxisAlignment: MainAxisAlignment.center,
-                            children: [
-                              ValueDataRow(
-                                  type: ValueType.fiat,
-                                  value: quantity.asDouble(),
-                                  label: 'Quantity'),
-                              ValueDataRow(
-                                  type: ValueType.text,
-                                  value: leverage.formatted(),
-                                  label: 'Leverage'),
-                              ValueDataRow(
-                                  type: ValueType.fiat,
-                                  value: liquidationPrice,
-                                  label: 'Liquidation price'),
                             ],
-                          ),
-                        )),
-                    CustomFramedContainer(
-                        text: 'Order cost',
-                        child: Padding(
-                          padding: const EdgeInsets.only(top: 15, bottom: 5, left: 10, right: 10),
-                          child: Column(
-                            mainAxisAlignment: MainAxisAlignment.center,
-                            children: [
-                              ValueDataRow(
-                                  type: ValueType.amount, value: traderMargin, label: 'Margin'),
-                              ValueDataRow(
-                                  type: ValueType.amount, value: traderReserve, label: 'Reserve'),
-                              FeeExpansionTile(
-                                  value: totalFee,
-                                  orderMatchingFee: orderMatchingFee,
-                                  fundingTxFee: fundingTxFee,
-                                  channelFeeReserve: channelFeeReserve),
-                              const Divider(),
-                              ValueDataRow(
-                                  type: ValueType.amount,
-                                  value: totalAmountToBeFunded,
-                                  label: "Total"),
-                            ],
-                          ),
-                        )),
-                    Row(
-                      mainAxisAlignment: MainAxisAlignment.start,
-                      children: [
-                        Checkbox(
-                          key: tradeScreenBottomSheetChannelConfigurationFundWithWalletCheckBox,
-                          value: useInnerWallet,
-                          onChanged: fundWithWalletEnabled
-                              ? (bool? value) {
-                                  setState(() {
-                                    useInnerWallet = value ?? false;
-                                  });
-                                }
-                              : null,
-                        ),
-                        Text(
-                          "Fund with internal 10101 wallet",
-                          style:
-                              TextStyle(color: fundWithWalletEnabled ? Colors.black : Colors.grey),
-                        )
-                      ],
-                    ),
-                    SizedBox(
-                      height: 50,
-                      child: Visibility(
-                        visible: useInnerWallet,
-                        replacement: Padding(
-                            padding: const EdgeInsets.only(top: 1, left: 8, right: 8, bottom: 8),
-                            child: ElevatedButton.icon(
-                                key: tradeScreenBottomSheetChannelConfigurationConfirmButton,
-                                onPressed: _formKey.currentState != null &&
-                                        _formKey.currentState!.validate() &&
-                                        !externalFundingChannelButtonPressed
-                                    ? () async {
-                                        logger.d(
-                                            "Submitting an order with ownTotalCollateral: $ownTotalCollateral orderMatchingFee: $orderMatchingFee, fundingTxFee: $fundingTxFee, channelFeeReserve: $channelFeeReserve, counterpartyCollateral: $counterpartyCollateral, ownMargin: ${widget.tradeValues.margin}");
-
-                                        setState(() => externalFundingChannelButtonPressed = true);
-
-                                        // TODO(holzeis): The coordinator leverage should not be hard coded here.
-                                        final coordinatorCollateral =
-                                            widget.tradeValues.calculateMargin(Leverage(2.0));
-
-                                        final coordinatorReserve = max(0,
-                                            counterpartyCollateral.sub(coordinatorCollateral).sats);
-                                        final traderReserve = max(
-                                            minTraderReserveSats,
-                                            ownTotalCollateral
-                                                .sub(widget.tradeValues.margin!)
-                                                .sats);
-
-                                        await submitOrderChangeNotifier
-                                            .submitUnfundedOrder(
-                                                widget.tradeValues,
-                                                ChannelOpeningParams(
-                                                    coordinatorReserve: Amount(coordinatorReserve),
-                                                    traderReserve: Amount(traderReserve)))
-                                            .then((ExternalFunding funding) {
-                                          externalFundingChannelButtonPressed = false;
-                                          GoRouter.of(context).push(ChannelFundingScreen.route,
-                                              extra: {
-                                                "funding": funding,
-                                                "amount": totalAmountToBeFunded
-                                              });
-                                        }).onError((error, stackTrace) {
-                                          setState(
-                                              () => externalFundingChannelButtonPressed = false);
-                                          logger.e("Failed at submitting unfunded order $error");
-                                          final messenger = ScaffoldMessenger.of(context);
-                                          showSnackBar(messenger,
-                                              "Failed creating order ${error.toString()}");
-                                        });
-                                      }
-                                    : null,
-                                icon: externalFundingChannelButtonPressed
-                                    ? const SizedBox(
-                                        width: 15,
-                                        height: 15,
-                                        child: CircularProgressIndicator(
-                                            color: Colors.white, strokeWidth: 2))
-                                    : Container(),
-                                label: const Text(
-                                  "Next",
-                                  style: TextStyle(color: Colors.white),
-                                ),
-                                style: ElevatedButton.styleFrom(
-                                    minimumSize: const Size.fromHeight(50),
-                                    disabledBackgroundColor: tenTenOnePurple.shade200))),
-                        child: Padding(
-                          padding: const EdgeInsets.only(top: 1, left: 8, right: 8, bottom: 8),
-                          child: ConfirmationSlider(
-                            key: tradeScreenBottomSheetChannelConfigurationConfirmSlider,
-                            text: "Swipe to confirm ${widget.tradeValues.direction.nameU}",
-                            textStyle: TextStyle(color: confirmationSliderColor),
-                            height: 40,
-                            foregroundColor: confirmationSliderColor,
-                            sliderButtonContent: const Icon(
-                              Icons.chevron_right,
-                              color: Colors.white,
-                              size: 20,
-                            ),
-                            onConfirmation: () async {
-                              logger.d("Submitting new order with "
-                                  "quantity: ${widget.tradeValues.quantity}, "
-                                  "leverage: ${widget.tradeValues.leverage.formatted()}, "
-                                  "direction: ${widget.tradeValues.direction}, "
-                                  "liquidationPrice: ${widget.tradeValues.liquidationPrice}, "
-                                  "margin: ${widget.tradeValues.margin}, "
-                                  "ownTotalCollateral: $ownTotalCollateral, "
-                                  "counterpartyCollateral: $counterpartyCollateral, "
-                                  "");
-                              submitOrderChangeNotifier
-                                  .submitOrder(widget.tradeValues,
-                                      channelOpeningParams: ChannelOpeningParams(
-                                          coordinatorReserve: counterpartyCollateral,
-                                          traderReserve: ownTotalCollateral))
-                                  .onError((error, stackTrace) {
-                                logger.e("Failed creating new channel due to $error");
-                                final messenger = ScaffoldMessenger.of(context);
-                                showSnackBar(messenger, "Failed creating order ${e.toString()}");
-                              }).then((ignored) => GoRouter.of(context).go(TradeScreen.route));
-                            },
                           ),
                         ),
                       ),
-                    ),
-                  ],
-                ),
-              ],
+                    ],
+                  ),
+                  Column(
+                    children: [
+                      CustomFramedContainer(
+                          text: 'Channel size',
+                          child: Column(
+                            mainAxisAlignment: MainAxisAlignment.center,
+                            children: [
+                              Padding(
+                                padding: const EdgeInsets.only(top: 5),
+                                child: slider_theme.SfSliderTheme(
+                                  data: slider_theme.SfSliderThemeData(
+                                    activeLabelStyle:
+                                        const TextStyle(color: Colors.black, fontSize: 12),
+                                    inactiveLabelStyle:
+                                        const TextStyle(color: Colors.black, fontSize: 12),
+                                    activeTrackColor: tenTenOnePurple.shade50,
+                                    inactiveTrackColor: tenTenOnePurple.shade50,
+                                    tickOffset: const Offset(0.0, 10.0),
+                                  ),
+                                  child: SfSlider(
+                                    // TODO(bonomat): don't hard code this value
+                                    min: 250000,
+                                    max: maxCounterpartyCollateralSats,
+                                    value: ownTotalCollateral.sats,
+                                    stepSize: 100000,
+                                    interval: 10000,
+                                    showTicks: false,
+                                    showLabels: true,
+                                    enableTooltip: true,
+                                    labelFormatterCallback:
+                                        (dynamic actualValue, String formattedText) {
+                                      if (actualValue == 250000) {
+                                        return "Min";
+                                      }
+
+                                      if (actualValue == maxCounterpartyCollateralSats) {
+                                        return "Max";
+                                      }
+
+                                      return "";
+                                    },
+                                    tooltipShape: const SfPaddleTooltipShape(),
+                                    tooltipTextFormatterCallback:
+                                        (dynamic actualValue, String formattedText) {
+                                      return "${(actualValue as double).toInt()} sats";
+                                    },
+                                    onChanged: (dynamic value) {
+                                      setState(() {
+                                        if (value < minMargin.sats) {
+                                          value = minMargin.sats.toDouble();
+                                        }
+
+                                        ownTotalCollateral = Amount((value as double).toInt());
+                                        fundWithWalletEnabled =
+                                            maxUsableOnChainBalance.sats >= ownTotalCollateral.sats;
+                                        if (!fundWithWalletEnabled) {
+                                          useInnerWallet = false;
+                                        }
+
+                                        updateCounterpartyCollateral();
+                                      });
+                                    },
+                                  ),
+                                ),
+                              ),
+                              Padding(
+                                padding:
+                                    const EdgeInsets.only(top: 15, bottom: 5, left: 10, right: 10),
+                                child: ValueDataRow(
+                                    type: ValueType.amount,
+                                    value: counterpartyCollateral,
+                                    label: 'Win up to'),
+                              )
+                            ],
+                          )),
+                      CustomFramedContainer(
+                          text: 'Order details',
+                          child: Padding(
+                            padding: const EdgeInsets.only(top: 15, bottom: 5, left: 10, right: 10),
+                            child: Column(
+                              mainAxisAlignment: MainAxisAlignment.center,
+                              children: [
+                                ValueDataRow(
+                                    type: ValueType.fiat,
+                                    value: quantity.asDouble(),
+                                    label: 'Quantity'),
+                                ValueDataRow(
+                                    type: ValueType.text,
+                                    value: leverage.formatted(),
+                                    label: 'Leverage'),
+                                ValueDataRow(
+                                    type: ValueType.fiat,
+                                    value: liquidationPrice,
+                                    label: 'Liquidation price'),
+                              ],
+                            ),
+                          )),
+                      CustomFramedContainer(
+                          text: 'Order cost',
+                          child: Padding(
+                            padding: const EdgeInsets.only(top: 15, bottom: 5, left: 10, right: 10),
+                            child: Column(
+                              mainAxisAlignment: MainAxisAlignment.center,
+                              children: [
+                                ValueDataRow(
+                                    type: ValueType.amount, value: traderMargin, label: 'Margin'),
+                                ValueDataRow(
+                                    type: ValueType.amount, value: traderReserve, label: 'Reserve'),
+                                FeeExpansionTile(
+                                    value: totalFee,
+                                    orderMatchingFee: orderMatchingFee,
+                                    fundingTxFee: fundingTxFee,
+                                    channelFeeReserve: channelFeeReserve),
+                                const Divider(),
+                                ValueDataRow(
+                                    type: ValueType.amount,
+                                    value: totalAmountToBeFunded,
+                                    label: "Total"),
+                              ],
+                            ),
+                          )),
+                      Row(
+                        mainAxisAlignment: MainAxisAlignment.start,
+                        children: [
+                          Checkbox(
+                            key: tradeScreenBottomSheetChannelConfigurationFundWithWalletCheckBox,
+                            value: useInnerWallet,
+                            onChanged: fundWithWalletEnabled
+                                ? (bool? value) {
+                                    setState(() {
+                                      useInnerWallet = value ?? false;
+                                    });
+                                  }
+                                : null,
+                          ),
+                          Text(
+                            "Fund with internal 10101 wallet",
+                            style: TextStyle(
+                                color: fundWithWalletEnabled ? Colors.black : Colors.grey),
+                          )
+                        ],
+                      ),
+                      SizedBox(
+                        height: 50,
+                        child: Visibility(
+                          visible: useInnerWallet,
+                          replacement: Padding(
+                              padding: const EdgeInsets.only(top: 1, left: 8, right: 8, bottom: 8),
+                              child: ElevatedButton.icon(
+                                  key: tradeScreenBottomSheetChannelConfigurationConfirmButton,
+                                  onPressed: _formKey.currentState != null &&
+                                          _formKey.currentState!.validate() &&
+                                          !externalFundingChannelButtonPressed
+                                      ? () async {
+                                          logger.d(
+                                              "Submitting an order with ownTotalCollateral: $ownTotalCollateral orderMatchingFee: $orderMatchingFee, fundingTxFee: $fundingTxFee, channelFeeReserve: $channelFeeReserve, counterpartyCollateral: $counterpartyCollateral, ownMargin: ${widget.tradeValues.margin}");
+
+                                          setState(
+                                              () => externalFundingChannelButtonPressed = true);
+
+                                          // TODO(holzeis): The coordinator leverage should not be hard coded here.
+                                          final coordinatorCollateral =
+                                              widget.tradeValues.calculateMargin(Leverage(2.0));
+
+                                          final coordinatorReserve = max(
+                                              0,
+                                              counterpartyCollateral
+                                                  .sub(coordinatorCollateral)
+                                                  .sats);
+                                          final traderReserve = max(
+                                              minTraderReserveSats,
+                                              ownTotalCollateral
+                                                  .sub(widget.tradeValues.margin!)
+                                                  .sats);
+
+                                          await submitOrderChangeNotifier
+                                              .submitUnfundedOrder(
+                                                  widget.tradeValues,
+                                                  ChannelOpeningParams(
+                                                      coordinatorReserve:
+                                                          Amount(coordinatorReserve),
+                                                      traderReserve: Amount(traderReserve)))
+                                              .then((ExternalFunding funding) {
+                                            externalFundingChannelButtonPressed = false;
+                                            GoRouter.of(context).push(ChannelFundingScreen.route,
+                                                extra: {
+                                                  "funding": funding,
+                                                  "amount": totalAmountToBeFunded
+                                                });
+                                          }).onError((error, stackTrace) {
+                                            setState(
+                                                () => externalFundingChannelButtonPressed = false);
+                                            logger.e("Failed at submitting unfunded order $error");
+                                            final messenger = ScaffoldMessenger.of(context);
+                                            showSnackBar(messenger,
+                                                "Failed creating order ${error.toString()}");
+                                          });
+                                        }
+                                      : null,
+                                  icon: externalFundingChannelButtonPressed
+                                      ? const SizedBox(
+                                          width: 15,
+                                          height: 15,
+                                          child: CircularProgressIndicator(
+                                              color: Colors.white, strokeWidth: 2))
+                                      : Container(),
+                                  label: const Text(
+                                    "Next",
+                                    style: TextStyle(color: Colors.white),
+                                  ),
+                                  style: ElevatedButton.styleFrom(
+                                      minimumSize: const Size.fromHeight(50),
+                                      disabledBackgroundColor: tenTenOnePurple.shade200))),
+                          child: Padding(
+                            padding: const EdgeInsets.only(top: 1, left: 8, right: 8, bottom: 8),
+                            child: ConfirmationSlider(
+                              key: tradeScreenBottomSheetChannelConfigurationConfirmSlider,
+                              text: "Swipe to confirm ${widget.tradeValues.direction.nameU}",
+                              textStyle: TextStyle(color: confirmationSliderColor),
+                              height: 40,
+                              foregroundColor: confirmationSliderColor,
+                              sliderButtonContent: const Icon(
+                                Icons.chevron_right,
+                                color: Colors.white,
+                                size: 20,
+                              ),
+                              onConfirmation: () async {
+                                logger.d("Submitting new order with "
+                                    "quantity: ${widget.tradeValues.quantity}, "
+                                    "leverage: ${widget.tradeValues.leverage.formatted()}, "
+                                    "direction: ${widget.tradeValues.direction}, "
+                                    "liquidationPrice: ${widget.tradeValues.liquidationPrice}, "
+                                    "margin: ${widget.tradeValues.margin}, "
+                                    "ownTotalCollateral: $ownTotalCollateral, "
+                                    "counterpartyCollateral: $counterpartyCollateral, "
+                                    "");
+                                submitOrderChangeNotifier
+                                    .submitOrder(widget.tradeValues,
+                                        channelOpeningParams: ChannelOpeningParams(
+                                            coordinatorReserve: counterpartyCollateral,
+                                            traderReserve: ownTotalCollateral))
+                                    .onError((error, stackTrace) {
+                                  logger.e("Failed creating new channel due to $error");
+                                  final messenger = ScaffoldMessenger.of(context);
+                                  showSnackBar(messenger, "Failed creating order ${e.toString()}");
+                                }).then((ignored) => GoRouter.of(context).go(TradeScreen.route));
+                              },
+                            ),
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                ],
+              ),
             ),
           ),
         ),

--- a/mobile/lib/features/trade/tradingview_candlestick.dart
+++ b/mobile/lib/features/trade/tradingview_candlestick.dart
@@ -119,9 +119,11 @@ class _TradingViewCandlestickState extends State<TradingViewCandlestick> {
                   return NavigationActionPolicy.ALLOW;
                 },
                 onProgressChanged: (controller, progress) {
-                  setState(() {
-                    this.progress = progress / 100;
-                  });
+                  if (mounted) {
+                    setState(() {
+                      this.progress = progress / 100;
+                    });
+                  }
                 },
               ),
               progress < 1.0 ? LinearProgressIndicator(value: progress) : Container(),

--- a/mobile/lib/features/wallet/receive_screen.dart
+++ b/mobile/lib/features/wallet/receive_screen.dart
@@ -75,6 +75,9 @@ class _ReceiveScreenState extends State<ReceiveScreen> {
               child: SizedBox(width: 20, height: 20, child: CircularProgressIndicator())));
     }
 
+    const double verticalSep = 15;
+    const double qrSize = 350;
+
     return Scaffold(
         body: ScrollableSafeArea(
             child: Container(
@@ -89,35 +92,38 @@ class _ReceiveScreenState extends State<ReceiveScreen> {
                 : null,
             child: Center(
                 child: _faucet
-                    ? Column(
-                        children: [
-                          const SizedBox(height: 125),
-                          OutlinedButton(
-                            onPressed: _isPayInvoiceButtonDisabled
-                                ? null
-                                : () async {
-                                    setState(() => _isPayInvoiceButtonDisabled = true);
-                                    final faucetService = context.read<FaucetService>();
-                                    faucetService
-                                        .payInvoiceWithFaucet(
-                                            rawInvoice(), amount, config.network, Layer.onchain)
-                                        .catchError((error) {
-                                      setState(() => _isPayInvoiceButtonDisabled = false);
-                                      showSnackBar(ScaffoldMessenger.of(context), error.toString());
-                                    }).then((value) => context.go(WalletScreen.route));
-                                  },
-                            style: ElevatedButton.styleFrom(
-                              shape: const RoundedRectangleBorder(
-                                  borderRadius: BorderRadius.all(Radius.circular(5.0))),
+                    ? AspectRatio(
+                        aspectRatio: 1,
+                        child: SizedBox.square(
+                          dimension: qrSize,
+                          child: Center(
+                            child: OutlinedButton(
+                              onPressed: _isPayInvoiceButtonDisabled
+                                  ? null
+                                  : () async {
+                                      setState(() => _isPayInvoiceButtonDisabled = true);
+                                      final faucetService = context.read<FaucetService>();
+                                      faucetService
+                                          .payInvoiceWithFaucet(
+                                              rawInvoice(), amount, config.network, Layer.onchain)
+                                          .catchError((error) {
+                                        setState(() => _isPayInvoiceButtonDisabled = false);
+                                        showSnackBar(
+                                            ScaffoldMessenger.of(context), error.toString());
+                                      }).then((value) => context.go(WalletScreen.route));
+                                    },
+                              style: ElevatedButton.styleFrom(
+                                shape: const RoundedRectangleBorder(
+                                    borderRadius: BorderRadius.all(Radius.circular(5.0))),
+                              ),
+                              child: config.network == "regtest"
+                                  ? const Text("Pay with 10101 faucet")
+                                  : const Text("Pay with Mutinynet faucet"),
                             ),
-                            child: config.network == "regtest"
-                                ? const Text("Pay with 10101 faucet")
-                                : const Text("Pay with Mutinynet faucet"),
                           ),
-                          const SizedBox(height: 125),
-                        ],
-                      )
+                        ))
                     : CustomQrCode(
+                        dimension: qrSize,
                         data: rawInvoice(),
                         embeddedImage:
                             const AssetImage("assets/10101_logo_icon_white_background.png"),
@@ -191,43 +197,46 @@ class _ReceiveScreenState extends State<ReceiveScreen> {
             ],
           ),
         ),
+        const SizedBox(height: verticalSep),
         BitcoinAddress(
           address: _paymentRequest == null ? "" : _paymentRequest!.address,
         ),
-        const Spacer(),
         Visibility(
           visible: !hasDlcChannel && balance.sats < minBalance,
-          child: Container(
-              padding: const EdgeInsets.symmetric(vertical: 10, horizontal: 20),
-              decoration: BoxDecoration(
-                  border: Border.all(color: tenTenOnePurple),
-                  color: Colors.white,
-                  borderRadius: BorderRadius.circular(10)),
-              child: Row(
-                mainAxisAlignment: MainAxisAlignment.start,
-                children: [
-                  const Icon(
-                    Icons.info,
-                    color: tenTenOnePurple,
-                    size: 22,
-                  ),
-                  const SizedBox(width: 15),
-                  Expanded(
-                      child: RichText(
-                    softWrap: true,
-                    text: TextSpan(
-                      text: "You will need around",
-                      style: const TextStyle(fontSize: 15, color: Colors.black87),
-                      children: [
-                        TextSpan(
-                            text: " ${formatSats(Amount(minBalance))} ",
-                            style: const TextStyle(fontWeight: FontWeight.bold)),
-                        const TextSpan(text: "in your on-chain wallet to start trading.")
-                      ],
+          child: Padding(
+            padding: const EdgeInsets.fromLTRB(0.0, verticalSep, 0.0, 0.0),
+            child: Container(
+                padding: const EdgeInsets.symmetric(vertical: 10, horizontal: 20),
+                decoration: BoxDecoration(
+                    border: Border.all(color: tenTenOnePurple),
+                    color: Colors.white,
+                    borderRadius: BorderRadius.circular(10)),
+                child: Row(
+                  mainAxisAlignment: MainAxisAlignment.start,
+                  children: [
+                    const Icon(
+                      Icons.info,
+                      color: tenTenOnePurple,
+                      size: 22,
                     ),
-                  ))
-                ],
-              )),
+                    const SizedBox(width: 15),
+                    Expanded(
+                        child: RichText(
+                      softWrap: true,
+                      text: TextSpan(
+                        text: "You will need around",
+                        style: const TextStyle(fontSize: 15, color: Colors.black87),
+                        children: [
+                          TextSpan(
+                              text: " ${formatSats(Amount(minBalance))} ",
+                              style: const TextStyle(fontWeight: FontWeight.bold)),
+                          const TextSpan(text: "in your on-chain wallet to start trading.")
+                        ],
+                      ),
+                    ))
+                  ],
+                )),
+          ),
         ),
       ]),
     )));
@@ -253,7 +262,6 @@ class BitcoinAddress extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Container(
-        margin: const EdgeInsets.fromLTRB(0, 15, 0, 0),
         decoration: BoxDecoration(
             border: Border.all(color: Colors.grey.shade200),
             borderRadius: BorderRadius.circular(10),

--- a/mobile/lib/features/wallet/referral_widget.dart
+++ b/mobile/lib/features/wallet/referral_widget.dart
@@ -37,98 +37,100 @@ class _ShareReferralWidgetState extends State<ShareReferralWidget> {
         "Enjoying 10101?",
         textAlign: TextAlign.center,
       ),
-      content: Column(
-        mainAxisSize: MainAxisSize.min,
-        mainAxisAlignment: MainAxisAlignment.start,
-        children: [
-          Center(
-            child: RichText(
-              textAlign: TextAlign.center,
-              text: const TextSpan(
-                text: "Invite your friends to join ",
-                children: [
-                  TextSpan(
-                      text: "10101",
-                      style: TextStyle(fontWeight: FontWeight.bold, color: tenTenOnePurple),
-                      children: [
-                        TextSpan(
-                            text: " and we’ll reduce your order matching fee.",
-                            style: TextStyle(fontWeight: FontWeight.normal, color: Colors.black))
-                      ])
-                ],
-                style: TextStyle(
-                  fontSize: 18,
-                  color: Colors.black,
+      content: SingleChildScrollView(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          mainAxisAlignment: MainAxisAlignment.start,
+          children: [
+            Center(
+              child: RichText(
+                textAlign: TextAlign.center,
+                text: const TextSpan(
+                  text: "Invite your friends to join ",
+                  children: [
+                    TextSpan(
+                        text: "10101",
+                        style: TextStyle(fontWeight: FontWeight.bold, color: tenTenOnePurple),
+                        children: [
+                          TextSpan(
+                              text: " and we’ll reduce your order matching fee.",
+                              style: TextStyle(fontWeight: FontWeight.normal, color: Colors.black))
+                        ])
+                  ],
+                  style: TextStyle(
+                    fontSize: 18,
+                    color: Colors.black,
+                  ),
                 ),
               ),
             ),
-          ),
-          const SizedBox(
-            height: 10,
-          ),
-          const Text("Your referral code is "),
-          const SizedBox(
-            height: 10,
-          ),
-          Stack(
-            children: [
-              SizedBox(
-                height: 50,
-                child: Center(
-                  child: Row(
-                    mainAxisAlignment: MainAxisAlignment.center,
-                    children: [
-                      RichText(
-                        text: TextSpan(
-                            text: referralCode,
-                            style: const TextStyle(
-                              fontWeight: FontWeight.bold,
-                              color: tenTenOnePurple,
-                              fontSize: 18,
-                            ),
-                            recognizer: TapGestureRecognizer()
-                              ..onTap = () {
-                                Clipboard.setData(ClipboardData(text: referralCode));
-                                ScaffoldMessenger.of(context).showSnackBar(
-                                  const SnackBar(
-                                    content: Text('Copied to clipboard'),
-                                  ),
-                                );
-                              }),
-                      ),
-                    ],
+            const SizedBox(
+              height: 10,
+            ),
+            const Text("Your referral code is "),
+            const SizedBox(
+              height: 10,
+            ),
+            Stack(
+              children: [
+                SizedBox(
+                  height: 50,
+                  child: Center(
+                    child: Row(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      children: [
+                        RichText(
+                          text: TextSpan(
+                              text: referralCode,
+                              style: const TextStyle(
+                                fontWeight: FontWeight.bold,
+                                color: tenTenOnePurple,
+                                fontSize: 18,
+                              ),
+                              recognizer: TapGestureRecognizer()
+                                ..onTap = () {
+                                  Clipboard.setData(ClipboardData(text: referralCode));
+                                  ScaffoldMessenger.of(context).showSnackBar(
+                                    const SnackBar(
+                                      content: Text('Copied to clipboard'),
+                                    ),
+                                  );
+                                }),
+                        ),
+                      ],
+                    ),
                   ),
                 ),
-              ),
-              SizedBox(
-                height: 50,
-                child: Center(
-                  child: Row(
-                    mainAxisAlignment: MainAxisAlignment.end,
-                    children: [
-                      IconButton(
-                          onPressed: () => Share.share(
-                              "Join me and trade without counter-party risk. https://referral.10101.finance?referral=$referralCode"),
-                          icon: const Icon(Icons.share, size: 18))
-                    ],
+                SizedBox(
+                  height: 50,
+                  child: Center(
+                    child: Row(
+                      mainAxisAlignment: MainAxisAlignment.end,
+                      children: [
+                        IconButton(
+                            onPressed: () => Share.share(
+                                "Join me and trade without counter-party risk. https://referral.10101.finance?referral=$referralCode"),
+                            icon: const Icon(Icons.share, size: 18))
+                      ],
+                    ),
                   ),
                 ),
-              ),
-            ],
-          ),
-          Screenshot(
-              controller: widget.screenShotController,
-              child: FittedBox(
-                fit: BoxFit.scaleDown,
-                child: SizedBox(
-                  width: 600,
-                  height: 800,
-                  child: ReferralWidget(
-                    referralCode: referralCode,
+              ],
+            ),
+            Screenshot(
+                controller: widget.screenShotController,
+                child: FittedBox(
+                  fit: BoxFit.scaleDown,
+                  child: SizedBox(
+                    width: 600,
+                    height: 800,
+                    child: ReferralWidget(
+                      referralCode: referralCode,
+                    ),
                   ),
-                ),
-              ))
-        ],
+                ))
+          ],
+        ),
       ),
       actions: <Widget>[
         TextButton(

--- a/mobile/lib/features/wallet/scanner_screen.dart
+++ b/mobile/lib/features/wallet/scanner_screen.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 import 'package:get_10101/common/color.dart';
+import 'package:get_10101/common/scrollable_safe_area.dart';
 import 'package:get_10101/features/wallet/domain/destination.dart';
 import 'package:get_10101/features/wallet/domain/wallet_type.dart';
 import 'package:get_10101/features/wallet/send/send_onchain_screen.dart';
@@ -55,7 +56,7 @@ class _ScannerScreenState extends State<ScannerScreen> {
     final walletService = context.read<WalletChangeNotifier>().service;
 
     return Scaffold(
-        body: SafeArea(
+        body: ScrollableSafeArea(
       child: Container(
         margin: const EdgeInsets.only(top: 10),
         child: Column(children: [

--- a/mobile/lib/features/wallet/send/send_onchain_screen.dart
+++ b/mobile/lib/features/wallet/send/send_onchain_screen.dart
@@ -330,7 +330,7 @@ class _SendOnChainScreenState extends State<SendOnChainScreen> {
                             await calculateCustomFee(feeConfig);
                           }
                         }),
-                    const Spacer(),
+                    const SizedBox(height: 20),
                     SizedBox(
                       width: MediaQuery.of(context).size.width * 0.9,
                       child: ElevatedButton(

--- a/mobile/lib/features/wallet/wallet_screen.dart
+++ b/mobile/lib/features/wallet/wallet_screen.dart
@@ -72,43 +72,44 @@ class _WalletScreenState extends State<WalletScreen> {
           await walletChangeNotifier.waitForSyncToComplete();
           await pollChangeNotifier.refresh();
         },
-        child: Container(
-          margin: const EdgeInsets.only(top: 7.0),
-          padding: const EdgeInsets.symmetric(horizontal: 20),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.stretch,
-            children: [
-              const Balance(),
-              const SizedBox(height: 10.0),
-              Container(
-                  margin: const EdgeInsets.only(left: 0, right: 0),
-                  child: Row(children: [
-                    Expanded(
-                      child: SecondaryActionButton(
-                        onPressed: () => context.go(ReceiveScreen.route),
-                        icon: FontAwesomeIcons.arrowDown,
-                        title: 'Receive',
-                      ),
+        child: ScrollConfiguration(
+          behavior: ScrollConfiguration.of(context).copyWith(
+            dragDevices: PointerDeviceKind.values.toSet(),
+          ),
+          child: ConstrainedBox(
+            constraints: const BoxConstraints.expand(),
+            child: SingleChildScrollView(
+              physics: const AlwaysScrollableScrollPhysics(),
+              child: Container(
+                margin: const EdgeInsets.only(top: 7.0),
+                padding: const EdgeInsets.symmetric(horizontal: 20),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: [
+                    const Balance(),
+                    const SizedBox(height: 10.0),
+                    Container(
+                        margin: const EdgeInsets.only(left: 0, right: 0),
+                        child: Row(children: [
+                          Expanded(
+                            child: SecondaryActionButton(
+                              onPressed: () => context.go(ReceiveScreen.route),
+                              icon: FontAwesomeIcons.arrowDown,
+                              title: 'Receive',
+                            ),
+                          ),
+                          const SizedBox(width: 10.0),
+                          Expanded(
+                              child: SecondaryActionButton(
+                            onPressed: () => GoRouter.of(context).go(ScannerScreen.route),
+                            icon: FontAwesomeIcons.arrowUp,
+                            title: 'Send',
+                          ))
+                        ])),
+                    const SizedBox(
+                      height: 10,
                     ),
-                    const SizedBox(width: 10.0),
-                    Expanded(
-                        child: SecondaryActionButton(
-                      onPressed: () => GoRouter.of(context).go(ScannerScreen.route),
-                      icon: FontAwesomeIcons.arrowUp,
-                      title: 'Send',
-                    ))
-                  ])),
-              const SizedBox(
-                height: 10,
-              ),
-              Expanded(
-                child: ScrollConfiguration(
-                  behavior: ScrollConfiguration.of(context).copyWith(
-                    dragDevices: PointerDeviceKind.values.toSet(),
-                  ),
-                  child: SingleChildScrollView(
-                    physics: const AlwaysScrollableScrollPhysics(),
-                    child: Column(
+                    Column(
                       children: [
                         const Padding(
                           padding: EdgeInsets.only(bottom: 8.0),
@@ -125,10 +126,10 @@ class _WalletScreenState extends State<WalletScreen> {
                         ),
                       ],
                     ),
-                  ),
+                  ],
                 ),
               ),
-            ],
+            ),
           ),
         ),
       ),


### PR DESCRIPTION
Addresses #1933 partially. This _does_ remove all overflow on small mobile screens that I could find, but it doesn't make it _nice_ necessarily in all cases (see below...)

Unfortunately, there is still one issue which will be harder to resolve:
- When the screen is very small, the position/order list in the trade tab correctly scrolls
- However, the TradingView chart takes up the lion's share of the space, meaning that you are viewing the position/order list through a pinhole, which is very frustrating and hard to see
- The ideal UX solution is to scroll the entire page - not just the position list. This way, the trading view widget will eventually disappear if you scroll down far enough.
- However, this is difficult. We can't just wrap the entire thing in a scroll widget because TabBarView also creates a scroll widget, so it won't work properly. If we remove the scroll widget in TabBarView, it has unconstrained height and refuses to lay itself out. IntrinsicHeight is flat-out disallowed it seems(?). The correct solution is a NestedScrollView, but this is a bit of a pain to implement.

Because it may take a bit longer to fix the trade screen, I've opened this PR in the meantime, as these fixes are separate.