### PR TITLE
fix: Block a db connection during a rollover as short as possible.

### DIFF
--- a/coordinator/src/routes/admin.rs
+++ b/coordinator/src/routes/admin.rs
@@ -428,12 +428,7 @@ pub async fn rollover(
 
     state
         .node
-        .propose_rollover(
-            &mut connection,
-            &dlc_channel_id,
-            position,
-            state.node.inner.network,
-        )
+        .propose_rollover(&dlc_channel_id, position, state.node.inner.network)
         .await
         .map_err(|e| {
             AppError::InternalServerError(format!("Failed to rollover DLC channel: {e:#}",))


### PR DESCRIPTION
Since the connections are limited it's better to not block a connection unnecessarily for a long time.

As we are using a connection pool (r2d2) getting a connection is very cheap.

This might help in the context of https://github.com/get10101/10101/issues/2629