### PR TITLE
fix: Only accept a rollover offer if the contract has been confirmed.

### DIFF
--- a/coordinator/src/bin/coordinator.rs
+++ b/coordinator/src/bin/coordinator.rs
@@ -263,11 +263,10 @@ async fn main() -> Result<()> {
         node.inner.oracle_pubkey,
     );
     let _handle = rollover::monitor(
-        pool.clone(),
+        node.clone(),
         node_event_handler.subscribe(),
         notification_service.get_sender(),
         network,
-        node.clone(),
     );
     let _handle = collaborative_revert::monitor(
         pool.clone(),

--- a/coordinator/src/node/rollover.rs
+++ b/coordinator/src/node/rollover.rs
@@ -180,6 +180,14 @@ impl Node {
     ) -> Result<()> {
         let trader_pubkey = position.trader;
 
+        if !self
+            .inner
+            .check_if_signed_channel_is_confirmed(trader_pubkey)
+            .await?
+        {
+            bail!("Cannot rollover a contract that is not confirmed");
+        }
+
         let next_expiry = commons::calculate_next_expiry(OffsetDateTime::now_utc(), network);
 
         let (oracle_pk, contract_tx_fee_rate) = {


### PR DESCRIPTION
Syncs the wallet eagerly if the channel is not yet confirmed.

If the contract is not confirmed, the rollover offer gets rejected. This fixes an issue where the app otherwise risk ending up in an intermediate state as it can't accept the `RenewConfirm` message.

fixes https://github.com/get10101/10101/issues/2630