### PR TITLE
Release version 2.4.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -961,7 +961,7 @@ dependencies = [
 
 [[package]]
 name = "coordinator"
-version = "2.4.5"
+version = "2.4.8"
 dependencies = [
  "anyhow",
  "atty",
@@ -2569,7 +2569,7 @@ dependencies = [
 
 [[package]]
 name = "native"
-version = "2.4.5"
+version = "2.4.8"
 dependencies = [
  "aes-gcm-siv",
  "anyhow",
@@ -5143,7 +5143,7 @@ dependencies = [
 
 [[package]]
 name = "webapp"
-version = "2.4.5"
+version = "2.4.8"
 dependencies = [
  "anyhow",
  "atty",

--- a/coordinator/Cargo.toml
+++ b/coordinator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coordinator"
-version = "2.4.5"
+version = "2.4.8"
 edition = "2021"
 
 [dependencies]

--- a/mobile/native/Cargo.toml
+++ b/mobile/native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "native"
-version = "2.4.5"
+version = "2.4.8"
 edition = "2021"
 
 [lib]

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -1,7 +1,7 @@
 name: get_10101
 description: 10101 combines the power of a self-custodial on-chain and off-chain wallet with the vast world of trading.
 publish_to: none
-version: 2.4.5
+version: 2.4.8
 environment:
   sdk: '>=3.1.2 <4.0.0'
   flutter: 3.22.1

--- a/webapp/Cargo.toml
+++ b/webapp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "webapp"
-version = "2.4.5"
+version = "2.4.8"
 build = "build.rs"
 edition = "2021"
 


### PR DESCRIPTION
Hi @holzeis!
This PR was created in response to a manual trigger of the release workflow here: https://github.com/get10101/10101/actions/runs/10214008436.
I've bumped the versions in the manifest files in this commit: 7b095129ff029827a2334abb0796ac4659498872.
Merging this PR will create a GitHub release!