### PR TITLE
Show 4 decimal places on next funding rate

### DIFF
--- a/mobile/lib/features/trade/trade_screen.dart
+++ b/mobile/lib/features/trade/trade_screen.dart
@@ -348,7 +348,7 @@ class FundingRateWidget extends StatelessWidget {
               style: DefaultTextStyle.of(context).style,
               children: [
                 TextSpan(
-                  text: " ${(rate!.rate.abs() * 100).toStringAsFixed(2)}% ",
+                  text: " ${(rate!.rate.abs() * 100).toStringAsFixed(4)}% ",
                   style: const TextStyle(fontWeight: FontWeight.bold),
                 ),
                 TextSpan(


### PR DESCRIPTION
It is very unlikely that the absolute funding rate will be below 0.0001, so 4 decimal places should be informational enough.

![image](https://github.com/user-attachments/assets/14d3982d-0c8c-443e-8f2a-1b3b4c2caca5)
