### PR TITLE
fix: fee rate was not parsed correctly

### DIFF
--- a/webapp/frontend/lib/common/model.dart
+++ b/webapp/frontend/lib/common/model.dart
@@ -235,8 +235,9 @@ class FeeRate implements Formattable {
     _feeRate = feeRate;
   }
 
-  FeeRate.parse(String value) {
-    FeeRate(double.parse(value));
+  factory FeeRate.parse(String feeRateString) {
+    double parsedRate = double.tryParse(feeRateString) ?? 1.0;
+    return FeeRate(parsedRate);
   }
 
   double get feeRate => _feeRate;


### PR DESCRIPTION
We should backport this to 2.4.5 and release a new version