### PR TITLE
Use blockstream's public API for clients

### DIFF
--- a/.github/workflows/build-release-binaries.yml
+++ b/.github/workflows/build-release-binaries.yml
@@ -26,7 +26,7 @@ jobs:
     uses: ./.github/workflows/ios-fastlane.yml
     secrets: inherit
     with:
-      electrs_endpoint: http://api.10101.finance:3000
+      electrs_endpoint: https://blockstream.info/api
       coordinator_p2p_endpoint: 022ae8dbec1caa4dac93f07f2ebf5ad7a5dd08d375b79f11095e81b065c2155156@66.248.204.223:9045
       coordinator_port_http: 80
       network: mainnet
@@ -46,7 +46,7 @@ jobs:
     secrets: inherit
     with:
       tag: ${{ github.ref_name }}
-      electrs_endpoint: http://api.10101.finance:3000
+      electrs_endpoint: https://blockstream.info/api
       coordinator_p2p_endpoint: 022ae8dbec1caa4dac93f07f2ebf5ad7a5dd08d375b79f11095e81b065c2155156@66.248.204.223:9045
       coordinator_port_http: 80
       network: mainnet

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1374,7 +1374,7 @@ dependencies = [
 [[package]]
 name = "dlc"
 version = "0.4.0"
-source = "git+https://github.com/get10101/rust-dlc?rev=41f34a3#41f34a33269153c4b05d623842b371fab47822a0"
+source = "git+https://github.com/get10101/rust-dlc?rev=81090c4#81090c4df533b7cc3d68e1b2c510e5fef02eab43"
 dependencies = [
  "bitcoin 0.29.2",
  "miniscript 8.0.2",
@@ -1386,7 +1386,7 @@ dependencies = [
 [[package]]
 name = "dlc-manager"
 version = "0.4.0"
-source = "git+https://github.com/get10101/rust-dlc?rev=41f34a3#41f34a33269153c4b05d623842b371fab47822a0"
+source = "git+https://github.com/get10101/rust-dlc?rev=81090c4#81090c4df533b7cc3d68e1b2c510e5fef02eab43"
 dependencies = [
  "async-trait",
  "bitcoin 0.29.2",
@@ -1402,7 +1402,7 @@ dependencies = [
 [[package]]
 name = "dlc-messages"
 version = "0.4.0"
-source = "git+https://github.com/get10101/rust-dlc?rev=41f34a3#41f34a33269153c4b05d623842b371fab47822a0"
+source = "git+https://github.com/get10101/rust-dlc?rev=81090c4#81090c4df533b7cc3d68e1b2c510e5fef02eab43"
 dependencies = [
  "bitcoin 0.29.2",
  "dlc",
@@ -1415,7 +1415,7 @@ dependencies = [
 [[package]]
 name = "dlc-trie"
 version = "0.4.0"
-source = "git+https://github.com/get10101/rust-dlc?rev=41f34a3#41f34a33269153c4b05d623842b371fab47822a0"
+source = "git+https://github.com/get10101/rust-dlc?rev=81090c4#81090c4df533b7cc3d68e1b2c510e5fef02eab43"
 dependencies = [
  "bitcoin 0.29.2",
  "dlc",
@@ -2879,7 +2879,7 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 [[package]]
 name = "p2pd-oracle-client"
 version = "0.1.0"
-source = "git+https://github.com/get10101/rust-dlc?rev=41f34a3#41f34a33269153c4b05d623842b371fab47822a0"
+source = "git+https://github.com/get10101/rust-dlc?rev=81090c4#81090c4df533b7cc3d68e1b2c510e5fef02eab43"
 dependencies = [
  "chrono",
  "dlc-manager",

--- a/webapp/README.md
+++ b/webapp/README.md
@@ -68,7 +68,7 @@ services:
     container_name: webapp
     command: |
       --coordinator-endpoint=022ae8dbec1caa4dac93f07f2ebf5ad7a5dd08d375b79f11095e81b065c2155156@66.248.204.223:9045
-      --esplora=http://api.10101.finance:3000
+      --esplora=https://blockstream.info/api
       --password=super_secret_password_please_change_before_use
       --coordinator-http-port=80
       --cert-dir=webapp/certs


### PR DESCRIPTION
Since we are winding down the 10101 coordinator, apps will only work if they use an alternative API, such as Blockstream's public API.