### PR TITLE
Use `ConfirmationTarget::Background` to claim settle TX outputs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1374,7 +1374,7 @@ dependencies = [
 [[package]]
 name = "dlc"
 version = "0.4.0"
-source = "git+https://github.com/get10101/rust-dlc?rev=81090c4#81090c4df533b7cc3d68e1b2c510e5fef02eab43"
+source = "git+https://github.com/get10101/rust-dlc?rev=906cb4d#906cb4d422dbd90bf2fe35991f2a709801c250e7"
 dependencies = [
  "bitcoin 0.29.2",
  "miniscript 8.0.2",
@@ -1386,7 +1386,7 @@ dependencies = [
 [[package]]
 name = "dlc-manager"
 version = "0.4.0"
-source = "git+https://github.com/get10101/rust-dlc?rev=81090c4#81090c4df533b7cc3d68e1b2c510e5fef02eab43"
+source = "git+https://github.com/get10101/rust-dlc?rev=906cb4d#906cb4d422dbd90bf2fe35991f2a709801c250e7"
 dependencies = [
  "async-trait",
  "bitcoin 0.29.2",
@@ -1402,7 +1402,7 @@ dependencies = [
 [[package]]
 name = "dlc-messages"
 version = "0.4.0"
-source = "git+https://github.com/get10101/rust-dlc?rev=81090c4#81090c4df533b7cc3d68e1b2c510e5fef02eab43"
+source = "git+https://github.com/get10101/rust-dlc?rev=906cb4d#906cb4d422dbd90bf2fe35991f2a709801c250e7"
 dependencies = [
  "bitcoin 0.29.2",
  "dlc",
@@ -1415,7 +1415,7 @@ dependencies = [
 [[package]]
 name = "dlc-trie"
 version = "0.4.0"
-source = "git+https://github.com/get10101/rust-dlc?rev=81090c4#81090c4df533b7cc3d68e1b2c510e5fef02eab43"
+source = "git+https://github.com/get10101/rust-dlc?rev=906cb4d#906cb4d422dbd90bf2fe35991f2a709801c250e7"
 dependencies = [
  "bitcoin 0.29.2",
  "dlc",
@@ -2879,7 +2879,7 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 [[package]]
 name = "p2pd-oracle-client"
 version = "0.1.0"
-source = "git+https://github.com/get10101/rust-dlc?rev=81090c4#81090c4df533b7cc3d68e1b2c510e5fef02eab43"
+source = "git+https://github.com/get10101/rust-dlc?rev=906cb4d#906cb4d422dbd90bf2fe35991f2a709801c250e7"
 dependencies = [
  "chrono",
  "dlc-manager",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,11 +19,11 @@ resolver = "2"
 # We are using our own fork of `rust-dlc` at least until we can drop all the LN-DLC features. Also,
 # `p2pderivatives/rust-dlc#master` is missing certain patches that can only be found in the LN-DLC
 # branch.
-dlc-manager = { git = "https://github.com/get10101/rust-dlc", rev = "81090c4" }
-dlc-messages = { git = "https://github.com/get10101/rust-dlc", rev = "81090c4" }
-dlc = { git = "https://github.com/get10101/rust-dlc", rev = "81090c4" }
-p2pd-oracle-client = { git = "https://github.com/get10101/rust-dlc", rev = "81090c4" }
-dlc-trie = { git = "https://github.com/get10101/rust-dlc", rev = "81090c4" }
+dlc-manager = { git = "https://github.com/get10101/rust-dlc", rev = "906cb4d" }
+dlc-messages = { git = "https://github.com/get10101/rust-dlc", rev = "906cb4d" }
+dlc = { git = "https://github.com/get10101/rust-dlc", rev = "906cb4d" }
+p2pd-oracle-client = { git = "https://github.com/get10101/rust-dlc", rev = "906cb4d" }
+dlc-trie = { git = "https://github.com/get10101/rust-dlc", rev = "906cb4d" }
 
 # We should usually track the `p2pderivatives/split-tx-experiment[-10101]` branch. For now we depend
 # on a special fork which removes a panic in `rust-lightning`.


### PR DESCRIPTION
There is actually no protocol pressure to claim these outputs quickly, so it seems foolish to pay a possibly very high price for these claim transactions.

See https://github.com/get10101/rust-dlc/commit/906cb4d422dbd90bf2fe35991f2a709801c250e7.